### PR TITLE
Add consts to typos allowlist

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -15,6 +15,7 @@ ehr = "ehr"
 nd = "nd"
 perfor = "perfor"
 wil = "wil"
+consts = "consts"
 
 [files]
 extend-exclude = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5951,7 +5951,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "survival"
-version = "1.2.1"
+version = "1.2.3"
 dependencies = [
  "burn",
  "divan",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "survival"
-version = "1.2.3"
+version = "1.2.4"
 edition = "2024"
 rust-version = "1.92"
 authors = ["Cameron Lyons <cameron.lyons2@gmail.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "survival"
-version = "1.2.3"
+version = "1.2.4"
 description = "A high-performance survival analysis library written in Rust with Python bindings"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary
- Adds `consts` to the typos allowlist in `.typos.toml` — this is a standard Rust module name, not a misspelling of "constants"
- Fixes the failing Spell Check / Veto CI on dependabot PRs #130, #131, #132

## Test plan
- [ ] Verify the Lint workflow passes (Spell Check + Veto)