### PR TITLE
Add enhanced calibration functions with Brier score integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "survival"
-version = "1.1.22"
+version = "1.1.23"
 edition = "2024"
 rust-version = "1.92"
 authors = ["Cameron Lyons <cameron.lyons2@gmail.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "survival"
-version = "1.1.22"
+version = "1.1.23"
 description = "A high-performance survival analysis library written in Rust with Python bindings"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,8 +118,9 @@ pub use validation::calibration::{
 };
 pub use validation::crossval::{CVResult, cv_cox_concordance, cv_survreg_loglik};
 pub use validation::d_calibration::{
-    CalibrationPlotData, DCalibrationResult, OneCalibrationResult, calibration_plot, d_calibration,
-    one_calibration,
+    BrierCalibrationResult, CalibrationPlotData, DCalibrationResult, MultiTimeCalibrationResult,
+    OneCalibrationResult, SmoothedCalibrationCurve, brier_calibration, calibration_plot,
+    d_calibration, multi_time_calibration, one_calibration, smoothed_calibration,
 };
 pub use validation::landmark::{
     ConditionalSurvivalResult, HazardRatioResult, LandmarkResult, LifeTableResult,
@@ -289,6 +290,9 @@ fn survival(_py: Python, m: Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(d_calibration, &m)?)?;
     m.add_function(wrap_pyfunction!(one_calibration, &m)?)?;
     m.add_function(wrap_pyfunction!(calibration_plot, &m)?)?;
+    m.add_function(wrap_pyfunction!(brier_calibration, &m)?)?;
+    m.add_function(wrap_pyfunction!(multi_time_calibration, &m)?)?;
+    m.add_function(wrap_pyfunction!(smoothed_calibration, &m)?)?;
     m.add_function(wrap_pyfunction!(rmst, &m)?)?;
     m.add_function(wrap_pyfunction!(rmst_comparison, &m)?)?;
     m.add_function(wrap_pyfunction!(rmst_optimal_threshold, &m)?)?;
@@ -402,6 +406,9 @@ fn survival(_py: Python, m: Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<DCalibrationResult>()?;
     m.add_class::<OneCalibrationResult>()?;
     m.add_class::<CalibrationPlotData>()?;
+    m.add_class::<BrierCalibrationResult>()?;
+    m.add_class::<MultiTimeCalibrationResult>()?;
+    m.add_class::<SmoothedCalibrationCurve>()?;
     m.add_class::<RMSTResult>()?;
     m.add_class::<RMSTComparisonResult>()?;
     m.add_class::<RMSTOptimalThresholdResult>()?;

--- a/src/validation/d_calibration.rs
+++ b/src/validation/d_calibration.rs
@@ -571,6 +571,582 @@ pub fn calibration_plot(
     ))
 }
 
+#[derive(Debug, Clone)]
+#[pyclass(str, get_all)]
+pub struct BrierCalibrationResult {
+    pub time_point: f64,
+    pub brier_score: f64,
+    pub calibration_slope: f64,
+    pub calibration_intercept: f64,
+    pub ici: f64,
+    pub e50: f64,
+    pub e90: f64,
+    pub emax: f64,
+    pub predicted: Vec<f64>,
+    pub observed: Vec<f64>,
+    pub ci_lower: Vec<f64>,
+    pub ci_upper: Vec<f64>,
+    pub n_per_group: Vec<usize>,
+}
+
+impl std::fmt::Display for BrierCalibrationResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "BrierCalibrationResult(t={:.2}, brier={:.4}, slope={:.3}, ici={:.4})",
+            self.time_point, self.brier_score, self.calibration_slope, self.ici
+        )
+    }
+}
+
+#[pymethods]
+impl BrierCalibrationResult {
+    #[new]
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        time_point: f64,
+        brier_score: f64,
+        calibration_slope: f64,
+        calibration_intercept: f64,
+        ici: f64,
+        e50: f64,
+        e90: f64,
+        emax: f64,
+        predicted: Vec<f64>,
+        observed: Vec<f64>,
+        ci_lower: Vec<f64>,
+        ci_upper: Vec<f64>,
+        n_per_group: Vec<usize>,
+    ) -> Self {
+        Self {
+            time_point,
+            brier_score,
+            calibration_slope,
+            calibration_intercept,
+            ici,
+            e50,
+            e90,
+            emax,
+            predicted,
+            observed,
+            ci_lower,
+            ci_upper,
+            n_per_group,
+        }
+    }
+}
+
+fn compute_calibration_slope_intercept(predicted: &[f64], observed: &[f64]) -> (f64, f64) {
+    let n = predicted.len();
+    if n < 2 {
+        return (1.0, 0.0);
+    }
+
+    let mean_pred: f64 = predicted.iter().sum::<f64>() / n as f64;
+    let mean_obs: f64 = observed.iter().sum::<f64>() / n as f64;
+
+    let mut numerator = 0.0;
+    let mut denominator = 0.0;
+
+    for i in 0..n {
+        let x_diff = predicted[i] - mean_pred;
+        let y_diff = observed[i] - mean_obs;
+        numerator += x_diff * y_diff;
+        denominator += x_diff * x_diff;
+    }
+
+    let slope = if denominator > 1e-10 {
+        numerator / denominator
+    } else {
+        1.0
+    };
+
+    let intercept = mean_obs - slope * mean_pred;
+
+    (slope, intercept)
+}
+
+pub fn brier_calibration_core(
+    time: &[f64],
+    status: &[i32],
+    predicted_survival_at_t: &[f64],
+    time_point: f64,
+    n_groups: usize,
+) -> BrierCalibrationResult {
+    let n = time.len();
+
+    if n == 0 {
+        return BrierCalibrationResult {
+            time_point,
+            brier_score: 0.0,
+            calibration_slope: 1.0,
+            calibration_intercept: 0.0,
+            ici: 0.0,
+            e50: 0.0,
+            e90: 0.0,
+            emax: 0.0,
+            predicted: vec![],
+            observed: vec![],
+            ci_lower: vec![],
+            ci_upper: vec![],
+            n_per_group: vec![],
+        };
+    }
+
+    let mut brier_sum = 0.0;
+    let mut brier_count = 0;
+
+    for i in 0..n {
+        let outcome = if time[i] <= time_point && status[i] == 1 {
+            0.0
+        } else if time[i] > time_point {
+            1.0
+        } else {
+            continue;
+        };
+
+        let pred = predicted_survival_at_t[i];
+        brier_sum += (pred - outcome).powi(2);
+        brier_count += 1;
+    }
+
+    let brier_score = if brier_count > 0 {
+        brier_sum / brier_count as f64
+    } else {
+        0.0
+    };
+
+    let plot_data =
+        calibration_plot_data_core(time, status, predicted_survival_at_t, time_point, n_groups);
+
+    let (slope, intercept) =
+        compute_calibration_slope_intercept(&plot_data.predicted, &plot_data.observed);
+
+    BrierCalibrationResult {
+        time_point,
+        brier_score,
+        calibration_slope: slope,
+        calibration_intercept: intercept,
+        ici: plot_data.ici,
+        e50: plot_data.e50,
+        e90: plot_data.e90,
+        emax: plot_data.emax,
+        predicted: plot_data.predicted,
+        observed: plot_data.observed,
+        ci_lower: plot_data.ci_lower,
+        ci_upper: plot_data.ci_upper,
+        n_per_group: plot_data.n_per_group,
+    }
+}
+
+#[pyfunction]
+#[pyo3(signature = (time, status, predicted_survival_at_t, time_point, n_groups=None))]
+pub fn brier_calibration(
+    time: Vec<f64>,
+    status: Vec<i32>,
+    predicted_survival_at_t: Vec<f64>,
+    time_point: f64,
+    n_groups: Option<usize>,
+) -> PyResult<BrierCalibrationResult> {
+    let n = time.len();
+    if n != status.len() || n != predicted_survival_at_t.len() {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "All input vectors must have the same length",
+        ));
+    }
+
+    let n_groups = n_groups.unwrap_or(10);
+    if n_groups < 2 {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "n_groups must be at least 2",
+        ));
+    }
+
+    Ok(brier_calibration_core(
+        &time,
+        &status,
+        &predicted_survival_at_t,
+        time_point,
+        n_groups,
+    ))
+}
+
+#[derive(Debug, Clone)]
+#[pyclass(str, get_all)]
+pub struct MultiTimeCalibrationResult {
+    pub time_points: Vec<f64>,
+    pub brier_scores: Vec<f64>,
+    pub integrated_brier: f64,
+    pub calibration_slopes: Vec<f64>,
+    pub calibration_intercepts: Vec<f64>,
+    pub ici_values: Vec<f64>,
+    pub mean_ici: f64,
+    pub mean_slope: f64,
+}
+
+impl std::fmt::Display for MultiTimeCalibrationResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "MultiTimeCalibrationResult(n_times={}, ibs={:.4}, mean_slope={:.3}, mean_ici={:.4})",
+            self.time_points.len(),
+            self.integrated_brier,
+            self.mean_slope,
+            self.mean_ici
+        )
+    }
+}
+
+#[pymethods]
+impl MultiTimeCalibrationResult {
+    #[new]
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        time_points: Vec<f64>,
+        brier_scores: Vec<f64>,
+        integrated_brier: f64,
+        calibration_slopes: Vec<f64>,
+        calibration_intercepts: Vec<f64>,
+        ici_values: Vec<f64>,
+        mean_ici: f64,
+        mean_slope: f64,
+    ) -> Self {
+        Self {
+            time_points,
+            brier_scores,
+            integrated_brier,
+            calibration_slopes,
+            calibration_intercepts,
+            ici_values,
+            mean_ici,
+            mean_slope,
+        }
+    }
+}
+
+pub fn multi_time_calibration_core(
+    time: &[f64],
+    status: &[i32],
+    survival_predictions: &[Vec<f64>],
+    prediction_times: &[f64],
+    n_groups: usize,
+) -> MultiTimeCalibrationResult {
+    let n_times = prediction_times.len();
+
+    if n_times == 0 || survival_predictions.is_empty() {
+        return MultiTimeCalibrationResult {
+            time_points: vec![],
+            brier_scores: vec![],
+            integrated_brier: 0.0,
+            calibration_slopes: vec![],
+            calibration_intercepts: vec![],
+            ici_values: vec![],
+            mean_ici: 0.0,
+            mean_slope: 1.0,
+        };
+    }
+
+    let mut brier_scores = Vec::with_capacity(n_times);
+    let mut calibration_slopes = Vec::with_capacity(n_times);
+    let mut calibration_intercepts = Vec::with_capacity(n_times);
+    let mut ici_values = Vec::with_capacity(n_times);
+
+    for (t_idx, &t) in prediction_times.iter().enumerate() {
+        let preds_at_t: Vec<f64> = survival_predictions.iter().map(|row| row[t_idx]).collect();
+
+        let result = brier_calibration_core(time, status, &preds_at_t, t, n_groups);
+
+        brier_scores.push(result.brier_score);
+        calibration_slopes.push(result.calibration_slope);
+        calibration_intercepts.push(result.calibration_intercept);
+        ici_values.push(result.ici);
+    }
+
+    let integrated_brier = if n_times >= 2 {
+        let mut integrated = 0.0;
+        let mut total_weight = 0.0;
+
+        for i in 0..n_times - 1 {
+            let dt = prediction_times[i + 1] - prediction_times[i];
+            let avg_brier = (brier_scores[i] + brier_scores[i + 1]) / 2.0;
+            integrated += avg_brier * dt;
+            total_weight += dt;
+        }
+
+        if total_weight > 0.0 {
+            integrated / total_weight
+        } else {
+            brier_scores.iter().sum::<f64>() / n_times as f64
+        }
+    } else {
+        brier_scores.first().copied().unwrap_or(0.0)
+    };
+
+    let mean_ici = if !ici_values.is_empty() {
+        ici_values.iter().sum::<f64>() / ici_values.len() as f64
+    } else {
+        0.0
+    };
+
+    let mean_slope = if !calibration_slopes.is_empty() {
+        calibration_slopes.iter().sum::<f64>() / calibration_slopes.len() as f64
+    } else {
+        1.0
+    };
+
+    MultiTimeCalibrationResult {
+        time_points: prediction_times.to_vec(),
+        brier_scores,
+        integrated_brier,
+        calibration_slopes,
+        calibration_intercepts,
+        ici_values,
+        mean_ici,
+        mean_slope,
+    }
+}
+
+#[pyfunction]
+#[pyo3(signature = (time, status, survival_predictions, prediction_times, n_groups=None))]
+pub fn multi_time_calibration(
+    time: Vec<f64>,
+    status: Vec<i32>,
+    survival_predictions: Vec<Vec<f64>>,
+    prediction_times: Vec<f64>,
+    n_groups: Option<usize>,
+) -> PyResult<MultiTimeCalibrationResult> {
+    let n = time.len();
+    if n != status.len() || n != survival_predictions.len() {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "time, status, and survival_predictions must have the same length",
+        ));
+    }
+
+    for (i, row) in survival_predictions.iter().enumerate() {
+        if row.len() != prediction_times.len() {
+            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                "survival_predictions row {} has {} elements, expected {}",
+                i,
+                row.len(),
+                prediction_times.len()
+            )));
+        }
+    }
+
+    let n_groups = n_groups.unwrap_or(10);
+    if n_groups < 2 {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "n_groups must be at least 2",
+        ));
+    }
+
+    Ok(multi_time_calibration_core(
+        &time,
+        &status,
+        &survival_predictions,
+        &prediction_times,
+        n_groups,
+    ))
+}
+
+#[derive(Debug, Clone)]
+#[pyclass(str, get_all)]
+pub struct SmoothedCalibrationCurve {
+    pub predicted_grid: Vec<f64>,
+    pub smoothed_observed: Vec<f64>,
+    pub ci_lower: Vec<f64>,
+    pub ci_upper: Vec<f64>,
+    pub bandwidth: f64,
+}
+
+impl std::fmt::Display for SmoothedCalibrationCurve {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "SmoothedCalibrationCurve(n_points={}, bandwidth={:.3})",
+            self.predicted_grid.len(),
+            self.bandwidth
+        )
+    }
+}
+
+#[pymethods]
+impl SmoothedCalibrationCurve {
+    #[new]
+    fn new(
+        predicted_grid: Vec<f64>,
+        smoothed_observed: Vec<f64>,
+        ci_lower: Vec<f64>,
+        ci_upper: Vec<f64>,
+        bandwidth: f64,
+    ) -> Self {
+        Self {
+            predicted_grid,
+            smoothed_observed,
+            ci_lower,
+            ci_upper,
+            bandwidth,
+        }
+    }
+}
+
+fn gaussian_kernel(x: f64, bandwidth: f64) -> f64 {
+    let z = x / bandwidth;
+    (-0.5 * z * z).exp() / (bandwidth * (2.0 * std::f64::consts::PI).sqrt())
+}
+
+pub fn smoothed_calibration_core(
+    time: &[f64],
+    status: &[i32],
+    predicted_survival_at_t: &[f64],
+    time_point: f64,
+    n_grid_points: usize,
+    bandwidth: Option<f64>,
+) -> SmoothedCalibrationCurve {
+    let n = time.len();
+
+    if n == 0 {
+        return SmoothedCalibrationCurve {
+            predicted_grid: vec![],
+            smoothed_observed: vec![],
+            ci_lower: vec![],
+            ci_upper: vec![],
+            bandwidth: 0.0,
+        };
+    }
+
+    let outcomes: Vec<f64> = (0..n)
+        .filter_map(|i| {
+            if time[i] <= time_point && status[i] == 1 {
+                Some(0.0)
+            } else if time[i] > time_point {
+                Some(1.0)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    let preds: Vec<f64> = (0..n)
+        .filter_map(|i| {
+            if time[i] > time_point || (time[i] <= time_point && status[i] == 1) {
+                Some(predicted_survival_at_t[i])
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    if preds.is_empty() {
+        return SmoothedCalibrationCurve {
+            predicted_grid: vec![],
+            smoothed_observed: vec![],
+            ci_lower: vec![],
+            ci_upper: vec![],
+            bandwidth: 0.0,
+        };
+    }
+
+    let h = bandwidth
+        .unwrap_or_else(|| {
+            let mut sorted_preds = preds.clone();
+            sorted_preds.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+            let q1_idx = sorted_preds.len() / 4;
+            let q3_idx = 3 * sorted_preds.len() / 4;
+            let iqr = sorted_preds[q3_idx] - sorted_preds[q1_idx];
+            0.9 * iqr.min(sorted_preds.iter().copied().fold(0.0_f64, f64::max) / 4.0)
+                * (preds.len() as f64).powf(-0.2)
+        })
+        .max(0.05);
+
+    let min_pred = preds.iter().copied().fold(f64::INFINITY, f64::min);
+    let max_pred = preds.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+
+    let grid_step = (max_pred - min_pred) / (n_grid_points - 1) as f64;
+    let predicted_grid: Vec<f64> = (0..n_grid_points)
+        .map(|i| min_pred + i as f64 * grid_step)
+        .collect();
+
+    let mut smoothed_observed = Vec::with_capacity(n_grid_points);
+    let mut ci_lower = Vec::with_capacity(n_grid_points);
+    let mut ci_upper = Vec::with_capacity(n_grid_points);
+
+    for &x in &predicted_grid {
+        let mut weighted_sum = 0.0;
+        let mut weight_sum = 0.0;
+        let mut weighted_sq_sum = 0.0;
+
+        for (i, &pred) in preds.iter().enumerate() {
+            let w = gaussian_kernel(x - pred, h);
+            weighted_sum += w * outcomes[i];
+            weight_sum += w;
+            weighted_sq_sum += w * outcomes[i] * outcomes[i];
+        }
+
+        let smoothed = if weight_sum > 1e-10 {
+            weighted_sum / weight_sum
+        } else {
+            0.5
+        };
+
+        let variance = if weight_sum > 1e-10 {
+            let mean_sq = weighted_sq_sum / weight_sum;
+            (mean_sq - smoothed * smoothed).max(0.0)
+        } else {
+            0.0
+        };
+
+        let se = (variance / weight_sum.max(1.0)).sqrt();
+        let z = 1.96;
+
+        smoothed_observed.push(smoothed);
+        ci_lower.push((smoothed - z * se).clamp(0.0, 1.0));
+        ci_upper.push((smoothed + z * se).clamp(0.0, 1.0));
+    }
+
+    SmoothedCalibrationCurve {
+        predicted_grid,
+        smoothed_observed,
+        ci_lower,
+        ci_upper,
+        bandwidth: h,
+    }
+}
+
+#[pyfunction]
+#[pyo3(signature = (time, status, predicted_survival_at_t, time_point, n_grid_points=None, bandwidth=None))]
+pub fn smoothed_calibration(
+    time: Vec<f64>,
+    status: Vec<i32>,
+    predicted_survival_at_t: Vec<f64>,
+    time_point: f64,
+    n_grid_points: Option<usize>,
+    bandwidth: Option<f64>,
+) -> PyResult<SmoothedCalibrationCurve> {
+    let n = time.len();
+    if n != status.len() || n != predicted_survival_at_t.len() {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "All input vectors must have the same length",
+        ));
+    }
+
+    let n_grid_points = n_grid_points.unwrap_or(100);
+    if n_grid_points < 10 {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "n_grid_points must be at least 10",
+        ));
+    }
+
+    Ok(smoothed_calibration_core(
+        &time,
+        &status,
+        &predicted_survival_at_t,
+        time_point,
+        n_grid_points,
+        bandwidth,
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary
- **brier_calibration**: Combines Brier score with calibration metrics (ICI, E50, E90, Emax, slope/intercept)
- **multi_time_calibration**: Evaluates calibration at multiple time points with integrated Brier score
- **smoothed_calibration**: Gaussian kernel-smoothed calibration curves with confidence intervals

## New types
- `BrierCalibrationResult` - Full calibration assessment at a single time point
- `MultiTimeCalibrationResult` - Aggregated calibration metrics across multiple times
- `SmoothedCalibrationCurve` - Smoothed calibration curve data for plotting

## Test plan
- [x] All 379 existing tests pass
- [x] Clippy passes with no warnings
- [x] Code formatted with cargo fmt

🤖 Generated with [Claude Code](https://claude.com/claude-code)