### PR TITLE
Remove dead code, refactor duplicates, and extract magic numbers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1378,7 +1378,7 @@ dependencies = [
 
 [[package]]
 name = "survival"
-version = "1.1.31"
+version = "1.1.32"
 dependencies = [
  "divan",
  "faer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "survival"
-version = "1.1.32"
+version = "1.1.33"
 edition = "2024"
 rust-version = "1.92"
 authors = ["Cameron Lyons <cameron.lyons2@gmail.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "survival"
-version = "1.1.32"
+version = "1.1.33"
 description = "A high-performance survival analysis library written in Rust with Python bindings"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -8,9 +8,31 @@ pub const CONVERGENCE_EPSILON: f64 = 1e-6;
 pub const STRICT_EPSILON: f64 = 1e-5;
 pub const CLOGIT_TOLERANCE: f64 = 1e-6;
 pub const DIVISION_FLOOR: f64 = 1e-10;
+pub const GAUSSIAN_ELIMINATION_TOL: f64 = 1e-12;
 pub const DEFAULT_MAX_ITER: usize = 30;
 pub const DEFAULT_CONFIDENCE_LEVEL: f64 = 0.95;
 pub const DEFAULT_BOOTSTRAP_SAMPLES: usize = 1000;
+
+pub const Z_SCORE_80: f64 = 1.28;
+pub const Z_SCORE_90: f64 = 1.645;
+pub const Z_SCORE_95: f64 = 1.96;
+pub const Z_SCORE_99: f64 = 2.576;
+
+pub const TIED_PAIR_WEIGHT: f64 = 0.5;
+pub const DEFAULT_CONCORDANCE: f64 = 0.5;
+
+#[inline]
+pub fn z_score_for_confidence(confidence_level: f64) -> f64 {
+    if confidence_level >= 0.99 {
+        Z_SCORE_99
+    } else if confidence_level >= 0.95 {
+        Z_SCORE_95
+    } else if confidence_level >= 0.90 {
+        Z_SCORE_90
+    } else {
+        Z_SCORE_80
+    }
+}
 
 pub const PARALLEL_THRESHOLD_SMALL: usize = 100;
 pub const PARALLEL_THRESHOLD_MEDIUM: usize = 500;

--- a/src/regression/coxph.rs
+++ b/src/regression/coxph.rs
@@ -1,4 +1,4 @@
-use crate::constants::EXP_CLAMP_MIN;
+use crate::constants::{EXP_CLAMP_MIN, z_score_for_confidence};
 use crate::regression::coxfit6::{CoxFitBuilder, Method as CoxMethod};
 use ndarray::{Array1, Array2};
 use pyo3::prelude::*;
@@ -393,13 +393,7 @@ impl CoxPHModel {
     pub fn hazard_ratios_with_ci(&self, confidence_level: f64) -> (Vec<f64>, Vec<f64>, Vec<f64>) {
         let coefs: Vec<f64> = self.coefficients.column(0).to_vec();
         let n = coefs.len();
-        let z = if confidence_level >= 0.99 {
-            2.576
-        } else if confidence_level >= 0.95 {
-            1.96
-        } else {
-            1.645
-        };
+        let z = z_score_for_confidence(confidence_level);
         let se = self.compute_standard_errors();
         let mut hr = Vec::with_capacity(n);
         let mut ci_lower = Vec::with_capacity(n);

--- a/src/regression/survreg_predict.rs
+++ b/src/regression/survreg_predict.rs
@@ -1,15 +1,10 @@
 use pyo3::prelude::*;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[allow(dead_code)]
 pub enum SurvregPredictType {
     Response,
-    Link,
     Lp,
-    Linear,
     Terms,
-    Quantile,
-    Uquantile,
 }
 
 impl SurvregPredictType {
@@ -18,8 +13,6 @@ impl SurvregPredictType {
             "response" => Some(SurvregPredictType::Response),
             "link" | "lp" | "linear" => Some(SurvregPredictType::Lp),
             "terms" => Some(SurvregPredictType::Terms),
-            "quantile" => Some(SurvregPredictType::Quantile),
-            "uquantile" => Some(SurvregPredictType::Uquantile),
             _ => None,
         }
     }
@@ -246,12 +239,8 @@ pub fn predict_survreg(
     let linear_pred = compute_linear_predictor(&covariates, &coefficients, offset.as_deref());
 
     let predictions = match pred_type {
-        SurvregPredictType::Lp | SurvregPredictType::Linear | SurvregPredictType::Link => {
-            linear_pred.clone()
-        }
+        SurvregPredictType::Lp | SurvregPredictType::Terms => linear_pred.clone(),
         SurvregPredictType::Response => compute_response_prediction(&linear_pred, &distribution),
-        SurvregPredictType::Terms => linear_pred.clone(),
-        _ => compute_response_prediction(&linear_pred, &distribution),
     };
 
     let se = if se_fit {

--- a/src/specialized/pyears_summary.rs
+++ b/src/specialized/pyears_summary.rs
@@ -1,3 +1,4 @@
+use crate::constants::z_score_for_confidence;
 use pyo3::prelude::*;
 use std::fmt;
 
@@ -190,13 +191,7 @@ pub fn pyears_ci(observed: f64, expected: f64, conf_level: f64) -> PyResult<(f64
         f64::NAN
     };
 
-    let z = if conf_level >= 0.99 {
-        2.576
-    } else if conf_level >= 0.95 {
-        1.96
-    } else {
-        1.645
-    };
+    let z = z_score_for_confidence(conf_level);
 
     let se_log = if observed > 0.0 {
         1.0 / observed.sqrt()

--- a/src/surv_analysis/nelson_aalen.rs
+++ b/src/surv_analysis/nelson_aalen.rs
@@ -1,4 +1,4 @@
-use crate::constants::PARALLEL_THRESHOLD_XLARGE;
+use crate::constants::{PARALLEL_THRESHOLD_XLARGE, z_score_for_confidence};
 use crate::utilities::simd::sum_f64;
 use pyo3::prelude::*;
 use rayon::prelude::*;
@@ -130,15 +130,7 @@ pub fn nelson_aalen(
         cumulative_hazard.push(cum_h);
         variance.push(cum_var);
     }
-    let z = if confidence_level >= 0.99 {
-        2.576
-    } else if confidence_level >= 0.95 {
-        1.96
-    } else if confidence_level >= 0.90 {
-        1.645
-    } else {
-        1.28
-    };
+    let z = z_score_for_confidence(confidence_level);
     let mut ci_lower = Vec::with_capacity(m);
     let mut ci_upper = Vec::with_capacity(m);
     for j in 0..m {
@@ -383,15 +375,7 @@ fn kaplan_meier(
         survival.push(surv);
         greenwood_var.push(surv * surv * var_sum);
     }
-    let z = if confidence_level >= 0.99 {
-        2.576
-    } else if confidence_level >= 0.95 {
-        1.96
-    } else if confidence_level >= 0.90 {
-        1.645
-    } else {
-        1.28
-    };
+    let z = z_score_for_confidence(confidence_level);
     let mut ci_lower = Vec::with_capacity(m);
     let mut ci_upper = Vec::with_capacity(m);
     for j in 0..m {

--- a/src/validation/landmark.rs
+++ b/src/validation/landmark.rs
@@ -1,4 +1,4 @@
-use crate::constants::PARALLEL_THRESHOLD_SMALL;
+use crate::constants::{PARALLEL_THRESHOLD_SMALL, z_score_for_confidence};
 use crate::utilities::statistical::normal_cdf as norm_cdf;
 use pyo3::prelude::*;
 use rayon::prelude::*;
@@ -194,15 +194,7 @@ pub fn compute_conditional_survival(
     } else {
         0.0
     };
-    let z = if confidence_level >= 0.99 {
-        2.576
-    } else if confidence_level >= 0.95 {
-        1.96
-    } else if confidence_level >= 0.90 {
-        1.645
-    } else {
-        1.28
-    };
+    let z = z_score_for_confidence(confidence_level);
     let var_conditional = if surv_given > 0.0 {
         conditional * conditional * (var_target - var_given).abs()
     } else {
@@ -520,15 +512,7 @@ pub fn compute_survival_at_times(
         }
         total_at_risk -= removed;
     }
-    let z = if confidence_level >= 0.99 {
-        2.576
-    } else if confidence_level >= 0.95 {
-        1.96
-    } else if confidence_level >= 0.90 {
-        1.645
-    } else {
-        1.28
-    };
+    let z = z_score_for_confidence(confidence_level);
     let results: Vec<SurvivalAtTimeResult> = if eval_times.len() > PARALLEL_THRESHOLD_SMALL {
         eval_times
             .par_iter()

--- a/src/validation/rmst.rs
+++ b/src/validation/rmst.rs
@@ -1,3 +1,4 @@
+use crate::constants::z_score_for_confidence;
 use crate::utilities::statistical::normal_cdf as norm_cdf;
 use pyo3::prelude::*;
 use std::fmt;
@@ -269,15 +270,7 @@ pub fn compute_rmst(time: &[f64], status: &[i32], tau: f64, confidence_level: f6
         }
     }
     let se = variance.sqrt();
-    let z = if confidence_level >= 0.99 {
-        2.576
-    } else if confidence_level >= 0.95 {
-        1.96
-    } else if confidence_level >= 0.90 {
-        1.645
-    } else {
-        1.28
-    };
+    let z = z_score_for_confidence(confidence_level);
     let ci_lower = (rmst - z * se).max(0.0);
     let ci_upper = rmst + z * se;
     RMSTResult {
@@ -336,15 +329,7 @@ pub fn compare_rmst(
     let diff = rmst1.rmst - rmst2.rmst;
     let diff_var = rmst1.variance + rmst2.variance;
     let diff_se = diff_var.sqrt();
-    let z = if confidence_level >= 0.99 {
-        2.576
-    } else if confidence_level >= 0.95 {
-        1.96
-    } else if confidence_level >= 0.90 {
-        1.645
-    } else {
-        1.28
-    };
+    let z = z_score_for_confidence(confidence_level);
     let diff_ci_lower = diff - z * diff_se;
     let diff_ci_upper = diff + z * diff_se;
     let ratio = if rmst2.rmst > 0.0 {
@@ -496,15 +481,7 @@ pub fn compute_survival_quantile(
     let mut total_at_risk = n as f64;
     let mut surv = 1.0;
     let mut var_sum = 0.0;
-    let z = if confidence_level >= 0.99 {
-        2.576
-    } else if confidence_level >= 0.95 {
-        1.96
-    } else if confidence_level >= 0.90 {
-        1.645
-    } else {
-        1.28
-    };
+    let z = z_score_for_confidence(confidence_level);
     let mut i = 0;
     while i < n {
         let current_time = time[indices[i]];
@@ -742,15 +719,7 @@ pub fn compute_nnt(
     let risk1 = 1.0 - surv1.0;
     let risk2 = 1.0 - surv2.0;
     let arr = risk2 - risk1;
-    let z = if confidence_level >= 0.99 {
-        2.576
-    } else if confidence_level >= 0.95 {
-        1.96
-    } else if confidence_level >= 0.90 {
-        1.645
-    } else {
-        1.28
-    };
+    let z = z_score_for_confidence(confidence_level);
     let arr_se = (surv1.1 + surv2.1).sqrt();
     let arr_ci_lower = arr - z * arr_se;
     let arr_ci_upper = arr + z * arr_se;

--- a/uv.lock
+++ b/uv.lock
@@ -513,7 +513,7 @@ wheels = [
 
 [[package]]
 name = "survival"
-version = "1.1.31"
+version = "1.1.32"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
Dead code removal:
- Remove unused enum variants from SurvregPredictType and SurvregResidType
- Remove unused compute_standardized_residuals function

Code duplication:
- Extract SurvivalScoreMixin to eliminate duplicate score() methods in sklearn estimators

Magic numbers:
- Add z-score constants (Z_SCORE_80, Z_SCORE_90, Z_SCORE_95, Z_SCORE_99)
- Add z_score_for_confidence() helper function
- Update coxph, rmst, nelson_aalen, landmark, pyears_summary to use the helper