### PR TITLE
Remove blanket clippy suppressions, add tests, consolidate code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1248,7 +1248,7 @@ dependencies = [
 
 [[package]]
 name = "survival"
-version = "1.1.13"
+version = "1.1.14"
 dependencies = [
  "faer",
  "fastrand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "survival"
-version = "1.1.14"
+version = "1.1.15"
 edition = "2024"
 rust-version = "1.92"
 authors = ["Cameron Lyons <cameron.lyons2@gmail.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "survival"
-version = "1.1.14"
+version = "1.1.15"
 description = "A high-performance survival analysis library written in Rust with Python bindings"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/causal/g_computation.rs
+++ b/src/causal/g_computation.rs
@@ -1,13 +1,3 @@
-#![allow(
-    unused_variables,
-    unused_imports,
-    unused_mut,
-    unused_assignments,
-    clippy::too_many_arguments,
-    clippy::needless_range_loop,
-    clippy::len_zero
-)]
-
 use pyo3::prelude::*;
 use rayon::prelude::*;
 
@@ -75,8 +65,6 @@ fn fit_outcome_model(time: &[f64], status: &[i32], x: &[f64], n: usize, p: usize
             for j in 0..p {
                 eta += x[i * p + j] * beta[j];
             }
-            let exp_eta = eta.clamp(-700.0, 700.0).exp();
-
             let log_t = time[i].max(1e-10).ln();
             let z = (log_t - scale.ln() - eta) * shape;
 
@@ -124,6 +112,7 @@ fn predict_survival(model: &OutcomeModel, x_row: &[f64], time_points: &[f64]) ->
 
 #[pyfunction]
 #[pyo3(signature = (time, status, treatment, x_confounders, n_obs, n_vars, tau=None, n_bootstrap=None))]
+#[allow(clippy::too_many_arguments)]
 pub fn g_computation(
     time: Vec<f64>,
     status: Vec<i32>,
@@ -263,6 +252,7 @@ fn compute_rmst(time_points: &[f64], survival: &[f64], tau: f64) -> f64 {
     rmst
 }
 
+#[allow(clippy::too_many_arguments)]
 fn bootstrap_se(
     time: &[f64],
     status: &[i32],
@@ -405,7 +395,7 @@ mod tests {
 
         let result = g_computation(time, status, treatment, x, 6, 1, Some(5.0), Some(10)).unwrap();
 
-        assert!(result.survival_treated.len() > 0);
-        assert!(result.survival_control.len() > 0);
+        assert!(!result.survival_treated.is_empty());
+        assert!(!result.survival_control.is_empty());
     }
 }

--- a/src/qol/qaly.rs
+++ b/src/qol/qaly.rs
@@ -1,12 +1,3 @@
-#![allow(
-    unused_variables,
-    unused_imports,
-    unused_mut,
-    unused_assignments,
-    clippy::needless_range_loop,
-    clippy::too_many_arguments
-)]
-
 use pyo3::prelude::*;
 use rayon::prelude::*;
 
@@ -246,6 +237,7 @@ fn bootstrap_qaly_ci(
     horizon=None,
     n_bootstrap=1000
 ))]
+#[allow(clippy::too_many_arguments)]
 pub fn qaly_comparison(
     time_treated: Vec<f64>,
     status_treated: Vec<i32>,
@@ -386,7 +378,7 @@ mod tests {
 
     #[test]
     fn test_icer() {
-        let (icer, nmb, cost_effective) =
+        let (icer, _nmb, cost_effective) =
             incremental_cost_effectiveness(10.0, 8.0, 50000.0, 30000.0, Some(50000.0)).unwrap();
 
         assert_eq!(icer, 10000.0);

--- a/src/qol/qtwist.rs
+++ b/src/qol/qtwist.rs
@@ -1,12 +1,3 @@
-#![allow(
-    unused_variables,
-    unused_imports,
-    unused_mut,
-    unused_assignments,
-    clippy::needless_range_loop,
-    clippy::too_many_arguments
-)]
-
 use pyo3::prelude::*;
 
 #[derive(Debug, Clone)]
@@ -45,6 +36,7 @@ pub struct QTWISTResult {
     utility_rel=0.5,
     tau=None
 ))]
+#[allow(clippy::too_many_arguments)]
 pub fn qtwist_analysis(
     time: Vec<f64>,
     status: Vec<i32>,
@@ -133,6 +125,7 @@ pub fn qtwist_analysis(
     tau=None,
     n_bootstrap=1000
 ))]
+#[allow(clippy::too_many_arguments)]
 pub fn qtwist_comparison(
     time_treated: Vec<f64>,
     status_treated: Vec<i32>,
@@ -263,6 +256,7 @@ pub fn qtwist_comparison(
 }
 
 #[pyfunction]
+#[allow(clippy::too_many_arguments)]
 pub fn qtwist_sensitivity(
     time: Vec<f64>,
     status: Vec<i32>,


### PR DESCRIPTION
## Summary
- Remove blanket `#![allow(...)]` suppressions from 4 files (`qaly.rs`, `qtwist.rs`, `ipcw.rs`, `g_computation.rs`)
- Add targeted `#[allow(clippy::too_many_arguments)]` where actually needed
- Add 26 tests to modules that had 0 test coverage (`rmst.rs`, `landmark.rs`, `coxfit6.rs`)
- Consolidate duplicate `strata()` and `strata_str()` functions into a generic `strata_internal()`
- Create `ComputeSurvregInput` struct to reduce parameter counts in `survreg6.rs`
- Fix various clippy warnings: unused imports, manual range contains, redundant closures

## Changes by file
| File | Changes |
|------|---------|
| `qaly.rs` | Remove blanket suppression, add targeted allow |
| `qtwist.rs` | Remove blanket suppression, add targeted allows |
| `ipcw.rs` | Remove unused imports, fix clippy warnings |
| `g_computation.rs` | Remove unused variables, fix clippy warnings |
| `strata.rs` | Consolidate to generic function (~130 → ~80 lines) |
| `survreg6.rs` | Create input struct, improve matrix operations |
| `rmst.rs` | Add 13 tests |
| `landmark.rs` | Add 7 tests |
| `coxfit6.rs` | Add 6 tests |

## Test plan
- [x] `cargo clippy -- -D warnings` passes with no warnings
- [x] All 337 tests pass