### PR TITLE
Fix MSRV workflow to read rust-version from Cargo.toml

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -10,7 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@1.100
+      - id: msrv
+        run: echo "version=$(grep '^rust-version' Cargo.toml | sed 's/.*"\(.*\)"/\1/')" >> $GITHUB_OUTPUT
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.msrv.outputs.version }}
       - uses: actions/cache@v5
         with:
           path: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5951,7 +5951,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "survival"
-version = "1.2.3"
+version = "1.2.5"
 dependencies = [
  "burn",
  "divan",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "survival"
-version = "1.2.5"
+version = "1.2.6"
 edition = "2024"
 rust-version = "1.92"
 authors = ["Cameron Lyons <cameron.lyons2@gmail.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "survival"
-version = "1.2.5"
+version = "1.2.6"
 description = "A high-performance survival analysis library written in Rust with Python bindings"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary
- The MSRV workflow hardcoded `dtolnay/rust-toolchain@1.100`, but Rust 1.100 doesn't exist
- Now reads `rust-version` from `Cargo.toml` (currently `1.92`) so the workflow stays in sync automatically

## Test plan
- [ ] MSRV CI job passes instead of failing with a 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)