### PR TITLE
Add Gönen-Heller concordance probability estimate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1369,7 +1369,7 @@ dependencies = [
 
 [[package]]
 name = "survival"
-version = "1.1.22"
+version = "1.1.24"
 dependencies = [
  "divan",
  "faer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "survival"
-version = "1.1.25"
+version = "1.1.26"
 edition = "2024"
 rust-version = "1.92"
 authors = ["Cameron Lyons <cameron.lyons2@gmail.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "survival"
-version = "1.1.25"
+version = "1.1.26"
 description = "A high-performance survival analysis library written in Rust with Python bindings"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,8 +156,8 @@ pub use validation::time_dependent_auc::{
     cumulative_dynamic_auc_core, time_dependent_auc, time_dependent_auc_core,
 };
 pub use validation::uno_c_index::{
-    CIndexDecompositionResult, ConcordanceComparisonResult, UnoCIndexResult, c_index_decomposition,
-    compare_uno_c_indices, uno_c_index,
+    CIndexDecompositionResult, ConcordanceComparisonResult, GonenHellerResult, UnoCIndexResult,
+    c_index_decomposition, compare_uno_c_indices, gonen_heller_concordance, uno_c_index,
 };
 pub use validation::yates::{
     YatesPairwiseResult, YatesResult, yates, yates_contrast, yates_pairwise,
@@ -342,6 +342,7 @@ fn survival(_py: Python, m: Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(uno_c_index, &m)?)?;
     m.add_function(wrap_pyfunction!(compare_uno_c_indices, &m)?)?;
     m.add_function(wrap_pyfunction!(c_index_decomposition, &m)?)?;
+    m.add_function(wrap_pyfunction!(gonen_heller_concordance, &m)?)?;
     m.add_function(wrap_pyfunction!(time_dependent_auc, &m)?)?;
     m.add_function(wrap_pyfunction!(cumulative_dynamic_auc, &m)?)?;
     m.add_function(wrap_pyfunction!(rcll, &m)?)?;
@@ -447,6 +448,7 @@ fn survival(_py: Python, m: Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<UnoCIndexResult>()?;
     m.add_class::<ConcordanceComparisonResult>()?;
     m.add_class::<CIndexDecompositionResult>()?;
+    m.add_class::<GonenHellerResult>()?;
     m.add_class::<TimeDepAUCResult>()?;
     m.add_class::<CumulativeDynamicAUCResult>()?;
     m.add_class::<RCLLResult>()?;

--- a/src/validation/uno_c_index.rs
+++ b/src/validation/uno_c_index.rs
@@ -696,6 +696,166 @@ pub fn c_index_decomposition(
     Ok(c_index_decomposition_core(&time, &status, &risk_score, tau))
 }
 
+#[derive(Debug, Clone)]
+#[pyclass(str, get_all)]
+pub struct GonenHellerResult {
+    pub cpe: f64,
+    pub n_pairs: usize,
+    pub n_ties: usize,
+    pub variance: f64,
+    pub std_error: f64,
+    pub ci_lower: f64,
+    pub ci_upper: f64,
+}
+
+impl fmt::Display for GonenHellerResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "GonenHellerResult(cpe={:.4}, se={:.4}, ci=[{:.4}, {:.4}])",
+            self.cpe, self.std_error, self.ci_lower, self.ci_upper
+        )
+    }
+}
+
+#[pymethods]
+impl GonenHellerResult {
+    #[new]
+    fn new(
+        cpe: f64,
+        n_pairs: usize,
+        n_ties: usize,
+        variance: f64,
+        std_error: f64,
+        ci_lower: f64,
+        ci_upper: f64,
+    ) -> Self {
+        Self {
+            cpe,
+            n_pairs,
+            n_ties,
+            variance,
+            std_error,
+            ci_lower,
+            ci_upper,
+        }
+    }
+}
+
+pub fn gonen_heller_core(linear_predictor: &[f64]) -> GonenHellerResult {
+    let n = linear_predictor.len();
+
+    if n < 2 {
+        return GonenHellerResult {
+            cpe: 0.5,
+            n_pairs: 0,
+            n_ties: 0,
+            variance: 0.0,
+            std_error: 0.0,
+            ci_lower: 0.5,
+            ci_upper: 0.5,
+        };
+    }
+
+    let compute_contributions = |i: usize| -> (f64, usize, usize, Vec<f64>) {
+        let mut sum = 0.0;
+        let mut pairs = 0usize;
+        let mut ties = 0usize;
+        let mut influence = vec![0.0; n];
+
+        for j in (i + 1)..n {
+            let diff = linear_predictor[i] - linear_predictor[j];
+
+            if diff.abs() < 1e-10 {
+                ties += 1;
+                continue;
+            }
+
+            pairs += 1;
+            let contribution = 1.0 / (1.0 + (-diff.abs()).exp());
+            sum += contribution;
+
+            let deriv = contribution * (1.0 - contribution);
+            if diff > 0.0 {
+                influence[i] += deriv;
+                influence[j] -= deriv;
+            } else {
+                influence[i] -= deriv;
+                influence[j] += deriv;
+            }
+        }
+
+        (sum, pairs, ties, influence)
+    };
+
+    let results: Vec<(f64, usize, usize, Vec<f64>)> = if n > PARALLEL_THRESHOLD_LARGE {
+        (0..n).into_par_iter().map(compute_contributions).collect()
+    } else {
+        (0..n).map(compute_contributions).collect()
+    };
+
+    let mut total_sum = 0.0;
+    let mut total_pairs = 0usize;
+    let mut total_ties = 0usize;
+    let mut influence_sums = vec![0.0; n];
+
+    for (sum, pairs, ties, influence) in results {
+        total_sum += sum;
+        total_pairs += pairs;
+        total_ties += ties;
+        for (k, &inf) in influence.iter().enumerate() {
+            influence_sums[k] += inf;
+        }
+    }
+
+    let cpe = if total_pairs > 0 {
+        total_sum / total_pairs as f64
+    } else {
+        0.5
+    };
+
+    let variance = if total_pairs > 0 {
+        let n_f = n as f64;
+        let pairs_f = total_pairs as f64;
+        let mut var_sum = 0.0;
+
+        for &inf in &influence_sums {
+            let normalized = inf / pairs_f;
+            var_sum += normalized * normalized;
+        }
+
+        var_sum / n_f
+    } else {
+        0.0
+    };
+
+    let std_error = variance.sqrt();
+    let z = 1.96;
+    let ci_lower = (cpe - z * std_error).clamp(0.0, 1.0);
+    let ci_upper = (cpe + z * std_error).clamp(0.0, 1.0);
+
+    GonenHellerResult {
+        cpe,
+        n_pairs: total_pairs,
+        n_ties: total_ties,
+        variance,
+        std_error,
+        ci_lower,
+        ci_upper,
+    }
+}
+
+#[pyfunction]
+pub fn gonen_heller_concordance(linear_predictor: Vec<f64>) -> PyResult<GonenHellerResult> {
+    if linear_predictor.is_empty() {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "linear_predictor must not be empty",
+        ));
+    }
+
+    Ok(gonen_heller_core(&linear_predictor))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -852,5 +1012,69 @@ mod tests {
         let uno = uno_c_index_core(&time, &status, &risk_score, None);
 
         assert!((decomp.c_index - uno.c_index).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_gonen_heller_basic() {
+        let lp = vec![2.0, 1.5, 1.0, 0.5, 0.0, -0.5, -1.0, -1.5];
+
+        let result = gonen_heller_core(&lp);
+
+        assert!((0.0..=1.0).contains(&result.cpe));
+        assert!(result.cpe > 0.5);
+        assert!(result.n_pairs > 0);
+        assert!(result.std_error >= 0.0);
+    }
+
+    #[test]
+    fn test_gonen_heller_good_discrimination() {
+        let lp = vec![10.0, 8.0, 6.0, 4.0, 2.0, 0.0];
+
+        let result = gonen_heller_core(&lp);
+
+        assert!(result.cpe > 0.9);
+        assert_eq!(result.n_ties, 0);
+    }
+
+    #[test]
+    fn test_gonen_heller_no_discrimination() {
+        let lp = vec![0.0, 0.0, 0.0, 0.0, 0.0];
+
+        let result = gonen_heller_core(&lp);
+
+        assert!((result.cpe - 0.5).abs() < 1e-10);
+        assert_eq!(result.n_pairs, 0);
+        assert!(result.n_ties > 0);
+    }
+
+    #[test]
+    fn test_gonen_heller_symmetric() {
+        let lp1 = vec![1.0, 0.5, 0.0, -0.5, -1.0];
+        let lp2: Vec<f64> = lp1.iter().map(|x| -x).collect();
+
+        let result1 = gonen_heller_core(&lp1);
+        let result2 = gonen_heller_core(&lp2);
+
+        assert!((result1.cpe - result2.cpe).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_gonen_heller_small_sample() {
+        let lp = vec![1.0, 0.0];
+
+        let result = gonen_heller_core(&lp);
+
+        assert!((0.0..=1.0).contains(&result.cpe));
+        assert_eq!(result.n_pairs, 1);
+    }
+
+    #[test]
+    fn test_gonen_heller_single_element() {
+        let lp = vec![1.0];
+
+        let result = gonen_heller_core(&lp);
+
+        assert!((result.cpe - 0.5).abs() < 1e-10);
+        assert_eq!(result.n_pairs, 0);
     }
 }


### PR DESCRIPTION
## Summary
Implements the Gönen & Heller (2005) concordance probability estimate (CPE), an alternative to Harrell's C-index that is not influenced by the censoring distribution.

- **gonen_heller_concordance**: Takes only linear predictors (risk scores)
- Based on formula: CPE = mean of σ(|lp_i - lp_j|) over all pairs
- Reference: Gönen M, Heller G. Concordance probability and discriminatory power in proportional hazards regression. *Biometrika* 2005;92(4):965-970

## Result fields
- `cpe` - concordance probability estimate
- `n_pairs` - number of comparable pairs (excluding ties)
- `n_ties` - number of tied risk score pairs  
- `variance`, `std_error`, `ci_lower`, `ci_upper`

## Test plan
- [x] All 390 tests pass (6 new Gönen-Heller tests)
- [x] Clippy passes with no warnings
- [x] Code formatted with cargo fmt

🤖 Generated with [Claude Code](https://claude.com/claude-code)