### PR TITLE
Add seamless pandas/polars/numpy array support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -765,6 +765,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "numpy"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aac2e6a6e4468ffa092ad43c39b81c79196c2bb773b8db4085f695efe3bba17"
+dependencies = [
+ "libc",
+ "ndarray",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "pyo3",
+ "pyo3-build-config",
+ "rustc-hash",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1102,6 +1118,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1218,11 +1240,12 @@ dependencies = [
 
 [[package]]
 name = "survival"
-version = "1.0.16"
+version = "1.1.0"
 dependencies = [
  "faer",
  "itertools",
  "ndarray",
+ "numpy",
  "pyo3",
  "rayon",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "survival"
-version = "1.0.17"
+version = "1.1.0"
 edition = "2024"
 rust-version = "1.92"
 authors = ["Cameron Lyons <cameron.lyons2@gmail.com>"]
@@ -21,6 +21,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 pyo3 = { version = "0.27.2", features = ["extension-module"] }
+numpy = "0.27"
 ndarray = "0.17.1"
 itertools = "0.14.0"
 rayon = "1.11.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,9 @@ pub use surv_analysis::nelson_aalen::{
 };
 pub use surv_analysis::survdiff2::{SurvDiffResult, survdiff2};
 pub use surv_analysis::survfitaj::{SurvFitAJ, survfitaj};
-pub use surv_analysis::survfitkm::{SurvFitKMOutput, survfitkm};
+pub use surv_analysis::survfitkm::{
+    SurvFitKMOutput, SurvfitKMOptions, survfitkm, survfitkm_with_options,
+};
 pub use utilities::agexact::agexact;
 pub use utilities::collapse::collapse;
 pub use utilities::survsplit::{SplitResult, survsplit};
@@ -104,6 +106,7 @@ fn survival(_py: Python, m: Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(agmart, &m)?)?;
     m.add_function(wrap_pyfunction!(coxmart, &m)?)?;
     m.add_function(wrap_pyfunction!(survfitkm, &m)?)?;
+    m.add_function(wrap_pyfunction!(survfitkm_with_options, &m)?)?;
     m.add_function(wrap_pyfunction!(survfitaj, &m)?)?;
     m.add_function(wrap_pyfunction!(survdiff2, &m)?)?;
     m.add_function(wrap_pyfunction!(finegray, &m)?)?;
@@ -155,6 +158,7 @@ fn survival(_py: Python, m: Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<CoxPHModel>()?;
     m.add_class::<Subject>()?;
     m.add_class::<SurvFitKMOutput>()?;
+    m.add_class::<SurvfitKMOptions>()?;
     m.add_class::<SurvFitAJ>()?;
     m.add_class::<FineGrayOutput>()?;
     m.add_class::<SurvivalFit>()?;

--- a/src/surv_analysis/survfitkm.rs
+++ b/src/surv_analysis/survfitkm.rs
@@ -1,7 +1,65 @@
+use crate::utilities::numpy_utils::{
+    extract_optional_vec_f64, extract_optional_vec_i32, extract_vec_f64,
+};
 use crate::utilities::validation::{
     clamp_probability, validate_length, validate_no_nan, validate_non_empty, validate_non_negative,
 };
 use pyo3::prelude::*;
+
+#[derive(Debug, Clone, Default)]
+#[pyclass]
+pub struct SurvfitKMOptions {
+    #[pyo3(get, set)]
+    pub weights: Option<Vec<f64>>,
+    #[pyo3(get, set)]
+    pub entry_times: Option<Vec<f64>>,
+    #[pyo3(get, set)]
+    pub position: Option<Vec<i32>>,
+    #[pyo3(get, set)]
+    pub reverse: Option<bool>,
+    #[pyo3(get, set)]
+    pub computation_type: Option<i32>,
+}
+
+#[pymethods]
+impl SurvfitKMOptions {
+    #[new]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_weights(mut self_: PyRefMut<'_, Self>, weights: Vec<f64>) -> PyRefMut<'_, Self> {
+        self_.weights = Some(weights);
+        self_
+    }
+
+    pub fn with_entry_times(
+        mut self_: PyRefMut<'_, Self>,
+        entry_times: Vec<f64>,
+    ) -> PyRefMut<'_, Self> {
+        self_.entry_times = Some(entry_times);
+        self_
+    }
+
+    pub fn with_position(mut self_: PyRefMut<'_, Self>, position: Vec<i32>) -> PyRefMut<'_, Self> {
+        self_.position = Some(position);
+        self_
+    }
+
+    pub fn with_reverse(mut self_: PyRefMut<'_, Self>, reverse: bool) -> PyRefMut<'_, Self> {
+        self_.reverse = Some(reverse);
+        self_
+    }
+
+    pub fn with_computation_type(
+        mut self_: PyRefMut<'_, Self>,
+        computation_type: i32,
+    ) -> PyRefMut<'_, Self> {
+        self_.computation_type = Some(computation_type);
+        self_
+    }
+}
+
 #[derive(Debug, Clone)]
 #[pyclass]
 pub struct SurvFitKMOutput {
@@ -26,20 +84,25 @@ pub struct SurvFitKMOutput {
 #[allow(clippy::too_many_arguments)]
 #[pyo3(signature = (time, status, weights=None, entry_times=None, position=None, reverse=None, computation_type=None))]
 pub fn survfitkm(
-    time: Vec<f64>,
-    status: Vec<f64>,
-    weights: Option<Vec<f64>>,
-    entry_times: Option<Vec<f64>>,
-    position: Option<Vec<i32>>,
+    time: &Bound<'_, PyAny>,
+    status: &Bound<'_, PyAny>,
+    weights: Option<&Bound<'_, PyAny>>,
+    entry_times: Option<&Bound<'_, PyAny>>,
+    position: Option<&Bound<'_, PyAny>>,
     reverse: Option<bool>,
     computation_type: Option<i32>,
 ) -> PyResult<SurvFitKMOutput> {
+    let time = extract_vec_f64(time)?;
+    let status = extract_vec_f64(status)?;
+    let weights_opt = extract_optional_vec_f64(weights)?;
+    let entry_times_opt = extract_optional_vec_f64(entry_times)?;
+    let position_opt = extract_optional_vec_i32(position)?;
     validate_non_empty(&time, "time")?;
     validate_length(time.len(), status.len(), "status")?;
     validate_non_negative(&time, "time")?;
     validate_no_nan(&time, "time")?;
     validate_no_nan(&status, "status")?;
-    let weights = match weights {
+    let weights = match weights_opt {
         Some(w) => {
             validate_length(time.len(), w.len(), "weights")?;
             validate_non_negative(&w, "weights")?;
@@ -47,14 +110,14 @@ pub fn survfitkm(
         }
         None => vec![1.0; time.len()],
     };
-    let position = match position {
+    let position = match position_opt {
         Some(p) => {
             validate_length(time.len(), p.len(), "position")?;
             p
         }
         None => vec![0; time.len()],
     };
-    if let Some(ref entry) = entry_times {
+    if let Some(ref entry) = entry_times_opt {
         validate_length(time.len(), entry.len(), "entry_times")?;
     }
     let _reverse = reverse.unwrap_or(false);
@@ -63,7 +126,7 @@ pub fn survfitkm(
         &time,
         &status,
         &weights,
-        entry_times.as_deref(),
+        entry_times_opt.as_deref(),
         &position,
         _reverse,
         _computation_type,
@@ -159,10 +222,55 @@ pub fn compute_survfitkm(
         conf_upper,
     }
 }
+#[pyfunction]
+pub fn survfitkm_with_options(
+    time: Vec<f64>,
+    status: Vec<f64>,
+    options: Option<&SurvfitKMOptions>,
+) -> PyResult<SurvFitKMOutput> {
+    let opts = options.cloned().unwrap_or_default();
+    validate_non_empty(&time, "time")?;
+    validate_length(time.len(), status.len(), "status")?;
+    validate_non_negative(&time, "time")?;
+    validate_no_nan(&time, "time")?;
+    validate_no_nan(&status, "status")?;
+    let weights = match opts.weights {
+        Some(w) => {
+            validate_length(time.len(), w.len(), "weights")?;
+            validate_non_negative(&w, "weights")?;
+            w
+        }
+        None => vec![1.0; time.len()],
+    };
+    let position = match opts.position {
+        Some(p) => {
+            validate_length(time.len(), p.len(), "position")?;
+            p
+        }
+        None => vec![0; time.len()],
+    };
+    if let Some(ref entry) = opts.entry_times {
+        validate_length(time.len(), entry.len(), "entry_times")?;
+    }
+    let reverse = opts.reverse.unwrap_or(false);
+    let computation_type = opts.computation_type.unwrap_or(0);
+    Ok(compute_survfitkm(
+        &time,
+        &status,
+        &weights,
+        opts.entry_times.as_deref(),
+        &position,
+        reverse,
+        computation_type,
+    ))
+}
+
 #[pymodule]
 #[pyo3(name = "survfitkm")]
 fn survfitkm_module(_py: Python, m: Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(survfitkm, &m)?)?;
+    m.add_function(wrap_pyfunction!(survfitkm_with_options, &m)?)?;
     m.add_class::<SurvFitKMOutput>()?;
+    m.add_class::<SurvfitKMOptions>()?;
     Ok(())
 }

--- a/src/utilities/mod.rs
+++ b/src/utilities/mod.rs
@@ -1,6 +1,7 @@
 pub mod agexact;
 pub mod collapse;
 pub mod matrix;
+pub mod numpy_utils;
 pub mod statistical;
 pub mod survsplit;
 pub mod tmerge;

--- a/src/utilities/numpy_utils.rs
+++ b/src/utilities/numpy_utils.rs
@@ -1,0 +1,133 @@
+use numpy::{PyArray1, PyReadonlyArray1, PyUntypedArrayMethods};
+use pyo3::prelude::*;
+use pyo3::types::PyList;
+
+#[allow(clippy::collapsible_if)]
+pub fn extract_vec_f64(obj: &Bound<'_, PyAny>) -> PyResult<Vec<f64>> {
+    if let Ok(arr) = obj.extract::<PyReadonlyArray1<'_, f64>>() {
+        return Ok(arr.as_slice()?.to_vec());
+    }
+    if let Ok(list) = obj.extract::<Vec<f64>>() {
+        return Ok(list);
+    }
+    if let Ok(values) = obj.getattr("values") {
+        if let Ok(arr) = values.extract::<PyReadonlyArray1<'_, f64>>() {
+            return Ok(arr.as_slice()?.to_vec());
+        }
+    }
+    if let Ok(to_numpy) = obj.getattr("to_numpy") {
+        if let Ok(arr_obj) = to_numpy.call0() {
+            if let Ok(arr) = arr_obj.extract::<PyReadonlyArray1<'_, f64>>() {
+                return Ok(arr.as_slice()?.to_vec());
+            }
+        }
+    }
+    Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+        "Expected numpy array, pandas Series, polars Series, or list of floats",
+    ))
+}
+
+#[allow(clippy::collapsible_if)]
+pub fn extract_vec_i32(obj: &Bound<'_, PyAny>) -> PyResult<Vec<i32>> {
+    if let Ok(arr) = obj.extract::<PyReadonlyArray1<'_, i32>>() {
+        return Ok(arr.as_slice()?.to_vec());
+    }
+    if let Ok(arr) = obj.extract::<PyReadonlyArray1<'_, i64>>() {
+        return Ok(arr.as_slice()?.iter().map(|&x| x as i32).collect());
+    }
+    if let Ok(list) = obj.extract::<Vec<i32>>() {
+        return Ok(list);
+    }
+    if let Ok(list) = obj.extract::<Vec<i64>>() {
+        return Ok(list.into_iter().map(|x| x as i32).collect());
+    }
+    if let Ok(values) = obj.getattr("values") {
+        if let Ok(arr) = values.extract::<PyReadonlyArray1<'_, i32>>() {
+            return Ok(arr.as_slice()?.to_vec());
+        }
+        if let Ok(arr) = values.extract::<PyReadonlyArray1<'_, i64>>() {
+            return Ok(arr.as_slice()?.iter().map(|&x| x as i32).collect());
+        }
+    }
+    if let Ok(to_numpy) = obj.getattr("to_numpy") {
+        if let Ok(arr_obj) = to_numpy.call0() {
+            if let Ok(arr) = arr_obj.extract::<PyReadonlyArray1<'_, i32>>() {
+                return Ok(arr.as_slice()?.to_vec());
+            }
+            if let Ok(arr) = arr_obj.extract::<PyReadonlyArray1<'_, i64>>() {
+                return Ok(arr.as_slice()?.iter().map(|&x| x as i32).collect());
+            }
+        }
+    }
+    Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+        "Expected numpy array, pandas Series, polars Series, or list of integers",
+    ))
+}
+
+pub fn extract_optional_vec_f64(obj: Option<&Bound<'_, PyAny>>) -> PyResult<Option<Vec<f64>>> {
+    match obj {
+        Some(o) => Ok(Some(extract_vec_f64(o)?)),
+        None => Ok(None),
+    }
+}
+
+pub fn extract_optional_vec_i32(obj: Option<&Bound<'_, PyAny>>) -> PyResult<Option<Vec<i32>>> {
+    match obj {
+        Some(o) => Ok(Some(extract_vec_i32(o)?)),
+        None => Ok(None),
+    }
+}
+
+#[allow(dead_code)]
+pub fn array_f64_to_vec(arr: PyReadonlyArray1<'_, f64>) -> Vec<f64> {
+    arr.as_slice().unwrap().to_vec()
+}
+
+#[allow(dead_code)]
+pub fn array_i32_to_vec(arr: PyReadonlyArray1<'_, i32>) -> Vec<i32> {
+    arr.as_slice().unwrap().to_vec()
+}
+
+#[allow(dead_code)]
+pub fn array_i64_to_vec(arr: PyReadonlyArray1<'_, i64>) -> Vec<i64> {
+    arr.as_slice().unwrap().to_vec()
+}
+
+#[allow(dead_code)]
+pub fn vec_to_array_f64<'py>(py: Python<'py>, vec: Vec<f64>) -> Bound<'py, PyArray1<f64>> {
+    PyArray1::from_vec(py, vec)
+}
+
+#[allow(dead_code)]
+pub fn vec_to_array_i32<'py>(py: Python<'py>, vec: Vec<i32>) -> Bound<'py, PyArray1<i32>> {
+    PyArray1::from_vec(py, vec)
+}
+
+#[allow(dead_code, clippy::collapsible_if)]
+pub fn extract_2d_vec_f64(obj: &Bound<'_, PyAny>) -> PyResult<Vec<Vec<f64>>> {
+    if let Ok(list) = obj.extract::<Bound<'_, PyList>>() {
+        let mut result = Vec::with_capacity(list.len());
+        for item in list.iter() {
+            result.push(extract_vec_f64(&item)?);
+        }
+        return Ok(result);
+    }
+    if let Ok(list) = obj.extract::<Vec<Vec<f64>>>() {
+        return Ok(list);
+    }
+    if let Ok(values) = obj.getattr("values") {
+        if let Ok(arr) = values.extract::<numpy::PyReadonlyArray2<'_, f64>>() {
+            let shape = arr.shape();
+            let slice = arr.as_slice()?;
+            let mut result = Vec::with_capacity(shape[0]);
+            for i in 0..shape[0] {
+                let row: Vec<f64> = slice[i * shape[1]..(i + 1) * shape[1]].to_vec();
+                result.push(row);
+            }
+            return Ok(result);
+        }
+    }
+    Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+        "Expected 2D array, DataFrame, or list of lists",
+    ))
+}

