### PR TITLE
Add C-index decomposition for event-event vs event-censored analysis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1369,7 +1369,7 @@ dependencies = [
 
 [[package]]
 name = "survival"
-version = "1.1.21"
+version = "1.1.22"
 dependencies = [
  "divan",
  "faer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "survival"
-version = "1.1.23"
+version = "1.1.24"
 edition = "2024"
 rust-version = "1.92"
 authors = ["Cameron Lyons <cameron.lyons2@gmail.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "survival"
-version = "1.1.23"
+version = "1.1.24"
 description = "A high-performance survival analysis library written in Rust with Python bindings"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,8 @@ pub use validation::time_dependent_auc::{
     cumulative_dynamic_auc_core, time_dependent_auc, time_dependent_auc_core,
 };
 pub use validation::uno_c_index::{
-    ConcordanceComparisonResult, UnoCIndexResult, compare_uno_c_indices, uno_c_index,
+    CIndexDecompositionResult, ConcordanceComparisonResult, UnoCIndexResult, c_index_decomposition,
+    compare_uno_c_indices, uno_c_index,
 };
 pub use validation::yates::{
     YatesPairwiseResult, YatesResult, yates, yates_contrast, yates_pairwise,
@@ -340,6 +341,7 @@ fn survival(_py: Python, m: Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(yates_pairwise, &m)?)?;
     m.add_function(wrap_pyfunction!(uno_c_index, &m)?)?;
     m.add_function(wrap_pyfunction!(compare_uno_c_indices, &m)?)?;
+    m.add_function(wrap_pyfunction!(c_index_decomposition, &m)?)?;
     m.add_function(wrap_pyfunction!(time_dependent_auc, &m)?)?;
     m.add_function(wrap_pyfunction!(cumulative_dynamic_auc, &m)?)?;
     m.add_function(wrap_pyfunction!(rcll, &m)?)?;
@@ -444,6 +446,7 @@ fn survival(_py: Python, m: Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<YatesPairwiseResult>()?;
     m.add_class::<UnoCIndexResult>()?;
     m.add_class::<ConcordanceComparisonResult>()?;
+    m.add_class::<CIndexDecompositionResult>()?;
     m.add_class::<TimeDepAUCResult>()?;
     m.add_class::<CumulativeDynamicAUCResult>()?;
     m.add_class::<RCLLResult>()?;

--- a/src/validation/uno_c_index.rs
+++ b/src/validation/uno_c_index.rs
@@ -493,6 +493,209 @@ pub fn compare_uno_c_indices(
     ))
 }
 
+#[derive(Debug, Clone)]
+#[pyclass(str, get_all)]
+pub struct CIndexDecompositionResult {
+    pub c_index: f64,
+    pub c_index_ee: f64,
+    pub c_index_ec: f64,
+    pub alpha: f64,
+    pub n_event_event_pairs: usize,
+    pub n_event_censored_pairs: usize,
+    pub concordant_ee: f64,
+    pub concordant_ec: f64,
+    pub discordant_ee: f64,
+    pub discordant_ec: f64,
+    pub tied_ee: f64,
+    pub tied_ec: f64,
+}
+
+impl fmt::Display for CIndexDecompositionResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "CIndexDecomposition(C={:.4}, C_ee={:.4}, C_ec={:.4}, alpha={:.4})",
+            self.c_index, self.c_index_ee, self.c_index_ec, self.alpha
+        )
+    }
+}
+
+#[pymethods]
+impl CIndexDecompositionResult {
+    #[new]
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        c_index: f64,
+        c_index_ee: f64,
+        c_index_ec: f64,
+        alpha: f64,
+        n_event_event_pairs: usize,
+        n_event_censored_pairs: usize,
+        concordant_ee: f64,
+        concordant_ec: f64,
+        discordant_ee: f64,
+        discordant_ec: f64,
+        tied_ee: f64,
+        tied_ec: f64,
+    ) -> Self {
+        Self {
+            c_index,
+            c_index_ee,
+            c_index_ec,
+            alpha,
+            n_event_event_pairs,
+            n_event_censored_pairs,
+            concordant_ee,
+            concordant_ec,
+            discordant_ee,
+            discordant_ec,
+            tied_ee,
+            tied_ec,
+        }
+    }
+}
+
+pub fn c_index_decomposition_core(
+    time: &[f64],
+    status: &[i32],
+    risk_score: &[f64],
+    tau: Option<f64>,
+) -> CIndexDecompositionResult {
+    let n = time.len();
+
+    if n == 0 {
+        return CIndexDecompositionResult {
+            c_index: 0.5,
+            c_index_ee: 0.5,
+            c_index_ec: 0.5,
+            alpha: 0.5,
+            n_event_event_pairs: 0,
+            n_event_censored_pairs: 0,
+            concordant_ee: 0.0,
+            concordant_ec: 0.0,
+            discordant_ee: 0.0,
+            discordant_ec: 0.0,
+            tied_ee: 0.0,
+            tied_ec: 0.0,
+        };
+    }
+
+    let tau_val = tau.unwrap_or_else(|| time.iter().copied().fold(f64::NEG_INFINITY, f64::max));
+
+    let (km_times, km_values) = compute_censoring_km(time, status);
+    let min_g = 0.01;
+
+    let mut concordant_ee = 0.0;
+    let mut concordant_ec = 0.0;
+    let mut discordant_ee = 0.0;
+    let mut discordant_ec = 0.0;
+    let mut tied_ee = 0.0;
+    let mut tied_ec = 0.0;
+    let mut n_ee_pairs = 0usize;
+    let mut n_ec_pairs = 0usize;
+
+    for i in 0..n {
+        if status[i] != 1 || time[i] > tau_val {
+            continue;
+        }
+
+        let g_ti = get_censoring_prob(time[i], &km_times, &km_values).max(min_g);
+        let weight = 1.0 / (g_ti * g_ti);
+
+        for j in 0..n {
+            if i == j || time[j] <= time[i] {
+                continue;
+            }
+
+            let is_event_event = status[j] == 1 && time[j] <= tau_val;
+
+            if is_event_event {
+                n_ee_pairs += 1;
+                if risk_score[i] > risk_score[j] {
+                    concordant_ee += weight;
+                } else if risk_score[i] < risk_score[j] {
+                    discordant_ee += weight;
+                } else {
+                    tied_ee += weight;
+                }
+            } else {
+                n_ec_pairs += 1;
+                if risk_score[i] > risk_score[j] {
+                    concordant_ec += weight;
+                } else if risk_score[i] < risk_score[j] {
+                    discordant_ec += weight;
+                } else {
+                    tied_ec += weight;
+                }
+            }
+        }
+    }
+
+    let total_ee = concordant_ee + discordant_ee + tied_ee;
+    let total_ec = concordant_ec + discordant_ec + tied_ec;
+    let total_pairs = total_ee + total_ec;
+
+    let c_index_ee = if total_ee > 0.0 {
+        (concordant_ee + 0.5 * tied_ee) / total_ee
+    } else {
+        0.5
+    };
+
+    let c_index_ec = if total_ec > 0.0 {
+        (concordant_ec + 0.5 * tied_ec) / total_ec
+    } else {
+        0.5
+    };
+
+    let c_index = if total_pairs > 0.0 {
+        (concordant_ee + concordant_ec + 0.5 * (tied_ee + tied_ec)) / total_pairs
+    } else {
+        0.5
+    };
+
+    let correctly_ordered_ee = concordant_ee + 0.5 * tied_ee;
+    let correctly_ordered_ec = concordant_ec + 0.5 * tied_ec;
+    let total_correctly_ordered = correctly_ordered_ee + correctly_ordered_ec;
+
+    let alpha = if total_correctly_ordered > 0.0 {
+        correctly_ordered_ee / total_correctly_ordered
+    } else {
+        0.5
+    };
+
+    CIndexDecompositionResult {
+        c_index,
+        c_index_ee,
+        c_index_ec,
+        alpha,
+        n_event_event_pairs: n_ee_pairs,
+        n_event_censored_pairs: n_ec_pairs,
+        concordant_ee,
+        concordant_ec,
+        discordant_ee,
+        discordant_ec,
+        tied_ee,
+        tied_ec,
+    }
+}
+
+#[pyfunction]
+#[pyo3(signature = (time, status, risk_score, tau=None))]
+pub fn c_index_decomposition(
+    time: Vec<f64>,
+    status: Vec<i32>,
+    risk_score: Vec<f64>,
+    tau: Option<f64>,
+) -> PyResult<CIndexDecompositionResult> {
+    if time.len() != status.len() || time.len() != risk_score.len() {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "time, status, and risk_score must have the same length",
+        ));
+    }
+
+    Ok(c_index_decomposition_core(&time, &status, &risk_score, tau))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -583,5 +786,71 @@ mod tests {
         for i in 1..values.len() {
             assert!(values[i] <= values[i - 1] + 1e-10);
         }
+    }
+
+    #[test]
+    fn test_c_index_decomposition_basic() {
+        let time = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
+        let status = vec![1, 1, 0, 1, 1, 0, 1, 1];
+        let risk_score = vec![0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1];
+
+        let result = c_index_decomposition_core(&time, &status, &risk_score, None);
+
+        assert!((0.0..=1.0).contains(&result.c_index));
+        assert!((0.0..=1.0).contains(&result.c_index_ee));
+        assert!((0.0..=1.0).contains(&result.c_index_ec));
+        assert!((0.0..=1.0).contains(&result.alpha));
+        assert!(result.n_event_event_pairs > 0);
+        assert!(result.n_event_censored_pairs > 0);
+    }
+
+    #[test]
+    fn test_c_index_decomposition_all_events() {
+        let time = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+        let status = vec![1, 1, 1, 1, 1];
+        let risk_score = vec![0.9, 0.7, 0.5, 0.3, 0.1];
+
+        let result = c_index_decomposition_core(&time, &status, &risk_score, None);
+
+        assert!(result.c_index > 0.9);
+        assert!(result.c_index_ee > 0.9);
+        assert_eq!(result.n_event_censored_pairs, 0);
+        assert!((result.alpha - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_c_index_decomposition_heavy_censoring() {
+        let time = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
+        let status = vec![1, 0, 0, 0, 1, 0, 0, 0];
+        let risk_score = vec![0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1];
+
+        let result = c_index_decomposition_core(&time, &status, &risk_score, None);
+
+        assert!((0.0..=1.0).contains(&result.c_index));
+        assert!(result.n_event_censored_pairs > result.n_event_event_pairs);
+        assert!(result.alpha < 0.5);
+    }
+
+    #[test]
+    fn test_c_index_decomposition_empty() {
+        let result = c_index_decomposition_core(&[], &[], &[], None);
+
+        assert!((result.c_index - 0.5).abs() < 1e-10);
+        assert!((result.c_index_ee - 0.5).abs() < 1e-10);
+        assert!((result.c_index_ec - 0.5).abs() < 1e-10);
+        assert_eq!(result.n_event_event_pairs, 0);
+        assert_eq!(result.n_event_censored_pairs, 0);
+    }
+
+    #[test]
+    fn test_c_index_decomposition_consistency() {
+        let time = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+        let status = vec![1, 1, 0, 1, 0, 1];
+        let risk_score = vec![0.9, 0.7, 0.8, 0.5, 0.4, 0.2];
+
+        let decomp = c_index_decomposition_core(&time, &status, &risk_score, None);
+        let uno = uno_c_index_core(&time, &status, &risk_score, None);
+
+        assert!((decomp.c_index - uno.c_index).abs() < 0.01);
     }
 }


### PR DESCRIPTION
## Summary
- **c_index_decomposition**: Separates concordance index into two components
  - **C_ee**: Performance on event-event pairs (both subjects experienced events)
  - **C_ec**: Performance on event-censored pairs
  - **alpha**: Weight representing proportion of event-event pairs among concordant pairs

This decomposition helps understand how models perform under varying censoring levels, as described in [The Concordance Index Decomposition](https://arxiv.org/html/2203.00144v3).

## New result fields
- `c_index`, `c_index_ee`, `c_index_ec`, `alpha`
- `n_event_event_pairs`, `n_event_censored_pairs`
- `concordant_ee`, `concordant_ec`, `discordant_ee`, `discordant_ec`, `tied_ee`, `tied_ec`

## Test plan
- [x] All 384 tests pass (5 new decomposition tests added)
- [x] Clippy passes with no warnings
- [x] Code formatted with cargo fmt

🤖 Generated with [Claude Code](https://claude.com/claude-code)