### PR TITLE
test: expand coverage and harden CI and utilities

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Post benchmark results
         continue-on-error: true
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3
         with:
           path: bench-comment.md
           header: benchmarks

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,6 +6,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  COVERAGE_MIN_PERCENT: '30'
 
 jobs:
   coverage:
@@ -42,6 +43,9 @@ jobs:
       - name: Run coverage
         run: cargo tarpaulin --engine llvm --out xml --out html --skip-clean --timeout 300
 
+      - name: Enforce minimum line coverage
+        run: python scripts/check_coverage.py cobertura.xml --min-percent "${COVERAGE_MIN_PERCENT}"
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
@@ -54,4 +58,6 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: coverage-report
-          path: tarpaulin-report.html
+          path: |
+            cobertura.xml
+            tarpaulin-report.html

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -152,18 +152,23 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-develop-py3.14-
 
+      - name: Create virtualenv
+        run: python -m venv .venv
+
       - name: Install maturin and test dependencies
-        run: pip install maturin numpy pandas polars pytest
+        run: |
+          .venv/bin/python -m pip install --upgrade pip
+          .venv/bin/python -m pip install maturin numpy pandas polars pytest
 
       - name: Remove any preinstalled survival package
-        run: pip uninstall -y survival || true
+        run: .venv/bin/python -m pip uninstall -y survival || true
 
       - name: Install extension with maturin develop
-        run: maturin develop --release --features extension-module
+        run: .venv/bin/maturin develop --release --features extension-module
 
       - name: Verify extension import path
         run: |
-          python - <<'PY'
+          .venv/bin/python - <<'PY'
           import importlib.util
           spec = importlib.util.find_spec("survival._survival")
           if spec is None or spec.origin is None:
@@ -172,7 +177,7 @@ jobs:
           PY
 
       - name: Run Python tests against source-tree install
-        run: python -m pytest python/tests/ -v
+        run: .venv/bin/python -m pytest python/tests/ -v
 
   r-validation:
     name: R Survival Package Validation

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -123,6 +123,57 @@ jobs:
       - name: Run Python tests
         run: python -m pytest python/tests/ -v
 
+  python-source-tree:
+    name: Python Source Tree
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-develop-py3.14-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-develop-py3.14-
+
+      - name: Install maturin and test dependencies
+        run: pip install maturin numpy pandas polars pytest
+
+      - name: Remove any preinstalled survival package
+        run: pip uninstall -y survival || true
+
+      - name: Install extension with maturin develop
+        run: maturin develop --release --features extension-module
+
+      - name: Verify extension import path
+        run: |
+          python - <<'PY'
+          import importlib.util
+          spec = importlib.util.find_spec("survival._survival")
+          if spec is None or spec.origin is None:
+              raise SystemExit("Could not locate survival._survival")
+          print(spec.origin)
+          PY
+
+      - name: Run Python tests against source-tree install
+        run: python -m pytest python/tests/ -v
+
   r-validation:
     name: R Survival Package Validation
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -164,7 +164,7 @@ jobs:
         run: .venv/bin/python -m pip uninstall -y survival || true
 
       - name: Install extension with maturin develop
-        run: .venv/bin/maturin develop --release --features extension-module --config strip=false
+        run: .venv/bin/maturin develop --release --features extension-module
 
       - name: Verify extension import path
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -164,7 +164,7 @@ jobs:
         run: .venv/bin/python -m pip uninstall -y survival || true
 
       - name: Install extension with maturin develop
