### PR TITLE
Add DeepHit, SurvTRACE models and optimize codebase

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "survival"
-version = "1.1.36"
+version = "1.1.37"
 edition = "2024"
 rust-version = "1.92"
 authors = ["Cameron Lyons <cameron.lyons2@gmail.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "survival"
-version = "1.1.36"
+version = "1.1.37"
 description = "A high-performance survival analysis library written in Rust with Python bindings"
 readme = "README.md"
 license = { text = "MIT" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,11 +46,11 @@ Issues = "https://github.com/Cameron-Lyons/survival/issues"
 dev = [
   "pre-commit==4.5.1",
   "pytest==9.0.2",
-  "numpy==2.4.1",
+  "numpy==2.4.0",
 ]
 test = [
   "pytest==9.0.2",
-  "numpy==2.4.1",
+  "numpy==2.4.0",
   "pandas==2.3.3",
   "polars==1.37.1",
 ]

--- a/src/regression/coxfit6.rs
+++ b/src/regression/coxfit6.rs
@@ -48,8 +48,6 @@ impl std::error::Error for CoxError {}
 #[derive(Debug, Clone, Copy)]
 pub enum Method {
     Breslow,
-    #[allow(dead_code)]
-    Efron,
 }
 pub type CoxFitResults = (
     Vec<f64>,
@@ -121,12 +119,6 @@ impl CoxFitBuilder {
         self
     }
 
-    #[allow(dead_code)]
-    pub fn offset(mut self, offset: Array1<f64>) -> Self {
-        self.offset = Some(offset);
-        self
-    }
-
     pub fn weights(mut self, weights: Array1<f64>) -> Self {
         self.weights = Some(weights);
         self
@@ -149,12 +141,6 @@ impl CoxFitBuilder {
 
     pub fn toler(mut self, toler: f64) -> Self {
         self.toler = toler;
-        self
-    }
-
-    #[allow(dead_code)]
-    pub fn doscale(mut self, doscale: Vec<bool>) -> Self {
-        self.doscale = Some(doscale);
         self
     }
 
@@ -436,44 +422,20 @@ impl CoxFit {
                 }
             }
             if ndead > 0 {
-                match method {
-                    Method::Breslow => {
-                        denom += denom2;
-                        loglik -= deadwt * denom.ln();
-                        #[allow(clippy::needless_range_loop)]
-                        for i in 0..nvar {
-                            a[i] += a2[i];
-                            let temp = a[i] / denom;
-                            self.u[i] -= deadwt * temp;
-                            for j in 0..=i {
-                                cmat[(i, j)] += cmat2[(i, j)];
-                                let val = deadwt * (cmat[(i, j)] - temp * a[j]) / denom;
-                                self.imat[(j, i)] += val;
-                                if i != j {
-                                    self.imat[(i, j)] += val;
-                                }
-                            }
-                        }
-                    }
-                    Method::Efron => {
-                        let wtave = deadwt / ndead as f64;
-                        for k in 0..ndead {
-                            let _kf = k as f64;
-                            denom += denom2 / ndead as f64;
-                            loglik -= wtave * denom.ln();
-                            for i in 0..nvar {
-                                a[i] += a2[i] / ndead as f64;
-                                let temp = a[i] / denom;
-                                self.u[i] -= wtave * temp;
-                                for j in 0..=i {
-                                    cmat[(i, j)] += cmat2[(i, j)] / ndead as f64;
-                                    let val = wtave * (cmat[(i, j)] - temp * a[j]) / denom;
-                                    self.imat[(j, i)] += val;
-                                    if i != j {
-                                        self.imat[(i, j)] += val;
-                                    }
-                                }
-                            }
+                let _ = method;
+                denom += denom2;
+                loglik -= deadwt * denom.ln();
+                #[allow(clippy::needless_range_loop)]
+                for i in 0..nvar {
+                    a[i] += a2[i];
+                    let temp = a[i] / denom;
+                    self.u[i] -= deadwt * temp;
+                    for j in 0..=i {
+                        cmat[(i, j)] += cmat2[(i, j)];
+                        let val = deadwt * (cmat[(i, j)] - temp * a[j]) / denom;
+                        self.imat[(j, i)] += val;
+                        if i != j {
+                            self.imat[(i, j)] += val;
                         }
                     }
                 }
@@ -706,9 +668,6 @@ mod tests {
     #[test]
     fn test_method_variants() {
         let breslow = Method::Breslow;
-        let efron = Method::Efron;
-
         assert!(matches!(breslow, Method::Breslow));
-        assert!(matches!(efron, Method::Efron));
     }
 }

--- a/src/surv_analysis/agsurv4.rs
+++ b/src/surv_analysis/agsurv4.rs
@@ -26,10 +26,9 @@ pub fn agsurv4(
                 let mut guess: f64 = 0.5;
                 let mut inc = 0.25;
                 let death_count = ndeath_slice[i] as usize;
-                let range = j..(j + death_count);
                 for _ in 0..35 {
                     let mut sumt = 0.0;
-                    for k in range.clone() {
+                    for k in j..(j + death_count) {
                         let term = wt_slice[k] * risk_slice[k] / (1.0 - guess.powf(risk_slice[k]));
                         sumt += term;
                     }


### PR DESCRIPTION
## Summary

- Add DeepHit neural network for survival analysis with competing risks
- Add SurvTRACE transformer model for survival analysis
- Remove dead code and consolidate duplicate utilities
- Performance optimizations across ML modules

### DeepHit Implementation
- Shared and cause-specific sub-networks
- PMF output with softmax over time bins
- Combined loss: negative log-likelihood + ranking loss
- Support for competing risks (multiple event types)

### SurvTRACE Implementation
- Categorical and numerical feature embeddings
- Multi-head self-attention transformer encoder
- Separate output heads per event type for competing risks
- Discrete hazard loss (negative log-likelihood)

### Code Cleanup
- Remove unused Efron method variant and related tests
- Remove unused builder methods: `offset()`, `doscale()`
- Remove duplicate `compute_survival_from_pmf` function
- Consolidate `gelu_cpu` and `layer_norm_cpu` to shared `ml/utils.rs`
- Remove unnecessary clones in training loops

### Performance Optimizations
- Add `#[inline]` to hot path functions (`linear_forward`, `relu_vec`, etc.)
- Cache basis matrix in `pspline.rs` penalty functions
- Remove unnecessary tensor clones in training loops
- Fix range cloning in `agsurv4.rs`

## Test plan
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --lib` passes (499 tests)
- [x] No `#[allow(dead_code)]` annotations remaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)