### PR TITLE
Fix survreg optimizer and add AFT model support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1378,7 +1378,7 @@ dependencies = [
 
 [[package]]
 name = "survival"
-version = "1.1.30"
+version = "1.1.31"
 dependencies = [
  "divan",
  "faer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "survival"
-version = "1.1.31"
+version = "1.1.32"
 edition = "2024"
 rust-version = "1.92"
 authors = ["Cameron Lyons <cameron.lyons2@gmail.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "survival"
-version = "1.1.31"
+version = "1.1.32"
 description = "A high-performance survival analysis library written in Rust with Python bindings"
 readme = "README.md"
 license = { text = "MIT" }

--- a/python/survival/__init__.py
+++ b/python/survival/__init__.py
@@ -1,7 +1,9 @@
 from survival._survival import *  # noqa: F401, F403
 from survival.sklearn_compat import (  # noqa: F401
+    AFTEstimator,
     CoxPHEstimator,
     GradientBoostSurvivalEstimator,
+    StreamingAFTEstimator,
     StreamingCoxPHEstimator,
     StreamingGradientBoostSurvivalEstimator,
     StreamingMixin,

--- a/python/survival/_survival.pyi
+++ b/python/survival/_survival.pyi
@@ -13,12 +13,12 @@ class SplitRule:
     LogRankScore: SplitRule
 
 class DistributionType:
+    ExtremeValue: DistributionType
     Weibull: DistributionType
-    Exponential: DistributionType
     Gaussian: DistributionType
     Logistic: DistributionType
-    Lognormal: DistributionType
-    Loglogistic: DistributionType
+    LogNormal: DistributionType
+    LogLogistic: DistributionType
 
 class DimType:
     Age: DimType

--- a/python/survival/sklearn_compat.py
+++ b/python/survival/sklearn_compat.py
@@ -566,6 +566,235 @@ class SurvivalForestEstimator(BaseEstimator, RegressorMixin):
         return _compute_concordance_index(time, status, risk_scores)
 
 
+class AFTEstimator(BaseEstimator, RegressorMixin):
+    """Scikit-learn compatible Accelerated Failure Time (AFT) model.
+
+    AFT models assume that covariates act multiplicatively on the survival time,
+    i.e., log(T) = X @ beta + sigma * epsilon, where epsilon follows a specified
+    error distribution.
+
+    Parameters
+    ----------
+    distribution : str, default="weibull"
+        Error distribution. One of:
+        - "weibull": Weibull distribution (extreme value errors)
+        - "lognormal": Log-normal distribution (Gaussian errors)
+        - "loglogistic": Log-logistic distribution (logistic errors)
+        - "exponential": Exponential distribution (special case of Weibull)
+        - "gaussian": Gaussian distribution (for linear models)
+        - "logistic": Logistic distribution (for linear models)
+    max_iter : int, default=100
+        Maximum number of iterations for optimization.
+    tol : float, default=1e-9
+        Convergence tolerance.
+
+    Attributes
+    ----------
+    model_ : SurvivalFit
+        The underlying fitted AFT model.
+    coef_ : ndarray of shape (n_features,)
+        Estimated coefficients (acceleration factors in log scale).
+    scale_ : float
+        Estimated scale parameter (sigma).
+    n_features_in_ : int
+        Number of features seen during fit.
+
+    Examples
+    --------
+    >>> from survival.sklearn_compat import AFTEstimator
+    >>> import numpy as np
+    >>> X = np.random.randn(100, 3)
+    >>> y = np.column_stack([np.random.exponential(10, 100), np.random.binomial(1, 0.7, 100)])
+    >>> model = AFTEstimator(distribution="weibull")
+    >>> model.fit(X, y)
+    >>> predicted_times = model.predict(X)
+
+    Notes
+    -----
+    The AFT model interprets coefficients as acceleration factors:
+    - Positive coefficients increase expected survival time
+    - Negative coefficients decrease expected survival time
+    - exp(coef) gives the multiplicative effect on survival time
+    """
+
+    def __init__(
+        self,
+        distribution: str = "weibull",
+        max_iter: int = 200,
+        tol: float = 1e-9,
+    ):
+        self.distribution = distribution
+        self.max_iter = max_iter
+        self.tol = tol
+
+    def fit(self, X: ArrayLike, y: ArrayLike) -> "AFTEstimator":
+        """Fit the AFT model using maximum likelihood estimation.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Training data.
+        y : array-like of shape (n_samples, 2)
+            Target values where y[:, 0] is survival time and y[:, 1] is event status.
+
+        Returns
+        -------
+        self : AFTEstimator
+            Fitted estimator.
+        """
+        X, time, status = _validate_survival_data(X, y)
+        self.n_features_in_ = X.shape[1]
+        n = len(time)
+
+        events = status == 1
+        n_events = events.sum()
+
+        if n_events < X.shape[1] + 1:
+            raise ValueError(
+                f"Not enough events ({n_events}) to fit model with {X.shape[1]} features"
+            )
+
+        X_with_intercept = np.column_stack([np.ones(n), X])
+
+        self.model_ = _surv.survreg(
+            time=time.tolist(),
+            status=status.tolist(),
+            covariates=X_with_intercept.tolist(),
+            distribution=self.distribution,
+            max_iter=self.max_iter,
+            eps=self.tol,
+        )
+
+        coefs = np.array(self.model_.coefficients)
+        self.intercept_ = coefs[0]
+        self.coef_ = coefs[1:-1]
+        self.scale_ = np.exp(coefs[-1])
+        self.converged_ = self.model_.convergence_flag == 0
+
+        self.is_fitted_ = True
+        return self
+
+    def predict(self, X: ArrayLike) -> NDArray[np.float64]:
+        """Predict expected survival time for samples.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Samples to predict.
+
+        Returns
+        -------
+        survival_times : ndarray of shape (n_samples,)
+            Predicted survival times (median by default).
+        """
+        check_is_fitted(self)
+        X = check_array(X, dtype=np.float64, ensure_2d=True)
+
+        if X.shape[1] != self.n_features_in_:
+            raise ValueError(
+                f"X has {X.shape[1]} features, but model expects {self.n_features_in_}"
+            )
+
+        linear_pred = self.intercept_ + X @ self.coef_
+        return np.exp(linear_pred)
+
+    def predict_median(self, X: ArrayLike) -> NDArray[np.float64]:
+        """Predict median survival time for samples.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Samples to predict.
+
+        Returns
+        -------
+        median_times : ndarray of shape (n_samples,)
+            Predicted median survival times.
+        """
+        check_is_fitted(self)
+        X = check_array(X, dtype=np.float64, ensure_2d=True)
+
+        linear_pred = self.intercept_ + X @ self.coef_
+
+        if self.distribution in ("weibull", "exponential", "extreme_value"):
+            median_z = np.log(np.log(2))
+        elif self.distribution in ("lognormal", "gaussian", "loglogistic", "logistic"):
+            median_z = 0.0
+        else:
+            median_z = 0.0
+
+        return np.exp(linear_pred + self.scale_ * median_z)
+
+    def predict_quantile(self, X: ArrayLike, q: float = 0.5) -> NDArray[np.float64]:
+        """Predict survival time quantile for samples.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Samples to predict.
+        q : float, default=0.5
+            Quantile to predict (0 < q < 1). Default is median (0.5).
+
+        Returns
+        -------
+        quantile_times : ndarray of shape (n_samples,)
+            Predicted survival times at the given quantile.
+        """
+        check_is_fitted(self)
+        X = check_array(X, dtype=np.float64, ensure_2d=True)
+
+        if not 0 < q < 1:
+            raise ValueError("q must be between 0 and 1")
+
+        linear_pred = self.intercept_ + X @ self.coef_
+
+        if self.distribution in ("weibull", "exponential", "extreme_value"):
+            z_q = np.log(-np.log(1 - q))
+        elif self.distribution in ("lognormal", "gaussian"):
+            from scipy.stats import norm
+
+            z_q = norm.ppf(q)
+        elif self.distribution in ("loglogistic", "logistic"):
+            z_q = np.log(q / (1 - q))
+        else:
+            z_q = 0.0
+
+        return np.exp(linear_pred + self.scale_ * z_q)
+
+    def score(self, X: ArrayLike, y: ArrayLike) -> float:
+        """Return the concordance index on the given test data.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            Test samples.
+        y : array-like of shape (n_samples, 2)
+            True target values.
+
+        Returns
+        -------
+        score : float
+            Concordance index (C-index), between 0 and 1.
+        """
+        check_is_fitted(self)
+        X, time, status = _validate_survival_data(X, y)
+        predicted_times = self.predict(X)
+        return _compute_concordance_index(time, status, -predicted_times)
+
+    @property
+    def acceleration_factors(self) -> NDArray[np.float64]:
+        """Return acceleration factors (exp of coefficients).
+
+        Returns
+        -------
+        af : ndarray of shape (n_features,)
+            Acceleration factors. Values > 1 increase survival time,
+            values < 1 decrease survival time.
+        """
+        check_is_fitted(self)
+        return np.exp(self.coef_)
+
+
 def _compute_concordance_index(
     time: NDArray[np.float64],
     status: NDArray[np.int32],
@@ -753,6 +982,18 @@ class StreamingSurvivalForestEstimator(SurvivalForestEstimator, StreamingMixin):
     large datasets that don't fit in memory.
 
     See SurvivalForestEstimator for full documentation.
+    """
+
+    pass
+
+
+class StreamingAFTEstimator(AFTEstimator, StreamingMixin):
+    """AFT Estimator with streaming/batched prediction support.
+
+    This class extends AFTEstimator with methods for processing large
+    datasets that don't fit in memory.
+
+    See AFTEstimator for full documentation.
     """
 
     pass

--- a/python/tests/test_aft_estimator.py
+++ b/python/tests/test_aft_estimator.py
@@ -1,0 +1,263 @@
+import numpy as np
+import survival._survival as _surv
+from survival.sklearn_compat import AFTEstimator, StreamingAFTEstimator
+
+
+class TestSurvreg:
+    def test_survreg_weibull_uncensored(self):
+        np.random.seed(42)
+        n = 100
+        X = np.column_stack([np.ones(n), np.random.randn(n, 2)])
+        true_beta = np.array([1.0, 0.5, -0.3])
+        log_time = X @ true_beta + 0.5 * np.random.randn(n)
+        time = np.exp(log_time)
+        status = np.ones(n, dtype=np.float64)
+
+        result = _surv.survreg(
+            time=time.tolist(),
+            status=status.tolist(),
+            covariates=X.tolist(),
+            distribution="weibull",
+            max_iter=100,
+        )
+
+        assert len(result.coefficients) == 4
+        assert result.log_likelihood < 0
+        assert np.isfinite(result.log_likelihood)
+
+    def test_survreg_weibull_censored(self):
+        np.random.seed(42)
+        n = 100
+        X = np.column_stack([np.ones(n), np.random.randn(n, 2)])
+        true_beta = np.array([1.0, 0.5, -0.3])
+        log_time = X @ true_beta + 0.5 * np.random.randn(n)
+        time = np.exp(log_time)
+        censor_time = np.random.exponential(3, n)
+        observed_time = np.minimum(time, censor_time)
+        status = (time <= censor_time).astype(np.float64)
+
+        result = _surv.survreg(
+            time=observed_time.tolist(),
+            status=status.tolist(),
+            covariates=X.tolist(),
+            distribution="weibull",
+            max_iter=100,
+        )
+
+        assert len(result.coefficients) == 4
+        assert result.log_likelihood < 0
+        assert np.isfinite(result.log_likelihood)
+
+    def test_survreg_lognormal(self):
+        np.random.seed(42)
+        n = 100
+        X = np.column_stack([np.ones(n), np.random.randn(n, 2)])
+        true_beta = np.array([2.0, 0.3, -0.5])
+        log_time = X @ true_beta + 0.8 * np.random.randn(n)
+        time = np.exp(log_time)
+        status = np.ones(n, dtype=np.float64)
+
+        result = _surv.survreg(
+            time=time.tolist(),
+            status=status.tolist(),
+            covariates=X.tolist(),
+            distribution="lognormal",
+            max_iter=100,
+        )
+
+        assert len(result.coefficients) == 4
+        assert np.isfinite(result.log_likelihood)
+
+    def test_survreg_loglogistic(self):
+        np.random.seed(42)
+        n = 100
+        X = np.column_stack([np.ones(n), np.random.randn(n)])
+        true_beta = np.array([1.5, 0.4])
+        u = np.random.uniform(0, 1, n)
+        log_time = X @ true_beta + 0.6 * np.log(u / (1 - u))
+        time = np.exp(log_time)
+        status = np.ones(n, dtype=np.float64)
+
+        result = _surv.survreg(
+            time=time.tolist(),
+            status=status.tolist(),
+            covariates=X.tolist(),
+            distribution="loglogistic",
+            max_iter=100,
+        )
+
+        assert len(result.coefficients) == 3
+        assert np.isfinite(result.log_likelihood)
+
+    def test_survreg_small_sample(self):
+        time = [1.0, 2.0, 3.0, 4.0, 5.0]
+        status = [1.0, 1.0, 1.0, 1.0, 1.0]
+        X = [[1.0], [1.0], [1.0], [1.0], [1.0]]
+
+        result = _surv.survreg(
+            time=time,
+            status=status,
+            covariates=X,
+            distribution="weibull",
+            max_iter=100,
+        )
+
+        assert len(result.coefficients) == 2
+        assert result.log_likelihood < 0
+
+
+class TestAFTEstimator:
+    def test_fit_uncensored(self):
+        np.random.seed(42)
+        n = 100
+        X = np.random.randn(n, 2)
+        true_beta = np.array([0.5, -0.3])
+        log_time = 1.0 + X @ true_beta + 0.5 * np.random.randn(n)
+        time = np.exp(log_time)
+        y = np.column_stack([time, np.ones(n)])
+
+        model = AFTEstimator(distribution="weibull")
+        model.fit(X, y)
+
+        assert model.n_features_in_ == 2
+        assert len(model.coef_) == 2
+        assert model.scale_ > 0
+        assert hasattr(model, "intercept_")
+        assert np.isfinite(model.intercept_)
+
+    def test_fit_censored(self):
+        np.random.seed(42)
+        n = 100
+        X = np.random.randn(n, 2)
+        true_beta = np.array([0.5, -0.3])
+        log_time = 1.0 + X @ true_beta + 0.5 * np.random.randn(n)
+        time = np.exp(log_time)
+        censor_time = np.random.exponential(3, n)
+        observed_time = np.minimum(time, censor_time)
+        status = (time <= censor_time).astype(float)
+        y = np.column_stack([observed_time, status])
+
+        model = AFTEstimator(distribution="weibull")
+        model.fit(X, y)
+
+        assert model.n_features_in_ == 2
+        assert np.isfinite(model.intercept_)
+
+    def test_predict(self):
+        np.random.seed(42)
+        n = 100
+        X = np.random.randn(n, 2)
+        log_time = 1.0 + X @ np.array([0.5, -0.3]) + 0.5 * np.random.randn(n)
+        time = np.exp(log_time)
+        y = np.column_stack([time, np.ones(n)])
+
+        model = AFTEstimator(distribution="weibull")
+        model.fit(X, y)
+        predictions = model.predict(X)
+
+        assert len(predictions) == n
+        assert all(predictions > 0)
+
+    def test_predict_median(self):
+        np.random.seed(42)
+        n = 100
+        X = np.random.randn(n, 2)
+        log_time = 1.0 + X @ np.array([0.5, -0.3]) + 0.5 * np.random.randn(n)
+        time = np.exp(log_time)
+        y = np.column_stack([time, np.ones(n)])
+
+        model = AFTEstimator(distribution="weibull")
+        model.fit(X, y)
+        median_times = model.predict_median(X)
+
+        assert len(median_times) == n
+        assert all(median_times > 0)
+
+    def test_score(self):
+        np.random.seed(42)
+        n = 100
+        X = np.random.randn(n, 2)
+        log_time = 1.0 + X @ np.array([0.5, -0.3]) + 0.5 * np.random.randn(n)
+        time = np.exp(log_time)
+        y = np.column_stack([time, np.ones(n)])
+
+        model = AFTEstimator(distribution="weibull")
+        model.fit(X, y)
+        c_index = model.score(X, y)
+
+        assert 0 <= c_index <= 1
+
+    def test_acceleration_factors(self):
+        np.random.seed(42)
+        n = 100
+        X = np.random.randn(n, 2)
+        log_time = 1.0 + X @ np.array([0.5, -0.3]) + 0.5 * np.random.randn(n)
+        time = np.exp(log_time)
+        y = np.column_stack([time, np.ones(n)])
+
+        model = AFTEstimator(distribution="weibull")
+        model.fit(X, y)
+        af = model.acceleration_factors
+
+        assert len(af) == 2
+        assert all(af > 0)
+
+    def test_different_distributions(self):
+        np.random.seed(42)
+        n = 100
+        X = np.random.randn(n, 2)
+        log_time = 1.0 + X @ np.array([0.5, -0.3]) + 0.5 * np.random.randn(n)
+        time = np.exp(log_time)
+        y = np.column_stack([time, np.ones(n)])
+
+        for dist in ["weibull", "lognormal", "loglogistic"]:
+            model = AFTEstimator(distribution=dist)
+            model.fit(X, y)
+            assert model.n_features_in_ == 2
+            assert np.isfinite(model.intercept_)
+
+    def test_not_enough_events(self):
+        X = np.random.randn(10, 5)
+        y = np.column_stack([np.exp(np.random.randn(10)), np.zeros(10)])
+        y[0, 1] = 1
+        y[1, 1] = 1
+
+        model = AFTEstimator(distribution="weibull")
+        try:
+            model.fit(X, y)
+            assert False, "Should have raised ValueError"
+        except ValueError as e:
+            assert "Not enough events" in str(e)
+
+
+class TestStreamingAFTEstimator:
+    def test_streaming_fit(self):
+        np.random.seed(42)
+        n = 100
+        X = np.random.randn(n, 2)
+        log_time = 1.0 + X @ np.array([0.5, -0.3]) + 0.5 * np.random.randn(n)
+        time = np.exp(log_time)
+        y = np.column_stack([time, np.ones(n)])
+
+        model = StreamingAFTEstimator(distribution="weibull")
+        model.fit(X, y)
+
+        assert model.n_features_in_ == 2
+        assert np.isfinite(model.intercept_)
+
+    def test_streaming_predict_batched(self):
+        np.random.seed(42)
+        n = 100
+        X = np.random.randn(n, 2)
+        log_time = 1.0 + X @ np.array([0.5, -0.3]) + 0.5 * np.random.randn(n)
+        time = np.exp(log_time)
+        y = np.column_stack([time, np.ones(n)])
+
+        model = StreamingAFTEstimator(distribution="weibull")
+        model.fit(X, y)
+
+        predictions = list(model.predict_batched(X, batch_size=20))
+        all_predictions = np.concatenate(predictions)
+
+        assert len(all_predictions) == n
+        assert all(all_predictions > 0)

--- a/src/validation/bootstrap.rs
+++ b/src/validation/bootstrap.rs
@@ -272,6 +272,9 @@ pub fn bootstrap_survreg(
         "gaussian" | "Gaussian" | "normal" | "Normal" => DistributionType::Gaussian,
         "weibull" | "Weibull" => DistributionType::Weibull,
         "lognormal" | "LogNormal" | "lognorm" | "LogNorm" => DistributionType::LogNormal,
+        "loglogistic" | "LogLogistic" | "log_logistic" | "log-logistic" => {
+            DistributionType::LogLogistic
+        }
         _ => DistributionType::ExtremeValue,
     };
 
@@ -281,6 +284,7 @@ pub fn bootstrap_survreg(
         DistributionType::Gaussian => "gaussian",
         DistributionType::Logistic => "logistic",
         DistributionType::LogNormal => "lognormal",
+        DistributionType::LogLogistic => "loglogistic",
     };
 
     let original = survreg(

--- a/uv.lock
+++ b/uv.lock
@@ -513,7 +513,7 @@ wheels = [
 
 [[package]]
 name = "survival"
-version = "1.1.30"
+version = "1.1.31"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
- Fix survreg numerical optimization with log-transform, Fisher scoring, and adaptive step size
- Add Log-Logistic distribution support to survreg
- Add AFTEstimator and StreamingAFTEstimator sklearn-compatible classes
- Add comprehensive Rust tests for survreg6 and survregc1 modules
- Add Python tests for survreg and AFT estimators