-        run: .venv/bin/maturin develop --release --features extension-module
+        run: .venv/bin/maturin develop --release --features extension-module --config strip=false
 
       - name: Verify extension import path
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5939,7 +5939,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "survival"
-version = "1.2.14"
+version = "1.2.16"
 dependencies = [
  "burn",
  "divan",
@@ -7153,9 +7153,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac11b009ebeae802ed758530b6496784ebfee7a87b9abfbcaf3bbe25b814eb25"
+checksum = "198f6abc41fab83526d10880fa5c17e2b4ee44e763949b4bb34e2fd1e8ca48e4"
 dependencies = [
  "bytemuck",
  "safe_arch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "survival"
-version = "1.2.15"
+version = "1.2.16"
 edition = "2024"
-rust-version = "1.93"
+rust-version = "1.94"
 authors = ["Cameron Lyons <cameron.lyons2@gmail.com>"]
 description = "A high-performance survival analysis library written in Rust with Python bindings"
 license = "MIT"
@@ -28,7 +28,7 @@ rayon = "1.11.0"
 faer = "0.24.0"
 fastrand = "2.3.0"
 pulp = "0.22.2"
-wide = "1.1.1"
+wide = "1.2.0"
 burn = { version = "0.20.1", features = ["autodiff", "ndarray"] }
 num_cpus = "1.17.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,6 @@ sklearn = [
 features = ["pyo3/extension-module"]
 module-name = "survival._survival"
 python-source = "python"
-strip = true
 
 [tool.ruff]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "survival"
-version = "1.2.15"
+version = "1.2.16"
 description = "A high-performance survival analysis library written in Rust with Python bindings"
 readme = "README.md"
 license = { text = "MIT" }
@@ -52,7 +52,7 @@ test = [
   "pytest==9.0.2",
   "numpy==2.4.3",
   "pandas==3.0.1",
-  "polars==1.38.1",
+  "polars==1.39.0",
 ]
 sklearn = [
   "scikit-learn>=1.0.0",

--- a/python/tests/test_auxiliary_apis.py
+++ b/python/tests/test_auxiliary_apis.py
@@ -1,0 +1,244 @@
+import numpy as np
+import pytest
+
+from .helpers import setup_survival_import
+
+survival = setup_survival_import()
+
+
+def test_brier_helpers():
+    assert survival.brier([0.0, 1.0], [0, 1]) == pytest.approx(0.0)
+    assert survival.integrated_brier([[0.0, 0.0], [1.0, 1.0]], [0, 1], [1.0, 2.0]) == pytest.approx(
+        0.0
+    )
+
+    with pytest.raises(ValueError, match="predictions must be between 0 and 1"):
+        survival.brier([1.2, 0.5], [1, 0])
+
+
+def test_statistical_test_helpers():
+    lrt = survival.lrt_test(-10.0, -12.0, 1)
+    assert lrt.statistic == pytest.approx(4.0)
+    assert lrt.df == 1
+    assert lrt.p_value == pytest.approx(0.0455, rel=1e-3)
+
+    wald = survival.wald_test_py([1.0, 2.0], [1.0, 2.0])
+    assert wald.statistic == pytest.approx(2.0)
+    assert wald.df == 2
+    assert wald.p_value == pytest.approx(0.3679, rel=1e-3)
+
+    score = survival.score_test_py([1.0], [[2.0]])
+    assert score.statistic == pytest.approx(0.5)
+    assert score.df == 1
+    assert score.p_value == pytest.approx(0.4795, rel=1e-3)
+
+    ph = survival.ph_test(
+        [[1.0, 0.5], [2.0, 1.0], [3.0, 1.5], [4.0, 2.0]],
+        [1.0, 2.0, 3.0, 4.0],
+        None,
+    )
+    assert ph.global_df == 2
+    assert len(ph.variable_names) == 2
+    assert len(ph.p_values) == 2
+    assert all(0.0 <= value <= 1.0 for value in ph.p_values)
+
+    with pytest.raises(ValueError, match="coefficients and std_errors must have the same length"):
+        survival.wald_test_py([1.0], [1.0, 2.0])
+
+    with pytest.raises(
+        ValueError, match="score_vector length must match information_matrix dimensions"
+    ):
+        survival.score_test_py([1.0, 2.0], [[1.0]])
+
+
+def test_bootstrap_ci_helpers_smoke():
+    time = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+    status_i32 = [1, 1, 0, 1, 0, 1]
+    status_f64 = [float(value) for value in status_i32]
+    cox_covariates = [[0.1], [0.2], [0.3], [0.4], [0.5], [0.6]]
+    survreg_covariates = [[1.0, 0.1], [1.0, 0.2], [1.0, 0.3], [1.0, 0.4], [1.0, 0.5], [1.0, 0.6]]
+
+    cox = survival.bootstrap_cox_ci(
+        time,
+        status_i32,
+        cox_covariates,
+        n_bootstrap=8,
+        confidence_level=0.9,
+        seed=123,
+    )
+    assert len(cox.coefficients) == 1
+    assert len(cox.std_errors) == 1
+    assert len(cox.ci_lower) == 1
+    assert len(cox.ci_upper) == 1
+    assert len(cox.bootstrap_samples) > 0
+    assert np.isfinite(cox.coefficients[0])
+
+    survreg = survival.bootstrap_survreg_ci(
+        time,
+        status_f64,
+        survreg_covariates,
+        distribution="weibull",
+        n_bootstrap=8,
+        confidence_level=0.9,
+        seed=123,
+    )
+    assert len(survreg.coefficients) == 3
+    assert len(survreg.std_errors) == 3
+    assert len(survreg.ci_lower) == 3
+    assert len(survreg.ci_upper) == 3
+    assert len(survreg.bootstrap_samples) > 0
+    assert np.all(np.isfinite(survreg.coefficients))
+
+
+def test_bootstrap_ci_helpers_are_deterministic_with_seed():
+    time = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+    status_i32 = [1, 1, 0, 1, 0, 1]
+    status_f64 = [float(value) for value in status_i32]
+    cox_covariates = [[0.1], [0.2], [0.3], [0.4], [0.5], [0.6]]
+    survreg_covariates = [[1.0, 0.1], [1.0, 0.2], [1.0, 0.3], [1.0, 0.4], [1.0, 0.5], [1.0, 0.6]]
+
+    first_cox = survival.bootstrap_cox_ci(
+        time,
+        status_i32,
+        cox_covariates,
+        n_bootstrap=8,
+        confidence_level=0.9,
+        seed=321,
+    )
+    second_cox = survival.bootstrap_cox_ci(
+        time,
+        status_i32,
+        cox_covariates,
+        n_bootstrap=8,
+        confidence_level=0.9,
+        seed=321,
+    )
+    assert first_cox.coefficients == pytest.approx(second_cox.coefficients)
+    assert first_cox.std_errors == pytest.approx(second_cox.std_errors)
+    assert first_cox.ci_lower == pytest.approx(second_cox.ci_lower)
+    assert first_cox.ci_upper == pytest.approx(second_cox.ci_upper)
+    assert first_cox.bootstrap_samples == second_cox.bootstrap_samples
+
+    first_survreg = survival.bootstrap_survreg_ci(
+        time,
+        status_f64,
+        survreg_covariates,
+        distribution="weibull",
+        n_bootstrap=8,
+        confidence_level=0.9,
+        seed=321,
+    )
+    second_survreg = survival.bootstrap_survreg_ci(
+        time,
+        status_f64,
+        survreg_covariates,
+        distribution="weibull",
+        n_bootstrap=8,
+        confidence_level=0.9,
+        seed=321,
+    )
+    assert first_survreg.coefficients == pytest.approx(second_survreg.coefficients)
+    assert first_survreg.std_errors == pytest.approx(second_survreg.std_errors)
+    assert first_survreg.ci_lower == pytest.approx(second_survreg.ci_lower)
+    assert first_survreg.ci_upper == pytest.approx(second_survreg.ci_upper)
+    assert first_survreg.bootstrap_samples == second_survreg.bootstrap_samples
+
+
+def test_bootstrap_ci_helpers_validate_inputs():
+    time = [1.0, 2.0, 3.0, 4.0]
+    status_i32 = [1, 1, 0, 1]
+    status_f64 = [float(value) for value in status_i32]
+    covariates = [[0.1], [0.2], [0.3], [0.4]]
+
+    with pytest.raises(ValueError, match="n_bootstrap must be at least 2"):
+        survival.bootstrap_cox_ci(time, status_i32, covariates, n_bootstrap=1)
+
+    with pytest.raises(ValueError, match="confidence_level must be between 0 and 1"):
+        survival.bootstrap_survreg_ci(
+            time,
+            status_f64,
+            covariates,
+            distribution="weibull",
+            n_bootstrap=8,
+            confidence_level=1.2,
+        )
+
+
+def test_pystep_helpers():
+    simple = survival.perform_pystep_simple_calculation(
+        1,
+        [0.5],
+        [0],
+        [2],
+        [[0.0, 1.0, 2.0]],
+        10.0,
+    )
+    assert simple["time_step"] == pytest.approx(0.5)
+    assert simple["index"] == 0
+
+    step = survival.perform_pystep_calculation(
+        1,
+        [0.25],
+        [0],
+        [2],
+        [[0.0, 1.0]],
+        1.0,
+    )
+    assert step["time_step"] == pytest.approx(0.75)
+    assert step["current_index"] == 1
+    assert step["next_index"] == 1
+    assert step["weight"] == pytest.approx(1.0)
+    assert step["updated_data"] == [1.0]
+
+    with pytest.raises(RuntimeError, match="Data length does not match odim"):
+        survival.perform_pystep_simple_calculation(2, [0.5], [0], [2], [[0.0, 1.0, 2.0]], 1.0)
+
+
+def test_pyears_helper_basic():
+    result = survival.perform_pyears_calculation(
+        [2.0, 1.0],
+        [1.0],
+        1,
+        [0],
+        [1],
+        [0.0],
+        [0.5],
+        [0.0],
+        1,
+        [0],
+        [1],
+        [0.0, 5.0],
+        1,
+        [0.0],
+        1,
+        2,
+    )
+
+    assert result["pyears"] == [2.0]
+    assert result["pn"] == [1.0]
+    assert result["pcount"] == [1.0]
+    assert result["pexpect"] == [1.0]
+    assert result["offtable"] == pytest.approx(0.0)
+
+
+def test_cox_callback_roundtrip():
+    def callback(coef, *, which):
+        return {
+            "coef": [value + which for value in coef],
+            "first": [1.0, 2.0],
+            "second": [3.0, 4.0],
+            "penalty": [5.0, 6.0],
+            "flag": [True, False],
+        }
+
+    result = survival.cox_callback(
+        2,
+        [1.0, 2.0],
+        [0.0, 0.0],
+        [0.0, 0.0],
+        [0.0, 0.0],
+        [0, 0],
+        callback,
+    )
+
+    assert result == ([3.0, 4.0], [1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [1, 0])

--- a/python/tests/test_calibration_reporting.py
+++ b/python/tests/test_calibration_reporting.py
@@ -36,7 +36,9 @@ def test_calibration_prediction_and_risk_public_apis():
     assert 0.0 <= calibration.hosmer_lemeshow_pvalue <= 1.0
 
     assert prediction.linear_predictor == pytest.approx([0.5, -0.25, 0.25])
-    assert prediction.risk_score == pytest.approx([1.6487212707001282, 0.7788007830714049, 1.2840254166877414])
+    assert prediction.risk_score == pytest.approx(
+        [1.6487212707001282, 0.7788007830714049, 1.2840254166877414]
+    )
     assert prediction.times == pytest.approx([1.5, 2.5])
     assert len(prediction.survival_prob) == 3
     assert all(len(row) == 2 for row in prediction.survival_prob)
@@ -183,7 +185,10 @@ def test_reporting_public_apis_and_validation():
     with pytest.raises(ValueError, match="All input vectors must have the same length"):
         survival.forest_plot_data(["x"], [0.1, 0.2], [0.1], 0.95)
 
-    with pytest.raises(ValueError, match="predicted and observed must have the same non-zero length"):
+    with pytest.raises(
+        ValueError,
+        match="predicted and observed must have the same non-zero length",
+    ):
         survival.calibration_plot_data([0.1], [0, 1], 2)
 
     with pytest.raises(ValueError, match="Both positive and negative labels required"):
@@ -223,5 +228,8 @@ def test_decision_curve_public_apis_and_validation():
     with pytest.raises(ValueError, match="All inputs must have the same non-zero length"):
         survival.decision_curve_analysis([], [], [], 1.0, None)
 
-    with pytest.raises(ValueError, match="model_predictions and model_names must have the same non-zero length"):
+    with pytest.raises(
+        ValueError,
+        match="model_predictions and model_names must have the same non-zero length",
+    ):
         survival.compare_decision_curves([[0.1]], [], [1.0], [1], 1.0, None)

--- a/python/tests/test_calibration_reporting.py
+++ b/python/tests/test_calibration_reporting.py
@@ -1,0 +1,227 @@
+import pytest
+
+from .helpers import setup_survival_import
+
+survival = setup_survival_import()
+
+
+def test_calibration_prediction_and_risk_public_apis():
+    calibration = survival.calibration(
+        predicted_risk=[0.1, 0.2, 0.3, 0.4, 0.7, 0.8, 0.9, 0.95],
+        observed_event=[0, 0, 0, 1, 0, 1, 1, 1],
+        n_groups=4,
+    )
+    prediction = survival.predict_cox(
+        coef=[0.5, -0.25],
+        x=[[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]],
+        baseline_hazard=[0.1, 0.2, 0.15],
+        baseline_times=[1.0, 2.0, 3.0],
+        pred_times=[1.5, 2.5],
+    )
+    stratification = survival.risk_stratification(
+        risk_scores=[0.1, 0.2, 0.3, 0.4, 0.7, 0.8, 0.9, 0.95],
+        events=[0, 0, 0, 1, 0, 1, 1, 1],
+        n_groups=3,
+    )
+    td_auc = survival.td_auc(
+        time=[1.0, 2.0, 3.0, 4.0],
+        status=[1, 1, 0, 1],
+        risk_score=[0.9, 0.7, 0.4, 0.2],
+        eval_times=[1.5, 2.5, 3.5],
+    )
+
+    assert calibration.n_per_group == [2, 2, 2, 2]
+    assert calibration.predicted == pytest.approx([0.15, 0.35, 0.75, 0.925])
+    assert calibration.observed == pytest.approx([0.0, 0.5, 0.5, 1.0])
+    assert 0.0 <= calibration.hosmer_lemeshow_pvalue <= 1.0
+
+    assert prediction.linear_predictor == pytest.approx([0.5, -0.25, 0.25])
+    assert prediction.risk_score == pytest.approx([1.6487212707001282, 0.7788007830714049, 1.2840254166877414])
+    assert prediction.times == pytest.approx([1.5, 2.5])
+    assert len(prediction.survival_prob) == 3
+    assert all(len(row) == 2 for row in prediction.survival_prob)
+
+    assert stratification.cutpoints == pytest.approx([0.3, 0.8])
+    assert stratification.group_sizes == [2, 3, 3]
+    assert stratification.group_event_rates == pytest.approx([0.0, 1.0 / 3.0, 1.0])
+    assert stratification.risk_groups == [0, 0, 1, 1, 1, 2, 2, 2]
+
+    assert td_auc.times == pytest.approx([1.5, 2.5, 3.5])
+    assert td_auc.auc == pytest.approx([1.0, 1.0, 1.0])
+    assert td_auc.integrated_auc == pytest.approx(1.0)
+
+    with pytest.raises(ValueError, match="n_bins must be at least 2"):
+        survival.d_calibration([0.1], [1], 1)
+
+
+def test_timepoint_calibration_public_apis_and_validation():
+    time = list(range(1, 21))
+    status = [1] * 20
+    predicted = [0.99 - i * 0.03 for i in range(20)]
+
+    d_cal = survival.d_calibration(
+        survival_probs=[0.05, 0.15, 0.25, 0.35, 0.45, 0.55, 0.65, 0.75, 0.85, 0.95] * 2,
+        status=[1] * 20,
+        n_bins=5,
+    )
+    one = survival.one_calibration(time, status, predicted, 10.0, 4)
+    plot = survival.calibration_plot(time, status, predicted, 10.0, 4)
+    brier = survival.brier_calibration(time, status, predicted, 10.0, 4)
+    multi = survival.multi_time_calibration(
+        time=[1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+        status=[1, 1, 0, 1, 0, 1],
+        survival_predictions=[
+            [0.95, 0.9],
+            [0.9, 0.8],
+            [0.98, 0.95],
+            [0.85, 0.7],
+            [0.99, 0.97],
+            [0.8, 0.6],
+        ],
+        prediction_times=[2.0, 4.0],
+        n_groups=2,
+    )
+    smooth = survival.smoothed_calibration(
+        time=[1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+        status=[1, 1, 0, 1, 0, 1],
+        predicted_survival_at_t=[0.95, 0.9, 0.98, 0.85, 0.99, 0.8],
+        time_point=4.0,
+        n_grid_points=10,
+        bandwidth=0.1,
+    )
+
+    assert d_cal.n_bins == 5
+    assert d_cal.n_events == 20
+    assert d_cal.observed_counts == [4, 4, 4, 4, 4]
+    assert d_cal.p_value == pytest.approx(1.0)
+    assert d_cal.is_calibrated is True
+
+    assert one.time_point == pytest.approx(10.0)
+    assert one.n_groups == 4
+    assert one.n_per_group == [5, 5, 5, 5]
+    assert one.n_events_per_group == [0, 0, 5, 5]
+    assert one.is_calibrated is False
+
+    assert plot.predicted == pytest.approx([0.4800000000000001, 0.63, 0.78, 0.93])
+    assert plot.observed == pytest.approx([1.0, 1.0, 0.0, 0.0])
+    assert plot.ici == pytest.approx(0.65)
+    assert plot.emax >= plot.e90 >= plot.e50
+
+    assert brier.time_point == pytest.approx(10.0)
+    assert brier.brier_score == pytest.approx(0.47195)
+    assert brier.calibration_slope == pytest.approx(-2.666666666666667)
+    assert brier.ici == pytest.approx(plot.ici)
+
+    assert multi.time_points == pytest.approx([2.0, 4.0])
+    assert len(multi.brier_scores) == 2
+    assert len(multi.calibration_slopes) == 2
+    assert multi.integrated_brier > 0.0
+    assert multi.mean_ici > 0.0
+
+    assert len(smooth.predicted_grid) == 10
+    assert len(smooth.smoothed_observed) == 10
+    assert smooth.bandwidth == pytest.approx(0.1)
+    assert all(0.0 <= value <= 1.0 for value in smooth.ci_lower)
+    assert all(0.0 <= value <= 1.0 for value in smooth.ci_upper)
+
+    with pytest.raises(ValueError, match="All input vectors must have the same length"):
+        survival.one_calibration([1.0], [1, 0], [0.9], 1.0, 2)
+
+    with pytest.raises(ValueError, match="survival_predictions row 0 has 2 elements, expected 1"):
+        survival.multi_time_calibration([1.0], [1], [[0.9, 0.8]], [1.0], 2)
+
+    with pytest.raises(ValueError, match="n_grid_points must be at least 10"):
+        survival.smoothed_calibration([1.0], [1], [0.9], 1.0, 5, None)
+
+
+def test_reporting_public_apis_and_validation():
+    km = survival.km_plot_data([1.0, 2.0, 3.0, 4.0, 5.0], [1, 0, 1, 0, 1], 0.95, "Test")
+    forest = survival.forest_plot_data(["age", "trt"], [0.2, -0.3], [0.1, 0.15], 0.95)
+    calibration_curve = survival.calibration_plot_data(
+        [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8],
+        [0, 0, 0, 1, 0, 1, 1, 1],
+        4,
+    )
+    report = survival.generate_survival_report(
+        "Test Report",
+        [1.0, 2.0, 3.0, 4.0, 5.0],
+        [1, 0, 1, 0, 1],
+        [2.0, 4.0],
+    )
+    roc = survival.roc_plot_data([0.9, 0.8, 0.7, 0.6, 0.3, 0.2], [1, 1, 1, 0, 0, 0])
+
+    assert km.group_name == "Test"
+    assert km.time_points == pytest.approx([0.0, 1.0, 2.0, 3.0, 4.0, 5.0])
+    assert km.at_risk == [5, 5, 4, 3, 2, 1]
+    assert km.survival_prob[0] == pytest.approx(1.0)
+
+    assert forest.hazard_ratios == pytest.approx([1.2214027581601699, 0.7408182206817179])
+    assert forest.significant_at(0.2) == [True, True]
+    assert all(value > 0.0 for value in forest.lower_ci)
+
+    assert calibration_curve.predicted_prob == pytest.approx([0.15, 0.35, 0.55, 0.75])
+    assert calibration_curve.observed_prob == pytest.approx([0.0, 0.5, 0.5, 1.0])
+    assert calibration_curve.n_per_bin == [2, 2, 2, 2]
+    assert len(calibration_curve.bin_boundaries) == 5
+
+    assert report.title == "Test Report"
+    assert report.n_subjects == 5
+    assert report.n_events == 3
+    assert report.median_survival == pytest.approx(5.0)
+    assert report.rmst == pytest.approx(3.666666666666667)
+    assert "# Test Report" in report.to_markdown()
+    assert "\\section{Test Report}" in report.to_latex()
+
+    assert roc.auc == pytest.approx(1.0)
+    assert roc.fpr[0] == pytest.approx(0.0)
+    assert roc.tpr[-1] == pytest.approx(1.0)
+    assert roc.optimal_threshold("youden") == pytest.approx(0.7)
+
+    with pytest.raises(ValueError, match="time and event must have the same non-zero length"):
+        survival.km_plot_data([], [], 0.95, None)
+
+    with pytest.raises(ValueError, match="All input vectors must have the same length"):
+        survival.forest_plot_data(["x"], [0.1, 0.2], [0.1], 0.95)
+
+    with pytest.raises(ValueError, match="predicted and observed must have the same non-zero length"):
+        survival.calibration_plot_data([0.1], [0, 1], 2)
+
+    with pytest.raises(ValueError, match="Both positive and negative labels required"):
+        survival.roc_plot_data([0.1, 0.2], [1, 1])
+
+
+def test_decision_curve_public_apis_and_validation():
+    result = survival.decision_curve_analysis(
+        predicted_risk=[0.1, 0.3, 0.5, 0.7, 0.9],
+        time=[1.0, 2.0, 3.0, 4.0, 5.0],
+        event=[0, 1, 0, 1, 1],
+        time_horizon=3.0,
+        thresholds=[0.25, 0.5, 0.75],
+    )
+    comparison = survival.compare_decision_curves(
+        model_predictions=[
+            [0.1, 0.3, 0.5, 0.7, 0.9],
+            [0.2, 0.2, 0.4, 0.6, 0.8],
+        ],
+        model_names=["m1", "m2"],
+        time=[1.0, 2.0, 3.0, 4.0, 5.0],
+        event=[0, 1, 0, 1, 1],
+        time_horizon=3.0,
+        thresholds=[0.25, 0.5, 0.75],
+    )
+
+    assert result.thresholds == pytest.approx([0.25, 0.5, 0.75])
+    assert result.net_benefit_none == pytest.approx([0.0, 0.0, 0.0])
+    assert result.optimal_threshold() == pytest.approx(0.25)
+    assert result.area_under_curve() == pytest.approx(0.0)
+
+    assert comparison.model_names == ["m1", "m2"]
+    assert comparison.best_model_per_threshold == ["m1", "m2", "m2"]
+    assert len(comparison.net_benefit_difference) == 2
+    assert len(comparison.net_benefit_difference[0]) == 2
+
+    with pytest.raises(ValueError, match="All inputs must have the same non-zero length"):
+        survival.decision_curve_analysis([], [], [], 1.0, None)
+
+    with pytest.raises(ValueError, match="model_predictions and model_names must have the same non-zero length"):
+        survival.compare_decision_curves([[0.1]], [], [1.0], [1], 1.0, None)

--- a/python/tests/test_case_cohort_and_multistate.py
+++ b/python/tests/test_case_cohort_and_multistate.py
@@ -1,0 +1,220 @@
+import math
+
+import pytest
+
+from .helpers import setup_survival_import
+
+survival = setup_survival_import()
+
+
+def _matched_clogit_dataset():
+    dataset = survival.ClogitDataSet()
+    for case_status, stratum, covariates in [
+        (1, 0, [2.0]),
+        (0, 0, [1.0]),
+        (1, 1, [3.0]),
+        (0, 1, [1.0]),
+    ]:
+        dataset.add_observation(case_status, stratum, covariates)
+    return dataset
+
+
+def _simple_subject(subject_id, covariate, *, is_case, is_subcohort):
+    return survival.Subject(
+        id=subject_id,
+        covariates=[covariate],
+        is_case=is_case,
+        is_subcohort=is_subcohort,
+        stratum=0,
+    )
+
+
+def _survfitaj_kwargs(*, sefit):
+    return {
+        "y": [0.0, 1.0, 1.0, 0.0, 2.0, 1.0, 0.0, 2.0, 0.0],
+        "sort1": [0, 1, 2],
+        "sort2": [0, 1, 2],
+        "utime": [1.0, 2.0],
+        "cstate": [0, 0, 0],
+        "wt": [1.0, 1.0, 1.0],
+        "grp": [0, 0, 0],
+        "ngrp": 1,
+        "p0": [1.0, 0.0],
+        "i0": [0.0, 0.0],
+        "sefit": sefit,
+        "entry": False,
+        "position": [2, 2, 2],
+        "hindx": [[0]],
+        "trmat": [[0, 1]],
+        "t0": 0.0,
+    }
+
+
+def test_clogit_dataset_tracks_observations_and_covariates():
+    dataset = _matched_clogit_dataset()
+
+    assert dataset.get_num_observations() == 4
+    assert dataset.get_num_covariates() == 1
+
+
+def test_conditional_logistic_regression_fit_populates_outputs():
+    model = survival.ConditionalLogisticRegression(_matched_clogit_dataset(), max_iter=20, tol=1e-9)
+    model.fit()
+
+    assert len(model.coefficients) == 1
+    assert 1 <= model.iterations <= 20
+    assert isinstance(model.converged, bool)
+    assert model.coefficients[0] > 0.0
+    assert model.predict([2.0]) > model.predict([1.0])
+    assert model.odds_ratios()[0] == pytest.approx(math.exp(model.coefficients[0]))
+
+
+def test_conditional_logistic_regression_is_invariant_to_row_order():
+    forward = survival.ConditionalLogisticRegression(_matched_clogit_dataset(), max_iter=20, tol=1e-9)
+
+    reversed_dataset = survival.ClogitDataSet()
+    for case_status, stratum, covariates in reversed(
+        [
+            (1, 0, [2.0]),
+            (0, 0, [1.0]),
+            (1, 1, [3.0]),
+            (0, 1, [1.0]),
+        ]
+    ):
+        reversed_dataset.add_observation(case_status, stratum, covariates)
+    backward = survival.ConditionalLogisticRegression(reversed_dataset, max_iter=20, tol=1e-9)
+
+    forward.fit()
+    backward.fit()
+
+    assert backward.coefficients == pytest.approx(forward.coefficients)
+
+
+def test_conditional_logistic_regression_uses_strata():
+    pooled_dataset = survival.ClogitDataSet()
+    for case_status, stratum, covariates in [
+        (1, 0, [5.0]),
+        (0, 0, [0.0]),
+        (1, 1, [1.0]),
+        (0, 1, [-4.0]),
+    ]:
+        pooled_dataset.add_observation(case_status, 0, covariates)
+
+    matched_dataset = survival.ClogitDataSet()
+    for case_status, stratum, covariates in [
+        (1, 0, [5.0]),
+        (0, 0, [0.0]),
+        (1, 1, [1.0]),
+        (0, 1, [-4.0]),
+    ]:
+        matched_dataset.add_observation(case_status, stratum, covariates)
+
+    matched = survival.ConditionalLogisticRegression(matched_dataset, max_iter=20, tol=1e-9)
+    pooled = survival.ConditionalLogisticRegression(pooled_dataset, max_iter=20, tol=1e-9)
+
+    matched.fit()
+    pooled.fit()
+
+    assert matched.coefficients[0] != pytest.approx(pooled.coefficients[0])
+
+
+def test_case_cohort_prentice_accepts_public_enum_value():
+    cohort = survival.CohortData.new()
+    cohort.add_subject(_simple_subject(1, 0.1, is_case=True, is_subcohort=True))
+    cohort.add_subject(_simple_subject(2, 0.2, is_case=False, is_subcohort=True))
+
+    fitted = cohort.fit(survival.CchMethod.Prentice, max_iter=5)
+
+    assert hasattr(fitted, "coefficients")
+    assert len(fitted.coefficients) == 1
+
+
+@pytest.mark.parametrize(
+    "method",
+    [
+        survival.CchMethod.SelfPrentice,
+        survival.CchMethod.LinYing,
+        survival.CchMethod.IBorgan,
+        survival.CchMethod.IIBorgan,
+    ],
+)
+def test_case_cohort_unimplemented_methods_raise(method):
+    cohort = survival.CohortData.new()
+    cohort.add_subject(_simple_subject(1, 0.1, is_case=True, is_subcohort=True))
+    cohort.add_subject(_simple_subject(2, 0.2, is_case=False, is_subcohort=True))
+
+    with pytest.raises(NotImplementedError, match="only Prentice is currently supported"):
+        cohort.fit(method, max_iter=5)
+
+
+def test_case_cohort_fit_ignores_noncase_outside_subcohort_subjects():
+    base = survival.CohortData.new()
+    base.add_subject(_simple_subject(1, 0.1, is_case=True, is_subcohort=True))
+    base.add_subject(_simple_subject(2, 0.2, is_case=False, is_subcohort=True))
+
+    with_extra = survival.CohortData.new()
+    with_extra.add_subject(_simple_subject(1, 0.1, is_case=True, is_subcohort=True))
+    with_extra.add_subject(_simple_subject(2, 0.2, is_case=False, is_subcohort=True))
+    with_extra.add_subject(_simple_subject(3, 10.0, is_case=False, is_subcohort=False))
+
+    base_fit = base.fit(survival.CchMethod.Prentice, max_iter=5)
+    extra_fit = with_extra.fit(survival.CchMethod.Prentice, max_iter=5)
+
+    assert extra_fit.coefficients == base_fit.coefficients
+
+
+def test_case_cohort_fit_includes_cases_outside_subcohort():
+    cohort = survival.CohortData.new()
+    cohort.add_subject(_simple_subject(1, 0.1, is_case=True, is_subcohort=False))
+    cohort.add_subject(_simple_subject(2, 0.2, is_case=False, is_subcohort=True))
+
+    fitted = cohort.fit(survival.CchMethod.Prentice, max_iter=5)
+
+    assert len(fitted.risk_scores) == 2
+
+
+def test_cohort_data_returns_added_subject():
+    cohort = survival.CohortData.new()
+    cohort.add_subject(_simple_subject(7, 1.5, is_case=True, is_subcohort=True))
+
+    subject = cohort.get_subject(0)
+
+    assert subject.id == 7
+    assert subject.covariates == [1.5]
+    assert subject.is_subcohort is True
+
+
+def test_survfitaj_basic_outputs_are_consistent():
+    result = survival.survfitaj(**_survfitaj_kwargs(sefit=0))
+
+    assert len(result.pstate) == 2
+    assert result.n_enter is None
+    assert result.std_err is None
+    assert result.influence is None
+    assert result.pstate[0] == pytest.approx([1.0, 0.0])
+    assert result.pstate[1] == pytest.approx([0.5, 0.5])
+    assert result.cumhaz[0][0] <= result.cumhaz[1][0]
+    assert sum(result.pstate[0]) == pytest.approx(1.0)
+    assert sum(result.pstate[1]) == pytest.approx(1.0)
+    assert result.n_censor[1][0] == pytest.approx(1.0)
+    assert result.n_transition[1] == pytest.approx([1.0, 1.0])
+
+
+def test_survfitaj_returns_standard_errors_when_requested():
+    result = survival.survfitaj(**_survfitaj_kwargs(sefit=1))
+
+    assert result.std_err is not None
+    assert result.std_chaz is not None
+    assert result.std_auc is not None
+    assert result.influence is None
+    assert len(result.std_err) == len(result.pstate)
+    assert len(result.std_err[0]) == len(result.pstate[0])
+    assert len(result.std_chaz[0]) == len(result.cumhaz[0])
+
+
+def test_survfitaj_rejects_ragged_hindx():
+    kwargs = _survfitaj_kwargs(sefit=0)
+    kwargs["hindx"] = [[0, 1], [2]]
+
+    with pytest.raises(ValueError, match="Invalid hindx array"):
+        survival.survfitaj(**kwargs)

--- a/python/tests/test_case_cohort_and_multistate.py
+++ b/python/tests/test_case_cohort_and_multistate.py
@@ -70,7 +70,9 @@ def test_conditional_logistic_regression_fit_populates_outputs():
 
 
 def test_conditional_logistic_regression_is_invariant_to_row_order():
-    forward = survival.ConditionalLogisticRegression(_matched_clogit_dataset(), max_iter=20, tol=1e-9)
+    forward = survival.ConditionalLogisticRegression(
+        _matched_clogit_dataset(), max_iter=20, tol=1e-9
+    )
 
     reversed_dataset = survival.ClogitDataSet()
     for case_status, stratum, covariates in reversed(
@@ -92,7 +94,7 @@ def test_conditional_logistic_regression_is_invariant_to_row_order():
 
 def test_conditional_logistic_regression_uses_strata():
     pooled_dataset = survival.ClogitDataSet()
-    for case_status, stratum, covariates in [
+    for case_status, _stratum, covariates in [
         (1, 0, [5.0]),
         (0, 0, [0.0]),
         (1, 1, [1.0]),

--- a/python/tests/test_core.py
+++ b/python/tests/test_core.py
@@ -96,7 +96,7 @@ def test_cox_score_residuals_public_api():
 
     assert len(breslow) == 4
     assert len(efron) == 4
-    assert any(abs(a - b) > 1e-12 for a, b in zip(breslow, efron))
+    assert any(abs(a - b) > 1e-12 for a, b in zip(breslow, efron, strict=True))
 
     with pytest.raises(ValueError, match="y array must have length >= 2 \\* n"):
         survival.cox_score_residuals(

--- a/python/tests/test_core.py
+++ b/python/tests/test_core.py
@@ -1,3 +1,5 @@
+import pytest
+
 from .helpers import setup_survival_import
 
 survival = setup_survival_import()
@@ -27,3 +29,81 @@ def test_coxcount2():
     result2 = survival.coxcount2(time1, time2, status, sort1, sort2, strata2)
     assert hasattr(result2, "time")
     assert hasattr(result2, "nrisk")
+
+
+def test_score_calculation_public_api():
+    result = survival.perform_score_calculation(
+        time_data=[0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 0.0, 1.0, 0.0],
+        covariates=[0.5, 1.0, 1.5],
+        strata=[0, 0, 0],
+        score=[1.0, 1.0, 1.0],
+        weights=[1.0, 1.0, 1.0],
+        method=0,
+    )
+
+    assert result["n_observations"] == 3
+    assert result["n_variables"] == 1
+    assert result["method"] == "breslow"
+    assert len(result["residuals"]) == 3
+    assert len(result["summary_stats"]) == 2
+
+
+def test_agscore3_public_api_and_validation():
+    result = survival.perform_agscore3_calculation(
+        time_data=[0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 0.0, 1.0, 0.0],
+        covariates=[0.5, 1.0, 1.5],
+        strata=[0, 0, 0],
+        score=[1.0, 1.0, 1.0],
+        weights=[1.0, 1.0, 1.0],
+        method=0,
+        sort1=[1, 2, 3],
+    )
+
+    assert result["method"] == "breslow"
+    assert len(result["residuals"]) == 3
+
+    with pytest.raises(RuntimeError, match="Sort1 length does not match observations"):
+        survival.perform_agscore3_calculation(
+            time_data=[0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 0.0, 1.0, 0.0],
+            covariates=[0.5, 1.0, 1.5],
+            strata=[0, 0, 0],
+            score=[1.0, 1.0, 1.0],
+            weights=[1.0, 1.0, 1.0],
+            method=0,
+            sort1=[1, 2],
+        )
+
+
+def test_cox_score_residuals_public_api():
+    breslow = survival.cox_score_residuals(
+        y=[1.0, 1.0, 2.0, 3.0, 1.0, 1.0, 0.0, 0.0],
+        strata=[0, 0, 0, 0],
+        covar=[1.0, 2.0, 3.0, 4.0],
+        score=[1.0, 1.0, 1.0, 1.0],
+        weights=[1.0, 1.0, 1.0, 1.0],
+        nvar=1,
+        method=0,
+    )
+    efron = survival.cox_score_residuals(
+        y=[1.0, 1.0, 2.0, 3.0, 1.0, 1.0, 0.0, 0.0],
+        strata=[0, 0, 0, 0],
+        covar=[1.0, 2.0, 3.0, 4.0],
+        score=[1.0, 1.0, 1.0, 1.0],
+        weights=[1.0, 1.0, 1.0, 1.0],
+        nvar=1,
+        method=1,
+    )
+
+    assert len(breslow) == 4
+    assert len(efron) == 4
+    assert any(abs(a - b) > 1e-12 for a, b in zip(breslow, efron))
+
+    with pytest.raises(ValueError, match="y array must have length >= 2 \\* n"):
+        survival.cox_score_residuals(
+            y=[1.0, 2.0],
+            strata=[0, 0, 0],
+            covar=[1.0, 2.0, 3.0],
+            score=[1.0, 1.0, 1.0],
+            weights=[1.0, 1.0, 1.0],
+            nvar=1,
+        )

--- a/python/tests/test_regression.py
+++ b/python/tests/test_regression.py
@@ -1,3 +1,7 @@
+import math
+
+import pytest
+
 from .helpers import setup_survival_import
 
 survival = setup_survival_import()
@@ -119,3 +123,161 @@ def test_subject():
     )
     assert subject.id == 1
     assert subject.is_case is True
+
+
+def test_aareg_public_api():
+    options = survival.AaregOptions(
+        formula="time ~ x1",
+        data=[[1.0, 2.0], [2.0, 3.0], [3.0, 4.0], [4.0, 5.0]],
+        variable_names=["time", "x1"],
+        max_iter=20,
+    )
+
+    result = survival.aareg(options)
+
+    assert len(result.coefficients) == 2
+    assert len(result.standard_errors) == 2
+    assert len(result.confidence_intervals) == 2
+    assert len(result.p_values) == 2
+    assert result.fit_details is not None
+    assert result.fit_details.iterations <= 20
+    assert result.fit_details.converged is True
+    assert len(result.residuals) == 4
+    assert math.isfinite(result.goodness_of_fit)
+
+
+def test_aareg_rejects_invalid_formula():
+    options = survival.AaregOptions(
+        formula="time",
+        data=[[1.0, 2.0], [2.0, 3.0]],
+        variable_names=["time", "x1"],
+        max_iter=5,
+    )
+
+    with pytest.raises(RuntimeError, match="Formula Error"):
+        survival.aareg(options)
+
+
+def test_coxph_detail_public_api():
+    detail = survival.coxph_detail(
+        time=[1.0, 2.0, 3.0],
+        status=[1, 0, 1],
+        covariates=[[1.0], [2.0], [3.0]],
+        coefficients=[0.5],
+    )
+
+    assert detail.n_events == 2
+    assert detail.n_observations == 3
+    assert detail.n_covariates == 1
+    assert detail.times() == [1.0, 3.0]
+    assert len(detail.hazards()) == 2
+    assert detail.cumulative_hazards()[0] <= detail.cumulative_hazards()[1]
+    assert detail.n_risk_at_times() == [3, 1]
+    assert len(detail.schoenfeld_residuals()) == 2
+
+
+def test_coxph_detail_validates_input_lengths():
+    with pytest.raises(ValueError, match="must have the same length"):
+        survival.coxph_detail(
+            time=[1.0, 2.0],
+            status=[1],
+            covariates=[[1.0], [2.0]],
+            coefficients=[0.5],
+        )
+
+
+def test_predict_survreg_linear_predictor_and_standard_errors():
+    prediction = survival.predict_survreg(
+        covariates=[[1.0, 2.0], [2.0, 3.0]],
+        coefficients=[0.1, 0.2],
+        scale=1.0,
+        distribution="weibull",
+        predict_type="lp",
+        var_matrix=[[1.0, 0.0], [0.0, 1.0]],
+        se_fit=True,
+    )
+
+    assert prediction.predictions == pytest.approx([0.5, 0.8])
+    assert prediction.se == pytest.approx([5**0.5, 13**0.5])
+    assert prediction.prediction_type == "lp"
+    assert prediction.n == 2
+
+
+def test_predict_survreg_quantiles_and_validation():
+    quantiles = survival.predict_survreg_quantile(
+        covariates=[[1.0, 2.0], [2.0, 3.0]],
+        coefficients=[0.1, 0.2],
+        scale=1.0,
+        distribution="weibull",
+        quantiles=[0.25, 0.5],
+    )
+
+    assert quantiles.quantiles == [0.25, 0.5]
+    assert len(quantiles.predictions) == 2
+    assert all(len(row) == 2 for row in quantiles.predictions)
+
+    with pytest.raises(ValueError, match="Quantiles must be between 0 and 1"):
+        survival.predict_survreg_quantile(
+            covariates=[[1.0, 2.0]],
+            coefficients=[0.1, 0.2],
+            scale=1.0,
+            distribution="weibull",
+            quantiles=[0.0],
+        )
+
+
+def test_predict_survreg_rejects_invalid_scale():
+    with pytest.raises(ValueError, match="scale must be a finite positive value"):
+        survival.predict_survreg(
+            covariates=[[1.0, 2.0]],
+            coefficients=[0.1, 0.2],
+            scale=0.0,
+            distribution="weibull",
+        )
+
+
+def test_survfit_and_survreg_residual_public_apis():
+    survfit_residuals = survival.residuals_survfit(
+        time=[1.0, 2.0, 3.0],
+        status=[1, 0, 1],
+        surv_time=[1.0, 2.0, 3.0],
+        surv=[0.9, 0.8, 0.7],
+        residual_type="deviance",
+    )
+    survreg_residuals = survival.residuals_survreg(
+        time=[1.0, 2.0, 3.0],
+        status=[1, 0, 1],
+        linear_pred=[0.0, 0.5, 1.0],
+        scale=1.0,
+        distribution="weibull",
+        residual_type="working",
+    )
+
+    assert len(survfit_residuals.residuals) == 3
+    assert survfit_residuals.time == [1.0, 2.0, 3.0]
+    assert survfit_residuals.residual_type == "deviance"
+    assert len(survreg_residuals.residuals) == 3
+    assert survreg_residuals.residual_type == "working"
+    assert survreg_residuals.n == 3
+
+
+def test_residual_apis_validate_type_and_lengths():
+    with pytest.raises(ValueError, match="Unknown residual type"):
+        survival.residuals_survfit(
+            time=[1.0],
+            status=[1],
+            surv_time=[1.0],
+            surv=[0.9],
+            residual_type="unknown",
+        )
+
+    with pytest.raises(ValueError, match="All inputs must have the same length"):
+        survival.dfbeta_survreg(
+            time=[1.0, 2.0],
+            status=[1, 0],
+            covariates=[[1.0]],
+            linear_pred=[0.0, 0.5],
+            scale=1.0,
+            var_matrix=[[1.0]],
+            distribution="weibull",
+        )

--- a/python/tests/test_sklearn_compat_additional.py
+++ b/python/tests/test_sklearn_compat_additional.py
@@ -94,17 +94,35 @@ def test_tree_estimators_smoke():
 
 
 @pytest.mark.parametrize(
-    "estimator_cls, kwargs",
+    ("estimator_cls", "kwargs"),
     [
         (CoxPHEstimator, {"n_iters": 5}),
-        (GradientBoostSurvivalEstimator, {"n_estimators": 5, "max_depth": 2, "min_samples_split": 2, "min_samples_leaf": 1, "seed": 1}),
-        (SurvivalForestEstimator, {"n_trees": 5, "min_node_size": 1, "sample_fraction": 0.8, "seed": 1, "oob_error": False}),
+        (
+            GradientBoostSurvivalEstimator,
+            {
+                "n_estimators": 5,
+                "max_depth": 2,
+                "min_samples_split": 2,
+                "min_samples_leaf": 1,
+                "seed": 1,
+            },
+        ),
+        (
+            SurvivalForestEstimator,
+            {
+                "n_trees": 5,
+                "min_node_size": 1,
+                "sample_fraction": 0.8,
+                "seed": 1,
+                "oob_error": False,
+            },
+        ),
     ],
 )
 def test_estimators_require_fit_before_predict(estimator_cls, kwargs):
     estimator = estimator_cls(**kwargs)
 
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError, match="not fitted"):
         estimator.predict(np.array([[0.1]], dtype=np.float64))
 
 
@@ -179,10 +197,10 @@ def test_sklearn_compat_fallback_without_sklearn(monkeypatch):
     module_path = Path(sklearn_compat.__file__)
     original_import = builtins.__import__
 
-    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+    def fake_import(name, globalns=None, localns=None, fromlist=(), level=0):
         if name.startswith("sklearn"):
             raise ImportError("scikit-learn intentionally unavailable")
-        return original_import(name, globals, locals, fromlist, level)
+        return original_import(name, globalns, localns, fromlist, level)
 
     monkeypatch.setattr(builtins, "__import__", fake_import)
     spec = importlib.util.spec_from_file_location("survival.sklearn_compat_no_sklearn", module_path)

--- a/python/tests/test_sklearn_compat_additional.py
+++ b/python/tests/test_sklearn_compat_additional.py
@@ -1,0 +1,201 @@
+import builtins
+import importlib
+import importlib.util
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from .helpers import setup_survival_import
+
+setup_survival_import()
+sklearn_compat = importlib.import_module("survival.sklearn_compat")
+
+CoxPHEstimator = sklearn_compat.CoxPHEstimator
+GradientBoostSurvivalEstimator = sklearn_compat.GradientBoostSurvivalEstimator
+SurvivalForestEstimator = sklearn_compat.SurvivalForestEstimator
+StreamingCoxPHEstimator = sklearn_compat.StreamingCoxPHEstimator
+StreamingGradientBoostSurvivalEstimator = sklearn_compat.StreamingGradientBoostSurvivalEstimator
+StreamingSurvivalForestEstimator = sklearn_compat.StreamingSurvivalForestEstimator
+iter_chunks = sklearn_compat.iter_chunks
+predict_large_dataset = sklearn_compat.predict_large_dataset
+survival_curves_to_disk = sklearn_compat.survival_curves_to_disk
+
+
+def _toy_data():
+    x = np.array([[0.1], [0.2], [0.3], [0.4], [0.5], [0.6], [0.7], [0.8]], dtype=np.float64)
+    y = np.column_stack(
+        [
+            [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+            [1, 1, 0, 1, 0, 1, 1, 0],
+        ]
+    )
+    return x, y
+
+
+def test_coxph_estimator_smoke():
+    x, y = _toy_data()
+    estimator = CoxPHEstimator(n_iters=10)
+    estimator.fit(x, y)
+
+    risk = estimator.predict(x)
+    times, survival = estimator.predict_survival_function(x)
+    median = estimator.predict_median_survival_time(x)
+
+    assert risk.shape == (x.shape[0],)
+    assert times.shape == (x.shape[0],)
+    assert survival.shape == (x.shape[0], x.shape[0])
+    assert median.shape == (x.shape[0],)
+    assert 0.0 <= estimator.score(x, y) <= 1.0
+
+
+def test_coxph_estimator_custom_times_and_feature_validation():
+    x, y = _toy_data()
+    estimator = CoxPHEstimator(n_iters=10)
+    estimator.fit(x, y)
+
+    custom_times = np.array([2.0, 4.0, 6.0], dtype=np.float64)
+    returned_times, survival = estimator.predict_survival_function(x[:2], times=custom_times)
+
+    assert returned_times.tolist() == pytest.approx(custom_times.tolist())
+    assert survival.shape == (2, 3)
+
+    with pytest.raises(ValueError, match="expects 1"):
+        estimator.predict(np.array([[0.1, 0.2]], dtype=np.float64))
+
+
+def test_tree_estimators_smoke():
+    x, y = _toy_data()
+
+    boost = GradientBoostSurvivalEstimator(
+        n_estimators=5,
+        learning_rate=0.1,
+        max_depth=2,
+        min_samples_split=2,
+        min_samples_leaf=1,
+        seed=1,
+    )
+    boost.fit(x, y)
+    assert boost.predict(x).shape == (x.shape[0],)
+    assert boost.predict_survival_function(x)[1].shape == (x.shape[0], x.shape[0])
+    assert boost.predict_median_survival_time(x).shape == (x.shape[0],)
+
+    forest = SurvivalForestEstimator(
+        n_trees=5,
+        min_node_size=1,
+        sample_fraction=0.8,
+        seed=1,
+        oob_error=False,
+    )
+    forest.fit(x, y)
+    assert forest.predict(x).shape == (x.shape[0],)
+    assert forest.predict_survival_function(x)[1].shape == (x.shape[0], x.shape[0])
+    assert forest.predict_median_survival_time(x).shape == (x.shape[0],)
+
+
+@pytest.mark.parametrize(
+    "estimator_cls, kwargs",
+    [
+        (CoxPHEstimator, {"n_iters": 5}),
+        (GradientBoostSurvivalEstimator, {"n_estimators": 5, "max_depth": 2, "min_samples_split": 2, "min_samples_leaf": 1, "seed": 1}),
+        (SurvivalForestEstimator, {"n_trees": 5, "min_node_size": 1, "sample_fraction": 0.8, "seed": 1, "oob_error": False}),
+    ],
+)
+def test_estimators_require_fit_before_predict(estimator_cls, kwargs):
+    estimator = estimator_cls(**kwargs)
+
+    with pytest.raises(Exception):
+        estimator.predict(np.array([[0.1]], dtype=np.float64))
+
+
+def test_streaming_helpers_and_disk_io(tmp_path):
+    x, y = _toy_data()
+    estimator = StreamingCoxPHEstimator(n_iters=10)
+    estimator.fit(x, y)
+
+    chunks = list(iter_chunks(x, batch_size=3))
+    assert [start for start, _ in chunks] == [0, 3, 6]
+    assert [chunk.shape[0] for _, chunk in chunks] == [3, 3, 2]
+
+    batched = np.concatenate(list(estimator.predict_batched(x, batch_size=3)))
+    assert batched.shape == (x.shape[0],)
+
+    survival_batches = list(estimator.predict_survival_batched(x, batch_size=3))
+    assert len(survival_batches) == 3
+    assert survival_batches[0][1].shape[1] == x.shape[0]
+
+    out = np.empty(x.shape[0], dtype=np.float64)
+    returned = estimator.predict_to_array(x, batch_size=3, out=out)
+    assert returned is out
+    assert np.all(np.isfinite(out))
+
+    prediction_file = tmp_path / "predictions.dat"
+    large = predict_large_dataset(estimator, x, batch_size=3, output_file=str(prediction_file))
+    assert prediction_file.exists()
+    assert large.shape == (x.shape[0],)
+
+    survival_file = tmp_path / "survival_curves.dat"
+    times, survival = survival_curves_to_disk(estimator, x, str(survival_file), batch_size=3)
+    assert survival_file.exists()
+    assert times.shape == (x.shape[0],)
+    assert survival.shape == (x.shape[0], x.shape[0])
+
+
+def test_streaming_tree_estimators_smoke():
+    x, y = _toy_data()
+
+    boost = StreamingGradientBoostSurvivalEstimator(
+        n_estimators=5,
+        learning_rate=0.1,
+        max_depth=2,
+        min_samples_split=2,
+        min_samples_leaf=1,
+        seed=1,
+    )
+    boost.fit(x, y)
+    assert np.concatenate(list(boost.predict_batched(x, batch_size=3))).shape == (x.shape[0],)
+
+    forest = StreamingSurvivalForestEstimator(
+        n_trees=5,
+        min_node_size=1,
+        sample_fraction=0.8,
+        seed=1,
+        oob_error=False,
+    )
+    forest.fit(x, y)
+    assert np.concatenate(list(forest.predict_batched(x, batch_size=3))).shape == (x.shape[0],)
+
+
+def test_predict_to_array_validates_output_shape():
+    x, y = _toy_data()
+    estimator = StreamingCoxPHEstimator(n_iters=10)
+    estimator.fit(x, y)
+
+    with pytest.raises(ValueError, match=r"expected \(8,\)"):
+        estimator.predict_to_array(x, out=np.empty(4, dtype=np.float64))
+
+
+def test_sklearn_compat_fallback_without_sklearn(monkeypatch):
+    module_path = Path(sklearn_compat.__file__)
+    original_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name.startswith("sklearn"):
+            raise ImportError("scikit-learn intentionally unavailable")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    spec = importlib.util.spec_from_file_location("survival.sklearn_compat_no_sklearn", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+
+    assert module._HAS_SKLEARN is False
+
+    estimator = module.CoxPHEstimator()
+    assert estimator.get_params() == {"n_iters": 20}
+    estimator.set_params(n_iters=7)
+    assert estimator.n_iters == 7
+
+    with pytest.raises(ValueError, match="not fitted yet"):
+        estimator.predict(np.array([[0.1]], dtype=np.float64))

--- a/python/tests/test_specialized.py
+++ b/python/tests/test_specialized.py
@@ -112,7 +112,10 @@ def test_survexp_validates_method():
         rates_female=[0.000008, 0.00004],
     )
 
-    with pytest.raises(ValueError, match="method must be 'hakulinen', 'conditional', or 'individual'"):
+    with pytest.raises(
+        ValueError,
+        match="method must be 'hakulinen', 'conditional', or 'individual'",
+    ):
         survival.survexp(
             time=[365.0],
             age=[18250.0],

--- a/python/tests/test_specialized.py
+++ b/python/tests/test_specialized.py
@@ -1,3 +1,5 @@
+import pytest
+
 from .helpers import setup_survival_import
 
 survival = setup_survival_import()
@@ -57,3 +59,138 @@ def test_finegray():
     assert hasattr(result, "end")
     assert hasattr(result, "wt")
     assert len(result.row) > 0
+
+
+def test_ratetable_and_survexp_public_apis():
+    ratetable = survival.create_simple_ratetable(
+        age_breaks=[0.0, 36500.0, 73000.0],
+        year_breaks=[1990.0, 2020.0],
+        rates_male=[0.00001, 0.00005],
+        rates_female=[0.000008, 0.00004],
+    )
+
+    assert ratetable.ndim() == 3
+    assert ratetable.dim_names() == ["age", "year", "sex"]
+    assert survival.is_ratetable(ratetable.ndim(), True, True) is True
+    assert ratetable.lookup({"age": 1000.0, "year": 2000.0, "sex": 0.0}) == pytest.approx(1e-05)
+
+    expected = ratetable.expected_survival(1000.0, 1010.0, 2000.0, 0)
+    assert 0.0 < expected <= 1.0
+
+    result = survival.survexp(
+        time=[365.0, 730.0],
+        age=[18250.0, 21900.0],
+        year=[2000.0, 2000.0],
+        ratetable=ratetable,
+        sex=[0, 1],
+        method="conditional",
+    )
+
+    assert result.method == "conditional"
+    assert result.n == 2
+    assert result.time == [365.0, 730.0]
+    assert len(result.surv) == 2
+    assert result.surv[0] >= result.surv[1]
+    assert result.n_risk == [2.0, 1.0]
+
+    individual = survival.survexp_individual(
+        time=[365.0, 730.0],
+        age=[18250.0, 21900.0],
+        year=[2000.0, 2000.0],
+        ratetable=ratetable,
+        sex=[0, 1],
+    )
+    assert len(individual) == 2
+    assert all(0.0 < value <= 1.0 for value in individual)
+
+
+def test_survexp_validates_method():
+    ratetable = survival.create_simple_ratetable(
+        age_breaks=[0.0, 36500.0, 73000.0],
+        year_breaks=[1990.0, 2020.0],
+        rates_male=[0.00001, 0.00005],
+        rates_female=[0.000008, 0.00004],
+    )
+
+    with pytest.raises(ValueError, match="method must be 'hakulinen', 'conditional', or 'individual'"):
+        survival.survexp(
+            time=[365.0],
+            age=[18250.0],
+            year=[2000.0],
+            ratetable=ratetable,
+            method="bad",
+        )
+
+
+def test_ratetable_date_roundtrip():
+    result = survival.ratetable_date(2000, 2, 29, 1960)
+
+    assert result.days == pytest.approx(14669.0)
+    assert result.origin_year == 1960
+    assert survival.days_to_date(result.days, result.origin_year) == (2000, 2, 29)
+
+
+def test_pyears_summary_and_cells():
+    summary = survival.summary_pyears(
+        pyears=[2.0, 3.0],
+        pn=[1.0, 1.0],
+        pcount=[1.0, 2.0],
+        pexpect=[0.5, 1.5],
+        offtable=0.25,
+    )
+    cells = survival.pyears_by_cell(
+        pyears=[2.0, 3.0],
+        pn=[1.0, 1.0],
+        pcount=[1.0, 2.0],
+        pexpect=[0.5, 1.5],
+    )
+    smr, lower, upper = survival.pyears_ci(5.0, 2.5, 0.95)
+
+    assert summary.total_person_years == pytest.approx(5.0)
+    assert summary.total_events == pytest.approx(3.0)
+    assert summary.smr == pytest.approx(1.5)
+    assert "SMR" in summary.to_table()
+    assert len(cells) == 2
+    assert cells[0].rate == pytest.approx(0.5)
+    assert cells[0].smr == pytest.approx(2.0)
+    assert smr == pytest.approx(2.0)
+    assert lower < smr < upper
+
+
+def test_reference_ratetables_and_expected_survival_helpers():
+    us = survival.survexp_us()
+    mn = survival.survexp_mn()
+    usr = survival.survexp_usr()
+    expected = survival.compute_expected_survival(
+        age=[365.25 * 50.0, 365.25 * 60.0],
+        sex=[0, 1],
+        year=[2000.0, 2005.0],
+        times=[365.25, 365.25 * 5.0],
+    )
+
+    assert us.ndim() == 3
+    assert mn.ndim() == 3
+    assert usr.ndim() == 3
+    assert us.dim_names() == ["year", "age", "sex"]
+    assert mn.dim_names() == ["year", "age", "sex"]
+    assert usr.dim_names() == us.dim_names()
+    assert us.lookup({"year": 2000.0, "age": 365.25 * 50.0, "sex": 0.0}) > 0.0
+    assert usr.lookup({"year": 2000.0, "age": 365.25 * 50.0, "sex": 0.0}) == pytest.approx(
+        us.lookup({"year": 2000.0, "age": 365.25 * 50.0, "sex": 0.0})
+    )
+
+    assert expected.n == 2
+    assert expected.time == pytest.approx([365.25, 365.25 * 5.0])
+    assert len(expected.expected_survival) == 2
+    assert all(0.0 < value <= 1.0 for value in expected.expected_survival)
+    assert expected.expected_survival[0] >= expected.expected_survival[1]
+
+
+def test_compute_expected_survival_validates_lengths():
+    with pytest.raises(ValueError, match="age, sex, and year must have the same length"):
+        survival.compute_expected_survival(
+            age=[365.25 * 50.0],
+            sex=[0, 1],
+            year=[2000.0],
+            times=[365.25],
+        )

--- a/python/tests/test_surv_analysis.py
+++ b/python/tests/test_surv_analysis.py
@@ -1,3 +1,5 @@
+import pytest
+
 from .helpers import setup_survival_import
 
 survival = setup_survival_import()
@@ -82,3 +84,263 @@ def test_survdiff2():
     assert hasattr(result, "expected")
     assert hasattr(result, "chi_squared")
     assert len(result.observed) > 0
+
+
+def test_aggregate_survfit_public_apis():
+    result = survival.aggregate_survfit(
+        times=[[1.0, 2.0], [1.5, 2.5]],
+        survs=[[0.9, 0.8], [0.95, 0.85]],
+        std_errs=[[0.05, 0.06], [0.04, 0.05]],
+        weights=[2.0, 1.0],
+        conf_level=0.95,
+    )
+    by_group = survival.aggregate_survfit_by_group(
+        times=[[1.0, 2.0], [1.0, 2.0], [1.5, 2.5]],
+        survs=[[0.9, 0.8], [0.8, 0.7], [0.95, 0.85]],
+        groups=[1, 1, 2],
+        weights=[1.0, 2.0, 1.0],
+    )
+    by_group_sorted = sorted(by_group, key=lambda item: item.n_curves)
+
+    assert result.n_curves == 2
+    assert result.time == pytest.approx([1.0, 1.5, 2.0, 2.5])
+    assert result.weights == pytest.approx([2.0 / 3.0, 1.0 / 3.0])
+    assert len(result.surv) == len(result.time)
+    assert len(result.std_err) == len(result.time)
+    assert all(0.0 <= value <= 1.0 for value in result.lower)
+    assert all(0.0 <= value <= 1.0 for value in result.upper)
+
+    assert len(by_group_sorted) == 2
+    assert by_group_sorted[0].n_curves == 1
+    assert by_group_sorted[0].surv == pytest.approx([0.95, 0.85])
+    assert by_group_sorted[1].n_curves == 2
+    assert by_group_sorted[1].weights == pytest.approx([1.0 / 3.0, 2.0 / 3.0])
+
+    with pytest.raises(ValueError, match="times and survs must have same length"):
+        survival.aggregate_survfit([[1.0]], [[0.9], [0.8]], None, None, None)
+
+
+def test_survcheck_public_apis_and_validation():
+    result = survival.survcheck(
+        id=[1, 1, 2],
+        time1=[0.0, 2.0, 0.0],
+        time2=[2.0, 4.0, 1.0],
+        status=[1, 0, 1],
+        istate=[0, 1, 0],
+    )
+    simple = survival.survcheck_simple(
+        time=[1.0, -1.0, float("nan")],
+        status=[1, 0, 2],
+    )
+
+    assert result.n_subjects == 2
+    assert result.n_transitions == 3
+    assert result.n_problems == 0
+    assert result.is_valid is True
+    assert result.transitions == {"0 -> 1": 2, "1 -> 0": 1}
+    assert result.flags == [0, 0, 0]
+
+    assert simple.n_subjects == 3
+    assert simple.n_problems == 2
+    assert simple.is_valid is False
+    assert simple.invalid_ids == [1, 2]
+    assert simple.flags == [0, 4, 4]
+    assert any("negative time" in message for message in simple.messages)
+
+    with pytest.raises(ValueError, match="All input vectors must have the same length"):
+        survival.survcheck([1], [0.0], [1.0, 2.0], [1], None)
+
+
+def test_royston_public_apis_and_validation():
+    result = survival.royston(
+        linear_predictor=[0.5, -0.3, 0.8, -0.1, 0.2, -0.5, 0.9, -0.2],
+        time=[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+        status=[1, 1, 1, 0, 1, 1, 1, 0],
+    )
+    from_model = survival.royston_from_model(
+        x=[1.0, 0.0, 0.0, 1.0, 1.0, 1.0],
+        coef=[0.5, 1.0],
+        n_obs=3,
+        time=[1.0, 2.0, 3.0],
+        status=[1, 1, 1],
+    )
+
+    assert result.d > 0.0
+    assert result.se > 0.0
+    assert 0.0 <= result.r_squared_d <= 1.0
+    assert 0.0 <= result.r_squared_ko <= 1.0
+    assert 0.0 <= result.p_value <= 1.0
+    assert result.n_events == 6
+    assert from_model.n_events == 3
+
+    with pytest.raises(ValueError, match="At least 2 events required"):
+        survival.royston([0.1, 0.2], [1.0, 2.0], [1, 0])
+
+
+def test_yates_public_apis_and_validation():
+    result = survival.yates(
+        predictions=[1.0, 2.0, 2.0, 4.0],
+        factor=["A", "A", "B", "B"],
+        weights=[1.0, 2.0, 1.0, 1.0],
+        conf_level=0.95,
+    )
+    pairwise = survival.yates_pairwise(result)
+    contrast = survival.yates_contrast(
+        x=[1.0, 0.0, 0.0, 1.0, 1.0, 1.0],
+        coef=[0.5, 1.0],
+        n_obs=3,
+        n_vars=2,
+        factor_col=0,
+        factor_levels=[0.0, 1.0],
+        predict_type="risk",
+    )
+
+    assert result.levels == ["A", "B"]
+    assert result.means == pytest.approx([5.0 / 3.0, 3.0])
+    assert result.n == [2, 2]
+    assert result.predict_type == "linear"
+    assert pairwise.level1 == ["A"]
+    assert pairwise.level2 == ["B"]
+    assert pairwise.difference == pytest.approx([-4.0 / 3.0])
+    assert contrast.levels == ["0", "1"]
+    assert contrast.predict_type == "risk"
+    assert contrast.means[1] > contrast.means[0]
+
+    with pytest.raises(ValueError, match="weights must have same length as predictions"):
+        survival.yates([1.0], ["A"], [1.0, 2.0], 0.95)
+
+
+def test_concordance_metric_public_apis_and_validation():
+    uno = survival.uno_c_index(
+        time=[1.0, 2.0, 3.0, 4.0],
+        status=[1, 1, 0, 1],
+        risk_score=[0.9, 0.7, 0.4, 0.2],
+    )
+    comparison = survival.compare_uno_c_indices(
+        time=[1.0, 2.0, 3.0, 4.0],
+        status=[1, 1, 0, 1],
+        risk_score_1=[0.9, 0.7, 0.4, 0.2],
+        risk_score_2=[0.2, 0.4, 0.7, 0.9],
+    )
+    decomposition = survival.c_index_decomposition(
+        time=[1.0, 2.0, 3.0, 4.0],
+        status=[1, 1, 0, 1],
+        risk_score=[0.9, 0.7, 0.4, 0.2],
+    )
+    gonen = survival.gonen_heller_concordance([0.9, 0.7, 0.4, 0.2])
+
+    assert uno.c_index == pytest.approx(1.0)
+    assert uno.comparable_pairs > 0.0
+    assert 0.0 <= uno.ci_lower <= uno.ci_upper <= 1.0
+    assert comparison.c_index_1 > comparison.c_index_2
+    assert comparison.difference > 0.0
+    assert 0.0 <= comparison.p_value <= 1.0
+    assert decomposition.c_index == pytest.approx(1.0)
+    assert 0.0 <= decomposition.alpha <= 1.0
+    assert decomposition.n_event_event_pairs > 0
+    assert 0.0 <= gonen.cpe <= 1.0
+    assert gonen.std_error >= 0.0
+
+    with pytest.raises(ValueError, match="time, status, and risk_score must have the same length"):
+        survival.uno_c_index([1.0], [1], [0.1, 0.2])
+
+
+def test_rcll_public_apis_and_validation():
+    result = survival.rcll(
+        survival_predictions=[
+            [0.95, 0.85, 0.70],
+            [0.90, 0.75, 0.55],
+            [0.98, 0.92, 0.80],
+        ],
+        prediction_times=[1.0, 2.0, 3.0],
+        event_times=[2.5, 1.5, 3.0],
+        status=[1, 1, 0],
+        weights=[1.0, 2.0, 1.0],
+    )
+    single_time = survival.rcll_single_time(
+        survival_probs=[0.8, 0.7, 0.9],
+        event_times=[1.0, 2.0, 3.0],
+        status=[1, 0, 1],
+        prediction_time=2.0,
+        weights=[1.0, 2.0, 1.0],
+    )
+
+    assert result.n_events == 2
+    assert result.n_censored == 1
+    assert result.mean_rcll > 0.0
+    assert result.event_contribution > result.censored_contribution
+    assert single_time.n_events == 1
+    assert single_time.n_censored == 2
+    assert single_time.rcll > 0.0
+
+    with pytest.raises(ValueError, match="survival_predictions row 0 has 1 elements, expected 2"):
+        survival.rcll([[0.9]], [1.0, 2.0], [1.0], [1], None)
+
+
+def test_ridge_public_apis_and_validation():
+    penalty = survival.RidgePenalty(0.1, False)
+    fit = survival.ridge_fit(
+        x=[1.0, 0.0, 0.0, 1.0, 1.0, 1.0],
+        n_obs=3,
+        n_vars=2,
+        time=[1.0, 2.0, 3.0],
+        status=[1, 1, 1],
+        penalty=penalty,
+        weights=None,
+    )
+    best_theta, cv_scores = survival.ridge_cv(
+        x=[1.0, 0.0, 0.0, 1.0, 1.0, 1.0],
+        n_obs=3,
+        n_vars=2,
+        time=[1.0, 2.0, 3.0],
+        status=[1, 1, 1],
+        theta_grid=[0.01, 0.1, 1.0],
+        n_folds=2,
+    )
+
+    assert penalty.penalty_value([1.0, 2.0]) == pytest.approx(0.25)
+    assert penalty.penalty_gradient([1.0, 2.0]) == pytest.approx([0.1, 0.2])
+    assert penalty.apply_to_information([1.0, 2.0]) == pytest.approx([1.1, 2.1])
+    assert len(fit.coefficients) == 2
+    assert len(fit.std_err) == 2
+    assert fit.theta == pytest.approx(0.1)
+    assert fit.df > 0.0
+    assert fit.scale_factors is None
+    assert best_theta in [0.01, 0.1, 1.0]
+    assert len(cv_scores) == 3
+
+    with pytest.raises(ValueError, match="x length must equal n_obs \\* n_vars"):
+        survival.ridge_fit([1.0], 2, 1, [1.0, 2.0], [1, 1], penalty, None)
+
+
+def test_anova_and_basehaz_public_apis():
+    anova = survival.anova_coxph(
+        logliks=[-10.0, -8.0, -7.5],
+        dfs=[1, 2, 3],
+        model_names=["null", "m1", "m2"],
+        test="LRT",
+    )
+    single = survival.anova_coxph_single(-10.0, -8.0, 1, 2)
+    times, hazard = survival.basehaz(
+        time=[1.0, 2.0, 3.0, 4.0],
+        status=[1, 0, 1, 1],
+        linear_predictors=[0.0, 0.2, 0.1, -0.1],
+        centered=False,
+    )
+
+    assert anova.test_type == "LRT"
+    assert len(anova.rows) == 3
+    assert anova.rows[1].chisq == pytest.approx(4.0)
+    assert "Analysis of Deviance Table" in anova.to_table()
+    assert len(single.rows) == 2
+    assert single.rows[0].model_name == "Null"
+    assert single.rows[1].chisq == pytest.approx(4.0)
+    assert times == pytest.approx([1.0, 3.0, 4.0])
+    assert len(hazard) == 3
+    assert hazard[0] < hazard[1] < hazard[2]
+
+    with pytest.raises(ValueError, match="Need at least 2 models for comparison"):
+        survival.anova_coxph([-1.0], [1], None, "LRT")
+
+    with pytest.raises(ValueError, match="time, status, and linear_predictors must have the same length"):
+        survival.basehaz([1.0], [1, 0], [0.1], False)

--- a/python/tests/test_surv_analysis.py
+++ b/python/tests/test_surv_analysis.py
@@ -342,5 +342,8 @@ def test_anova_and_basehaz_public_apis():
     with pytest.raises(ValueError, match="Need at least 2 models for comparison"):
         survival.anova_coxph([-1.0], [1], None, "LRT")
 
-    with pytest.raises(ValueError, match="time, status, and linear_predictors must have the same length"):
+    with pytest.raises(
+        ValueError,
+        match="time, status, and linear_predictors must have the same length",
+    ):
         survival.basehaz([1.0], [1, 0], [0.1], False)

--- a/python/tests/test_utilities.py
+++ b/python/tests/test_utilities.py
@@ -1,3 +1,5 @@
+import pytest
+
 from .helpers import setup_survival_import
 
 survival = setup_survival_import()
@@ -15,3 +17,127 @@ def test_collapse():
     assert isinstance(result, dict)
     assert "matrix" in result
     assert "dimnames" in result
+
+
+def test_tmerge_family_public_apis():
+    merged = survival.tmerge(
+        [1, 1, 2],
+        [1.0, 2.0, 1.0],
+        [0.0, float("nan"), 0.0],
+        [1, 1, 2],
+        [0.5, 1.5, 0.5],
+        [2.0, 3.0, 4.0],
+    )
+    indices = survival.tmerge2(
+        [1, 1, 2],
+        [1.0, 2.0, 1.0],
+        [1, 1, 2],
+        [0.5, 1.5, 0.5],
+    )
+    carry = survival.tmerge3([1, 1, 1, 2, 2], [False, True, False, True, False])
+
+    assert merged == pytest.approx([2.0, 5.0, 4.0])
+    assert indices == [1, 2, 3]
+    assert carry == [1, 1, 3, 0, 5]
+
+
+def test_surv2data_and_survcondense_public_apis():
+    surv2data = survival.surv2data(
+        [2, 1, 1, 2],
+        [3.0, 0.0, 2.0, 0.0],
+        [5.0, 4.0, 4.0, 5.0],
+        [0, 1, 1, 0],
+    )
+    condensed = survival.survcondense(
+        [2, 1, 1, 2],
+        [0.0, 0.0, 5.0, 3.0],
+        [3.0, 5.0, 8.0, 5.0],
+        [1, 0, 0, 0],
+    )
+
+    assert surv2data.id == [1, 1, 2, 2]
+    assert surv2data.time1 == pytest.approx([0.0, 2.0, 0.0, 3.0])
+    assert surv2data.time2 == pytest.approx([2.0, 4.0, 3.0, 5.0])
+    assert surv2data.status == [0, 1, 0, 0]
+    assert surv2data.row_index == [2, 3, 4, 1]
+
+    assert condensed.id == [1, 2, 2]
+    assert condensed.time1 == pytest.approx([0.0, 0.0, 3.0])
+    assert condensed.time2 == pytest.approx([8.0, 3.0, 5.0])
+    assert condensed.status == [0, 1, 0]
+    assert condensed.row_map == [[2, 3], [1], [4]]
+
+
+def test_rttright_public_apis_and_validation():
+    result = survival.rttright([3.0, 1.0, 2.0], [1, 0, 1])
+    stratified = survival.rttright_stratified(
+        [3.0, 1.0, 2.0, 1.5],
+        [1, 0, 1, 1],
+        [0, 0, 1, 1],
+    )
+
+    assert result.time == pytest.approx([1.0, 2.0, 3.0])
+    assert result.status == [0, 1, 1]
+    assert result.weights == pytest.approx([0.0, 1.0, 2.0])
+    assert result.order == [1, 2, 0]
+
+    assert stratified.time == pytest.approx([3.0, 1.0, 2.0, 1.5])
+    assert stratified.status == [1, 0, 1, 1]
+    assert all(weight >= 0.0 for weight in stratified.weights)
+    assert sum(weight > 0.0 for weight in stratified.weights) == 3
+    assert sorted(stratified.order) == [0, 1, 2, 3]
+
+    with pytest.raises(ValueError, match="time and status must have same length"):
+        survival.rttright([1.0], [1, 0])
+
+
+def test_agexact_public_api_and_validation():
+    result = survival.agexact(
+        0,
+        1,
+        1,
+        [0.0],
+        [1.0],
+        [1],
+        [1.0],
+        [0.0],
+        [0],
+        [0.0],
+        [0.0],
+        [0.0],
+        [0.0],
+        [0.0, 0.0],
+        [0.0] * 5,
+        [0, 0],
+        1e-9,
+        1e-9,
+        [1],
+    )
+
+    assert sorted(result) == ["beta", "covar", "flag", "imat", "loglik", "maxiter", "means", "sctest", "u"]
+    assert result["beta"] == pytest.approx([0.0])
+    assert result["loglik"] == pytest.approx([0.0, 0.0])
+    assert result["flag"] == 0
+
+    with pytest.raises(ValueError, match="work must have length at least 5"):
+        survival.agexact(
+            1,
+            1,
+            1,
+            [0.0],
+            [1.0],
+            [1],
+            [1.0],
+            [0.0],
+            [0],
+            [0.0],
+            [0.0],
+            [0.0],
+            [1.0],
+            [0.0, 0.0],
+            [0.0],
+            [0, 0],
+            1e-9,
+            1e-9,
+            [1],
+        )

--- a/python/tests/test_utilities.py
+++ b/python/tests/test_utilities.py
@@ -114,7 +114,17 @@ def test_agexact_public_api_and_validation():
         [1],
     )
 
-    assert sorted(result) == ["beta", "covar", "flag", "imat", "loglik", "maxiter", "means", "sctest", "u"]
+    assert sorted(result) == [
+        "beta",
+        "covar",
+        "flag",
+        "imat",
+        "loglik",
+        "maxiter",
+        "means",
+        "sctest",
+        "u",
+    ]
     assert result["beta"] == pytest.approx([0.0])
     assert result["loglik"] == pytest.approx([0.0, 0.0])
     assert result["flag"] == 0

--- a/scripts/check_coverage.py
+++ b/scripts/check_coverage.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Fail if a Cobertura-style coverage report is below a minimum line coverage percentage."
+    )
+    parser.add_argument("report", type=Path, help="Path to cobertura.xml")
+    parser.add_argument(
+        "--min-percent",
+        type=float,
+        required=True,
+        help="Minimum acceptable line coverage percentage, for example 30",
+    )
+    return parser.parse_args()
+
+
+def extract_line_rate(root: ET.Element) -> float:
+    raw_line_rate = root.attrib.get("line-rate")
+    if raw_line_rate is not None:
+        return float(raw_line_rate)
+
+    raw_lines_covered = root.attrib.get("lines-covered")
+    raw_lines_valid = root.attrib.get("lines-valid")
+    if raw_lines_covered is not None and raw_lines_valid is not None:
+        covered = float(raw_lines_covered)
+        valid = float(raw_lines_valid)
+        if valid <= 0.0:
+            raise ValueError("coverage report has no valid lines")
+        return covered / valid
+
+    raise ValueError("could not determine line coverage from report")
+
+
+def main() -> int:
+    args = parse_args()
+    if not args.report.is_file():
+        print(f"coverage report not found: {args.report}", file=sys.stderr)
+        return 1
+
+    root = ET.parse(args.report).getroot()
+    line_rate = extract_line_rate(root)
+    percent = line_rate * 100.0
+
+    print(f"Line coverage: {percent:.2f}%")
+    print(f"Minimum required: {args.min_percent:.2f}%")
+
+    if percent + 1e-9 < args.min_percent:
+        print(
+            f"coverage check failed: {percent:.2f}% is below {args.min_percent:.2f}%",
+            file=sys.stderr,
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/ml/contrastive_surv.rs
+++ b/src/ml/contrastive_surv.rs
@@ -8,7 +8,10 @@ use burn::{
 };
 use pyo3::prelude::*;
 
-use super::utils::{compute_duration_bins, tensor_to_vec_f32};
+use super::utils::{
+    EarlyStopping, compute_duration_bins, shuffled_epoch_indices, tensor_to_vec_f32,
+    train_validation_split_indices,
+};
 
 type Backend = NdArray;
 type AutodiffBackend = Autodiff<Backend>;
@@ -672,30 +675,17 @@ fn fit_contrastive_surv_inner(
 
     let mut optimizer = AdamConfig::new().init();
 
-    let n_val = (n_obs as f64 * config.validation_fraction).floor() as usize;
-    let n_train = n_obs - n_val;
-
     let mut rng = fastrand::Rng::with_seed(seed);
-    let mut shuffled_indices: Vec<usize> = (0..n_obs).collect();
-    for i in (1..n_obs).rev() {
-        let j = rng.usize(0..=i);
-        shuffled_indices.swap(i, j);
-    }
-
-    let train_indices: Vec<usize> = shuffled_indices[..n_train].to_vec();
+    let split = train_validation_split_indices(n_obs, config.validation_fraction, &mut rng);
+    let n_train = split.train_indices.len();
+    let train_indices = split.train_indices;
 
     let mut train_loss_history = Vec::new();
     let mut val_loss_history = Vec::new();
-    let mut best_val_loss = f64::INFINITY;
-    let mut epochs_without_improvement = 0;
-    let mut best_weights: Option<StoredWeights> = None;
+    let mut early_stopping = EarlyStopping::new(config.early_stopping_patience);
 
     for _epoch in 0..config.n_epochs {
-        let mut epoch_indices = train_indices.clone();
-        for i in (1..epoch_indices.len()).rev() {
-            let j = rng.usize(0..=i);
-            epoch_indices.swap(i, j);
-        }
+        let epoch_indices = shuffled_epoch_indices(&train_indices, &mut rng);
 
         let mut epoch_loss = 0.0;
         let mut n_batches = 0;
@@ -758,24 +748,17 @@ fn fit_contrastive_surv_inner(
             0.0
         };
         train_loss_history.push(avg_train_loss);
-        val_loss_history.push(avg_train_loss * 1.1);
-
-        if val_loss_history.last().copied().unwrap_or(f64::INFINITY) < best_val_loss {
-            best_val_loss = val_loss_history.last().copied().unwrap_or(f64::INFINITY);
-            epochs_without_improvement = 0;
-            best_weights = Some(extract_weights(&model, config, n_features));
-        } else {
-            epochs_without_improvement += 1;
-        }
-
-        if let Some(patience) = config.early_stopping_patience
-            && epochs_without_improvement >= patience
-        {
+        let val_loss = avg_train_loss * 1.1;
+        val_loss_history.push(val_loss);
+        early_stopping.record(val_loss, || extract_weights(&model, config, n_features));
+        if early_stopping.should_stop() {
             break;
         }
     }
 
-    let final_weights = best_weights.unwrap_or_else(|| extract_weights(&model, config, n_features));
+    let final_weights = early_stopping
+        .into_best_state()
+        .unwrap_or_else(|| extract_weights(&model, config, n_features));
 
     ContrastiveSurv {
         weights: final_weights,

--- a/src/ml/deep_surv.rs
+++ b/src/ml/deep_surv.rs
@@ -12,7 +12,9 @@ use rayon::prelude::*;
 use super::config_validation::{
     ensure_open_unit_interval, ensure_positive_f64, ensure_positive_usize,
 };
-use super::utils::tensor_to_vec_f32;
+use super::utils::{
+    EarlyStopping, shuffled_epoch_indices, tensor_to_vec_f32, train_validation_split_indices,
+};
 
 type Backend = NdArray;
 type AutodiffBackend = Autodiff<Backend>;
@@ -478,33 +480,21 @@ fn fit_deep_surv_inner(
         )))
         .init();
 
-    let n_val = (n_obs as f64 * config.validation_fraction).floor() as usize;
-    let n_train = n_obs - n_val;
-
     let mut rng = fastrand::Rng::with_seed(seed);
-    let mut shuffled_indices: Vec<usize> = (0..n_obs).collect();
-    for i in (1..n_obs).rev() {
-        let j = rng.usize(0..=i);
-        shuffled_indices.swap(i, j);
-    }
-
-    let train_indices: Vec<usize> = shuffled_indices[..n_train].to_vec();
-    let val_indices: Vec<usize> = shuffled_indices[n_train..].to_vec();
+    let split = train_validation_split_indices(n_obs, config.validation_fraction, &mut rng);
+    let n_train = split.train_indices.len();
+    let n_val = split.val_indices.len();
+    let train_indices = split.train_indices;
+    let val_indices = split.val_indices;
 
     let mut train_loss_history = Vec::new();
     let mut val_loss_history = Vec::new();
-    let mut best_val_loss = f64::INFINITY;
-    let mut epochs_without_improvement = 0;
-    let mut best_weights: Option<StoredWeights> = None;
+    let mut early_stopping = EarlyStopping::new(config.early_stopping_patience);
 
     let activation = config.activation;
 
     for _epoch in 0..config.n_epochs {
-        let mut epoch_indices = train_indices.clone();
-        for i in (1..epoch_indices.len()).rev() {
-            let j = rng.usize(0..=i);
-            epoch_indices.swap(i, j);
-        }
+        let epoch_indices = shuffled_epoch_indices(&train_indices, &mut rng);
 
         let mut epoch_loss = 0.0;
         let mut n_batches = 0;
@@ -563,31 +553,18 @@ fn fit_deep_surv_inner(
             let val_loss = compute_cox_loss_cpu(&val_risk_vec, time, status, &val_indices);
             val_loss_history.push(val_loss);
 
-            if val_loss < best_val_loss {
-                best_val_loss = val_loss;
-                epochs_without_improvement = 0;
-                best_weights = Some(extract_weights_from_autodiff(
-                    &model,
-                    &config.hidden_layers,
-                    n_vars,
-                ));
-            } else {
-                epochs_without_improvement += 1;
-            }
-
-            if let Some(patience) = config.early_stopping_patience
-                && epochs_without_improvement >= patience
-            {
+            early_stopping.record(val_loss, || {
+                extract_weights_from_autodiff(&model, &config.hidden_layers, n_vars)
+            });
+            if early_stopping.should_stop() {
                 break;
             }
         }
     }
 
-    let final_weights = if let Some(weights) = best_weights {
-        weights
-    } else {
-        extract_weights_from_autodiff(&model, &config.hidden_layers, n_vars)
-    };
+    let final_weights = early_stopping
+        .into_best_state()
+        .unwrap_or_else(|| extract_weights_from_autodiff(&model, &config.hidden_layers, n_vars));
 
     let all_risks = predict_with_weights(x, n_obs, n_vars, &final_weights, config.activation);
 

--- a/src/ml/deephit.rs
+++ b/src/ml/deephit.rs
@@ -13,7 +13,10 @@ use super::config_validation::{
     ensure_closed_unit_interval, ensure_open_unit_interval, ensure_positive_f64,
     ensure_positive_usize,
 };
-use super::utils::{compute_duration_bins, linear_forward, relu_vec, tensor_to_vec_f32};
+use super::utils::{
+    EarlyStopping, compute_duration_bins, linear_forward, relu_vec, shuffled_epoch_indices,
+    tensor_to_vec_f32, train_validation_split_indices,
+};
 
 type Backend = NdArray;
 type AutodiffBackend = Autodiff<Backend>;
@@ -693,31 +696,19 @@ fn fit_deephit_inner(
         )))
         .init();
 
-    let n_val = (n_obs as f64 * config.validation_fraction).floor() as usize;
-    let n_train = n_obs - n_val;
-
     let mut rng = fastrand::Rng::with_seed(seed);
-    let mut shuffled_indices: Vec<usize> = (0..n_obs).collect();
-    for i in (1..n_obs).rev() {
-        let j = rng.usize(0..=i);
-        shuffled_indices.swap(i, j);
-    }
-
-    let train_indices: Vec<usize> = shuffled_indices[..n_train].to_vec();
-    let val_indices: Vec<usize> = shuffled_indices[n_train..].to_vec();
+    let split = train_validation_split_indices(n_obs, config.validation_fraction, &mut rng);
+    let n_train = split.train_indices.len();
+    let n_val = split.val_indices.len();
+    let train_indices = split.train_indices;
+    let val_indices = split.val_indices;
 
     let mut train_loss_history = Vec::new();
     let mut val_loss_history = Vec::new();
-    let mut best_val_loss = f64::INFINITY;
-    let mut epochs_without_improvement = 0;
-    let mut best_weights: Option<StoredWeights> = None;
+    let mut early_stopping = EarlyStopping::new(config.early_stopping_patience);
 
     for _epoch in 0..config.n_epochs {
-        let mut epoch_indices = train_indices.clone();
-        for i in (1..epoch_indices.len()).rev() {
-            let j = rng.usize(0..=i);
-            epoch_indices.swap(i, j);
-        }
+        let epoch_indices = shuffled_epoch_indices(&train_indices, &mut rng);
 
         let mut epoch_loss = 0.0;
         let mut n_batches = 0;
@@ -826,23 +817,16 @@ fn fit_deephit_inner(
             );
             val_loss_history.push(val_loss);
 
-            if val_loss < best_val_loss {
-                best_val_loss = val_loss;
-                epochs_without_improvement = 0;
-                best_weights = Some(extract_weights(&model, config, n_features));
-            } else {
-                epochs_without_improvement += 1;
-            }
-
-            if let Some(patience) = config.early_stopping_patience
-                && epochs_without_improvement >= patience
-            {
+            early_stopping.record(val_loss, || extract_weights(&model, config, n_features));
+            if early_stopping.should_stop() {
                 break;
             }
         }
     }
 
-    let final_weights = best_weights.unwrap_or_else(|| extract_weights(&model, config, n_features));
+    let final_weights = early_stopping
+        .into_best_state()
+        .unwrap_or_else(|| extract_weights(&model, config, n_features));
 
     DeepHit {
         weights: final_weights,

--- a/src/ml/dynamic_deephit.rs
+++ b/src/ml/dynamic_deephit.rs
@@ -8,7 +8,10 @@ use burn::{
 };
 use pyo3::prelude::*;
 
-use super::utils::{compute_duration_bins, tensor_to_vec_f32};
+use super::utils::{
+    EarlyStopping, compute_duration_bins, shuffled_epoch_indices, tensor_to_vec_f32,
+    train_validation_split_indices,
+};
 
 type Backend = NdArray;
 type AutodiffBackend = Autodiff<Backend>;
@@ -861,31 +864,18 @@ fn fit_dynamic_deephit_inner(
 
     let mut optimizer = AdamConfig::new().init();
 
-    let n_val = (n_obs as f64 * config.validation_fraction).floor() as usize;
-    let n_train = n_obs - n_val;
-
     let mut rng = fastrand::Rng::with_seed(seed);
-    let mut shuffled_indices: Vec<usize> = (0..n_obs).collect();
-    for i in (1..n_obs).rev() {
-        let j = rng.usize(0..=i);
-        shuffled_indices.swap(i, j);
-    }
-
-    let train_indices: Vec<usize> = shuffled_indices[..n_train].to_vec();
-    let val_indices: Vec<usize> = shuffled_indices[n_train..].to_vec();
+    let split = train_validation_split_indices(n_obs, config.validation_fraction, &mut rng);
+    let n_train = split.train_indices.len();
+    let train_indices = split.train_indices;
+    let val_indices = split.val_indices;
 
     let mut train_loss_history = Vec::new();
     let mut val_loss_history = Vec::new();
-    let mut best_val_loss = f64::INFINITY;
-    let mut epochs_without_improvement = 0;
-    let mut best_weights: Option<StoredWeights> = None;
+    let mut early_stopping = EarlyStopping::new(config.early_stopping_patience);
 
     for _epoch in 0..config.n_epochs {
-        let mut epoch_indices = train_indices.clone();
-        for i in (1..epoch_indices.len()).rev() {
-            let j = rng.usize(0..=i);
-            epoch_indices.swap(i, j);
-        }
+        let epoch_indices = shuffled_epoch_indices(&train_indices, &mut rng);
 
         let mut epoch_loss = 0.0;
         let mut n_batches = 0;
@@ -974,25 +964,18 @@ fn fit_dynamic_deephit_inner(
         train_loss_history.push(avg_train_loss);
 
         if !val_indices.is_empty() {
-            val_loss_history.push(avg_train_loss * 1.1);
-
-            if val_loss_history.last().copied().unwrap_or(f64::INFINITY) < best_val_loss {
-                best_val_loss = val_loss_history.last().copied().unwrap_or(f64::INFINITY);
-                epochs_without_improvement = 0;
-                best_weights = Some(extract_weights(&model, config, n_features));
-            } else {
-                epochs_without_improvement += 1;
-            }
-
-            if let Some(patience) = config.early_stopping_patience
-                && epochs_without_improvement >= patience
-            {
+            let val_loss = avg_train_loss * 1.1;
+            val_loss_history.push(val_loss);
+            early_stopping.record(val_loss, || extract_weights(&model, config, n_features));
+            if early_stopping.should_stop() {
                 break;
             }
         }
     }
 
-    let final_weights = best_weights.unwrap_or_else(|| extract_weights(&model, config, n_features));
+    let final_weights = early_stopping
+        .into_best_state()
+        .unwrap_or_else(|| extract_weights(&model, config, n_features));
 
     DynamicDeepHit {
         weights: final_weights,

--- a/src/ml/galee.rs
+++ b/src/ml/galee.rs
@@ -8,7 +8,10 @@ use burn::{
 };
 use pyo3::prelude::*;
 
-use super::utils::{compute_duration_bins, tensor_to_vec_f32};
+use super::utils::{
+    EarlyStopping, compute_duration_bins, shuffled_epoch_indices, tensor_to_vec_f32,
+    train_validation_split_indices,
+};
 
 type Backend = NdArray;
 type AutodiffBackend = Autodiff<Backend>;
@@ -647,30 +650,17 @@ fn fit_galee_inner(
 
     let mut optimizer = AdamConfig::new().init();
 
-    let n_val = (n_obs as f64 * config.validation_fraction).floor() as usize;
-    let n_train = n_obs - n_val;
-
     let mut rng = fastrand::Rng::with_seed(seed);
-    let mut shuffled_indices: Vec<usize> = (0..n_obs).collect();
-    for i in (1..n_obs).rev() {
-        let j = rng.usize(0..=i);
-        shuffled_indices.swap(i, j);
-    }
-
-    let train_indices: Vec<usize> = shuffled_indices[..n_train].to_vec();
+    let split = train_validation_split_indices(n_obs, config.validation_fraction, &mut rng);
+    let n_train = split.train_indices.len();
+    let train_indices = split.train_indices;
 
     let mut train_loss_history = Vec::new();
     let mut val_loss_history = Vec::new();
-    let mut best_val_loss = f64::INFINITY;
-    let mut epochs_without_improvement = 0;
-    let mut best_weights: Option<StoredWeights> = None;
+    let mut early_stopping = EarlyStopping::new(config.early_stopping_patience);
 
     for _epoch in 0..config.n_epochs {
-        let mut epoch_indices = train_indices.clone();
-        for i in (1..epoch_indices.len()).rev() {
-            let j = rng.usize(0..=i);
-            epoch_indices.swap(i, j);
-        }
+        let epoch_indices = shuffled_epoch_indices(&train_indices, &mut rng);
 
         let mut epoch_loss = 0.0;
         let mut n_batches = 0;
@@ -747,24 +737,17 @@ fn fit_galee_inner(
             0.0
         };
         train_loss_history.push(avg_train_loss);
-        val_loss_history.push(avg_train_loss * 1.1);
-
-        if val_loss_history.last().copied().unwrap_or(f64::INFINITY) < best_val_loss {
-            best_val_loss = val_loss_history.last().copied().unwrap_or(f64::INFINITY);
-            epochs_without_improvement = 0;
-            best_weights = Some(extract_weights(&model, config, n_features));
-        } else {
-            epochs_without_improvement += 1;
-        }
-
-        if let Some(patience) = config.early_stopping_patience
-            && epochs_without_improvement >= patience
-        {
+        let val_loss = avg_train_loss * 1.1;
+        val_loss_history.push(val_loss);
+        early_stopping.record(val_loss, || extract_weights(&model, config, n_features));
+        if early_stopping.should_stop() {
             break;
         }
     }
 
-    let final_weights = best_weights.unwrap_or_else(|| extract_weights(&model, config, n_features));
+    let final_weights = early_stopping
+        .into_best_state()
+        .unwrap_or_else(|| extract_weights(&model, config, n_features));
 
     GALEE {
         weights: final_weights,

--- a/src/ml/survtrace.rs
+++ b/src/ml/survtrace.rs
@@ -10,7 +10,8 @@ use rayon::prelude::*;
 
 use super::config_validation::{ensure_open_unit_interval, ensure_positive_usize};
 use super::utils::{
-    compute_duration_bins, gelu_cpu, layer_norm_cpu, linear_forward, tensor_to_vec_f32,
+    EarlyStopping, compute_duration_bins, gelu_cpu, layer_norm_cpu, linear_forward,
+    shuffled_epoch_indices, tensor_to_vec_f32, train_validation_split_indices,
 };
 
 type Backend = NdArray;
@@ -857,31 +858,19 @@ fn fit_survtrace_inner(
         )))
         .init();
 
-    let n_val = (n_obs as f64 * config.validation_fraction).floor() as usize;
-    let n_train = n_obs - n_val;
-
     let mut rng = fastrand::Rng::with_seed(seed);
-    let mut shuffled_indices: Vec<usize> = (0..n_obs).collect();
-    for i in (1..n_obs).rev() {
-        let j = rng.usize(0..=i);
-        shuffled_indices.swap(i, j);
-    }
-
-    let train_indices: Vec<usize> = shuffled_indices[..n_train].to_vec();
-    let val_indices: Vec<usize> = shuffled_indices[n_train..].to_vec();
+    let split = train_validation_split_indices(n_obs, config.validation_fraction, &mut rng);
+    let n_train = split.train_indices.len();
+    let n_val = split.val_indices.len();
+    let train_indices = split.train_indices;
+    let val_indices = split.val_indices;
 
     let mut train_loss_history = Vec::new();
     let mut val_loss_history = Vec::new();
-    let mut best_val_loss = f64::INFINITY;
-    let mut epochs_without_improvement = 0;
-    let mut best_weights: Option<StoredWeights> = None;
+    let mut early_stopping = EarlyStopping::new(config.early_stopping_patience);
 
     for _epoch in 0..config.n_epochs {
-        let mut epoch_indices = train_indices.clone();
-        for i in (1..epoch_indices.len()).rev() {
-            let j = rng.usize(0..=i);
-            epoch_indices.swap(i, j);
-        }
+        let epoch_indices = shuffled_epoch_indices(&train_indices, &mut rng);
 
         let mut epoch_loss = 0.0;
         let mut n_batches = 0;
@@ -1020,24 +1009,18 @@ fn fit_survtrace_inner(
             }
             val_loss_history.push(val_loss);
 
-            if val_loss < best_val_loss {
-                best_val_loss = val_loss;
-                epochs_without_improvement = 0;
-                best_weights = Some(extract_weights(&model, config, cat_cardinalities));
-            } else {
-                epochs_without_improvement += 1;
-            }
-
-            if let Some(patience) = config.early_stopping_patience
-                && epochs_without_improvement >= patience
-            {
+            early_stopping.record(val_loss, || {
+                extract_weights(&model, config, cat_cardinalities)
+            });
+            if early_stopping.should_stop() {
                 break;
             }
         }
     }
 
-    let final_weights =
-        best_weights.unwrap_or_else(|| extract_weights(&model, config, cat_cardinalities));
+    let final_weights = early_stopping
+        .into_best_state()
+        .unwrap_or_else(|| extract_weights(&model, config, cat_cardinalities));
 
     SurvTrace {
         weights: final_weights,

--- a/src/ml/tracer.rs
+++ b/src/ml/tracer.rs
@@ -10,7 +10,10 @@ use pyo3::prelude::*;
 use rayon::prelude::*;
 
 use super::config_validation::{ensure_open_unit_interval, ensure_positive_usize};
-use super::utils::{compute_duration_bins, linear_forward, relu_vec, tensor_to_vec_f32};
+use super::utils::{
+    EarlyStopping, compute_duration_bins, gelu_cpu, layer_norm_cpu, linear_forward, relu_vec,
+    shuffled_epoch_indices, tensor_to_vec_f32, train_validation_split_indices,
+};
 
 type Backend = NdArray;
 type AutodiffBackend = Autodiff<Backend>;
@@ -1034,51 +1037,6 @@ fn extract_weights(model: &TracerNetwork<AutodiffBackend>, config: &TracerConfig
     }
 }
 
-fn erf_approx(x: f64) -> f64 {
-    let a1 = 0.254829592;
-    let a2 = -0.284496736;
-    let a3 = 1.421413741;
-    let a4 = -1.453152027;
-    let a5 = 1.061405429;
-    let p = 0.3275911;
-
-    let sign = if x < 0.0 { -1.0 } else { 1.0 };
-    let x = x.abs();
-
-    let t = 1.0 / (1.0 + p * x);
-    let y = 1.0 - (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t * (-x * x).exp();
-
-    sign * y
-}
-
-fn gelu_cpu(x: f64) -> f64 {
-    let sqrt_2 = std::f64::consts::SQRT_2;
-    x * 0.5 * (1.0 + erf_approx(x / sqrt_2))
-}
-
-fn layer_norm_cpu(x: &[f64], gamma: &[f32], beta: &[f32], eps: f32) -> Vec<f64> {
-    let n = x.len();
-    if n == 0 {
-        return vec![];
-    }
-    let mean: f64 = x.iter().sum::<f64>() / n as f64;
-    let var: f64 = x.iter().map(|&xi| (xi - mean).powi(2)).sum::<f64>() / n as f64;
-    let std = (var + eps as f64).sqrt();
-
-    x.iter()
-        .enumerate()
-        .map(|(i, &xi)| {
-            let g = if i < gamma.len() {
-                gamma[i] as f64
-            } else {
-                1.0
-            };
-            let b = if i < beta.len() { beta[i] as f64 } else { 0.0 };
-            (xi - mean) / std * g + b
-        })
-        .collect()
-}
-
 #[allow(clippy::too_many_arguments)]
 fn apply_mha_cpu(
     x: &[f64],
@@ -1308,31 +1266,19 @@ fn fit_tracer_inner(
 
     let event_weights = compute_event_weights(event, config.num_events);
 
-    let n_val = (n_obs as f64 * config.validation_fraction).floor() as usize;
-    let n_train = n_obs - n_val;
-
     let mut rng = fastrand::Rng::with_seed(seed);
-    let mut shuffled_indices: Vec<usize> = (0..n_obs).collect();
-    for i in (1..n_obs).rev() {
-        let j = rng.usize(0..=i);
-        shuffled_indices.swap(i, j);
-    }
-
-    let train_indices: Vec<usize> = shuffled_indices[..n_train].to_vec();
-    let val_indices: Vec<usize> = shuffled_indices[n_train..].to_vec();
+    let split = train_validation_split_indices(n_obs, config.validation_fraction, &mut rng);
+    let n_train = split.train_indices.len();
+    let n_val = split.val_indices.len();
+    let train_indices = split.train_indices;
+    let val_indices = split.val_indices;
 
     let mut train_loss_history = Vec::new();
     let mut val_loss_history = Vec::new();
-    let mut best_val_loss = f64::INFINITY;
-    let mut epochs_without_improvement = 0;
-    let mut best_weights: Option<StoredWeights> = None;
+    let mut early_stopping = EarlyStopping::new(config.early_stopping_patience);
 
     for _epoch in 0..config.n_epochs {
-        let mut epoch_indices = train_indices.clone();
-        for i in (1..epoch_indices.len()).rev() {
-            let j = rng.usize(0..=i);
-            epoch_indices.swap(i, j);
-        }
+        let epoch_indices = shuffled_epoch_indices(&train_indices, &mut rng);
 
         let mut epoch_loss = 0.0;
         let mut n_batches = 0;
@@ -1513,23 +1459,16 @@ fn fit_tracer_inner(
             );
             val_loss_history.push(val_loss);
 
-            if val_loss < best_val_loss {
-                best_val_loss = val_loss;
-                epochs_without_improvement = 0;
-                best_weights = Some(extract_weights(&model, config));
-            } else {
-                epochs_without_improvement += 1;
-            }
-
-            if let Some(patience) = config.early_stopping_patience
-                && epochs_without_improvement >= patience
-            {
+            early_stopping.record(val_loss, || extract_weights(&model, config));
+            if early_stopping.should_stop() {
                 break;
             }
         }
     }
 
-    let final_weights = best_weights.unwrap_or_else(|| extract_weights(&model, config));
+    let final_weights = early_stopping
+        .into_best_state()
+        .unwrap_or_else(|| extract_weights(&model, config));
 
     Tracer {
         weights: final_weights,

--- a/src/ml/utils.rs
+++ b/src/ml/utils.rs
@@ -1,6 +1,87 @@
 use burn::prelude::Backend;
 use burn::tensor::Tensor;
+use fastrand::Rng;
 use std::f64::consts::SQRT_2;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrainValidationSplit {
+    pub train_indices: Vec<usize>,
+    pub val_indices: Vec<usize>,
+}
+
+#[derive(Debug, Clone)]
+pub struct EarlyStopping<T> {
+    best_metric: f64,
+    best_state: Option<T>,
+    patience: Option<usize>,
+    epochs_without_improvement: usize,
+}
+
+impl<T> EarlyStopping<T> {
+    pub fn new(patience: Option<usize>) -> Self {
+        Self {
+            best_metric: f64::INFINITY,
+            best_state: None,
+            patience,
+            epochs_without_improvement: 0,
+        }
+    }
+
+    pub fn record<F>(&mut self, metric: f64, build_state: F)
+    where
+        F: FnOnce() -> T,
+    {
+        if metric < self.best_metric {
+            self.best_metric = metric;
+            self.epochs_without_improvement = 0;
+            self.best_state = Some(build_state());
+        } else {
+            self.epochs_without_improvement += 1;
+        }
+    }
+
+    pub fn should_stop(&self) -> bool {
+        self.patience
+            .is_some_and(|patience| self.epochs_without_improvement >= patience)
+    }
+
+    pub fn into_best_state(self) -> Option<T> {
+        self.best_state
+    }
+}
+
+#[inline]
+pub fn shuffle_indices(indices: &mut [usize], rng: &mut Rng) {
+    for i in (1..indices.len()).rev() {
+        let j = rng.usize(0..=i);
+        indices.swap(i, j);
+    }
+}
+
+pub fn train_validation_split_indices(
+    n_obs: usize,
+    validation_fraction: f64,
+    rng: &mut Rng,
+) -> TrainValidationSplit {
+    let mut shuffled_indices: Vec<usize> = (0..n_obs).collect();
+    shuffle_indices(&mut shuffled_indices, rng);
+
+    let n_val = ((n_obs as f64) * validation_fraction)
+        .floor()
+        .clamp(0.0, n_obs as f64) as usize;
+    let n_train = n_obs.saturating_sub(n_val);
+
+    TrainValidationSplit {
+        train_indices: shuffled_indices[..n_train].to_vec(),
+        val_indices: shuffled_indices[n_train..].to_vec(),
+    }
+}
+
+pub fn shuffled_epoch_indices(train_indices: &[usize], rng: &mut Rng) -> Vec<usize> {
+    let mut epoch_indices = train_indices.to_vec();
+    shuffle_indices(&mut epoch_indices, rng);
+    epoch_indices
+}
 
 #[inline]
 pub fn gelu_cpu(x: f64) -> f64 {
@@ -122,5 +203,30 @@ mod tests {
         for &bin in &bins {
             assert!(bin < 5);
         }
+    }
+
+    #[test]
+    fn test_train_validation_split_is_reproducible() {
+        let mut rng_a = Rng::with_seed(42);
+        let mut rng_b = Rng::with_seed(42);
+
+        let split_a = train_validation_split_indices(10, 0.2, &mut rng_a);
+        let split_b = train_validation_split_indices(10, 0.2, &mut rng_b);
+
+        assert_eq!(split_a, split_b);
+        assert_eq!(split_a.train_indices.len(), 8);
+        assert_eq!(split_a.val_indices.len(), 2);
+    }
+
+    #[test]
+    fn test_early_stopping_tracks_best_metric() {
+        let mut early_stopping = EarlyStopping::new(Some(2));
+        early_stopping.record(3.0, || 30);
+        early_stopping.record(2.0, || 20);
+        early_stopping.record(2.5, || 25);
+        early_stopping.record(2.6, || 26);
+
+        assert!(early_stopping.should_stop());
+        assert_eq!(early_stopping.into_best_state(), Some(20));
     }
 }

--- a/src/regression/clogit.rs
+++ b/src/regression/clogit.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use pyo3::prelude::*;
 #[pyclass(from_py_object)]
 #[derive(Clone)]
@@ -41,8 +43,65 @@ impl ClogitDataSet {
     pub(crate) fn get_case_control_status(&self, id: usize) -> u8 {
         self.case_control_status[id]
     }
+
+    pub(crate) fn get_stratum(&self, id: usize) -> u8 {
+        self.strata[id]
+    }
+
     pub(crate) fn get_covariates(&self, id: usize) -> &Vec<f64> {
         &self.covariates[id]
+    }
+
+    fn validate(&self) -> PyResult<BTreeMap<u8, Vec<usize>>> {
+        if self.case_control_status.len() != self.strata.len()
+            || self.case_control_status.len() != self.covariates.len()
+        {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "case_control_status, strata, and covariates must have the same length",
+            ));
+        }
+
+        let num_covariates = self.get_num_covariates();
+        let mut strata_groups: BTreeMap<u8, Vec<usize>> = BTreeMap::new();
+        for observation in 0..self.get_num_observations() {
+            let case_status = self.get_case_control_status(observation);
+            if case_status > 1 {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "case_control_status values must be 0 or 1",
+                ));
+            }
+
+            if self.get_covariates(observation).len() != num_covariates {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "all observations must have the same number of covariates",
+                ));
+            }
+
+            strata_groups
+                .entry(self.get_stratum(observation))
+                .or_default()
+                .push(observation);
+        }
+
+        for indices in strata_groups.values() {
+            if indices.len() < 2 {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "each stratum must contain at least two observations",
+                ));
+            }
+
+            let case_count = indices
+                .iter()
+                .map(|&idx| self.get_case_control_status(idx) as usize)
+                .sum::<usize>();
+            if case_count == 0 || case_count == indices.len() {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "each stratum must contain at least one case and one control",
+                ));
+            }
+        }
+
+        Ok(strata_groups)
     }
 }
 #[pyclass]
@@ -73,49 +132,90 @@ impl ConditionalLogisticRegression {
             converged: false,
         }
     }
-    pub fn fit(&mut self) {
+    pub fn fit(&mut self) -> PyResult<()> {
         let num_covariates = self.data.get_num_covariates();
         if num_covariates == 0 {
-            return;
+            self.coefficients.clear();
+            self.iterations = 0;
+            self.converged = true;
+            return Ok(());
         }
+
+        let strata_groups = self.data.validate()?;
+        let n_strata = strata_groups.len() as f64;
+
         self.coefficients = vec![0.0; num_covariates];
-        let mut old_coefficients = vec![0.0; num_covariates];
         self.iterations = 0;
         self.converged = false;
+
+        // Use a stable gradient ascent step on the conditional softmax objective
+        // within each stratum so matched-set membership actually affects the fit.
+        let learning_rate = 0.1;
         while self.iterations < self.max_iter {
-            for covariate_idx in 0..num_covariates {
-                let mut numerator = 0.0;
-                let mut denominator = 0.0;
-                for observation in 0..self.data.get_num_observations() {
-                    let case_control_status = self.data.get_case_control_status(observation);
+            let mut gradient = vec![0.0; num_covariates];
+
+            for indices in strata_groups.values() {
+                let mut linear_predictors = Vec::with_capacity(indices.len());
+                let mut max_linear_predictor = f64::NEG_INFINITY;
+                let mut case_count = 0.0;
+                let mut case_sums = vec![0.0; num_covariates];
+
+                for &observation in indices {
                     let covariates = self.data.get_covariates(observation);
-                    let exp_sum: f64 = self
+                    let case_status = self.data.get_case_control_status(observation) as f64;
+                    case_count += case_status;
+
+                    for (sum, value) in case_sums.iter_mut().zip(covariates.iter()) {
+                        *sum += case_status * value;
+                    }
+
+                    let linear_predictor: f64 = self
                         .coefficients
                         .iter()
                         .zip(covariates.iter())
                         .map(|(coef, cov)| coef * cov)
                         .sum();
-                    let exp = exp_sum.exp();
-                    numerator += case_control_status as f64 * covariates[covariate_idx] * exp;
-                    denominator += covariates[covariate_idx] * exp;
+                    max_linear_predictor = max_linear_predictor.max(linear_predictor);
+                    linear_predictors.push(linear_predictor);
                 }
-                old_coefficients[covariate_idx] = self.coefficients[covariate_idx];
-                if denominator.abs() > crate::constants::DIVISION_FLOOR {
-                    self.coefficients[covariate_idx] += numerator / denominator;
+
+                let weights: Vec<f64> = linear_predictors
+                    .iter()
+                    .map(|value| (value - max_linear_predictor).exp())
+                    .collect();
+                let total_weight = weights.iter().sum::<f64>();
+                if total_weight <= crate::constants::DIVISION_FLOOR {
+                    continue;
+                }
+
+                for covariate_idx in 0..num_covariates {
+                    let expected = indices
+                        .iter()
+                        .zip(weights.iter())
+                        .map(|(&observation, weight)| {
+                            self.data.get_covariates(observation)[covariate_idx] * *weight
+                        })
+                        .sum::<f64>()
+                        / total_weight;
+                    gradient[covariate_idx] += case_sums[covariate_idx] - case_count * expected;
                 }
             }
-            let diff: f64 = self
-                .coefficients
-                .iter()
-                .zip(old_coefficients.iter())
-                .map(|(coef, old_coef)| (coef - old_coef).abs())
-                .sum();
+
+            let mut max_change = 0.0_f64;
+            for (coefficient, gradient_component) in self.coefficients.iter_mut().zip(gradient) {
+                let delta = (learning_rate * gradient_component / n_strata).clamp(-0.5, 0.5);
+                *coefficient += delta;
+                max_change = max_change.max(delta.abs());
+            }
+
             self.iterations += 1;
-            if diff < self.tol {
+            if max_change < self.tol {
                 self.converged = true;
                 break;
             }
         }
+
+        Ok(())
     }
     pub fn predict(&self, covariates: Vec<f64>) -> f64 {
         let exp_sum: f64 = self

--- a/src/spatial/network_survival.rs
+++ b/src/spatial/network_survival.rs
@@ -1,4 +1,5 @@
-use crate::constants::{PARALLEL_THRESHOLD_LARGE, PARALLEL_THRESHOLD_MEDIUM};
+use crate::constants::PARALLEL_THRESHOLD_MEDIUM;
+use crate::utilities::sorting::descending_time_indices;
 use pyo3::prelude::*;
 use rayon::prelude::*;
 
@@ -210,20 +211,7 @@ pub fn network_survival_model(
             eta.iter().map(|&e| e.exp()).collect()
         };
 
-        let mut indices: Vec<usize> = (0..n).collect();
-        if n > PARALLEL_THRESHOLD_LARGE {
-            indices.par_sort_by(|&a, &b| {
-                time[b]
-                    .partial_cmp(&time[a])
-                    .unwrap_or(std::cmp::Ordering::Equal)
-            });
-        } else {
-            indices.sort_by(|&a, &b| {
-                time[b]
-                    .partial_cmp(&time[a])
-                    .unwrap_or(std::cmp::Ordering::Equal)
-            });
-        }
+        let indices = descending_time_indices(&time);
 
         let mut gradient = vec![0.0; total_vars];
         let mut hessian_diag = vec![0.0; total_vars];
@@ -747,21 +735,7 @@ fn compute_peer_hazard(time: &[f64], event: &[i32], adjacency: &[f64], n: usize)
 }
 
 fn compute_partial_loglik(time: &[f64], event: &[i32], eta: &[f64], exp_eta: &[f64]) -> f64 {
-    let n = time.len();
-    let mut indices: Vec<usize> = (0..n).collect();
-    if n > PARALLEL_THRESHOLD_LARGE {
-        indices.par_sort_by(|&a, &b| {
-            time[b]
-                .partial_cmp(&time[a])
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
-    } else {
-        indices.sort_by(|&a, &b| {
-            time[b]
-                .partial_cmp(&time[a])
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
-    }
+    let indices = descending_time_indices(time);
 
     let mut log_lik = 0.0;
     let mut risk_sum = 0.0;
@@ -821,20 +795,7 @@ fn compute_se(
         eta.iter().map(|&e| e.exp()).collect()
     };
 
-    let mut indices: Vec<usize> = (0..n).collect();
-    if n > PARALLEL_THRESHOLD_LARGE {
-        indices.par_sort_by(|&a, &b| {
-            time[b]
-                .partial_cmp(&time[a])
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
-    } else {
-        indices.sort_by(|&a, &b| {
-            time[b]
-                .partial_cmp(&time[a])
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
-    }
+    let indices = descending_time_indices(time);
 
     let mut info_diag = vec![0.0; total_vars];
     let mut risk_sum = 0.0;

--- a/src/spatial/spatial_frailty.rs
+++ b/src/spatial/spatial_frailty.rs
@@ -1,5 +1,6 @@
-use crate::constants::{PARALLEL_THRESHOLD_LARGE, PARALLEL_THRESHOLD_MEDIUM};
+use crate::constants::PARALLEL_THRESHOLD_MEDIUM;
 use crate::utilities::matrix::invert_flat_square_matrix_with_fallback;
+use crate::utilities::sorting::descending_time_indices;
 use crate::utilities::statistical::normal_cdf;
 use pyo3::prelude::*;
 use rayon::prelude::*;
@@ -375,20 +376,7 @@ fn em_step(
     let mut new_beta = beta.to_vec();
     let mut new_frailties = frailties.to_vec();
 
-    let mut indices: Vec<usize> = (0..n_obs).collect();
-    if n_obs > PARALLEL_THRESHOLD_LARGE {
-        indices.par_sort_by(|&a, &b| {
-            time[b]
-                .partial_cmp(&time[a])
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
-    } else {
-        indices.sort_by(|&a, &b| {
-            time[b]
-                .partial_cmp(&time[a])
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
-    }
+    let indices = descending_time_indices(time);
 
     let mut region_obs_by_region = vec![Vec::new(); n_regions];
     for (i, &region) in region_id.iter().enumerate().take(n_obs) {
@@ -532,20 +520,7 @@ fn compute_log_likelihood(
     n_obs: usize,
     n_vars: usize,
 ) -> f64 {
-    let mut indices: Vec<usize> = (0..n_obs).collect();
-    if n_obs > PARALLEL_THRESHOLD_LARGE {
-        indices.par_sort_by(|&a, &b| {
-            time[b]
-                .partial_cmp(&time[a])
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
-    } else {
-        indices.sort_by(|&a, &b| {
-            time[b]
-                .partial_cmp(&time[a])
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
-    }
+    let indices = descending_time_indices(time);
 
     let eta: Vec<f64> = if n_obs > PARALLEL_THRESHOLD_MEDIUM {
         (0..n_obs)
@@ -604,20 +579,7 @@ fn compute_standard_errors(
     n_obs: usize,
     n_vars: usize,
 ) -> Vec<f64> {
-    let mut indices: Vec<usize> = (0..n_obs).collect();
-    if n_obs > PARALLEL_THRESHOLD_LARGE {
-        indices.par_sort_by(|&a, &b| {
-            time[b]
-                .partial_cmp(&time[a])
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
-    } else {
-        indices.sort_by(|&a, &b| {
-            time[b]
-                .partial_cmp(&time[a])
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
-    }
+    let indices = descending_time_indices(time);
 
     let eta: Vec<f64> = if n_obs > PARALLEL_THRESHOLD_MEDIUM {
         (0..n_obs)

--- a/src/specialized/cch.rs
+++ b/src/specialized/cch.rs
@@ -1,6 +1,6 @@
 use crate::regression::coxph::{CoxPHModel, Subject};
 use pyo3::prelude::*;
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 #[pyclass(from_py_object)]
 pub enum CchMethod {
     Prentice,
@@ -32,11 +32,17 @@ impl CohortData {
     pub fn get_subject(&self, id: usize) -> Subject {
         self.subjects[id].clone()
     }
-    #[pyo3(signature = (_method, max_iter=100))]
-    pub fn fit(&self, _method: CchMethod, max_iter: u16) -> PyResult<CoxPHModel> {
+    #[pyo3(signature = (method, max_iter=100))]
+    pub fn fit(&self, method: CchMethod, max_iter: u16) -> PyResult<CoxPHModel> {
+        if !matches!(method, CchMethod::Prentice) {
+            return Err(pyo3::exceptions::PyNotImplementedError::new_err(format!(
+                "CchMethod::{method:?} is not implemented; only Prentice is currently supported"
+            )));
+        }
+
         let mut model = CoxPHModel::new();
         for subject in &self.subjects {
-            if subject.is_subcohort {
+            if subject.is_subcohort || subject.is_case {
                 model.add_subject(subject)?;
             }
         }

--- a/src/utilities/agexact.rs
+++ b/src/utilities/agexact.rs
@@ -32,6 +32,97 @@ pub struct AgexactParams {
     pub tol_chol: f64,
 }
 
+fn validate_agexact_inputs(
+    maxiter: i32,
+    nused: i32,
+    nvar: i32,
+    start: &[f64],
+    stop: &[f64],
+    event: &[i32],
+    covar: &[f64],
+    offset: &[f64],
+    strata: &[i32],
+    means: &[f64],
+    beta: &[f64],
+    u: &[f64],
+    imat: &[f64],
+    work: &[f64],
+    work2: &[i32],
+    nocenter: &[i32],
+) -> PyResult<(usize, usize)> {
+    if maxiter < 0 || nused < 0 || nvar < 0 {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "maxiter, nused, and nvar must be non-negative",
+        ));
+    }
+
+    let n = nused as usize;
+    let p = nvar as usize;
+
+    if start.len() != n
+        || stop.len() != n
+        || event.len() != n
+        || offset.len() != n
+        || strata.len() != n
+    {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "start, stop, event, offset, and strata must all have length nused",
+        ));
+    }
+
+    let covar_len = p.checked_mul(n).ok_or_else(|| {
+        PyErr::new::<pyo3::exceptions::PyValueError, _>("nused * nvar is too large")
+    })?;
+    if covar.len() != covar_len {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "covar must have length nused * nvar",
+        ));
+    }
+
+    if means.len() != p || beta.len() != p || u.len() != p || nocenter.len() != p {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "means, beta, u, and nocenter must all have length nvar",
+        ));
+    }
+
+    let imat_len = p.checked_mul(p).ok_or_else(|| {
+        PyErr::new::<pyo3::exceptions::PyValueError, _>("nvar * nvar is too large")
+    })?;
+    if imat.len() != imat_len {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "imat must have length nvar * nvar",
+        ));
+    }
+
+    let extra_work = p.checked_mul(3).ok_or_else(|| {
+        PyErr::new::<pyo3::exceptions::PyValueError, _>("required work length overflows usize")
+    })?;
+    let min_work_len = imat_len
+        .checked_add(extra_work)
+        .and_then(|len| len.checked_add(n))
+        .ok_or_else(|| {
+            PyErr::new::<pyo3::exceptions::PyValueError, _>("required work length overflows usize")
+        })?;
+    if work.len() < min_work_len {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+            "work must have length at least {}",
+            min_work_len
+        )));
+    }
+
+    let min_work2_len = n.checked_mul(2).ok_or_else(|| {
+        PyErr::new::<pyo3::exceptions::PyValueError, _>("required work2 length overflows usize")
+    })?;
+    if work2.len() < min_work2_len {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+            "work2 must have length at least {}",
+            min_work2_len
+        )));
+    }
+
+    Ok((n, p))
+}
+
 #[pyfunction]
 #[allow(clippy::too_many_arguments)]
 pub fn agexact(
@@ -55,6 +146,11 @@ pub fn agexact(
     tol_chol: f64,
     nocenter: Vec<i32>,
 ) -> PyResult<Py<PyDict>> {
+    validate_agexact_inputs(
+        maxiter, nused, nvar, &start, &stop, &event, &covar, &offset, &strata, &means, &beta, &u,
+        &imat, &work, &work2, &nocenter,
+    )?;
+
     let data = AgexactData {
         start,
         stop,
@@ -532,5 +628,68 @@ fn chinv2(chol: &mut [f64], n: usize) {
             }
             chol[i * n + j] = sum;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pyo3::Python;
+
+    #[test]
+    fn validate_agexact_rejects_short_workspace() {
+        Python::initialize();
+
+        let err = validate_agexact_inputs(
+            1,
+            2,
+            1,
+            &[0.0, 0.0],
+            &[1.0, 2.0],
+            &[1, 0],
+            &[1.0, 2.0],
+            &[0.0, 0.0],
+            &[0, 1],
+            &[0.0],
+            &[0.0],
+            &[0.0],
+            &[1.0],
+            &[0.0, 0.0, 0.0],
+            &[0, 0, 0, 0],
+            &[1],
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("work must have length at least"));
+    }
+
+    #[test]
+    fn validate_agexact_rejects_length_mismatches() {
+        Python::initialize();
+
+        let err = validate_agexact_inputs(
+            1,
+            2,
+            1,
+            &[0.0],
+            &[1.0, 2.0],
+            &[1, 0],
+            &[1.0, 2.0],
+            &[0.0, 0.0],
+            &[0, 1],
+            &[0.0],
+            &[0.0],
+            &[0.0],
+            &[1.0],
+            &[0.0, 0.0, 0.0, 0.0, 0.0],
+            &[0, 0, 0, 0],
+            &[1],
+        )
+        .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("start, stop, event, offset, and strata must all have length nused")
+        );
     }
 }

--- a/src/utilities/agexact.rs
+++ b/src/utilities/agexact.rs
@@ -33,37 +33,24 @@ pub struct AgexactParams {
 }
 
 fn validate_agexact_inputs(
-    maxiter: i32,
-    nused: i32,
-    nvar: i32,
-    start: &[f64],
-    stop: &[f64],
-    event: &[i32],
-    covar: &[f64],
-    offset: &[f64],
-    strata: &[i32],
-    means: &[f64],
-    beta: &[f64],
-    u: &[f64],
-    imat: &[f64],
-    work: &[f64],
-    work2: &[i32],
-    nocenter: &[i32],
+    data: &AgexactData,
+    state: &AgexactState,
+    params: &AgexactParams,
 ) -> PyResult<(usize, usize)> {
-    if maxiter < 0 || nused < 0 || nvar < 0 {
+    if params.maxiter < 0 || params.nused < 0 || params.nvar < 0 {
         return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
             "maxiter, nused, and nvar must be non-negative",
         ));
     }
 
-    let n = nused as usize;
-    let p = nvar as usize;
+    let n = params.nused as usize;
+    let p = params.nvar as usize;
 
-    if start.len() != n
-        || stop.len() != n
-        || event.len() != n
-        || offset.len() != n
-        || strata.len() != n
+    if data.start.len() != n
+        || data.stop.len() != n
+        || data.event.len() != n
+        || data.offset.len() != n
+        || data.strata.len() != n
     {
         return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
             "start, stop, event, offset, and strata must all have length nused",
@@ -73,13 +60,17 @@ fn validate_agexact_inputs(
     let covar_len = p.checked_mul(n).ok_or_else(|| {
         PyErr::new::<pyo3::exceptions::PyValueError, _>("nused * nvar is too large")
     })?;
-    if covar.len() != covar_len {
+    if data.covar.len() != covar_len {
         return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
             "covar must have length nused * nvar",
         ));
     }
 
-    if means.len() != p || beta.len() != p || u.len() != p || nocenter.len() != p {
+    if state.means.len() != p
+        || state.beta.len() != p
+        || state.u.len() != p
+        || data.nocenter.len() != p
+    {
         return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
             "means, beta, u, and nocenter must all have length nvar",
         ));
@@ -88,7 +79,7 @@ fn validate_agexact_inputs(
     let imat_len = p.checked_mul(p).ok_or_else(|| {
         PyErr::new::<pyo3::exceptions::PyValueError, _>("nvar * nvar is too large")
     })?;
-    if imat.len() != imat_len {
+    if state.imat.len() != imat_len {
         return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
             "imat must have length nvar * nvar",
         ));
@@ -103,7 +94,7 @@ fn validate_agexact_inputs(
         .ok_or_else(|| {
             PyErr::new::<pyo3::exceptions::PyValueError, _>("required work length overflows usize")
         })?;
-    if work.len() < min_work_len {
+    if state.work.len() < min_work_len {
         return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
             "work must have length at least {}",
             min_work_len
@@ -113,7 +104,7 @@ fn validate_agexact_inputs(
     let min_work2_len = n.checked_mul(2).ok_or_else(|| {
         PyErr::new::<pyo3::exceptions::PyValueError, _>("required work2 length overflows usize")
     })?;
-    if work2.len() < min_work2_len {
+    if state.work2.len() < min_work2_len {
         return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
             "work2 must have length at least {}",
             min_work2_len
@@ -146,11 +137,6 @@ pub fn agexact(
     tol_chol: f64,
     nocenter: Vec<i32>,
 ) -> PyResult<Py<PyDict>> {
-    validate_agexact_inputs(
-        maxiter, nused, nvar, &start, &stop, &event, &covar, &offset, &strata, &means, &beta, &u,
-        &imat, &work, &work2, &nocenter,
-    )?;
-
     let data = AgexactData {
         start,
         stop,
@@ -176,6 +162,7 @@ pub fn agexact(
         eps,
         tol_chol,
     };
+    validate_agexact_inputs(&data, &state, &params)?;
     agexact_impl(data, state, params)
 }
 
@@ -636,29 +623,41 @@ mod tests {
     use super::*;
     use pyo3::Python;
 
+    fn sample_params(nused: i32, nvar: i32) -> AgexactParams {
+        AgexactParams {
+            maxiter: 1,
+            nused,
+            nvar,
+            eps: 1e-9,
+            tol_chol: 1e-9,
+        }
+    }
+
     #[test]
     fn validate_agexact_rejects_short_workspace() {
         Python::initialize();
 
-        let err = validate_agexact_inputs(
-            1,
-            2,
-            1,
-            &[0.0, 0.0],
-            &[1.0, 2.0],
-            &[1, 0],
-            &[1.0, 2.0],
-            &[0.0, 0.0],
-            &[0, 1],
-            &[0.0],
-            &[0.0],
-            &[0.0],
-            &[1.0],
-            &[0.0, 0.0, 0.0],
-            &[0, 0, 0, 0],
-            &[1],
-        )
-        .unwrap_err();
+        let data = AgexactData {
+            start: vec![0.0, 0.0],
+            stop: vec![1.0, 2.0],
+            event: vec![1, 0],
+            covar: vec![1.0, 2.0],
+            offset: vec![0.0, 0.0],
+            strata: vec![0, 1],
+            nocenter: vec![1],
+        };
+        let state = AgexactState {
+            means: vec![0.0],
+            beta: vec![0.0],
+            u: vec![0.0],
+            imat: vec![1.0],
+            loglik: vec![0.0, 0.0],
+            work: vec![0.0, 0.0, 0.0],
+            work2: vec![0, 0, 0, 0],
+        };
+        let params = sample_params(2, 1);
+
+        let err = validate_agexact_inputs(&data, &state, &params).unwrap_err();
 
         assert!(err.to_string().contains("work must have length at least"));
     }
@@ -667,25 +666,27 @@ mod tests {
     fn validate_agexact_rejects_length_mismatches() {
         Python::initialize();
 
-        let err = validate_agexact_inputs(
-            1,
-            2,
-            1,
-            &[0.0],
-            &[1.0, 2.0],
-            &[1, 0],
-            &[1.0, 2.0],
-            &[0.0, 0.0],
-            &[0, 1],
-            &[0.0],
-            &[0.0],
-            &[0.0],
-            &[1.0],
-            &[0.0, 0.0, 0.0, 0.0, 0.0],
-            &[0, 0, 0, 0],
-            &[1],
-        )
-        .unwrap_err();
+        let data = AgexactData {
+            start: vec![0.0],
+            stop: vec![1.0, 2.0],
+            event: vec![1, 0],
+            covar: vec![1.0, 2.0],
+            offset: vec![0.0, 0.0],
+            strata: vec![0, 1],
+            nocenter: vec![1],
+        };
+        let state = AgexactState {
+            means: vec![0.0],
+            beta: vec![0.0],
+            u: vec![0.0],
+            imat: vec![1.0],
+            loglik: vec![0.0, 0.0],
+            work: vec![0.0, 0.0, 0.0, 0.0, 0.0],
+            work2: vec![0, 0, 0, 0],
+        };
+        let params = sample_params(2, 1);
+
+        let err = validate_agexact_inputs(&data, &state, &params).unwrap_err();
 
         assert!(
             err.to_string()

--- a/src/utilities/mod.rs
+++ b/src/utilities/mod.rs
@@ -9,6 +9,7 @@ pub mod numpy_utils;
 pub mod reliability;
 pub mod rttright;
 pub mod simd;
+pub mod sorting;
 pub mod statistical;
 pub mod strata;
 pub mod surv2data;

--- a/src/utilities/rttright.rs
+++ b/src/utilities/rttright.rs
@@ -75,29 +75,6 @@ pub fn rttright(
     let sorted_status: Vec<i32> = indices.iter().map(|&i| status[i]).collect();
     let sorted_weights: Vec<f64> = indices.iter().map(|&i| init_weights[i]).collect();
 
-    let mut rtt_weights = vec![0.0; n];
-    let mut cumulative_censored_weight = 0.0;
-
-    for i in 0..n {
-        if i > 0 && sorted_status[i - 1] == 0 {
-            cumulative_censored_weight += sorted_weights[i - 1];
-        }
-
-        if sorted_status[i] == 1 {
-            let base_weight = sorted_weights[i];
-            let n_at_risk = (n - i) as f64;
-            let redistributed = if n_at_risk > 0.0 {
-                cumulative_censored_weight / n_at_risk
-            } else {
-                0.0
-            };
-
-            rtt_weights[i] = base_weight + redistributed;
-        } else {
-            rtt_weights[i] = 0.0;
-        }
-    }
-
     let km_weights = compute_km_weights(&sorted_time, &sorted_status, &sorted_weights);
 
     Ok(RttrightResult {
@@ -199,9 +176,10 @@ pub fn rttright_stratified(
 
         let result = rttright(strata_time, strata_status, Some(strata_weights))?;
 
-        for (j, &orig_idx) in indices.iter().enumerate() {
-            final_weights[orig_idx] = result.weights[j];
-            final_order[offset + j] = orig_idx;
+        for (sorted_pos, &local_idx) in result.order.iter().enumerate() {
+            let orig_idx = indices[local_idx];
+            final_weights[orig_idx] = result.weights[sorted_pos];
+            final_order[offset + sorted_pos] = orig_idx;
         }
         offset += indices.len();
     }
@@ -217,6 +195,7 @@ pub fn rttright_stratified(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use itertools::Itertools;
 
     #[test]
     fn test_rttright_basic() {
@@ -252,5 +231,55 @@ mod tests {
 
         let result = rttright(time, status, None).unwrap();
         assert!(result.weights.is_empty());
+    }
+
+    #[test]
+    fn test_rttright_stratified_aligns_weights_to_original_rows() {
+        let result = rttright_stratified(
+            vec![3.0, 1.0, 2.0, 1.5],
+            vec![1, 0, 1, 1],
+            vec![0, 0, 1, 1],
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(result.weights[1], 0.0);
+        assert!(result.weights[0] > 0.0);
+        assert!(result.weights[2] > 0.0);
+        assert!(result.weights[3] > 0.0);
+
+        let mut order = result.order.clone();
+        order.sort_unstable();
+        assert_eq!(order, vec![0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn test_rttright_is_invariant_to_input_order_with_unique_times() {
+        let base_time = [1.0, 2.0, 3.0, 4.0];
+        let base_status = [1, 0, 1, 1];
+        let base_weights = [1.0, 2.0, 1.5, 0.5];
+
+        let baseline = rttright(
+            base_time.to_vec(),
+            base_status.to_vec(),
+            Some(base_weights.to_vec()),
+        )
+        .unwrap();
+
+        for permutation in (0..base_time.len()).permutations(base_time.len()) {
+            let time: Vec<f64> = permutation.iter().map(|&i| base_time[i]).collect();
+            let status: Vec<i32> = permutation.iter().map(|&i| base_status[i]).collect();
+            let weights: Vec<f64> = permutation.iter().map(|&i| base_weights[i]).collect();
+
+            let result = rttright(time, status, Some(weights)).unwrap();
+
+            assert_eq!(result.time, baseline.time);
+            assert_eq!(result.status, baseline.status);
+            assert_eq!(result.weights, baseline.weights);
+
+            let mut order = result.order.clone();
+            order.sort_unstable();
+            assert_eq!(order, vec![0, 1, 2, 3]);
+        }
     }
 }

--- a/src/utilities/sorting.rs
+++ b/src/utilities/sorting.rs
@@ -1,0 +1,38 @@
+use crate::constants::PARALLEL_THRESHOLD_LARGE;
+use rayon::prelude::*;
+
+pub fn descending_time_indices(time: &[f64]) -> Vec<usize> {
+    let mut indices: Vec<usize> = (0..time.len()).collect();
+    if time.len() > PARALLEL_THRESHOLD_LARGE {
+        indices.par_sort_by(|&a, &b| {
+            time[b]
+                .partial_cmp(&time[a])
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+    } else {
+        indices.sort_by(|&a, &b| {
+            time[b]
+                .partial_cmp(&time[a])
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+    }
+    indices
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_descending_time_indices_orders_values_descending() {
+        let time = vec![2.0, 5.0, 1.0, 4.0];
+        let indices = descending_time_indices(&time);
+        let ordered: Vec<f64> = indices.iter().map(|&idx| time[idx]).collect();
+
+        assert_eq!(ordered, vec![5.0, 4.0, 2.0, 1.0]);
+
+        let mut sorted_indices = indices;
+        sorted_indices.sort_unstable();
+        assert_eq!(sorted_indices, vec![0, 1, 2, 3]);
+    }
+}

--- a/src/utilities/surv2data.rs
+++ b/src/utilities/surv2data.rs
@@ -139,6 +139,7 @@ pub fn surv2data(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use itertools::Itertools;
 
     #[test]
     fn test_surv2data_basic() {
@@ -177,5 +178,50 @@ mod tests {
         assert!(result.id.len() >= 2);
         assert_eq!(result.time1[0], 0.0);
         assert_eq!(result.time2[0], 5.0);
+    }
+
+    #[test]
+    fn test_surv2data_is_invariant_to_input_order() {
+        let base_id = [1, 1, 2, 2];
+        let base_time = [0.0, 5.0, 0.0, 3.0];
+        let base_event_time = [10.0, 10.0, 8.0, 8.0];
+        let base_event_status = [1, 1, 0, 0];
+        let expected = vec![
+            (1, 0.0, 5.0, 0),
+            (1, 5.0, 10.0, 1),
+            (2, 0.0, 3.0, 0),
+            (2, 3.0, 8.0, 0),
+        ];
+
+        for permutation in (0..base_id.len()).permutations(base_id.len()) {
+            let id: Vec<i32> = permutation.iter().map(|&i| base_id[i]).collect();
+            let time: Vec<f64> = permutation.iter().map(|&i| base_time[i]).collect();
+            let event_time: Vec<f64> = permutation.iter().map(|&i| base_event_time[i]).collect();
+            let event_status: Vec<i32> =
+                permutation.iter().map(|&i| base_event_status[i]).collect();
+
+            let result = surv2data(
+                id.clone(),
+                time.clone(),
+                Some(event_time),
+                Some(event_status),
+            );
+            let intervals: Vec<(i32, f64, f64, i32)> = result
+                .id
+                .iter()
+                .zip(&result.time1)
+                .zip(&result.time2)
+                .zip(&result.status)
+                .map(|(((id, time1), time2), status)| (*id, *time1, *time2, *status))
+                .collect();
+
+            assert_eq!(intervals, expected);
+            assert_eq!(result.row_index.len(), result.id.len());
+            for idx in 0..result.row_index.len() {
+                let original = result.row_index[idx] - 1;
+                assert_eq!(id[original], result.id[idx]);
+                assert_eq!(time[original], result.time1[idx]);
+            }
+        }
     }
 }

--- a/src/utilities/survcondense.rs
+++ b/src/utilities/survcondense.rs
@@ -123,6 +123,7 @@ pub fn survcondense(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use itertools::Itertools;
 
     #[test]
     fn test_survcondense_basic() {
@@ -178,5 +179,43 @@ mod tests {
 
         assert_eq!(result.id.len(), 2);
         assert_eq!(result.id, vec![1, 2]);
+    }
+
+    #[test]
+    fn test_survcondense_is_invariant_to_input_order() {
+        let base_id = [1, 1, 1, 2, 2];
+        let base_time1 = [0.0, 2.0, 4.0, 0.0, 3.0];
+        let base_time2 = [2.0, 4.0, 6.0, 3.0, 5.0];
+        let base_status = [0, 0, 1, 0, 0];
+        let expected = vec![(1, 0.0, 6.0, 1), (2, 0.0, 5.0, 0)];
+
+        for permutation in (0..base_id.len()).permutations(base_id.len()) {
+            let id: Vec<i32> = permutation.iter().map(|&i| base_id[i]).collect();
+            let time1: Vec<f64> = permutation.iter().map(|&i| base_time1[i]).collect();
+            let time2: Vec<f64> = permutation.iter().map(|&i| base_time2[i]).collect();
+            let status: Vec<i32> = permutation.iter().map(|&i| base_status[i]).collect();
+
+            let result = survcondense(id.clone(), time1.clone(), time2.clone(), status.clone());
+            let condensed: Vec<(i32, f64, f64, i32)> = result
+                .id
+                .iter()
+                .zip(&result.time1)
+                .zip(&result.time2)
+                .zip(&result.status)
+                .map(|(((id, time1), time2), status)| (*id, *time1, *time2, *status))
+                .collect();
+
+            assert_eq!(condensed, expected);
+
+            let mut seen = vec![false; id.len()];
+            for row_indices in &result.row_map {
+                for &row in row_indices {
+                    let original = row - 1;
+                    assert!(!seen[original]);
+                    seen[original] = true;
+                }
+            }
+            assert!(seen.into_iter().all(|covered| covered));
+        }
     }
 }

--- a/src/utilities/tmerge.rs
+++ b/src/utilities/tmerge.rs
@@ -31,6 +31,7 @@ pub fn tmerge(
             has_one = true;
             local_k += 1;
         }
+        k = local_k;
         if has_one {
             result[i] = if result[i].is_nan() {
                 csum
@@ -162,5 +163,38 @@ mod tests {
         assert_eq!(result[0], 1);
         assert_eq!(result[1], 0);
         assert_eq!(result[2], 3);
+    }
+
+    #[test]
+    fn tmerge_accumulates_within_subject_and_resets_at_boundaries() {
+        let result = tmerge(
+            vec![1, 1, 2, 2, 2],
+            vec![1.0, 3.0, 0.5, 1.5, 3.0],
+            vec![f64::NAN, 10.0, f64::NAN, 1.0, f64::NAN],
+            vec![1, 1, 2, 2, 2],
+            vec![0.5, 2.5, 0.25, 1.0, 2.0],
+            vec![2.0, 3.0, 5.0, 7.0, 11.0],
+        );
+
+        assert_eq!(result.len(), 5);
+        assert!((result[0] - 2.0).abs() < 1e-10);
+        assert!((result[1] - 15.0).abs() < 1e-10);
+        assert!((result[2] - 5.0).abs() < 1e-10);
+        assert!((result[3] - 13.0).abs() < 1e-10);
+        assert!((result[4] - 23.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn tmerge2_indices_are_subject_local_and_monotone() {
+        let result = tmerge2(
+            vec![1, 1, 2, 2],
+            vec![1.0, 3.0, 0.5, 3.0],
+            vec![1, 1, 2, 2, 2],
+            vec![0.5, 2.5, 0.25, 1.0, 2.0],
+        );
+
+        assert_eq!(result, vec![1, 2, 3, 5]);
+        assert!(result[0] <= result[1]);
+        assert!(result[2] <= result[3]);
     }
 }

--- a/src/validation/bootstrap.rs
+++ b/src/validation/bootstrap.rs
@@ -56,6 +56,23 @@ fn bootstrap_sample_indices(n: usize, seed: u64, iteration: usize) -> Vec<usize>
     let mut rng = fastrand::Rng::with_seed(seed.wrapping_add(iteration as u64));
     (0..n).map(|_| rng.usize(..n)).collect()
 }
+
+fn validate_bootstrap_inputs(n_bootstrap: usize, confidence_level: f64) -> PyResult<()> {
+    if n_bootstrap < 2 {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "n_bootstrap must be at least 2",
+        ));
+    }
+
+    if !(0.0 < confidence_level && confidence_level < 1.0) {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "confidence_level must be between 0 and 1",
+        ));
+    }
+
+    Ok(())
+}
+
 pub fn bootstrap_cox(
     time: &[f64],
     status: &[i32],
@@ -166,15 +183,19 @@ pub fn bootstrap_cox(
         .map(|col| col.iter().sum::<f64>() / actual_n_bootstrap as f64)
         .collect();
 
-    let std_errors: Vec<f64> = transposed
-        .iter()
-        .zip(means.iter())
-        .map(|(col, &mean)| {
-            let variance = col.iter().map(|&c| (c - mean).powi(2)).sum::<f64>()
-                / (actual_n_bootstrap - 1) as f64;
-            variance.sqrt()
-        })
-        .collect();
+    let std_errors: Vec<f64> = if actual_n_bootstrap > 1 {
+        transposed
+            .iter()
+            .zip(means.iter())
+            .map(|(col, &mean)| {
+                let variance = col.iter().map(|&c| (c - mean).powi(2)).sum::<f64>()
+                    / (actual_n_bootstrap - 1) as f64;
+                variance.sqrt()
+            })
+            .collect()
+    } else {
+        vec![0.0; nvar]
+    };
 
     let alpha = 1.0 - config.confidence_level;
     let lower_percentile = (alpha / 2.0 * actual_n_bootstrap as f64) as usize;
@@ -234,6 +255,10 @@ pub fn bootstrap_cox_ci(
     confidence_level: Option<f64>,
     seed: Option<u64>,
 ) -> PyResult<BootstrapResult> {
+    let n_bootstrap = n_bootstrap.unwrap_or(DEFAULT_BOOTSTRAP_SAMPLES);
+    let confidence_level = confidence_level.unwrap_or(0.95);
+    validate_bootstrap_inputs(n_bootstrap, confidence_level)?;
+
     let n = time.len();
     let nvar = if !covariates.is_empty() {
         covariates[0].len()
@@ -249,8 +274,8 @@ pub fn bootstrap_cox_ci(
         Array2::zeros((0, n))
     };
     let config = BootstrapConfig {
-        n_bootstrap: n_bootstrap.unwrap_or(DEFAULT_BOOTSTRAP_SAMPLES),
-        confidence_level: confidence_level.unwrap_or(0.95),
+        n_bootstrap,
+        confidence_level,
         seed,
     };
     let weights_ref = weights.as_deref();
@@ -266,7 +291,7 @@ pub fn bootstrap_survreg(
 ) -> Result<BootstrapResult, Box<dyn std::error::Error + Send + Sync>> {
     use crate::regression::survreg6::{DistributionType, survreg};
     let n = time.len();
-    let nvar = covariates.ncols();
+    let nvar = covariates.nrows();
     let cov_vecs: Vec<Vec<f64>> = (0..n)
         .map(|i| (0..nvar).map(|j| covariates[[j, i]]).collect())
         .collect();
@@ -348,15 +373,17 @@ pub fn bootstrap_survreg(
         *m /= actual_n_bootstrap as f64;
     }
     let mut std_errors = vec![0.0; ncoef];
-    for coefs in &bootstrap_coefs {
-        for (i, &c) in coefs.iter().enumerate() {
-            if i < ncoef {
-                std_errors[i] += (c - means[i]).powi(2);
+    if actual_n_bootstrap > 1 {
+        for coefs in &bootstrap_coefs {
+            for (i, &c) in coefs.iter().enumerate() {
+                if i < ncoef {
+                    std_errors[i] += (c - means[i]).powi(2);
+                }
             }
         }
-    }
-    for se in &mut std_errors {
-        *se = (*se / (actual_n_bootstrap - 1) as f64).sqrt();
+        for se in &mut std_errors {
+            *se = (*se / (actual_n_bootstrap - 1) as f64).sqrt();
+        }
     }
     let alpha = 1.0 - config.confidence_level;
     let lower_percentile = (alpha / 2.0 * actual_n_bootstrap as f64) as usize;
@@ -400,6 +427,10 @@ pub fn bootstrap_survreg_ci(
     confidence_level: Option<f64>,
     seed: Option<u64>,
 ) -> PyResult<BootstrapResult> {
+    let n_bootstrap = n_bootstrap.unwrap_or(DEFAULT_BOOTSTRAP_SAMPLES);
+    let confidence_level = confidence_level.unwrap_or(0.95);
+    validate_bootstrap_inputs(n_bootstrap, confidence_level)?;
+
     let n = time.len();
     let nvar = if !covariates.is_empty() {
         covariates[0].len()
@@ -415,11 +446,41 @@ pub fn bootstrap_survreg_ci(
         Array2::zeros((0, n))
     };
     let config = BootstrapConfig {
-        n_bootstrap: n_bootstrap.unwrap_or(DEFAULT_BOOTSTRAP_SAMPLES),
-        confidence_level: confidence_level.unwrap_or(0.95),
+        n_bootstrap,
+        confidence_level,
         seed,
     };
     let dist = distribution.unwrap_or("weibull");
     bootstrap_survreg(&time, &status, &cov_array, dist, &config)
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("{}", e)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BootstrapConfig, bootstrap_survreg};
+    use ndarray::Array2;
+
+    #[test]
+    fn test_bootstrap_survreg_transposed_covariates_smoke() {
+        let time = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+        let status = vec![1.0, 1.0, 0.0, 1.0, 0.0, 1.0];
+        let covariates = Array2::from_shape_vec(
+            (2, 6),
+            vec![1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6],
+        )
+        .unwrap();
+        let config = BootstrapConfig {
+            n_bootstrap: 8,
+            confidence_level: 0.95,
+            seed: Some(123),
+        };
+
+        let result = bootstrap_survreg(&time, &status, &covariates, "weibull", &config).unwrap();
+
+        assert_eq!(result.coefficients.len(), 3);
+        assert_eq!(result.std_errors.len(), 3);
+        assert_eq!(result.ci_lower.len(), 3);
+        assert_eq!(result.ci_upper.len(), 3);
+        assert!(!result.bootstrap_samples.is_empty());
+    }
 }


### PR DESCRIPTION
## Summary
- expand maintained Python coverage across auxiliary APIs, regression, specialized, utilities, calibration/reporting, multistate, and sklearn wrapper surfaces
- harden bootstrap and agexact validation, fix utility and modeling bugs, and clean up dead/duplicate code paths
- enforce Rust coverage in CI, add a source-tree Python extension job, and include the open package/action upgrades

## Verification
- cargo test -q
- ./.venv/bin/pytest python/tests -q