--- a/src/validation/crossval.rs
+++ b/src/validation/crossval.rs
@@ -1,3 +1,4 @@
+use crate::utilities::numpy_utils::{extract_optional_vec_f64, extract_vec_f64, extract_vec_i32};
 use ndarray::Array2;
 use pyo3::prelude::*;
 use rayon::prelude::*;
@@ -215,14 +216,17 @@ pub fn cv_cox(
 #[pyfunction]
 #[pyo3(signature = (time, status, covariates, weights=None, n_folds=None, shuffle=None, seed=None))]
 pub fn cv_cox_concordance(
-    time: Vec<f64>,
-    status: Vec<i32>,
+    time: &Bound<'_, PyAny>,
+    status: &Bound<'_, PyAny>,
     covariates: Vec<Vec<f64>>,
-    weights: Option<Vec<f64>>,
+    weights: Option<&Bound<'_, PyAny>>,
     n_folds: Option<usize>,
     shuffle: Option<bool>,
     seed: Option<u64>,
 ) -> PyResult<CVResult> {
+    let time = extract_vec_f64(time)?;
+    let status = extract_vec_i32(status)?;
+    let weights = extract_optional_vec_f64(weights)?;
     let n = time.len();
     let nvar = if !covariates.is_empty() {
         covariates[0].len()
@@ -331,14 +335,16 @@ pub fn cv_survreg(
 #[pyfunction]
 #[pyo3(signature = (time, status, covariates, distribution=None, n_folds=None, shuffle=None, seed=None))]
 pub fn cv_survreg_loglik(
-    time: Vec<f64>,
-    status: Vec<f64>,
+    time: &Bound<'_, PyAny>,
+    status: &Bound<'_, PyAny>,
     covariates: Vec<Vec<f64>>,
     distribution: Option<&str>,
     n_folds: Option<usize>,
     shuffle: Option<bool>,
     seed: Option<u64>,
 ) -> PyResult<CVResult> {
+    let time = extract_vec_f64(time)?;
+    let status = extract_vec_f64(status)?;
     let n = time.len();
     let nvar = if !covariates.is_empty() {
         covariates[0].len()

--- a/src/validation/logrank.rs
+++ b/src/validation/logrank.rs
@@ -1,3 +1,4 @@
+use crate::utilities::numpy_utils::{extract_vec_f64, extract_vec_i32};
 use crate::utilities::statistical::chi2_sf;
 use pyo3::prelude::*;
 #[derive(Debug, Clone)]
@@ -177,11 +178,14 @@ fn weight_name(weight_type: &WeightType) -> String {
 #[pyfunction]
 #[pyo3(signature = (time, status, group, weight_type=None))]
 pub fn logrank_test(
-    time: Vec<f64>,
-    status: Vec<i32>,
-    group: Vec<i32>,
+    time: &Bound<'_, PyAny>,
+    status: &Bound<'_, PyAny>,
+    group: &Bound<'_, PyAny>,
     weight_type: Option<&str>,
 ) -> PyResult<LogRankResult> {
+    let time = extract_vec_f64(time)?;
+    let status = extract_vec_i32(status)?;
+    let group = extract_vec_i32(group)?;
     let wt = match weight_type {
         Some("wilcoxon") | Some("Wilcoxon") => WeightType::Wilcoxon,
         Some("tarone-ware") | Some("TaroneWare") => WeightType::TaroneWare,
@@ -193,12 +197,15 @@ pub fn logrank_test(
 #[pyfunction]
 #[pyo3(signature = (time, status, group, p, q))]
 pub fn fleming_harrington_test(
-    time: Vec<f64>,
-    status: Vec<i32>,
-    group: Vec<i32>,
+    time: &Bound<'_, PyAny>,
+    status: &Bound<'_, PyAny>,
+    group: &Bound<'_, PyAny>,
     p: f64,
     q: f64,
 ) -> PyResult<LogRankResult> {
+    let time = extract_vec_f64(time)?;
+    let status = extract_vec_i32(status)?;
+    let group = extract_vec_i32(group)?;
     Ok(weighted_logrank_test(
         &time,
         &status,
@@ -325,11 +332,14 @@ pub fn logrank_trend_test(
 #[pyfunction]
 #[pyo3(signature = (time, status, group, scores=None))]
 pub fn logrank_trend(
-    time: Vec<f64>,
-    status: Vec<i32>,
-    group: Vec<i32>,
+    time: &Bound<'_, PyAny>,
+    status: &Bound<'_, PyAny>,
+    group: &Bound<'_, PyAny>,
     scores: Option<Vec<f64>>,
 ) -> PyResult<TrendTestResult> {
+    let time = extract_vec_f64(time)?;
+    let status = extract_vec_i32(status)?;
+    let group = extract_vec_i32(group)?;
     let scores_ref = scores.as_deref();
     Ok(logrank_trend_test(&time, &status, &group, scores_ref))
 }

--- a/test/README.md
+++ b/test/README.md
@@ -12,6 +12,7 @@ This directory contains tests for the Python bindings of the survival-rs library
 - `test_concordance_additional.py` - Concordance tests
 - `test_regression.py` - Tests for regression models (survreg, coxmart, CoxPHModel, Subject)
 - `test_edge_cases.py` - Tests for edge cases and boundary conditions
+- `test_array_inputs.py` - Tests for different input types (numpy arrays, pandas Series, polars Series)
 - `test_all.py` - Runner script to execute all tests
 
 ## Running Tests

--- a/test/test_array_inputs.py
+++ b/test/test_array_inputs.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""
+Test that survival functions accept various array-like inputs:
+- Python lists
+- NumPy arrays
+- Pandas Series
+- Polars Series
+"""
+
+import os
+import sys
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from helpers import setup_survival_import
+
+survival = setup_survival_import()
+print("Successfully imported survival module")
+
+print("\n=== Testing survfitkm with different input types ===")
+
+time_list = [1.0, 2.0, 3.0, 4.0, 5.0]
+status_list = [1.0, 1.0, 0.0, 1.0, 0.0]
+
+print("\n1. Testing with Python lists...")
+result = survival.survfitkm(time_list, status_list)
+assert hasattr(result, "estimate"), "Should have estimate attribute"
+assert len(result.estimate) > 0, "Should have estimates"
+print(f"   Passed - estimates: {result.estimate}")
+
+print("\n2. Testing with NumPy arrays...")
+time_np = np.array(time_list)
+status_np = np.array(status_list)
+result = survival.survfitkm(time_np, status_np)
+assert hasattr(result, "estimate"), "Should have estimate attribute"
+assert len(result.estimate) > 0, "Should have estimates"
+print(f"   Passed - estimates: {result.estimate}")
+
+try:
+    import pandas as pd
+
+    print("\n3. Testing with Pandas Series...")
+    df = pd.DataFrame({"time": time_list, "status": status_list})
+    result = survival.survfitkm(df["time"], df["status"])
+    assert hasattr(result, "estimate"), "Should have estimate attribute"
+    assert len(result.estimate) > 0, "Should have estimates"
+    print(f"   Passed - estimates: {result.estimate}")
+
+    print("\n4. Testing with Pandas DataFrame columns (via .values)...")
+    result = survival.survfitkm(df["time"].values, df["status"].values)
+    assert hasattr(result, "estimate"), "Should have estimate attribute"
+    print("   Passed")
+
+except ImportError:
+    print("\n3-4. Skipping Pandas tests (pandas not installed)")
+
+try:
+    import polars as pl
+
+    print("\n5. Testing with Polars Series...")
+    df = pl.DataFrame({"time": time_list, "status": status_list})
+    result = survival.survfitkm(df["time"], df["status"])
+    assert hasattr(result, "estimate"), "Should have estimate attribute"
+    assert len(result.estimate) > 0, "Should have estimates"
+    print(f"   Passed - estimates: {result.estimate}")
+
+except ImportError:
+    print("\n5. Skipping Polars tests (polars not installed)")
+
+
+print("\n=== Testing logrank_test with different input types ===")
+
+time_list = [1.0, 2.0, 3.0, 4.0, 5.0, 1.5, 2.5, 3.5, 4.5, 5.5]
+status_list = [1, 1, 0, 1, 0, 1, 1, 1, 0, 1]
+group_list = [0, 0, 0, 0, 0, 1, 1, 1, 1, 1]
+
+print("\n1. Testing with Python lists...")
+result = survival.logrank_test(time_list, status_list, group_list)
+assert hasattr(result, "statistic"), "Should have statistic"
+assert hasattr(result, "p_value"), "Should have p_value"
+print(f"   Passed - statistic: {result.statistic:.4f}, p-value: {result.p_value:.4f}")
+
+print("\n2. Testing with NumPy arrays...")
+time_np = np.array(time_list)
+status_np = np.array(status_list, dtype=np.int32)
+group_np = np.array(group_list, dtype=np.int32)
+result = survival.logrank_test(time_np, status_np, group_np)
+assert hasattr(result, "statistic"), "Should have statistic"
+print(f"   Passed - statistic: {result.statistic:.4f}")
+
+print("\n3. Testing with NumPy int64 arrays (should auto-convert)...")
+status_np64 = np.array(status_list, dtype=np.int64)
+group_np64 = np.array(group_list, dtype=np.int64)
+result = survival.logrank_test(time_np, status_np64, group_np64)
+assert hasattr(result, "statistic"), "Should have statistic"
+print(f"   Passed - statistic: {result.statistic:.4f}")
+
+try:
+    import pandas as pd
+
+    print("\n4. Testing with Pandas Series...")
+    df = pd.DataFrame({"time": time_list, "status": status_list, "group": group_list})
+    result = survival.logrank_test(df["time"], df["status"], df["group"])
+    assert hasattr(result, "statistic"), "Should have statistic"
+    print(f"   Passed - statistic: {result.statistic:.4f}")
+
+except ImportError:
+    print("\n4. Skipping Pandas tests (pandas not installed)")
+
+try:
+    import polars as pl
+
+    print("\n5. Testing with Polars Series...")
+    df = pl.DataFrame({"time": time_list, "status": status_list, "group": group_list})
+    result = survival.logrank_test(df["time"], df["status"], df["group"])
+    assert hasattr(result, "statistic"), "Should have statistic"
+    print(f"   Passed - statistic: {result.statistic:.4f}")
+
+except ImportError:
+    print("\n5. Skipping Polars tests (polars not installed)")
+
+
+print("\n=== Testing cv_cox_concordance with different input types ===")
+
+time_list = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+status_list = [1, 1, 0, 1, 0, 1, 1, 0, 1, 0]
+covariates = [[0.5], [0.3], [0.8], [0.2], [0.9], [0.4], [0.6], [0.1], [0.7], [0.5]]
+
+print("\n1. Testing with Python lists...")
+result = survival.cv_cox_concordance(time_list, status_list, covariates, n_folds=2)
+assert hasattr(result, "mean_score"), "Should have mean_score"
+print(f"   Passed - mean C-index: {result.mean_score:.4f}")
+
+print("\n2. Testing with NumPy arrays...")
+time_np = np.array(time_list)
+status_np = np.array(status_list, dtype=np.int32)
+result = survival.cv_cox_concordance(time_np, status_np, covariates, n_folds=2)
+assert hasattr(result, "mean_score"), "Should have mean_score"
+print(f"   Passed - mean C-index: {result.mean_score:.4f}")
+
+try:
+    import pandas as pd
+
+    print("\n3. Testing with Pandas Series...")
+    df = pd.DataFrame({"time": time_list, "status": status_list})
+    result = survival.cv_cox_concordance(df["time"], df["status"], covariates, n_folds=2)
+    assert hasattr(result, "mean_score"), "Should have mean_score"
+    print(f"   Passed - mean C-index: {result.mean_score:.4f}")
+
+except ImportError:
+    print("\n3. Skipping Pandas tests (pandas not installed)")
+
+
+print("\n=== Testing optional parameters with different types ===")
+
+print("\n1. Testing survfitkm with optional weights as numpy array...")
+weights_np = np.array([1.0, 1.0, 2.0, 1.0, 1.5])
+result = survival.survfitkm(
+    np.array([1.0, 2.0, 3.0, 4.0, 5.0]),
+    np.array([1.0, 1.0, 0.0, 1.0, 0.0]),
+    weights=weights_np,
+)
+assert hasattr(result, "estimate"), "Should have estimate"
+print("   Passed")
+
+try:
+    import pandas as pd
+
+    print("\n2. Testing survfitkm with optional weights as Pandas Series...")
+    df = pd.DataFrame(
+        {
+            "time": [1.0, 2.0, 3.0, 4.0, 5.0],
+            "status": [1.0, 1.0, 0.0, 1.0, 0.0],
+            "weights": [1.0, 1.0, 2.0, 1.0, 1.5],
+        }
+    )
+    result = survival.survfitkm(df["time"], df["status"], weights=df["weights"])
+    assert hasattr(result, "estimate"), "Should have estimate"
+    print("   Passed")
+
+except ImportError:
+    print("\n2. Skipping Pandas optional weights test")
+
+
+print("\n" + "=" * 50)
+print("All array input tests passed!")
+print("=" * 50)

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,8 @@
+version = 1
+revision = 3
+requires-python = ">=3.9"
+
+[[package]]
+name = "survival-rs"
+version = "1.0.17"
+source = { editable = "." }


### PR DESCRIPTION
- Add numpy crate dependency for PyO3 array bindings
- Create extraction helpers that accept PyAny and auto-detect input type
- Update survfitkm, logrank_test, logrank_trend, cv_cox_concordance, cv_survreg_loglik
- Functions now accept: Python lists, numpy arrays, pandas Series, polars Series
- Add comprehensive Python tests for array input types
- Bump version to 1.1.0