### PR TITLE
Performance optimizations: parallelization and algorithm improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "survival"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2024"
 rust-version = "1.92"
 authors = ["Cameron Lyons <cameron.lyons2@gmail.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "survival-rs"
-version = "1.1.1"
+version = "1.1.2"
 description = "A high-performance survival analysis library written in Rust with Python bindings"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
- Parallelize C-index calculation in cross-validation for large test sets (>100 samples)
- Pre-compute zbeta/risk values in parallel for Cox fitting (>500 samples)
- Add parallel covariate scaling using AtomicPtr for thread-safe column updates
- Replace O(n) linear search with O(log n) binary search in interpolate_cumhaz
- Parallelize predict_survival for large subject counts (>100)
- Parallelize group median calculation in risk stratification (>1000 samples)
- Optimize ndarray<->faer matrix conversions with parallel row processing
- Use unsafe unchecked access for contiguous arrays and uninit arrays for column conversion