### PR TITLE
Expand R API compatibility

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -16,6 +16,7 @@ nd = "nd"
 perfor = "perfor"
 wil = "wil"
 consts = "consts"
+parms = "parms"
 
 [files]
 extend-exclude = [

--- a/benches/survival_benchmarks.rs
+++ b/benches/survival_benchmarks.rs
@@ -196,6 +196,7 @@ mod cox_regression {
                 Some(1e-9),
                 Some("efron"),
                 None,
+                None,
             )
             .expect("benchmark Cox PH Efron fit should converge");
             black_box(fit);
@@ -219,6 +220,7 @@ mod cox_regression {
                 Some(1e-7),
                 Some(1e-9),
                 Some("breslow"),
+                None,
                 None,
             )
             .expect("benchmark Cox PH Breslow fit should converge");
@@ -246,6 +248,7 @@ mod cox_regression {
                 Some(1e-9),
                 Some("efron"),
                 None,
+                None,
             )
             .expect("benchmark weighted stratified Cox PH fit should converge");
             black_box(fit);
@@ -271,6 +274,7 @@ mod cox_regression {
             Some(1e-9),
             Some("efron"),
             Some(entry_times),
+            None,
         )
         .expect("benchmark Cox PH fit should converge");
 
@@ -299,6 +303,7 @@ mod cox_regression {
             Some(1e-7),
             Some(1e-9),
             Some("efron"),
+            None,
             None,
         )
         .expect("benchmark Cox PH fit should converge");
@@ -332,6 +337,7 @@ mod cox_regression {
             Some(1e-9),
             Some("efron"),
             Some(entry_times),
+            None,
         )
         .expect("benchmark Cox PH fit should converge");
 
@@ -362,6 +368,7 @@ mod cox_regression {
             Some(1e-9),
             Some("efron"),
             Some(entry_times),
+            None,
         )
         .expect("benchmark Cox PH fit should converge");
 
@@ -440,6 +447,7 @@ mod survreg_bench {
                 Some(1e-7),
                 Some(1e-9),
                 None,
+                None,
             )
             .expect("benchmark Weibull survreg fit should converge");
             black_box(fit);
@@ -469,6 +477,7 @@ mod survreg_bench {
                 Some(30),
                 Some(1e-7),
                 Some(1e-9),
+                None,
                 None,
             )
             .expect("benchmark weighted stratified lognormal survreg fit should converge");

--- a/python/survival/_survival.pyi
+++ b/python/survival/_survival.pyi
@@ -955,6 +955,8 @@ class CoxPHFit:
     def strata(self) -> list[int]: ...
     @property
     def method(self) -> str: ...
+    @property
+    def nocenter(self) -> list[float]: ...
 
 class CoxphDetailRow:
     @property
@@ -6420,6 +6422,7 @@ def coxph_fit(
     toler: float | None = None,
     method: str | None = None,
     entry_times: list[float] | None = None,
+    nocenter: list[float] | None = None,
 ) -> CoxPHFit: ...
 def coxph_detail(
     time: list[float],
@@ -6492,6 +6495,7 @@ def survreg(
     eps: float | None = None,
     tol_chol: float | None = None,
     time2: list[float] | None = None,
+    fixed_scale: float | None = None,
 ) -> SurvivalFit: ...
 def predict_survreg(
     covariates: list[list[float]],
@@ -6636,23 +6640,31 @@ def concordance_index(
     time: list[float],
     status: list[int],
     risk_scores: list[float],
+    weights: list[float] | None = None,
+    timewt: str = "n",
 ) -> float: ...
 def concordance_summary(
     time: list[float],
     status: list[int],
     risk_scores: list[float],
+    weights: list[float] | None = None,
+    timewt: str = "n",
 ) -> dict[str, float]: ...
 def counting_concordance_index(
     start: list[float],
     stop: list[float],
     status: list[int],
     risk_scores: list[float],
+    weights: list[float] | None = None,
+    timewt: str = "n",
 ) -> float: ...
 def counting_concordance_summary(
     start: list[float],
     stop: list[float],
     status: list[int],
     risk_scores: list[float],
+    weights: list[float] | None = None,
+    timewt: str = "n",
 ) -> dict[str, float]: ...
 def brier(
     time: list[float],

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -37,6 +37,8 @@ _EXP_CLAMP_MIN = -745.0
 _EXP_CLAMP_MAX = 709.0
 _SURVFIT_TIME_EPSILON = 1e-9
 _VARIANCE_SCALE_FLOOR = 1e-12
+_COX_DFBETAS_SCALE_FLOOR = 1e-10
+_CONCORDANCE_RISK_TIE_FLOOR = 1e-10
 _SURV_TYPES = ("right", "left", "interval", "counting", "interval2")
 
 
@@ -104,15 +106,52 @@ class _FormulaFit:
     robust_variance: list[list[float]] | None = None
     naive_variance: list[list[float]] | None = None
     cluster: list[Any] | None = None
+    id_values: list[Any] | None = None
+    x_matrix: list[list[float]] | None = None
+    y_response: Surv | None = None
+    model_frame: dict[str, Any] | None = None
+    score_values: list[float] | None = None
 
     def __getattr__(self, name: str) -> Any:
+        if name == "id" and self.id_values is not None:
+            return self.id_values
+        if name == "x" and self.x_matrix is not None:
+            return self.x_matrix
+        if name == "y" and self.y_response is not None:
+            return self.y_response
+        if name == "model" and self.model_frame is not None:
+            return self.model_frame
+        if name == "score" and self.score_values is not None:
+            return self.score_values
+        if name == "scaled_schoenfeld_residuals" and hasattr(self.fit, "schoenfeld_residuals"):
+            return self._cox_scaled_schoenfeld_residuals
+        if name == "dfbeta" and hasattr(self.fit, "score_residuals"):
+            return self._cox_dfbeta
+        if name == "dfbetas" and hasattr(self.fit, "score_residuals"):
+            return self._cox_dfbetas
         return getattr(self.fit, name)
+
+    def _cox_scaled_schoenfeld_residuals(self) -> list[list[float]]:
+        raw = [[float(value) for value in row] for row in self.fit.schoenfeld_residuals()]
+        return _cox_scaled_schoenfeld_from_raw(self, raw)
+
+    def _cox_dfbeta(self) -> list[list[float]]:
+        return _cox_dfbeta_from_score_residuals(self, scaled=False)
+
+    def _cox_dfbetas(self) -> list[list[float]]:
+        return _cox_dfbeta_from_score_residuals(self, scaled=True)
 
     @property
     def information_matrix(self) -> list[list[float]]:
         if self.robust_variance is not None:
             return self.robust_variance
-        return self.fit.information_matrix
+        matrix = getattr(self.fit, "information_matrix", None)
+        if matrix is not None:
+            return matrix
+        matrix = getattr(self.fit, "variance_matrix", None)
+        if matrix is not None:
+            return matrix
+        raise AttributeError("wrapped fit does not expose a variance matrix")
 
     @property
     def variance_matrix(self) -> list[list[float]]:
@@ -147,14 +186,25 @@ class _ResponseOperand:
 
 @dataclass(frozen=True)
 class ConcordanceResult:
-    concordance: float
+    concordance: float | list[float]
     n: int
     n_event: int
     reverse: bool = False
+    concordant: float | list[float] = 0.0
+    comparable: float | list[float] = 0.0
+    ranks: list[dict[str, float]] | list[list[dict[str, float]] | None] | None = None
+    dfbeta: list[float] | list[list[float] | None] | None = None
+    influence: list[list[float]] | list[list[list[float]] | None] | None = None
+    variance: float | list[float | None] | None = None
+    score_names: list[str] | None = None
 
     @property
-    def c_index(self) -> float:
+    def c_index(self) -> float | list[float]:
         return self.concordance
+
+    @property
+    def var(self) -> float | list[float | None] | None:
+        return self.variance
 
 
 @dataclass(frozen=True)
@@ -304,6 +354,7 @@ class CoxSurvfitResult:
     std_chaz: list[list[float]] = field(default_factory=list)
     conf_lower: list[list[float]] = field(default_factory=list)
     conf_upper: list[list[float]] = field(default_factory=list)
+    model: dict[str, Any] | None = None
 
     def __iter__(self):
         yield self.time
@@ -338,6 +389,8 @@ class SurvfitResult:
     conf_upper: list[float]
     cumhaz: list[float]
     std_chaz: list[float]
+    n_enter: list[float] | None = None
+    model: dict[str, Any] | None = None
 
     @property
     def surv(self) -> list[float]:
@@ -350,6 +403,17 @@ class SurvfitResult:
     @property
     def cumulative_hazard_std_err(self) -> list[float]:
         return self.std_chaz
+
+
+@dataclass(frozen=True)
+class TurnbullSurvfitResult:
+    time_points: list[float]
+    survival: list[float]
+    survival_lower: list[float]
+    survival_upper: list[float]
+    n_iter: int
+    converged: bool
+    model: dict[str, Any] | None = None
 
 
 @dataclass(frozen=True)
@@ -637,6 +701,73 @@ def _as_matrix_rows(
     if any(len(row) != width for row in matrix):
         raise ValueError(f"{name} must be rectangular")
     return matrix
+
+
+def _cox_centered_design_rank(
+    rows: list[list[float]],
+    weights: list[float] | None,
+    tolerance: float,
+) -> int:
+    width = len(rows[0]) if rows else 0
+    if width == 0:
+        return 0
+
+    case_weights = [1.0] * len(rows) if weights is None else weights
+    active = [
+        idx for idx, weight in enumerate(case_weights) if math.isfinite(weight) and weight > 0.0
+    ]
+    if not active:
+        return width
+
+    total_weight = math.fsum(case_weights[idx] for idx in active)
+    if not math.isfinite(total_weight) or total_weight <= 0.0:
+        return width
+
+    means = [
+        math.fsum(case_weights[idx] * rows[idx][col_idx] for idx in active) / total_weight
+        for col_idx in range(width)
+    ]
+    columns: list[list[float]] = []
+    for col_idx in range(width):
+        column = [
+            (rows[idx][col_idx] - means[col_idx]) * math.sqrt(case_weights[idx]) for idx in active
+        ]
+        scale = max((abs(value) for value in column), default=0.0)
+        columns.append([value / scale for value in column] if scale > 0.0 else column)
+
+    rank = 0
+    basis: list[list[float]] = []
+    pivot_tolerance = max(abs(tolerance), 1e-12) * max(len(active), width, 1)
+    for column in columns:
+        residual = list(column)
+        for basis_column in basis:
+            projection = math.fsum(
+                value * basis_value
+                for value, basis_value in zip(residual, basis_column, strict=True)
+            )
+            residual = [
+                value - projection * basis_value
+                for value, basis_value in zip(residual, basis_column, strict=True)
+            ]
+        norm = math.sqrt(math.fsum(value * value for value in residual))
+        if norm > pivot_tolerance:
+            basis.append([value / norm for value in residual])
+            rank += 1
+    return rank
+
+
+def _check_cox_design_full_rank(
+    rows: list[list[float]],
+    weights: list[float] | None,
+    tolerance: float,
+) -> None:
+    width = len(rows[0]) if rows else 0
+    if width == 0:
+        return
+    if _cox_centered_design_rank(rows, weights, tolerance) < width:
+        raise ValueError(
+            "coxph design matrix is singular; use singular_ok=True to allow dependent covariates"
+        )
 
 
 def _column(data: Any, name: str) -> list[Any]:
@@ -1694,6 +1825,27 @@ def _split_terms(rhs: str, dot_terms: list[str] | None = None) -> _FormulaTerms:
     )
 
 
+def _formula_has_time_transform_term(formula: str) -> bool:
+    _lhs, sep, rhs = formula.partition("~")
+    if not sep:
+        return False
+
+    in_backtick = False
+    for idx, char in enumerate(rhs):
+        if char == "`":
+            in_backtick = not in_backtick
+            continue
+        if in_backtick or char != "t":
+            continue
+        if rhs[idx : idx + 2] != "tt":
+            continue
+        previous = rhs[idx - 1] if idx > 0 else ""
+        next_char = rhs[idx + 2] if idx + 2 < len(rhs) else ""
+        if (not previous or not (previous.isalnum() or previous in "._")) and next_char == "(":
+            return True
+    return False
+
+
 def _parse_formula(formula: str, data: Any) -> tuple[Surv, _FormulaTerms]:
     _lhs, sep, rhs = formula.partition("~")
     if not sep:
@@ -1958,6 +2110,147 @@ def _formula_design_columns(design: _FormulaDesign) -> list[str]:
     columns = [column for term in design.covariates for column in _design_term_columns_used(term)]
     columns.extend(_offset_columns(design.offsets))
     return list(dict.fromkeys(columns))
+
+
+def _surv_response_model_name(spec: _SurvResponseSpec) -> str:
+    return f"Surv({', '.join(spec.arguments)})"
+
+
+def _formula_model_frame(
+    data: Any,
+    response: Surv,
+    design: _FormulaDesign,
+    *,
+    extra_columns: Sequence[str] = (),
+    weights: Any | None = None,
+    offset: Any | None = None,
+    offsets: Any | None = None,
+    strata: Any | None = None,
+    cluster: Any | None = None,
+    id: Any | None = None,  # noqa: A002
+) -> dict[str, Any]:
+    frame: dict[str, Any] = {_surv_response_model_name(design.response): response}
+    columns: list[str] = []
+    _append_unique(columns, design.response.columns)
+    _append_unique(columns, _formula_design_columns(design))
+    _append_unique(columns, list(design.strata))
+    _append_unique(columns, list(extra_columns))
+    for column in columns:
+        frame[column] = _column(data, column)
+    for name, values in (
+        ("(weights)", weights),
+        ("(offset)", offsets if offsets is not None else offset),
+        ("(strata)", strata),
+        ("(cluster)", cluster),
+        ("(id)", id),
+    ):
+        if values is not None:
+            frame[name] = _materialize_1d(values, name)
+    return frame
+
+
+def _matrix_model_frame(
+    response: Surv,
+    rows: list[list[float]],
+    *,
+    weights: Any | None = None,
+    offset: Any | None = None,
+    offsets: Any | None = None,
+    strata: Any | None = None,
+    cluster: Any | None = None,
+    id: Any | None = None,  # noqa: A002
+) -> dict[str, Any]:
+    frame: dict[str, Any] = {
+        "response": response,
+        "x": [list(row) for row in rows],
+    }
+    for name, values in (
+        ("(weights)", weights),
+        ("(offset)", offsets if offsets is not None else offset),
+        ("(strata)", strata),
+        ("(cluster)", cluster),
+        ("(id)", id),
+    ):
+        if values is not None:
+            frame[name] = _materialize_1d(values, name)
+    return frame
+
+
+def _survreg_matrix_model_frame(
+    time: list[float],
+    status: list[float],
+    time2: list[float] | None,
+    rows: list[list[float]],
+    *,
+    weights: Any | None = None,
+    offset: Any | None = None,
+    offsets: Any | None = None,
+    strata: Any | None = None,
+    cluster: Any | None = None,
+) -> dict[str, Any]:
+    frame: dict[str, Any] = {
+        "time": list(time),
+        "status": list(status),
+        "x": [list(row) for row in rows],
+    }
+    if time2 is not None:
+        frame["time2"] = list(time2)
+    for name, values in (
+        ("(weights)", weights),
+        ("(offset)", offsets if offsets is not None else offset),
+        ("(strata)", strata),
+        ("(cluster)", cluster),
+    ):
+        if values is not None:
+            frame[name] = _materialize_1d(values, name)
+    return frame
+
+
+def _survfit_formula_model_frame(
+    formula: str,
+    data: Any,
+    response: Surv,
+    weights: Any | None,
+    id: Any | None = None,  # noqa: A002
+    id_column: str | None = None,
+) -> dict[str, Any]:
+    response_spec = _formula_response_spec(formula)
+    frame: dict[str, Any] = {_surv_response_model_name(response_spec): response}
+    for column in _formula_columns(formula, data):
+        frame[column] = _column(data, column)
+    if id_column is not None and id_column not in frame:
+        frame[id_column] = _column(data, id_column)
+    if weights is not None:
+        frame["(weights)"] = _materialize_1d(weights, "(weights)")
+    if id is not None:
+        frame["(id)"] = _materialize_1d(id, "(id)")
+    return frame
+
+
+def _survfit_model_frame(
+    response: Surv,
+    group: Any | None,
+    weights: Any | None,
+    id: Any | None = None,  # noqa: A002
+) -> dict[str, Any]:
+    frame: dict[str, Any] = {"response": response}
+    if group is not None:
+        frame["group"] = _materialize_1d(group, "group")
+    if weights is not None:
+        frame["(weights)"] = _materialize_1d(weights, "(weights)")
+    if id is not None:
+        frame["(id)"] = _materialize_1d(id, "(id)")
+    return frame
+
+
+def _cox_survfit_model_frame(fit: Any, newdata: Any | None) -> dict[str, Any]:
+    frame: dict[str, Any] = {"fit": fit}
+    model = getattr(fit, "model", None)
+    if model is not None:
+        frame["model"] = model
+    if newdata is not None:
+        frame["newdata"] = newdata
+    return frame
 
 
 def _formula_design_row_count(data: Any, design: _FormulaDesign) -> int:
@@ -2496,6 +2789,24 @@ def _normalize_bool_option(value: Any | None, name: str) -> bool:
     return bool(value)
 
 
+def _normalize_bool_option_with_default(value: Any | None, name: str, default: bool) -> bool:
+    if value is None:
+        return default
+    return _normalize_bool_option(value, name)
+
+
+def _normalize_numeric_sequence_or_none(value: Any, name: str) -> list[float] | None:
+    if value is None:
+        return None
+    if isinstance(value, str | bytes):
+        raise TypeError(f"{name} must be numeric or array-like")
+    try:
+        return [_finite_float(value, name)]
+    except TypeError:
+        pass
+    return [_finite_float(item, name) for item in _materialize_1d(value, name)]
+
+
 def _normalize_optional_bool_option(value: Any | None, name: str) -> bool | None:
     if value is None:
         return None
@@ -2542,34 +2853,28 @@ def _pop_control_alias(
     return value, first
 
 
-def _control_value_matches_default(value: Any, default: bool | float | int, name: str) -> bool:
-    if isinstance(default, bool):
-        try:
-            return _normalize_bool_option(value, name) is default
-        except (TypeError, ValueError):
-            return False
-    try:
-        return math.isclose(
-            _finite_float(value, name),
-            float(default),
-            rel_tol=1e-12,
-            abs_tol=1e-12,
-        )
-    except (TypeError, ValueError):
-        return False
-
-
-def _reject_nondefault_control_options(
+def _pop_finite_control_value(
     control: dict[str, Any],
-    function_name: str,
-    defaults: Mapping[str, bool | float | int],
-) -> None:
-    for name, default in defaults.items():
-        if name not in control:
-            continue
-        value = control.pop(name)
-        if not _control_value_matches_default(value, default, f"control.{name}"):
-            raise NotImplementedError(f"{function_name} control option {name!r} is not supported")
+    aliases: tuple[str, ...],
+    *,
+    positive: bool,
+) -> float | None:
+    present = [alias for alias in aliases if alias in control]
+    if not present:
+        return None
+    first = present[0]
+    value = control.pop(first)
+    for alias in present[1:]:
+        other = control.pop(alias)
+        if other != value:
+            raise ValueError(f"use only one of control.{first} or control.{alias}")
+    numeric = _finite_float(value, f"control.{first}")
+    if positive and numeric <= 0.0:
+        raise ValueError(f"control.{first} must be positive")
+    return numeric
+
+
+def _reject_unknown_control_options(control: dict[str, Any], function_name: str) -> None:
     if control:
         unexpected = ", ".join(sorted(control))
         raise ValueError(f"{function_name} control has unsupported option(s): {unexpected}")
@@ -2580,10 +2885,10 @@ def _apply_coxph_control(
     max_iter: int,
     eps: float | None,
     toler: float | None,
-) -> tuple[int, float | None, float | None]:
+) -> tuple[int, float | None, float | None, bool]:
     values = _control_mapping(control, "coxph control")
     if not values:
-        return max_iter, eps, toler
+        return max_iter, eps, toler, True
 
     max_iter_value, name = _pop_control_alias(
         values,
@@ -2609,19 +2914,19 @@ def _apply_coxph_control(
     if name is not None:
         toler = _finite_float(toler_value, f"control.{name}")
 
-    toler_inf_default = math.sqrt(float(eps if eps is not None else 1e-9))
-    _reject_nondefault_control_options(
+    timefix_value, name = _pop_control_alias(
         values,
-        "coxph",
-        {
-            "toler.inf": toler_inf_default,
-            "toler_inf": toler_inf_default,
-            "outer.max": 10,
-            "outer_max": 10,
-            "timefix": True,
-        },
+        ("timefix", "time.fix", "time_fix"),
+        "timefix",
+        True,
+        True,
     )
-    return max_iter, eps, toler
+    fix_time = _normalize_bool_option(timefix_value, f"control.{name}") if name else True
+
+    _pop_finite_control_value(values, ("toler.inf", "toler_inf"), positive=True)
+    _pop_finite_control_value(values, ("outer.max", "outer_max"), positive=True)
+    _reject_unknown_control_options(values, "coxph")
+    return max_iter, eps, toler, fix_time
 
 
 def _apply_survreg_control(
@@ -2664,15 +2969,9 @@ def _apply_survreg_control(
     if name is not None:
         tol_chol = _finite_float(tol_chol_value, f"control.{name}")
 
-    _reject_nondefault_control_options(
-        values,
-        "survreg",
-        {
-            "debug": 0,
-            "outer.max": 10,
-            "outer_max": 10,
-        },
-    )
+    _pop_finite_control_value(values, ("debug",), positive=False)
+    _pop_finite_control_value(values, ("outer.max", "outer_max"), positive=True)
+    _reject_unknown_control_options(values, "survreg")
     return max_iter, eps, tol_chol
 
 
@@ -2767,7 +3066,15 @@ def _unweighted_survfit_event_counts(
     status: list[int],
     *,
     reverse: bool,
+    timefix: bool,
 ) -> list[float]:
+    if not timefix:
+        event_counts: dict[float, float] = {}
+        for event_time, event in zip(time, status, strict=True):
+            if event <= 0 if reverse else event > 0:
+                event_counts[event_time] = event_counts.get(event_time, 0.0) + 1.0
+        return [event_counts.get(output_time, 0.0) for output_time in output_times]
+
     event_times = sorted(
         float(event_time)
         for event_time, event in zip(time, status, strict=True)
@@ -2788,6 +3095,143 @@ def _unweighted_survfit_event_counts(
             matched += 1
         counts.append(float(matched - cursor))
     return counts
+
+
+def _exact_survfitkm(
+    time: list[float],
+    status: list[int],
+    weights: list[float] | None,
+    entry_times: list[float] | None,
+    *,
+    reverse: bool,
+    conf_level: float,
+    conf_type: str,
+) -> SurvfitResult:
+    n = len(time)
+    case_weights = [1.0] * n if weights is None else weights
+    order = sorted(range(n), key=lambda idx: (time[idx], idx))
+    entry_order = (
+        sorted(range(n), key=lambda idx: (entry_times[idx], idx)) if entry_times is not None else []
+    )
+    entry_cursor = 0
+    current_risk = 0.0 if entry_times is not None else float(sum(case_weights))
+    current_estimate = 1.0
+    cumulative_variance = 0.0
+    cumulative_hazard = 0.0
+    cumulative_hazard_variance = 0.0
+    alpha = 1.0 - conf_level
+    z = NormalDist().inv_cdf(1.0 - alpha / 2.0)
+
+    output_time: list[float] = []
+    n_risk: list[float] = []
+    n_event: list[float] = []
+    n_censor: list[float] = []
+    estimate: list[float] = []
+    std_err: list[float] = []
+    cumhaz: list[float] = []
+    std_chaz: list[float] = []
+    conf_lower: list[float] = []
+    conf_upper: list[float] = []
+
+    cursor = 0
+    while cursor < n:
+        current_time = time[order[cursor]]
+        if entry_times is not None:
+            while entry_cursor < n and entry_times[entry_order[entry_cursor]] < current_time:
+                current_risk += case_weights[entry_order[entry_cursor]]
+                entry_cursor += 1
+
+        weighted_events = 0.0
+        weighted_censor = 0.0
+        scan = cursor
+        while scan < n and time[order[scan]] == current_time:
+            idx = order[scan]
+            is_event = status[idx] <= 0 if reverse else status[idx] > 0
+            if is_event:
+                weighted_events += case_weights[idx]
+            else:
+                weighted_censor += case_weights[idx]
+            scan += 1
+
+        if weighted_events > 0.0 or weighted_censor > 0.0:
+            risk_at_time = current_risk
+            if weighted_events > 0.0 and risk_at_time > 0.0:
+                hazard = weighted_events / risk_at_time
+                cumulative_hazard += hazard
+                cumulative_hazard_variance += weighted_events / (risk_at_time * risk_at_time)
+                current_estimate *= 1.0 - hazard
+                if risk_at_time > weighted_events:
+                    cumulative_variance += weighted_events / (
+                        risk_at_time * (risk_at_time - weighted_events)
+                    )
+
+            se = current_estimate * math.sqrt(max(cumulative_variance, 0.0))
+            output_time.append(current_time)
+            n_risk.append(risk_at_time)
+            n_event.append(weighted_events)
+            n_censor.append(weighted_censor)
+            estimate.append(current_estimate)
+            std_err.append(se)
+            cumhaz.append(cumulative_hazard)
+            std_chaz.append(math.sqrt(max(cumulative_hazard_variance, 0.0)))
+            if conf_type != "none":
+                lower, upper = _survfit_confidence_interval(
+                    current_estimate,
+                    se,
+                    z,
+                    conf_type,
+                )
+                conf_lower.append(lower)
+                conf_upper.append(upper)
+
+        current_risk -= weighted_events + weighted_censor
+        cursor = scan
+
+    return SurvfitResult(
+        time=output_time,
+        n_risk=n_risk,
+        n_event=n_event,
+        n_censor=n_censor,
+        estimate=estimate,
+        std_err=std_err,
+        conf_lower=conf_lower,
+        conf_upper=conf_upper,
+        cumhaz=cumhaz,
+        std_chaz=std_chaz,
+    )
+
+
+def _survfitkm(
+    time: list[float],
+    status: list[int],
+    *,
+    weights: list[float] | None,
+    entry_times: list[float] | None,
+    reverse: bool,
+    conf_level: float,
+    conf_type: str,
+    timefix: bool,
+) -> Any:
+    if not timefix:
+        return _exact_survfitkm(
+            time,
+            status,
+            weights,
+            entry_times,
+            reverse=reverse,
+            conf_level=conf_level,
+            conf_type=conf_type,
+        )
+    return _core.survfitkm(
+        time,
+        status,
+        weights=weights,
+        entry_times=entry_times,
+        reverse=reverse,
+        computation_type=0,
+        conf_level=conf_level,
+        conf_type=conf_type,
+    )
 
 
 def _survfit_from_km_counts(
@@ -2862,15 +3306,296 @@ def _survfit_from_km_counts(
         conf_upper=conf_upper,
         cumhaz=cumhaz,
         std_chaz=std_chaz,
+        n_enter=(
+            [float(value) for value in km.n_enter]
+            if getattr(km, "n_enter", None) is not None
+            else None
+        ),
     )
 
 
-def _survfit_start_time_indices(response: Surv, start_time: float) -> list[int]:
-    indices = [
-        idx
-        for idx, stop_time in enumerate(response.time)
-        if stop_time >= start_time - _SURVFIT_TIME_EPSILON
-    ]
+def _survfit_time_equal(left: float, right: float, timefix: bool) -> bool:
+    return abs(left - right) < _SURVFIT_TIME_EPSILON if timefix else left == right
+
+
+def _survfit_time_less(left: float, right: float, timefix: bool) -> bool:
+    return left < right - _SURVFIT_TIME_EPSILON if timefix else left < right
+
+
+def _survfit_positions(
+    response: Surv,
+    id_values: list[Any],
+    timefix: bool,
+) -> list[int]:
+    if response.start is None:
+        return [3] * len(response)
+
+    id_labels = _label_levels(id_values, "id")
+    id_codes = {value: idx for idx, value in enumerate(id_labels)}
+    starts = [float(value) for value in response.start]
+    stops = [float(value) for value in response.time]
+    order = sorted(
+        range(len(response)),
+        key=lambda idx: (id_codes[id_values[idx]], stops[idx], idx),
+    )
+    positions = [0] * len(response)
+    for sorted_idx, row_idx in enumerate(order):
+        current_id = id_codes[id_values[row_idx]]
+        previous_row = order[sorted_idx - 1] if sorted_idx > 0 else None
+        next_row = order[sorted_idx + 1] if sorted_idx + 1 < len(order) else None
+
+        first = previous_row is None or id_codes[id_values[previous_row]] != current_id
+        if previous_row is not None and not first:
+            first = _survfit_time_less(stops[previous_row], starts[row_idx], timefix)
+
+        last = next_row is None or id_codes[id_values[next_row]] != current_id
+        if next_row is not None and not last:
+            last = _survfit_time_less(stops[row_idx], starts[next_row], timefix)
+
+        positions[row_idx] = (1 if first else 0) + (2 if last else 0)
+    return positions
+
+
+def _survfit_counting_times(
+    starts: list[float],
+    stops: list[float],
+    status: list[int],
+    positions: list[int],
+    include_entry: bool,
+    timefix: bool,
+) -> list[float]:
+    n = len(stops)
+    sort_stop = sorted(range(n), key=lambda idx: (stops[idx], idx))
+    if not include_entry:
+        times: list[float] = []
+        for idx in sort_stop:
+            if (positions[idx] > 1 or status[idx] > 0 or not times) and (
+                not times or not _survfit_time_equal(stops[idx], times[-1], timefix)
+            ):
+                times.append(stops[idx])
+        return times
+
+    sort_start = sorted(range(n), key=lambda idx: (starts[idx], idx))
+    times = [starts[sort_start[0]]]
+    current = times[0]
+    entry_cursor = 1
+    for stop_idx in sort_stop:
+        while entry_cursor < n and _survfit_time_less(
+            starts[sort_start[entry_cursor]],
+            stops[stop_idx],
+            timefix,
+        ):
+            start_idx = sort_start[entry_cursor]
+            if positions[start_idx] & 1 and not _survfit_time_equal(
+                starts[start_idx],
+                current,
+                timefix,
+            ):
+                current = starts[start_idx]
+                times.append(current)
+            entry_cursor += 1
+
+        if (positions[stop_idx] > 1 or status[stop_idx] > 0) and not _survfit_time_equal(
+            stops[stop_idx],
+            current,
+            timefix,
+        ):
+            current = stops[stop_idx]
+            times.append(current)
+    return times
+
+
+def _survfit_from_count_tables(
+    times: list[float],
+    n_risk: list[float],
+    n_event: list[float],
+    n_event_count: list[float],
+    n_censor: list[float],
+    n_censor_count: list[float],
+    n_enter: list[float] | None,
+    *,
+    reverse: bool,
+    conf_level: float,
+    conf_type: str,
+    computation: _SurvfitComputation,
+) -> SurvfitResult:
+    current_survival = 1.0
+    greenwood_variance = 0.0
+    cumulative_hazard = 0.0
+    cumulative_hazard_variance = 0.0
+    alpha = 1.0 - conf_level
+    z = NormalDist().inv_cdf(1.0 - alpha / 2.0)
+
+    estimate: list[float] = []
+    std_err: list[float] = []
+    cumhaz: list[float] = []
+    std_chaz: list[float] = []
+    conf_lower: list[float] = []
+    conf_upper: list[float] = []
+
+    for idx, risk_count in enumerate(n_risk):
+        event_weight = n_censor[idx] if reverse else n_event[idx]
+        event_count = n_censor_count[idx] if reverse else n_event_count[idx]
+        risk_for_curve = risk_count - n_event[idx] if reverse else risk_count
+
+        if event_weight > 0.0 and event_count > 0.0 and risk_for_curve > 0.0:
+            if computation.ctype == 1:
+                cumulative_hazard += event_weight / risk_for_curve
+                cumulative_hazard_variance += event_weight / (risk_for_curve * risk_for_curve)
+            else:
+                for step in range(int(event_count)):
+                    denominator = risk_for_curve - step * event_weight / event_count
+                    if denominator > 0.0:
+                        cumulative_hazard += event_weight / (event_count * denominator)
+                        cumulative_hazard_variance += event_weight / (
+                            event_count * denominator * denominator
+                        )
+
+        if computation.stype == 1:
+            if event_weight > 0.0 and event_count > 0.0 and risk_for_curve > 0.0:
+                current_survival *= max((risk_for_curve - event_weight) / risk_for_curve, 0.0)
+                if risk_for_curve > event_weight:
+                    greenwood_variance += event_weight / (
+                        risk_for_curve * (risk_for_curve - event_weight)
+                    )
+            survival = current_survival
+            survival_se = survival * math.sqrt(max(greenwood_variance, 0.0))
+        else:
+            survival = _safe_exp(-cumulative_hazard)
+            survival_se = survival * math.sqrt(max(cumulative_hazard_variance, 0.0))
+
+        estimate.append(survival)
+        std_err.append(survival_se)
+        cumhaz.append(cumulative_hazard)
+        std_chaz.append(math.sqrt(max(cumulative_hazard_variance, 0.0)))
+        if conf_type != "none":
+            lower, upper = _survfit_confidence_interval(survival, survival_se, z, conf_type)
+            conf_lower.append(lower)
+            conf_upper.append(upper)
+
+    return SurvfitResult(
+        time=times,
+        n_risk=n_risk,
+        n_event=n_event,
+        n_censor=n_censor,
+        estimate=estimate,
+        std_err=std_err,
+        conf_lower=conf_lower,
+        conf_upper=conf_upper,
+        cumhaz=cumhaz,
+        std_chaz=std_chaz,
+        n_enter=n_enter,
+    )
+
+
+def _survfit_counting_with_id(
+    response: Surv,
+    weights: list[float] | None,
+    id_values: list[Any],
+    *,
+    include_entry: bool,
+    reverse: bool,
+    conf_level: float,
+    conf_type: str,
+    computation: _SurvfitComputation,
+    timefix: bool,
+) -> SurvfitResult:
+    if response.start is None:
+        raise ValueError("survfit id-aware entry counts require counting-process Surv input")
+
+    n = len(response)
+    starts = [float(value) for value in response.start]
+    stops = [float(value) for value in response.time]
+    status = [int(value) for value in response.event]
+    case_weights = [1.0] * n if weights is None else [float(value) for value in weights]
+    positions = _survfit_positions(response, id_values, timefix)
+    times = _survfit_counting_times(starts, stops, status, positions, include_entry, timefix)
+    sort_start = sorted(range(n), key=lambda idx: (starts[idx], idx))
+    sort_stop = sorted(range(n), key=lambda idx: (stops[idx], idx))
+
+    n_risk = [0.0] * len(times)
+    n_event = [0.0] * len(times)
+    n_event_count = [0.0] * len(times)
+    n_censor = [0.0] * len(times)
+    n_censor_count = [0.0] * len(times)
+    n_enter = [0.0] * len(times) if include_entry else None
+
+    stop_cursor = n - 1
+    start_cursor = n - 1
+    weighted_risk = 0.0
+    for time_idx in range(len(times) - 1, -1, -1):
+        current_time = times[time_idx]
+        event_weight = 0.0
+        event_count = 0.0
+        censor_weight = 0.0
+        censor_count = 0.0
+        while stop_cursor >= 0 and not _survfit_time_less(
+            stops[sort_stop[stop_cursor]],
+            current_time,
+            timefix,
+        ):
+            row_idx = sort_stop[stop_cursor]
+            weighted_risk += case_weights[row_idx]
+            if status[row_idx] > 0:
+                event_count += 1.0
+                event_weight += case_weights[row_idx]
+            elif positions[row_idx] & 2:
+                censor_count += 1.0
+                censor_weight += case_weights[row_idx]
+            stop_cursor -= 1
+
+        enter_weight = 0.0
+        while start_cursor >= 0 and not _survfit_time_less(
+            starts[sort_start[start_cursor]],
+            current_time,
+            timefix,
+        ):
+            row_idx = sort_start[start_cursor]
+            weighted_risk -= case_weights[row_idx]
+            if (
+                include_entry
+                and positions[row_idx] & 1
+                and _survfit_time_equal(starts[row_idx], current_time, timefix)
+            ):
+                enter_weight += case_weights[row_idx]
+            start_cursor -= 1
+
+        n_risk[time_idx] = max(weighted_risk, 0.0)
+        n_event[time_idx] = event_weight
+        n_event_count[time_idx] = event_count
+        n_censor[time_idx] = censor_weight
+        n_censor_count[time_idx] = censor_count
+        if n_enter is not None:
+            n_enter[time_idx] = enter_weight
+
+    return _survfit_from_count_tables(
+        times,
+        n_risk,
+        n_event,
+        n_event_count,
+        n_censor,
+        n_censor_count,
+        n_enter,
+        reverse=reverse,
+        conf_level=conf_level,
+        conf_type=conf_type,
+        computation=computation,
+    )
+
+
+def _survfit_start_time_indices(
+    response: Surv,
+    start_time: float,
+    timefix: bool,
+) -> list[int]:
+    if timefix:
+        indices = [
+            idx
+            for idx, stop_time in enumerate(response.time)
+            if stop_time >= start_time - _SURVFIT_TIME_EPSILON
+        ]
+    else:
+        indices = [idx for idx, stop_time in enumerate(response.time) if stop_time >= start_time]
     if not indices:
         raise ValueError("all observations removed by start_time")
     return indices
@@ -2883,10 +3608,28 @@ def _survfit_default_time0(response: Surv) -> float:
     return float(min(values))
 
 
-def _initial_survfit_risk(response: Surv, weights: list[float] | None, t0: float) -> float:
+def _initial_survfit_risk(
+    response: Surv,
+    weights: list[float] | None,
+    t0: float,
+    timefix: bool,
+) -> float:
     case_weights = [1.0] * len(response) if weights is None else weights
     if response.start is None:
         return float(sum(case_weights))
+    if not timefix:
+        return float(
+            sum(
+                weight
+                for start, stop, weight in zip(
+                    response.start,
+                    response.time,
+                    case_weights,
+                    strict=True,
+                )
+                if start <= t0 <= stop
+            )
+        )
     return float(
         sum(
             weight
@@ -2921,9 +3664,10 @@ def _survfit_with_time0(
     t0: float,
     conf_type: str,
     initial_n_risk: float,
+    timefix: bool,
 ) -> Any:
     times = [float(value) for value in result.time]
-    if times and abs(times[0] - t0) < _SURVFIT_TIME_EPSILON:
+    if times and (abs(times[0] - t0) < _SURVFIT_TIME_EPSILON if timefix else times[0] == t0):
         return result
 
     n_risk = [float(value) for value in result.n_risk]
@@ -2956,7 +3700,146 @@ def _survfit_with_time0(
         conf_upper=([1.0, *conf_upper] if conf_type != "none" else []),
         cumhaz=[0.0, *cumhaz],
         std_chaz=[0.0, *std_chaz],
+        n_enter=([0.0, *result.n_enter] if getattr(result, "n_enter", None) is not None else None),
     )
+
+
+def _survfit_without_standard_errors(result: Any) -> Any:
+    if isinstance(result, SurvfitResult):
+        return SurvfitResult(
+            time=result.time,
+            n_risk=result.n_risk,
+            n_event=result.n_event,
+            n_censor=result.n_censor,
+            estimate=result.estimate,
+            std_err=[],
+            conf_lower=[],
+            conf_upper=[],
+            cumhaz=result.cumhaz,
+            std_chaz=[],
+            n_enter=result.n_enter,
+            model=result.model,
+        )
+    if all(
+        hasattr(result, name)
+        for name in ("time", "n_risk", "n_event", "n_censor", "estimate", "cumhaz")
+    ):
+        return SurvfitResult(
+            time=[float(value) for value in result.time],
+            n_risk=[float(value) for value in result.n_risk],
+            n_event=[float(value) for value in result.n_event],
+            n_censor=[float(value) for value in result.n_censor],
+            estimate=[float(value) for value in result.estimate],
+            std_err=[],
+            conf_lower=[],
+            conf_upper=[],
+            cumhaz=[float(value) for value in result.cumhaz],
+            std_chaz=[],
+            n_enter=(
+                [float(value) for value in result.n_enter]
+                if getattr(result, "n_enter", None) is not None
+                else None
+            ),
+            model=getattr(result, "model", None),
+        )
+    if isinstance(result, CoxSurvfitResult):
+        return CoxSurvfitResult(
+            time=result.time,
+            surv=result.surv,
+            cumhaz=result.cumhaz,
+            linear_predictors=result.linear_predictors,
+            centered=result.centered,
+            strata=result.strata,
+            start_time=result.start_time,
+            std_err=[],
+            std_chaz=[],
+            conf_lower=[],
+            conf_upper=[],
+            model=result.model,
+        )
+    if isinstance(result, Mapping):
+        return {label: _survfit_without_standard_errors(curve) for label, curve in result.items()}
+    return result
+
+
+def _survfit_with_model_frame(result: Any, model_frame: dict[str, Any]) -> Any:
+    if isinstance(result, SurvfitResult):
+        return SurvfitResult(
+            time=result.time,
+            n_risk=result.n_risk,
+            n_event=result.n_event,
+            n_censor=result.n_censor,
+            estimate=result.estimate,
+            std_err=result.std_err,
+            conf_lower=result.conf_lower,
+            conf_upper=result.conf_upper,
+            cumhaz=result.cumhaz,
+            std_chaz=result.std_chaz,
+            n_enter=result.n_enter,
+            model=model_frame,
+        )
+    if all(
+        hasattr(result, name)
+        for name in (
+            "time_points",
+            "survival",
+            "survival_lower",
+            "survival_upper",
+            "n_iter",
+            "converged",
+        )
+    ):
+        return TurnbullSurvfitResult(
+            time_points=[float(value) for value in result.time_points],
+            survival=[float(value) for value in result.survival],
+            survival_lower=[float(value) for value in result.survival_lower],
+            survival_upper=[float(value) for value in result.survival_upper],
+            n_iter=int(result.n_iter),
+            converged=bool(result.converged),
+            model=model_frame,
+        )
+    if all(
+        hasattr(result, name)
+        for name in ("time", "n_risk", "n_event", "n_censor", "estimate", "cumhaz")
+    ):
+        return SurvfitResult(
+            time=[float(value) for value in result.time],
+            n_risk=[float(value) for value in result.n_risk],
+            n_event=[float(value) for value in result.n_event],
+            n_censor=[float(value) for value in result.n_censor],
+            estimate=[float(value) for value in result.estimate],
+            std_err=[float(value) for value in result.std_err],
+            conf_lower=[float(value) for value in result.conf_lower],
+            conf_upper=[float(value) for value in result.conf_upper],
+            cumhaz=[float(value) for value in result.cumhaz],
+            std_chaz=[float(value) for value in result.std_chaz],
+            n_enter=(
+                [float(value) for value in result.n_enter]
+                if getattr(result, "n_enter", None) is not None
+                else None
+            ),
+            model=model_frame,
+        )
+    if isinstance(result, CoxSurvfitResult):
+        return CoxSurvfitResult(
+            time=result.time,
+            surv=result.surv,
+            cumhaz=result.cumhaz,
+            linear_predictors=result.linear_predictors,
+            centered=result.centered,
+            strata=result.strata,
+            start_time=result.start_time,
+            std_err=result.std_err,
+            std_chaz=result.std_chaz,
+            conf_lower=result.conf_lower,
+            conf_upper=result.conf_upper,
+            model=model_frame,
+        )
+    if isinstance(result, Mapping):
+        return {
+            label: _survfit_with_model_frame(curve, model_frame) for label, curve in result.items()
+        }
+    return result
 
 
 def _cox_flat_basehaz_with_training_times(
@@ -3028,6 +3911,7 @@ def survfit(
     conf_level: float = 0.95,
     conf_int: Any | None = None,
     conf_type: str | None = "log",
+    se_fit: Any = True,
     start_time: Any | None = None,
     time0: bool = False,
     reverse: bool = False,
@@ -3035,17 +3919,41 @@ def survfit(
     type: str | None = None,  # noqa: A002
     stype: int | None = None,
     ctype: int | None = None,
+    id: Any | None = None,  # noqa: A002
+    cluster: Any | None = None,
+    robust: Any | None = None,
+    istate: Any | None = None,
+    etype: Any | None = None,
+    model: Any = False,
+    error: Any | None = None,
+    entry: Any = False,
+    timefix: bool = True,
     **kwargs: Any,
 ):
     """Fit Kaplan-Meier curves or Cox-model survival curves."""
 
     conf_int = _pop_dotted_keyword(kwargs, "conf.int", "conf_int", conf_int, None)
     conf_type = _pop_dotted_keyword(kwargs, "conf.type", "conf_type", conf_type, "log")
+    se_fit = _pop_dotted_keyword(kwargs, "se.fit", "se_fit", se_fit, True)
     start_time = _pop_dotted_keyword(kwargs, "start.time", "start_time", start_time, None)
     na_action = _pop_dotted_keyword(kwargs, "na.action", "na_action", na_action, "fail")
+    timefix = _pop_dotted_keyword(kwargs, "time.fix", "timefix", timefix, True)
     if kwargs:
         unexpected = ", ".join(sorted(kwargs))
         raise TypeError(f"survfit got unexpected keyword argument(s): {unexpected}")
+
+    keep_model = _normalize_bool_option_with_default(model, "model", False)
+    include_entry = _normalize_bool_option_with_default(entry, "entry", False)
+    include_se = _normalize_bool_option_with_default(se_fit, "se_fit", True)
+    robust_value = _normalize_optional_bool_option(robust, "robust")
+    id_arg = id
+    if cluster is not None:
+        raise NotImplementedError("survfit cluster is not supported")
+    if robust_value is True:
+        raise NotImplementedError("survfit robust variance is not supported")
+    if istate is not None or etype is not None:
+        raise NotImplementedError("survfit multi-state istate/etype inputs are not supported")
+    # R's survival keeps `error` for backward compatibility but no longer uses it.
 
     computation = _normalize_survfit_type(type, stype, ctype)
     normalized_conf_level = _normalize_survfit_conf_level(conf_level, conf_int)
@@ -3054,16 +3962,45 @@ def survfit(
     include_time0 = _normalize_bool_option(time0, "time0")
     reverse_curve = _normalize_bool_option(reverse, "reverse")
     include_censor = _normalize_bool_option(censor, "censor")
+    fix_time = _normalize_bool_option(timefix, "timefix")
+    model_frame = None
     if isinstance(response, str):
+        formula = response
+        id_column = id_arg if isinstance(id_arg, str) else None
+        if id_column is not None:
+            id_arg = _column(data, id_column)
         if subset is not None:
-            data, aligned = _subset_formula_inputs(response, data, subset, weights=weights)
+            data, aligned = _subset_formula_inputs(
+                formula,
+                data,
+                subset,
+                weights=weights,
+                id=id_arg,
+            )
             weights = aligned["weights"]
+            id_arg = aligned["id"]
             subset = None
-        data, aligned = _apply_formula_na_action(response, data, na_action, weights=weights)
+        data, aligned = _apply_formula_na_action(
+            formula,
+            data,
+            na_action,
+            weights=weights,
+            id=id_arg,
+        )
         weights = aligned["weights"]
+        id_arg = aligned["id"]
         na_action = "pass"
-        response, terms = _parse_formula(response, data)
+        response, terms = _parse_formula(formula, data)
         _reject_formula_clusters("survfit", terms)
+        if keep_model:
+            model_frame = _survfit_formula_model_frame(
+                formula,
+                data,
+                response,
+                weights,
+                id_arg,
+                id_column,
+            )
         if terms.strata or terms.covariates:
             group = _combined_formula_groups(data, terms.strata, terms.covariates, len(response))
 
@@ -3078,7 +4015,7 @@ def survfit(
             raise ValueError("subset is only supported for Surv or formula inputs")
         rows, offsets = _prediction_inputs(response, newdata)
         if hasattr(response, "means"):
-            return _cox_survfit_result(
+            result = _cox_survfit_result(
                 response,
                 rows,
                 offsets,
@@ -3089,11 +4026,21 @@ def survfit(
                 include_censor,
                 normalized_conf_level,
                 normalized_conf_type,
+                compute_confidence=include_se,
+            )
+            return (
+                _survfit_with_model_frame(result, _cox_survfit_model_frame(response, newdata))
+                if keep_model
+                else result
             )
         if normalized_start_time is not None:
             raise ValueError("start_time is only supported for Surv, formula, or fitted Cox inputs")
         if include_time0:
             raise ValueError("time0 is only supported for Surv, formula, or fitted Cox inputs")
+        if keep_model:
+            raise NotImplementedError(
+                "survfit model=TRUE is only supported for Surv, formula, or fitted Cox inputs"
+            )
         if rows is None:
             coefficients = getattr(response, "coefficients", [])
             width = len(coefficients[0]) if coefficients else 0
@@ -3109,19 +4056,29 @@ def survfit(
         response = _subset_surv(response, indices)
         group = _subset_optional_sequence(group, indices, "group")
         weights = _subset_optional_sequence(weights, indices, "weights")
+        id_arg = _subset_optional_sequence(id_arg, indices, "id")
     response, aligned = _apply_surv_na_action(
         response,
         na_action,
         "survfit inputs",
         group=group,
         weights=weights,
+        id=id_arg,
     )
     group = aligned["group"]
     weights = aligned["weights"]
+    id_arg = aligned["id"]
+    id_values = _materialize_labels(id_arg, "id") if id_arg is not None else None
+    if id_values is not None and len(id_values) != len(response):
+        raise ValueError("id must have the same length as the Surv response")
+    if keep_model and model_frame is None:
+        model_frame = _survfit_model_frame(response, group, weights, id_values)
     if newdata is not None:
         raise ValueError("newdata is only supported for fitted Cox models")
     if not include_censor:
         raise ValueError("censor is only supported for fitted Cox models")
+    if include_entry and (response.start is None or id_values is None):
+        raise ValueError("survfit entry=TRUE requires counting-process Surv input and id")
     if response.type in {"left", "interval", "interval2"}:
         if not computation.is_kaplan_meier:
             raise ValueError(
@@ -3142,7 +4099,12 @@ def survfit(
             raise ValueError("interval-censored survfit does not support entry times")
         if group is None:
             left, right = _turnbull_intervals(response)
-            return _core.turnbull_estimator(left, right, weights=wt)
+            result = _core.turnbull_estimator(left, right, weights=wt)
+            return (
+                _survfit_with_model_frame(result, model_frame)
+                if keep_model and model_frame is not None
+                else result
+            )
 
         turnbull_results: dict[Any, Any] = {}
         for label, indices in _group_indices(group, len(response)).items():
@@ -3150,7 +4112,11 @@ def survfit(
             left, right = _turnbull_intervals(group_response)
             group_weights = [wt[idx] for idx in indices] if wt is not None else None
             turnbull_results[label] = _core.turnbull_estimator(left, right, weights=group_weights)
-        return turnbull_results
+        return (
+            _survfit_with_model_frame(turnbull_results, model_frame)
+            if keep_model and model_frame is not None
+            else turnbull_results
+        )
 
     wt = _float_vector(weights, "weights") if weights is not None else None
     if wt is not None and len(wt) != len(response):
@@ -3161,39 +4127,62 @@ def survfit(
         else _survfit_default_time0(response)
     )
     if normalized_start_time is not None:
-        indices = _survfit_start_time_indices(response, normalized_start_time)
+        indices = _survfit_start_time_indices(response, normalized_start_time, fix_time)
         response = _subset_surv(response, indices)
         group = _subset_optional_sequence(group, indices, "group")
         wt = _subset_optional_sequence(wt, indices, "weights")
+        id_values = _subset_optional_sequence(id_values, indices, "id")
     entry_times = list(response.start) if response.start is not None else None
 
     if group is None:
-        km = _core.survfitkm(
-            list(response.time),
-            list(response.event),
-            weights=wt,
-            entry_times=entry_times,
-            reverse=reverse_curve,
-            computation_type=0,
-            conf_level=normalized_conf_level,
-            conf_type=normalized_conf_type,
+        km = (
+            _survfit_counting_with_id(
+                response,
+                wt,
+                id_values,
+                include_entry=include_entry,
+                reverse=reverse_curve,
+                conf_level=normalized_conf_level,
+                conf_type=normalized_conf_type,
+                computation=computation,
+                timefix=fix_time,
+            )
+            if response.start is not None and id_values is not None
+            else _survfitkm(
+                list(response.time),
+                list(response.event),
+                weights=wt,
+                entry_times=entry_times,
+                reverse=reverse_curve,
+                conf_level=normalized_conf_level,
+                conf_type=normalized_conf_type,
+                timefix=fix_time,
+            )
         )
         if computation.is_kaplan_meier:
-            return (
+            result = (
                 _survfit_with_time0(
                     km,
                     t0,
                     normalized_conf_type,
-                    _initial_survfit_risk(response, wt, t0),
+                    _initial_survfit_risk(response, wt, t0, fix_time),
+                    fix_time,
                 )
                 if include_time0
                 else km
+            )
+            result = _survfit_without_standard_errors(result) if not include_se else result
+            return (
+                _survfit_with_model_frame(result, model_frame)
+                if model_frame is not None
+                else result
             )
         event_counts = _unweighted_survfit_event_counts(
             [float(value) for value in km.time],
             list(response.time),
             list(response.event),
             reverse=reverse_curve,
+            timefix=fix_time,
         )
         result = _survfit_from_km_counts(
             km,
@@ -3202,30 +4191,50 @@ def survfit(
             event_counts,
             normalized_conf_type,
         )
-        return (
+        result = (
             _survfit_with_time0(
                 result,
                 t0,
                 normalized_conf_type,
-                _initial_survfit_risk(response, wt, t0),
+                _initial_survfit_risk(response, wt, t0, fix_time),
+                fix_time,
             )
             if include_time0
             else result
         )
+        result = _survfit_without_standard_errors(result) if not include_se else result
+        return _survfit_with_model_frame(result, model_frame) if model_frame is not None else result
 
     results: dict[Any, Any] = {}
     for label, indices in _group_indices(group, len(response)).items():
         group_response = _subset_surv(response, indices)
         group_weights = [wt[idx] for idx in indices] if wt is not None else None
-        km = _core.survfitkm(
-            list(group_response.time),
-            list(group_response.event),
-            weights=group_weights,
-            entry_times=list(group_response.start) if group_response.start is not None else None,
-            reverse=reverse_curve,
-            computation_type=0,
-            conf_level=normalized_conf_level,
-            conf_type=normalized_conf_type,
+        group_ids = [id_values[idx] for idx in indices] if id_values is not None else None
+        km = (
+            _survfit_counting_with_id(
+                group_response,
+                group_weights,
+                group_ids,
+                include_entry=include_entry,
+                reverse=reverse_curve,
+                conf_level=normalized_conf_level,
+                conf_type=normalized_conf_type,
+                computation=computation,
+                timefix=fix_time,
+            )
+            if group_response.start is not None and group_ids is not None
+            else _survfitkm(
+                list(group_response.time),
+                list(group_response.event),
+                weights=group_weights,
+                entry_times=(
+                    list(group_response.start) if group_response.start is not None else None
+                ),
+                reverse=reverse_curve,
+                conf_level=normalized_conf_level,
+                conf_type=normalized_conf_type,
+                timefix=fix_time,
+            )
         )
         if computation.is_kaplan_meier:
             results[label] = (
@@ -3233,7 +4242,8 @@ def survfit(
                     km,
                     t0,
                     normalized_conf_type,
-                    _initial_survfit_risk(group_response, group_weights, t0),
+                    _initial_survfit_risk(group_response, group_weights, t0, fix_time),
+                    fix_time,
                 )
                 if include_time0
                 else km
@@ -3244,6 +4254,7 @@ def survfit(
                 list(group_response.time),
                 list(group_response.event),
                 reverse=reverse_curve,
+                timefix=fix_time,
             )
             result = _survfit_from_km_counts(
                 km,
@@ -3257,12 +4268,14 @@ def survfit(
                     result,
                     t0,
                     normalized_conf_type,
-                    _initial_survfit_risk(group_response, group_weights, t0),
+                    _initial_survfit_risk(group_response, group_weights, t0, fix_time),
+                    fix_time,
                 )
                 if include_time0
                 else result
             )
-    return results
+    result = _survfit_without_standard_errors(results) if not include_se else results
+    return _survfit_with_model_frame(result, model_frame) if model_frame is not None else result
 
 
 def _survdiff_weight_type(rho: float) -> str:
@@ -3308,6 +4321,26 @@ def _survdiff_timefix_values(times: list[float], timefix: bool) -> list[float]:
     return fixed
 
 
+def _timefix_vectors(*vectors: list[float]) -> tuple[list[float], ...]:
+    fixed = [list(vector) for vector in vectors]
+    points = [
+        (value, vector_idx, row_idx)
+        for vector_idx, vector in enumerate(fixed)
+        for row_idx, value in enumerate(vector)
+    ]
+    points.sort(key=lambda item: (item[0], item[1], item[2]))
+    cursor = 0
+    while cursor < len(points):
+        base = points[cursor][0]
+        scan = cursor + 1
+        while scan < len(points) and points[scan][0] - base < _SURVFIT_TIME_EPSILON:
+            _value, vector_idx, row_idx = points[scan]
+            fixed[vector_idx][row_idx] = base
+            scan += 1
+        cursor = scan
+    return tuple(fixed)
+
+
 def _survdiff_result_from_components(components: Any, rho: float) -> Any:
     statistic = float(components.chi_squared)
     df = int(components.degrees_of_freedom)
@@ -3326,13 +4359,91 @@ def _survdiff_result_from_components(components: Any, rho: float) -> Any:
     )
 
 
+def _survdiff_result_from_summary(
+    observed: list[float],
+    expected: list[float],
+    variance: float,
+    rho: float,
+) -> Any:
+    df = max(len(observed) - 1, 0)
+    statistic = (observed[0] - expected[0]) ** 2 / variance if df > 0 and variance > 0.0 else 0.0
+    p_value = 1.0 if df == 0 else float(_core.lrt_test(statistic / 2.0, 0.0, df).p_value)
+    return _core.LogRankResult(
+        statistic,
+        p_value,
+        df,
+        observed,
+        expected,
+        variance,
+        _survdiff_weight_type(rho),
+    )
+
+
+def _exact_counting_survdiff_result(
+    stop_times: list[float],
+    status: list[int],
+    entry_times: list[float],
+    group_codes: list[int],
+    n_groups: int,
+    rho: float,
+) -> Any:
+    observed = [0.0] * n_groups
+    expected = [0.0] * n_groups
+    variance = 0.0
+    if n_groups < 2:
+        return _survdiff_result_from_summary(observed, expected, variance, rho)
+
+    event_times = sorted(
+        {time for time, event in zip(stop_times, status, strict=True) if event == 1}
+    )
+    km_survival = 1.0
+    for event_time in event_times:
+        at_risk = [0.0] * n_groups
+        events = [0.0] * n_groups
+        total_events = 0.0
+        for idx, stop_time in enumerate(stop_times):
+            group_idx = group_codes[idx]
+            if entry_times[idx] < event_time <= stop_time:
+                at_risk[group_idx] += 1.0
+            if status[idx] == 1 and stop_time == event_time:
+                events[group_idx] += 1.0
+                total_events += 1.0
+
+        total_at_risk = sum(at_risk)
+        if total_events <= 0.0 or total_at_risk <= 0.0:
+            continue
+
+        weight = km_survival**rho
+        for group_idx in range(n_groups):
+            observed[group_idx] += weight * events[group_idx]
+            expected[group_idx] += weight * total_events * at_risk[group_idx] / total_at_risk
+
+        if total_at_risk > 1.0:
+            var_factor = (
+                total_events
+                * (total_at_risk - total_events)
+                / (total_at_risk * total_at_risk * (total_at_risk - 1.0))
+            )
+            for n_group in at_risk[: n_groups - 1]:
+                variance += weight * weight * var_factor * n_group * (total_at_risk - n_group)
+
+        km_survival *= 1.0 - total_events / total_at_risk
+
+    return _survdiff_result_from_summary(observed, expected, variance, rho)
+
+
 def _exact_survdiff(response: Surv, group: Any, rho: float, timefix: bool) -> Any:
+    group_codes = _encode_groups(group, len(response))
     if response.start is not None:
-        raise NotImplementedError(
-            "survdiff timefix=False is currently supported only for right-censored Surv responses"
+        return _exact_counting_survdiff_result(
+            list(response.time),
+            list(response.event),
+            list(response.start),
+            group_codes,
+            len(set(group_codes)),
+            rho,
         )
 
-    group_codes = _encode_groups(group, len(response))
     components = _core.survdiff2(
         _survdiff_timefix_values(list(response.time), timefix),
         list(response.event),
@@ -3350,15 +4461,57 @@ def _stratified_survdiff(
     rho: float,
     timefix: bool,
 ) -> Any:
-    if response.start is not None:
-        raise NotImplementedError(
-            "survdiff formula strata are currently supported only for right-censored Surv responses"
-        )
-
     n = len(response)
     group_codes = _encode_groups(group, n)
     strata_codes = _encode_groups(strata, n)
     times = _survdiff_timefix_values(list(response.time), timefix)
+    if response.start is not None:
+        n_groups = len(set(group_codes))
+        observed = [0.0] * n_groups
+        expected = [0.0] * n_groups
+        variance = 0.0
+        starts = list(response.start)
+        for indices in _group_indices(strata_codes, n).values():
+            local_groups = [group_codes[idx] for idx in indices]
+            if not timefix:
+                local_result = _exact_counting_survdiff_result(
+                    [times[idx] for idx in indices],
+                    [response.event[idx] for idx in indices],
+                    [starts[idx] for idx in indices],
+                    local_groups,
+                    n_groups,
+                    rho,
+                )
+            else:
+                local_result = (
+                    _core.logrank_test(
+                        [times[idx] for idx in indices],
+                        [response.event[idx] for idx in indices],
+                        local_groups,
+                        entry_times=[starts[idx] for idx in indices],
+                    )
+                    if rho == 0.0
+                    else _core.fleming_harrington_test(
+                        [times[idx] for idx in indices],
+                        [response.event[idx] for idx in indices],
+                        local_groups,
+                        rho,
+                        0.0,
+                        entry_times=[starts[idx] for idx in indices],
+                    )
+                )
+            if not timefix:
+                for group_idx in range(n_groups):
+                    observed[group_idx] += float(local_result.observed[group_idx])
+                    expected[group_idx] += float(local_result.expected[group_idx])
+            else:
+                for local_idx, group_code in enumerate(sorted(set(local_groups))):
+                    observed[group_code] += float(local_result.observed[local_idx])
+                    expected[group_code] += float(local_result.expected[local_idx])
+            variance += float(local_result.variance)
+
+        return _survdiff_result_from_summary(observed, expected, variance, rho)
+
     order = sorted(range(n), key=lambda idx: (strata_codes[idx], times[idx], idx))
     sorted_strata = [strata_codes[idx] for idx in order]
     components = _core.survdiff2(
@@ -3385,6 +4538,7 @@ def survdiff(
     """Compare survival curves with R's G-rho family for common survdiff use."""
 
     na_action = _pop_dotted_keyword(kwargs, "na.action", "na_action", na_action, "fail")
+    timefix = _pop_dotted_keyword(kwargs, "time.fix", "timefix", timefix, True)
     if kwargs:
         unexpected = ", ".join(sorted(kwargs))
         raise TypeError(f"survdiff got unexpected keyword argument(s): {unexpected}")
@@ -3543,8 +4697,7 @@ def cox_zph(
 ) -> CoxZPHResult:
     """R-style proportional hazards diagnostic for fitted Cox models."""
 
-    if "global" in kwargs:
-        global_test = kwargs.pop("global")
+    global_test = _pop_dotted_keyword(kwargs, "global", "global_test", global_test, True)
     if kwargs:
         unexpected = ", ".join(sorted(kwargs))
         raise TypeError(f"unexpected cox_zph argument(s): {unexpected}")
@@ -3555,7 +4708,7 @@ def cox_zph(
     include_global = _normalize_bool_option(global_test, "global")
 
     raw = [[float(value) for value in row] for row in fit.schoenfeld_residuals()]
-    scaled = [[float(value) for value in row] for row in fit.scaled_schoenfeld_residuals()]
+    scaled = _cox_scaled_schoenfeld_from_raw(fit, raw)
     if len(raw) != len(scaled):
         raise ValueError("Schoenfeld residual arrays have inconsistent lengths")
     if not raw:
@@ -3587,6 +4740,7 @@ def cox_zph(
     event_times = [float(fit.event_times[idx]) for idx in event_indices]
     transform_name, transformed_time = _cox_zph_transform(fit, event_times, transform)
     groups = _cox_zph_column_groups(fit, nvar, group_terms)
+    test_residuals = scaled
 
     variable_names: list[str] = []
     chi2_values: list[float] = []
@@ -3596,7 +4750,7 @@ def cox_zph(
         variable_names.append(name)
         if single_df and len(columns) > 1:
             residual_matrix = [
-                [sum(row[col_idx] * beta[col_idx] for col_idx in columns)] for row in raw
+                [sum(row[col_idx] * beta[col_idx] for col_idx in columns)] for row in test_residuals
             ]
             test = _core.ph_test(residual_matrix, transformed_time, None)
             chi2_values.append(float(test.chi2_values[0]) if test.chi2_values else 0.0)
@@ -3604,12 +4758,14 @@ def cox_zph(
             p_values.append(float(test.p_values[0]) if test.p_values else 1.0)
             continue
 
-        test = _core.ph_test(_matrix_columns(raw, columns), transformed_time, None)
+        test = _core.ph_test(_matrix_columns(test_residuals, columns), transformed_time, None)
         chi2_values.append(float(test.global_chi2))
         df_values.append(int(test.global_df))
         p_values.append(float(test.global_p_value))
 
-    global_result = _core.ph_test(raw, transformed_time, None) if include_global else None
+    global_result = (
+        _core.ph_test(test_residuals, transformed_time, None) if include_global else None
+    )
     grouped_y = (
         _cox_zph_term_matrix(scaled, groups, beta)
         if group_terms
@@ -4002,6 +5158,41 @@ def _cox_predict_terms(
     ]
 
 
+def _cox_partial_residuals(
+    fit: Any,
+    terms: Any | None,
+    martingale_weights: list[float] | None = None,
+) -> list[list[float]]:
+    martingale_method = getattr(fit, "martingale_residuals", None)
+    if martingale_method is None:
+        raise TypeError("model does not support partial residuals")
+    martingale = [float(value) for value in martingale_method()]
+    if martingale_weights is not None:
+        if len(martingale_weights) != len(martingale):
+            raise ValueError("weights must have the same length as martingale residuals")
+        martingale = [
+            residual * float(weight)
+            for residual, weight in zip(martingale, martingale_weights, strict=True)
+        ]
+    contributions = _cox_term_contributions(fit, len(martingale))
+    if terms is None:
+        return [
+            [martingale[row_idx] + term for term in row_terms]
+            for row_idx, row_terms in enumerate(contributions)
+        ]
+
+    groups = _cox_predict_term_groups(fit, len(_cox_beta(fit)))
+    selected = _predict_terms_selection(terms, [name for name, _columns in groups])
+    return [
+        [
+            martingale[row_idx]
+            + sum(contributions[row_idx][col_idx] for col_idx in groups[group_idx][1])
+            for group_idx in selected
+        ]
+        for row_idx in range(len(martingale))
+    ]
+
+
 def _cox_event_indices(fit: Any) -> list[int]:
     status = [int(value) for value in fit.status]
     times = [float(value) for value in fit.event_times]
@@ -4057,6 +5248,42 @@ def _cox_scaled_schoenfeld_from_raw(fit: Any, raw: list[list[float]]) -> list[li
             for col_idx in range(nvar)
         ]
         for row in raw
+    ]
+
+
+def _cox_dfbeta_from_score_residuals(fit: Any, *, scaled: bool) -> list[list[float]]:
+    beta = _cox_beta(fit)
+    nvar = len(beta)
+    score_method = getattr(fit, "score_residuals", None)
+    if score_method is None:
+        raise TypeError("model does not expose score residuals")
+    score = [[float(value) for value in row] for row in score_method()]
+    if nvar == 0:
+        return score
+    variance = getattr(fit, "information_matrix", None)
+    if variance is None:
+        raise TypeError("model does not expose coefficient variance")
+    matrix = [list(row) for row in variance]
+    if len(matrix) != nvar or any(len(row) != nvar for row in matrix):
+        raise ValueError("fitted Cox model information matrix does not match coefficient width")
+    if any(len(row) != nvar for row in score):
+        raise ValueError("score residuals do not match coefficient width")
+
+    scales = (
+        [
+            max(math.sqrt(abs(matrix[col_idx][col_idx])), _COX_DFBETAS_SCALE_FLOOR)
+            for col_idx in range(nvar)
+        ]
+        if scaled
+        else [1.0] * nvar
+    )
+    return [
+        [
+            sum(matrix[col_idx][inner_idx] * row[inner_idx] for inner_idx in range(nvar))
+            / scales[col_idx]
+            for col_idx in range(nvar)
+        ]
+        for row in score
     ]
 
 
@@ -4335,6 +5562,7 @@ def _cox_fit_offset(fit: Any, beta: list[float]) -> list[float] | None:
 
 def _cox_refit_loglik(fit: Any, width: int, offset: list[float] | None) -> float:
     rows = [[float(value) for value in row[:width]] for row in fit.covariates]
+    nocenter = getattr(fit, "nocenter", None)
     refit = _core.coxph_fit(
         [float(value) for value in fit.event_times],
         [int(value) for value in fit.status],
@@ -4352,6 +5580,7 @@ def _cox_refit_loglik(fit: Any, width: int, offset: list[float] | None) -> float
             if getattr(fit, "entry_times", None) is not None
             else None
         ),
+        nocenter=[float(value) for value in nocenter] if nocenter is not None else None,
     )
     return _cox_full_loglik(refit)
 
@@ -4546,10 +5775,15 @@ def _cox_nocenter_columns(fit: Any, nvar: int) -> set[int]:
     rows = [[float(value) for value in row] for row in covariates]
     if not rows or any(len(row) != nvar for row in rows):
         return set()
+    values = getattr(fit, "nocenter", (-1.0, 0.0, 1.0))
+    if values is None:
+        return set()
+    nocenter_values = [float(value) for value in values]
+    if not nocenter_values:
+        return set()
     nocenter: set[int] = set()
     for col_idx in range(nvar):
-        values = {row[col_idx] for row in rows}
-        if values <= {-1.0, 0.0, 1.0}:
+        if all(any(row[col_idx] == value for value in nocenter_values) for row in rows):
             nocenter.add(col_idx)
     return nocenter
 
@@ -4901,6 +6135,37 @@ def _cox_robust_variance_matrix(
     return robust, naive, cluster_values
 
 
+def _crossprod_rows(rows: list[list[float]], width: int, name: str) -> list[list[float]]:
+    if any(len(row) != width for row in rows):
+        raise ValueError(f"{name} rows must be rectangular")
+    result = [[0.0 for _ in range(width)] for _ in range(width)]
+    for row in rows:
+        for row_idx in range(width):
+            for col_idx in range(width):
+                result[row_idx][col_idx] += row[row_idx] * row[col_idx]
+    return result
+
+
+def _survreg_robust_variance_matrix(
+    fit: Any,
+    cluster: Any,
+) -> tuple[list[list[float]], list[list[float]], list[Any]]:
+    cluster_values = _materialize_labels(cluster, "cluster")
+    _label_levels(cluster_values, "cluster")
+    dfbeta_rows = _survreg_dfbeta_residuals(fit, "dfbeta", rsigma=True)
+    n = len(dfbeta_rows)
+    if len(cluster_values) != n:
+        raise ValueError("cluster must have the same length as the Surv response")
+
+    width = len(dfbeta_rows[0]) if dfbeta_rows else len(list(getattr(fit, "variance_matrix", [])))
+    naive = _survreg_variance_matrix(fit, width)
+    weights = _model_residual_weights(fit, n)
+    weighted_rows = _weight_residual_result(dfbeta_rows, weights)
+    collapsed_rows = _collapse_residual_result(weighted_rows, cluster_values, n)
+    robust = _crossprod_rows(collapsed_rows, width, "survreg dfbeta")
+    return robust, naive, cluster_values
+
+
 def _cox_linear_prediction_se(
     fit: Any,
     rows: list[list[float]] | None,
@@ -4974,7 +6239,7 @@ def _survreg_term_prediction_se(
         result_row: list[float] = []
         for group_idx in selected:
             columns = groups[group_idx][1]
-            values = [float(row[col_idx]) * beta[col_idx] for col_idx in columns]
+            values = [float(row[col_idx]) for col_idx in columns]
             result_row.append(
                 math.sqrt(max(_quadratic_form(values, _submatrix(variance, columns)), 0.0))
             )
@@ -5555,12 +6820,8 @@ def _cox_expected_events_with_se(
         stop_delta = [
             stop_hazard * centered_row[col_idx] - stop_xbar[col_idx] for col_idx in range(nvar)
         ]
-        variance_value = (
-            stop_varhaz
-            - start_varhaz
-            + _quadratic_form(stop_delta, variance)
-            - _quadratic_form(start_delta, variance)
-        )
+        interval_delta = [stop_delta[col_idx] - start_delta[col_idx] for col_idx in range(nvar)]
+        variance_value = stop_varhaz - start_varhaz + _quadratic_form(interval_delta, variance)
         risk = _safe_exp(float(linear_predictor))
         predictions.append(max(stop_hazard - start_hazard, 0.0) * risk)
         se.append(math.sqrt(max(variance_value, 0.0)) * risk)
@@ -5944,12 +7205,8 @@ def _cox_survfit_with_confidence(
             stop_delta = [
                 stop_hazard * centered_row[col_idx] - stop_xbar[col_idx] for col_idx in range(nvar)
             ]
-            variance_value = (
-                stop_varhaz
-                - start_varhaz
-                + _quadratic_form(stop_delta, variance)
-                - _quadratic_form(start_delta, variance)
-            )
+            interval_delta = [stop_delta[col_idx] - start_delta[col_idx] for col_idx in range(nvar)]
+            variance_value = stop_varhaz - start_varhaz + _quadratic_form(interval_delta, variance)
             chaz_se = math.sqrt(max(variance_value, 0.0)) * risk
             surv_se = float(survival) * chaz_se
             curve_std_chaz.append(chaz_se)
@@ -6084,35 +7341,741 @@ def _cox_survival_curve_with_se(
     )
 
 
-def _concordance_scores(data: Any, terms: _FormulaTerms, n: int) -> list[float]:
+def _matrix_score_columns(rows: list[list[float]]) -> tuple[list[list[float]], list[str]]:
+    width = len(rows[0]) if rows else 0
+    columns = [[row[col_idx] for row in rows] for col_idx in range(width)]
+    names = [f"score{col_idx + 1}" for col_idx in range(width)]
+    return columns, names
+
+
+def _external_concordance_score_columns(
+    scores: Any,
+    n: int,
+) -> tuple[list[list[float]], list[str]]:
+    rows = _as_matrix_rows(scores, "scores", allow_empty_columns=False)
+    if len(rows) != n:
+        raise ValueError("scores must have the same number of rows as the Surv response")
+    return _matrix_score_columns(rows)
+
+
+def _concordance_score_columns(
+    data: Any,
+    terms: _FormulaTerms,
+    n: int,
+) -> tuple[list[list[float]], list[str]]:
     if not terms.covariates and not terms.offsets:
         raise ValueError("concordance formula requires a risk score or offset term")
-    rows = _design_rows(data, terms.covariates, n) if terms.covariates else [[] for _ in range(n)]
-    if terms.covariates and rows and len(rows[0]) != 1:
-        raise ValueError("concordance formula must produce exactly one risk score column")
+
+    columns: list[list[float]] = []
+    names: list[str] = []
+    for term in terms.covariates:
+        design_term = _fit_design_term(data, term, n)
+        term_columns = _design_term_columns(data, design_term, n)
+        columns.extend(term_columns)
+        names.extend(_design_term_output_names(design_term))
+
     offsets = _offset_vector(data, terms.offsets, n) if terms.offsets else None
-    return [
-        (row[0] if row else 0.0) + (offsets[idx] if offsets is not None else 0.0)
-        for idx, row in enumerate(rows)
-    ]
+    if not columns:
+        if offsets is None:
+            raise ValueError("concordance formula requires a risk score or offset term")
+        return [offsets], ["offset"]
+
+    if offsets is not None:
+        columns = [[value + offsets[idx] for idx, value in enumerate(column)] for column in columns]
+    return columns, names
 
 
-def _single_concordance_summary(response: Surv, risk_values: list[float]) -> dict[str, float]:
-    if response.type == "right":
-        return _core.concordance_summary(
-            list(response.time),
-            list(response.event),
-            risk_values,
+_CONCORDANCE_TIMEWT_CHOICES = ("n", "S", "S/G", "n/G2", "I")
+
+
+def _normalize_concordance_timewt(timewt: Any) -> str:
+    if timewt is None:
+        return "n"
+    if isinstance(timewt, str):
+        value = timewt
+    else:
+        try:
+            values = list(timewt)
+        except TypeError as exc:
+            raise TypeError("timewt must be a string") from exc
+        if tuple(values) == _CONCORDANCE_TIMEWT_CHOICES:
+            return "n"
+        if len(values) != 1:
+            raise ValueError("timewt must be a single value")
+        value = str(values[0])
+    if value not in _CONCORDANCE_TIMEWT_CHOICES:
+        choices = "', '".join(_CONCORDANCE_TIMEWT_CHOICES)
+        raise ValueError(f"timewt must be one of '{choices}'")
+    return value
+
+
+def _normalize_concordance_influence(influence: Any) -> int:
+    if influence is None:
+        return 0
+    if _is_bool_like(influence):
+        value = int(bool(influence))
+    else:
+        value = _integer_scalar(influence, "influence")
+    if value not in {0, 1, 2, 3}:
+        raise ValueError("influence must be 0, 1, 2, or 3")
+    return value
+
+
+def _validate_concordance_keepstrata(keepstrata: Any) -> None:
+    if keepstrata is None:
+        return
+    if _is_bool_like(keepstrata):
+        return
+    _finite_float(keepstrata, "keepstrata")
+
+
+def _normalize_concordance_time_bound(value: Any | None, name: str) -> float | None:
+    if value is None:
+        return None
+    return _finite_float(value, name)
+
+
+def _formula_weight_values(data: Any, weights: Any | None) -> Any | None:
+    if isinstance(weights, str):
+        return _column(data, weights)
+    return weights
+
+
+def _formula_cluster_values(data: Any, cluster: Any | None) -> Any | None:
+    if isinstance(cluster, str):
+        return _column(data, cluster)
+    return cluster
+
+
+def _concordance_weight_values(weights: Any | None, n: int) -> list[float] | None:
+    values = _optional_float_vector(weights, "weights", n)
+    if values is None:
+        return None
+    if any(not math.isfinite(value) for value in values):
+        raise ValueError("weights must be finite")
+    if any(value < 0.0 for value in values):
+        raise ValueError("weights must be non-negative")
+    return values
+
+
+def _exact_counting_concordance_summary(
+    start: list[float],
+    stop: list[float],
+    status: list[int],
+    risk_values: list[float],
+    weights: list[float] | None,
+    timewt: str,
+) -> dict[str, float]:
+    event_time_multipliers = _counting_time_weight_multipliers(
+        start,
+        stop,
+        status,
+        weights,
+        timewt,
+    )
+    concordant = 0.0
+    comparable = 0.0
+    for event_idx, event in enumerate(status):
+        if event != 1:
+            continue
+        event_time = stop[event_idx]
+        event_time_multiplier = event_time_multipliers.get(event_time, 0.0)
+        if event_time_multiplier <= 0.0:
+            continue
+        for risk_idx in range(len(stop)):
+            if risk_idx == event_idx:
+                continue
+            if start[risk_idx] < event_time < stop[risk_idx]:
+                pair_weight = (
+                    1.0 if weights is None else float(weights[event_idx]) * float(weights[risk_idx])
+                ) * event_time_multiplier
+                comparable += pair_weight
+                diff = risk_values[event_idx] - risk_values[risk_idx]
+                if diff > 0.0:
+                    concordant += pair_weight
+                elif abs(diff) < _CONCORDANCE_RISK_TIE_FLOOR:
+                    concordant += 0.5 * pair_weight
+    return {
+        "concordance": concordant / comparable if comparable > 0.0 else 0.5,
+        "concordant": concordant,
+        "comparable": comparable,
+    }
+
+
+def _concordance_time_weight_multiplier(
+    timewt: str,
+    total_weight: float,
+    survival: float,
+    censoring_survival: float,
+    nrisk: float,
+) -> float:
+    if nrisk <= 0.0:
+        return 0.0
+    if timewt == "S":
+        return total_weight * survival / nrisk
+    if timewt == "S/G":
+        return (
+            total_weight * survival / (censoring_survival * nrisk)
+            if censoring_survival > 0.0
+            else 0.0
         )
+    if timewt == "n/G2":
+        return 1.0 / (censoring_survival * censoring_survival) if censoring_survival > 0.0 else 0.0
+    if timewt == "I":
+        return 1.0 / nrisk
+    return 1.0
+
+
+def _counting_time_weight_multipliers(
+    start: list[float],
+    stop: list[float],
+    status: list[int],
+    weights: list[float] | None,
+    timewt: str,
+) -> dict[float, float]:
+    if timewt == "n":
+        return dict.fromkeys(
+            {stop[idx] for idx, event in enumerate(status) if event == 1},
+            1.0,
+        )
+    total_weight = float(len(stop)) if weights is None else sum(float(value) for value in weights)
+    survival = 1.0
+    multipliers: dict[float, float] = {}
+    for event_time in sorted({stop[idx] for idx, event in enumerate(status) if event == 1}):
+        nrisk = sum(
+            (1.0 if weights is None else float(weights[idx]))
+            for idx, (entry, exit_time) in enumerate(zip(start, stop, strict=True))
+            if entry < event_time <= exit_time
+        )
+        multipliers[event_time] = _concordance_time_weight_multiplier(
+            timewt,
+            total_weight,
+            survival,
+            1.0,
+            nrisk,
+        )
+        death_weight = sum(
+            (1.0 if weights is None else float(weights[idx]))
+            for idx, event in enumerate(status)
+            if event == 1 and stop[idx] == event_time
+        )
+        if nrisk > 0.0:
+            survival *= max((nrisk - death_weight) / nrisk, 0.0)
+    return multipliers
+
+
+def _concordance_bounded_times_and_status(
+    times: list[float],
+    status: list[int],
+    ymin: float | None,
+    ymax: float | None,
+) -> tuple[list[float], list[int]]:
+    bounded_times = [max(value, ymin) for value in times] if ymin is not None else list(times)
+    bounded_status = list(status)
+    if ymax is not None:
+        bounded_status = [
+            0 if event == 1 and bounded_times[idx] > ymax else event
+            for idx, event in enumerate(bounded_status)
+        ]
+    return bounded_times, bounded_status
+
+
+def _right_concordance_time_weight_multipliers(
+    time: list[float],
+    status: list[int],
+    weights: list[float],
+    timewt: str,
+) -> dict[float, float]:
+    if timewt == "n":
+        return dict.fromkeys(
+            {time[idx] for idx, event in enumerate(status) if event == 1},
+            1.0,
+        )
+    total_weight = math.fsum(weights)
+    survival = 1.0
+    censoring_survival = 1.0
+    multipliers: dict[float, float] = {}
+    for event_time in sorted(set(time)):
+        indices = [idx for idx, value in enumerate(time) if value == event_time]
+        nrisk = math.fsum(weights[idx] for idx, value in enumerate(time) if value >= event_time)
+        death_weight = math.fsum(weights[idx] for idx in indices if status[idx] == 1)
+        censor_weight = math.fsum(weights[idx] for idx in indices if status[idx] != 1)
+        if death_weight > 0.0:
+            multipliers[event_time] = _concordance_time_weight_multiplier(
+                timewt,
+                total_weight,
+                survival,
+                censoring_survival,
+                nrisk,
+            )
+            if nrisk > 0.0:
+                survival *= max((nrisk - death_weight) / nrisk, 0.0)
+        if censor_weight > 0.0 and nrisk > 0.0:
+            censoring_survival *= max((nrisk - censor_weight) / nrisk, 0.0)
+    return multipliers
+
+
+def _concordance_rank_at_event(
+    risk_values: list[float],
+    weights: list[float],
+    event_idx: int,
+    at_risk: list[int],
+) -> tuple[float, float] | None:
+    risk_weight = math.fsum(weights[idx] for idx in at_risk)
+    if risk_weight <= 0.0:
+        return None
+    event_risk = risk_values[event_idx]
+    greater = 0.0
+    lower = 0.0
+    for idx in at_risk:
+        diff = risk_values[idx] - event_risk
+        if diff > _CONCORDANCE_RISK_TIE_FLOOR:
+            greater += weights[idx]
+        elif diff < -_CONCORDANCE_RISK_TIE_FLOOR:
+            lower += weights[idx]
+    return (lower - greater) / risk_weight, risk_weight
+
+
+def _single_concordance_ranks(
+    response: Surv,
+    risk_values: list[float],
+    weights: list[float] | None,
+    timefix: bool,
+    timewt: str,
+    ymin: float | None,
+    ymax: float | None,
+) -> list[dict[str, float]]:
+    case_weights = [1.0] * len(response) if weights is None else list(weights)
+    rows: list[dict[str, float]] = []
+    if response.type == "right":
+        times = _survdiff_timefix_values(list(response.time), timefix)
+        status = list(response.event)
+        times, status = _concordance_bounded_times_and_status(times, status, ymin, ymax)
+        multipliers = _right_concordance_time_weight_multipliers(
+            times,
+            status,
+            case_weights,
+            timewt,
+        )
+        event_indices = sorted(
+            (idx for idx, event in enumerate(status) if event == 1),
+            key=lambda idx: (times[idx], idx),
+        )
+        for event_idx in event_indices:
+            event_time = times[event_idx]
+            multiplier = multipliers.get(event_time, 0.0)
+            if multiplier <= 0.0:
+                continue
+            at_risk = [idx for idx, value in enumerate(times) if value >= event_time]
+            rank_result = _concordance_rank_at_event(
+                risk_values,
+                case_weights,
+                event_idx,
+                at_risk,
+            )
+            if rank_result is None:
+                continue
+            rank, risk_weight = rank_result
+            rows.append(
+                {
+                    "time": event_time,
+                    "rank": rank,
+                    "timewt": risk_weight * multiplier,
+                    "casewt": case_weights[event_idx],
+                }
+            )
+        return rows
     if response.type == "counting":
+        if timewt in {"S/G", "n/G2"}:
+            raise ValueError(
+                "S/G and n/G2 timewt options are not supported for counting-process data"
+            )
         if response.start is None:
             raise ValueError("counting-process concordance requires start times")
-        return _core.counting_concordance_summary(
-            list(response.start),
-            list(response.time),
-            list(response.event),
-            risk_values,
+        start = list(response.start)
+        stop = list(response.time)
+        if timefix:
+            start, stop = _timefix_vectors(start, stop)
+        status = list(response.event)
+        stop, status = _concordance_bounded_times_and_status(stop, status, ymin, ymax)
+        multipliers = _counting_time_weight_multipliers(
+            start,
+            stop,
+            status,
+            case_weights,
+            timewt,
         )
+        event_indices = sorted(
+            (idx for idx, event in enumerate(status) if event == 1),
+            key=lambda idx: (stop[idx], idx),
+        )
+        for event_idx in event_indices:
+            event_time = stop[event_idx]
+            multiplier = multipliers.get(event_time, 0.0)
+            if multiplier <= 0.0:
+                continue
+            at_risk = [
+                idx
+                for idx, (entry, exit_time) in enumerate(zip(start, stop, strict=True))
+                if entry < event_time <= exit_time
+            ]
+            rank_result = _concordance_rank_at_event(
+                risk_values,
+                case_weights,
+                event_idx,
+                at_risk,
+            )
+            if rank_result is None:
+                continue
+            rank, risk_weight = rank_result
+            rows.append(
+                {
+                    "time": event_time,
+                    "rank": rank,
+                    "timewt": risk_weight * multiplier,
+                    "casewt": case_weights[event_idx],
+                }
+            )
+        return rows
+    raise NotImplementedError(
+        "concordance currently supports right-censored and counting Surv responses"
+    )
+
+
+def _concordance_ranks(
+    response: Surv,
+    risk_values: list[float],
+    weights: list[float] | None,
+    strata: Any | None,
+    timefix: bool,
+    timewt: str,
+    ymin: float | None,
+    ymax: float | None,
+) -> list[dict[str, float]]:
+    if strata is None:
+        return _single_concordance_ranks(
+            response,
+            risk_values,
+            weights,
+            timefix,
+            timewt,
+            ymin,
+            ymax,
+        )
+    rows: list[dict[str, float]] = []
+    for indices in _group_indices(strata, len(response)).values():
+        group_response = _subset_surv(response, indices)
+        group_risk = [risk_values[idx] for idx in indices]
+        group_weights = [weights[idx] for idx in indices] if weights is not None else None
+        rows.extend(
+            _single_concordance_ranks(
+                group_response,
+                group_risk,
+                group_weights,
+                timefix,
+                timewt,
+                ymin,
+                ymax,
+            )
+        )
+    return sorted(rows, key=lambda row: row["time"])
+
+
+def _add_concordance_pair_influence(
+    influence_rows: list[list[float]],
+    left: int,
+    right: int,
+    column: int,
+    value: float,
+) -> None:
+    share = 0.5 * value
+    influence_rows[left][column] += share
+    influence_rows[right][column] += share
+
+
+def _concordance_influence_from_rows(
+    influence_rows: list[list[float]],
+    concordant: float,
+    comparable: float,
+) -> tuple[list[list[float]], list[float], float | None]:
+    if comparable <= 0.0:
+        return influence_rows, [0.0 for _ in influence_rows], 0.0
+    somer = (2.0 * concordant - comparable) / comparable
+    dfbeta = []
+    for row in influence_rows:
+        comparable_row = row[0] + row[1] + row[2]
+        dfbeta.append(((row[0] - row[1]) - comparable_row * somer) / (2.0 * comparable))
+    return influence_rows, dfbeta, math.fsum(value * value for value in dfbeta)
+
+
+def _single_concordance_influence(
+    response: Surv,
+    risk_values: list[float],
+    weights: list[float] | None,
+    timefix: bool,
+    timewt: str,
+    ymin: float | None,
+    ymax: float | None,
+) -> tuple[list[list[float]], list[float], float | None]:
+    case_weights = [1.0] * len(response) if weights is None else list(weights)
+    influence_rows = [[0.0, 0.0, 0.0, 0.0, 0.0] for _ in range(len(response))]
+    concordant = 0.0
+    comparable = 0.0
+    if response.type == "right":
+        times = _survdiff_timefix_values(list(response.time), timefix)
+        status = list(response.event)
+        times, status = _concordance_bounded_times_and_status(times, status, ymin, ymax)
+        multipliers = _right_concordance_time_weight_multipliers(
+            times,
+            status,
+            case_weights,
+            timewt,
+        )
+        for left in range(len(times)):
+            for right in range(left + 1, len(times)):
+                if status[left] == 1 and status[right] == 1 and times[left] == times[right]:
+                    multiplier = multipliers.get(times[left], 0.0)
+                    pair_weight = case_weights[left] * case_weights[right] * multiplier
+                    if pair_weight <= 0.0:
+                        continue
+                    column = (
+                        4
+                        if abs(risk_values[left] - risk_values[right]) < _CONCORDANCE_RISK_TIE_FLOOR
+                        else 3
+                    )
+                    _add_concordance_pair_influence(
+                        influence_rows,
+                        left,
+                        right,
+                        column,
+                        pair_weight,
+                    )
+                    continue
+                if status[left] == 1 and times[left] < times[right]:
+                    event_idx, risk_idx = left, right
+                elif status[right] == 1 and times[right] < times[left]:
+                    event_idx, risk_idx = right, left
+                else:
+                    continue
+                multiplier = multipliers.get(times[event_idx], 0.0)
+                pair_weight = case_weights[event_idx] * case_weights[risk_idx] * multiplier
+                if pair_weight <= 0.0:
+                    continue
+                comparable += pair_weight
+                diff = risk_values[event_idx] - risk_values[risk_idx]
+                if diff > _CONCORDANCE_RISK_TIE_FLOOR:
+                    concordant += pair_weight
+                    column = 0
+                elif diff < -_CONCORDANCE_RISK_TIE_FLOOR:
+                    column = 1
+                else:
+                    concordant += 0.5 * pair_weight
+                    column = 2
+                _add_concordance_pair_influence(
+                    influence_rows,
+                    event_idx,
+                    risk_idx,
+                    column,
+                    pair_weight,
+                )
+        return _concordance_influence_from_rows(influence_rows, concordant, comparable)
+    if response.type == "counting":
+        if timewt in {"S/G", "n/G2"}:
+            raise ValueError(
+                "S/G and n/G2 timewt options are not supported for counting-process data"
+            )
+        if response.start is None:
+            raise ValueError("counting-process concordance requires start times")
+        start = list(response.start)
+        stop = list(response.time)
+        if timefix:
+            start, stop = _timefix_vectors(start, stop)
+        status = list(response.event)
+        stop, status = _concordance_bounded_times_and_status(stop, status, ymin, ymax)
+        multipliers = _counting_time_weight_multipliers(
+            start,
+            stop,
+            status,
+            case_weights,
+            timewt,
+        )
+        for event_idx, event in enumerate(status):
+            if event != 1:
+                continue
+            event_time = stop[event_idx]
+            multiplier = multipliers.get(event_time, 0.0)
+            if multiplier <= 0.0:
+                continue
+            for risk_idx in range(len(stop)):
+                if risk_idx == event_idx:
+                    continue
+                pair_weight = case_weights[event_idx] * case_weights[risk_idx] * multiplier
+                if pair_weight <= 0.0:
+                    continue
+                if status[risk_idx] == 1 and stop[risk_idx] == event_time:
+                    if event_idx < risk_idx:
+                        column = (
+                            4
+                            if abs(risk_values[event_idx] - risk_values[risk_idx])
+                            < _CONCORDANCE_RISK_TIE_FLOOR
+                            else 3
+                        )
+                        _add_concordance_pair_influence(
+                            influence_rows,
+                            event_idx,
+                            risk_idx,
+                            column,
+                            pair_weight,
+                        )
+                    continue
+                if not (start[risk_idx] < event_time < stop[risk_idx]):
+                    continue
+                comparable += pair_weight
+                diff = risk_values[event_idx] - risk_values[risk_idx]
+                if diff > _CONCORDANCE_RISK_TIE_FLOOR:
+                    concordant += pair_weight
+                    column = 0
+                elif diff < -_CONCORDANCE_RISK_TIE_FLOOR:
+                    column = 1
+                else:
+                    concordant += 0.5 * pair_weight
+                    column = 2
+                _add_concordance_pair_influence(
+                    influence_rows,
+                    event_idx,
+                    risk_idx,
+                    column,
+                    pair_weight,
+                )
+        return _concordance_influence_from_rows(influence_rows, concordant, comparable)
+    raise NotImplementedError(
+        "concordance currently supports right-censored and counting Surv responses"
+    )
+
+
+def _concordance_influence(
+    response: Surv,
+    risk_values: list[float],
+    weights: list[float] | None,
+    strata: Any | None,
+    timefix: bool,
+    timewt: str,
+    ymin: float | None,
+    ymax: float | None,
+) -> tuple[list[list[float]], list[float], float | None]:
+    if strata is None:
+        return _single_concordance_influence(
+            response,
+            risk_values,
+            weights,
+            timefix,
+            timewt,
+            ymin,
+            ymax,
+        )
+    influence_rows = [[0.0, 0.0, 0.0, 0.0, 0.0] for _ in range(len(response))]
+    dfbeta = [0.0 for _ in range(len(response))]
+    variance = 0.0
+    for indices in _group_indices(strata, len(response)).values():
+        group_response = _subset_surv(response, indices)
+        group_risk = [risk_values[idx] for idx in indices]
+        group_weights = [weights[idx] for idx in indices] if weights is not None else None
+        group_influence, group_dfbeta, group_variance = _single_concordance_influence(
+            group_response,
+            group_risk,
+            group_weights,
+            timefix,
+            timewt,
+            ymin,
+            ymax,
+        )
+        for local_idx, original_idx in enumerate(indices):
+            influence_rows[original_idx] = group_influence[local_idx]
+            dfbeta[original_idx] = group_dfbeta[local_idx]
+        if group_variance is not None:
+            variance += group_variance
+    return influence_rows, dfbeta, variance
+
+
+def _concordance_cluster_values(cluster: Any, n: int) -> list[Any]:
+    values = _materialize_labels(cluster, "cluster")
+    if len(values) != n:
+        raise ValueError("cluster must have the same length as the Surv response")
+    _label_levels(values, "cluster")
+    return values
+
+
+def _clustered_concordance_dfbeta(
+    dfbeta: list[float],
+    cluster: list[Any],
+) -> tuple[list[float], float]:
+    collapsed: dict[Any, float] = {}
+    order: list[Any] = []
+    for label, value in zip(cluster, dfbeta, strict=True):
+        if label not in collapsed:
+            collapsed[label] = 0.0
+            order.append(label)
+        collapsed[label] += value
+    cluster_dfbeta = [collapsed[label] for label in order]
+    return cluster_dfbeta, math.fsum(value * value for value in cluster_dfbeta)
+
+
+def _single_concordance_summary(
+    response: Surv,
+    risk_values: list[float],
+    weights: list[float] | None,
+    timefix: bool,
+    timewt: str,
+    ymin: float | None,
+    ymax: float | None,
+) -> dict[str, float]:
+    if response.type == "right":
+        times = _survdiff_timefix_values(list(response.time), timefix)
+        status = list(response.event)
+        times, status = _concordance_bounded_times_and_status(times, status, ymin, ymax)
+        summary = _core.concordance_summary(
+            times,
+            status,
+            risk_values,
+            weights,
+            timewt,
+        )
+        summary["n_event"] = float(sum(1 for event in status if event == 1))
+        return summary
+    if response.type == "counting":
+        if timewt in {"S/G", "n/G2"}:
+            raise ValueError(
+                "S/G and n/G2 timewt options are not supported for counting-process data"
+            )
+        if response.start is None:
+            raise ValueError("counting-process concordance requires start times")
+        start = list(response.start)
+        stop = list(response.time)
+        if timefix:
+            start, stop = _timefix_vectors(start, stop)
+        status = list(response.event)
+        stop, status = _concordance_bounded_times_and_status(stop, status, ymin, ymax)
+        if not timefix:
+            summary = _exact_counting_concordance_summary(
+                start,
+                stop,
+                status,
+                risk_values,
+                weights,
+                timewt,
+            )
+            summary["n_event"] = float(sum(1 for event in status if event == 1))
+            return summary
+        summary = _core.counting_concordance_summary(
+            start,
+            stop,
+            status,
+            risk_values,
+            weights,
+            timewt,
+        )
+        summary["n_event"] = float(sum(1 for event in status if event == 1))
+        return summary
     raise NotImplementedError(
         "concordance currently supports right-censored and counting Surv responses"
     )
@@ -6121,25 +8084,173 @@ def _single_concordance_summary(response: Surv, risk_values: list[float]) -> dic
 def _concordance_summary(
     response: Surv,
     risk_values: list[float],
+    weights: list[float] | None,
     strata: Any | None,
+    timefix: bool,
+    timewt: str,
+    ymin: float | None,
+    ymax: float | None,
 ) -> dict[str, float]:
     if strata is None:
-        return _single_concordance_summary(response, risk_values)
+        return _single_concordance_summary(
+            response,
+            risk_values,
+            weights,
+            timefix,
+            timewt,
+            ymin,
+            ymax,
+        )
 
     concordant = 0.0
     comparable = 0.0
+    n_event = 0.0
     for indices in _group_indices(strata, len(response)).values():
         group_response = _subset_surv(response, indices)
         group_risk = [risk_values[idx] for idx in indices]
-        summary = _single_concordance_summary(group_response, group_risk)
+        group_weights = [weights[idx] for idx in indices] if weights is not None else None
+        summary = _single_concordance_summary(
+            group_response,
+            group_risk,
+            group_weights,
+            timefix,
+            timewt,
+            ymin,
+            ymax,
+        )
         concordant += float(summary["concordant"])
         comparable += float(summary["comparable"])
+        n_event += float(summary["n_event"])
 
     return {
         "concordance": concordant / comparable if comparable > 0.0 else 0.5,
         "concordant": concordant,
         "comparable": comparable,
+        "n_event": n_event,
     }
+
+
+def _single_score_concordance_result(
+    response: Surv,
+    score_values: list[float],
+    weight_values: list[float] | None,
+    strata_values: Any | None,
+    cluster_values: list[Any] | None,
+    reverse_scores: bool,
+    fix_time: bool,
+    time_weight: str,
+    lower_bound: float | None,
+    upper_bound: float | None,
+    influence_value: int,
+    include_ranks: bool,
+) -> ConcordanceResult:
+    if len(score_values) != len(response):
+        raise ValueError("scores must have the same length as the Surv response")
+
+    risk_values = [-value for value in score_values] if reverse_scores else score_values
+    summary = _concordance_summary(
+        response,
+        risk_values,
+        weight_values,
+        strata_values,
+        fix_time,
+        time_weight,
+        lower_bound,
+        upper_bound,
+    )
+    rank_rows = (
+        _concordance_ranks(
+            response,
+            risk_values,
+            weight_values,
+            strata_values,
+            fix_time,
+            time_weight,
+            lower_bound,
+            upper_bound,
+        )
+        if include_ranks
+        else None
+    )
+    influence_rows = None
+    dfbeta = None
+    variance = None
+    if influence_value or cluster_values is not None:
+        influence_rows, dfbeta, variance = _concordance_influence(
+            response,
+            risk_values,
+            weight_values,
+            strata_values,
+            fix_time,
+            time_weight,
+            lower_bound,
+            upper_bound,
+        )
+        if cluster_values is not None and dfbeta is not None:
+            dfbeta, variance = _clustered_concordance_dfbeta(dfbeta, cluster_values)
+    return ConcordanceResult(
+        concordance=float(summary["concordance"]),
+        n=len(response),
+        n_event=int(summary["n_event"]),
+        reverse=reverse_scores,
+        concordant=float(summary["concordant"]),
+        comparable=float(summary["comparable"]),
+        ranks=rank_rows,
+        dfbeta=dfbeta if influence_value in {1, 3} else None,
+        influence=influence_rows if influence_value in {2, 3} else None,
+        variance=variance if influence_value or cluster_values is not None else None,
+    )
+
+
+def _multi_score_concordance_result(
+    response: Surv,
+    score_columns: list[list[float]],
+    score_names: list[str],
+    weight_values: list[float] | None,
+    strata_values: Any | None,
+    cluster_values: list[Any] | None,
+    reverse_scores: bool,
+    fix_time: bool,
+    time_weight: str,
+    lower_bound: float | None,
+    upper_bound: float | None,
+    influence_value: int,
+    include_ranks: bool,
+) -> ConcordanceResult:
+    results = [
+        _single_score_concordance_result(
+            response,
+            score_values,
+            weight_values,
+            strata_values,
+            cluster_values,
+            reverse_scores,
+            fix_time,
+            time_weight,
+            lower_bound,
+            upper_bound,
+            influence_value,
+            include_ranks,
+        )
+        for score_values in score_columns
+    ]
+    return ConcordanceResult(
+        concordance=[float(result.concordance) for result in results],
+        n=len(response),
+        n_event=results[0].n_event if results else 0,
+        reverse=reverse_scores,
+        concordant=[float(result.concordant) for result in results],
+        comparable=[float(result.comparable) for result in results],
+        ranks=[result.ranks for result in results] if include_ranks else None,
+        dfbeta=[result.dfbeta for result in results] if influence_value in {1, 3} else None,
+        influence=[result.influence for result in results] if influence_value in {2, 3} else None,
+        variance=(
+            [result.variance for result in results]
+            if influence_value or cluster_values is not None
+            else None
+        ),
+        score_names=score_names,
+    )
 
 
 def concordance(
@@ -6148,37 +8259,78 @@ def concordance(
     *,
     scores: Any | None = None,
     risk_scores: Any | None = None,
+    weights: Any | None = None,
     subset: Any | None = None,
     na_action: str | None = "fail",
+    cluster: Any | None = None,
+    ymin: Any | None = None,
+    ymax: Any | None = None,
+    timewt: Any = "n",
+    influence: Any = 0,
+    ranks: bool = False,
     reverse: bool = False,
+    timefix: bool = True,
+    keepstrata: Any = 10,
     **kwargs: Any,
 ) -> ConcordanceResult:
     """R-style concordance wrapper backed by Rust Harrell C-index."""
 
     na_action = _pop_dotted_keyword(kwargs, "na.action", "na_action", na_action, "fail")
+    timefix = _pop_dotted_keyword(kwargs, "time.fix", "timefix", timefix, True)
     if kwargs:
         unexpected = ", ".join(sorted(kwargs))
         raise TypeError(f"concordance got unexpected keyword argument(s): {unexpected}")
 
     reverse_scores = _normalize_bool_option(reverse, "reverse")
+    fix_time = _normalize_bool_option(timefix, "timefix")
+    time_weight = _normalize_concordance_timewt(timewt)
+    lower_bound = _normalize_concordance_time_bound(ymin, "ymin")
+    upper_bound = _normalize_concordance_time_bound(ymax, "ymax")
+    influence_value = _normalize_concordance_influence(influence)
+    include_ranks = _normalize_bool_option(ranks, "ranks")
+    _validate_concordance_keepstrata(keepstrata)
     if scores is not None and risk_scores is not None:
         raise ValueError("use only one of scores or risk_scores")
     external_scores = risk_scores if risk_scores is not None else scores
     strata_values = None
+    cluster_values = None
+    score_names: list[str] | None = None
 
     if isinstance(response, str):
         if external_scores is not None:
             raise ValueError("concordance formula input cannot be combined with scores")
+        weights = _formula_weight_values(data, weights)
+        cluster = _formula_cluster_values(data, cluster)
         if subset is not None:
-            data, _aligned = _subset_formula_inputs(response, data, subset)
+            data, aligned = _subset_formula_inputs(
+                response,
+                data,
+                subset,
+                weights=weights,
+                cluster=cluster,
+            )
+            weights = aligned["weights"]
+            cluster = aligned["cluster"]
             subset = None
-        data, _aligned = _apply_formula_na_action(response, data, na_action)
+        data, aligned = _apply_formula_na_action(
+            response,
+            data,
+            na_action,
+            weights=weights,
+            cluster=cluster,
+        )
+        weights = aligned["weights"]
+        cluster = aligned["cluster"]
         na_action = "pass"
         response, terms = _parse_formula(response, data)
-        _reject_formula_clusters("concordance", terms)
-        score_values = _concordance_scores(data, terms, len(response))
+        if terms.clusters:
+            if cluster is not None:
+                raise ValueError("use only one of formula cluster(...) or cluster")
+            cluster = _combined_columns(data, terms.clusters, len(response))
+        score_columns, score_names = _concordance_score_columns(data, terms, len(response))
         if terms.strata:
             strata_values = _combined_columns(data, terms.strata, len(response))
+        weight_values = _concordance_weight_values(weights, len(response))
     else:
         if not isinstance(response, Surv):
             raise TypeError("concordance response must be a Surv object or formula")
@@ -6188,25 +8340,75 @@ def concordance(
             indices = _subset_indices(subset, len(response))
             response = _subset_surv(response, indices)
             external_scores = _subset_sequence(external_scores, indices, "scores")
+            weights = _subset_optional_sequence(weights, indices, "weights")
+            cluster = _subset_optional_sequence(cluster, indices, "cluster")
         response, aligned = _apply_surv_na_action(
             response,
             na_action,
             "concordance inputs",
             scores=external_scores,
+            weights=weights,
+            cluster=cluster,
         )
         external_scores = aligned["scores"]
-        score_values = _float_vector(external_scores, "scores")
+        weights = aligned["weights"]
+        cluster = aligned["cluster"]
+        score_columns, score_names = _external_concordance_score_columns(
+            external_scores,
+            len(response),
+        )
+        weight_values = _concordance_weight_values(weights, len(response))
 
-    if len(score_values) != len(response):
-        raise ValueError("scores must have the same length as the Surv response")
+    if cluster is not None:
+        cluster_values = _concordance_cluster_values(cluster, len(response))
 
-    risk_values = [-value for value in score_values] if reverse_scores else score_values
-    summary = _concordance_summary(response, risk_values, strata_values)
-    return ConcordanceResult(
-        concordance=float(summary["concordance"]),
-        n=len(response),
-        n_event=sum(1 for value in response.event if value == 1),
-        reverse=reverse_scores,
+    if len(score_columns) == 1:
+        result = _single_score_concordance_result(
+            response,
+            score_columns[0],
+            weight_values,
+            strata_values,
+            cluster_values,
+            reverse_scores,
+            fix_time,
+            time_weight,
+            lower_bound,
+            upper_bound,
+            influence_value,
+            include_ranks,
+        )
+        return (
+            ConcordanceResult(
+                concordance=result.concordance,
+                n=result.n,
+                n_event=result.n_event,
+                reverse=result.reverse,
+                concordant=result.concordant,
+                comparable=result.comparable,
+                ranks=result.ranks,
+                dfbeta=result.dfbeta,
+                influence=result.influence,
+                variance=result.variance,
+                score_names=score_names,
+            )
+            if score_names is not None
+            else result
+        )
+
+    return _multi_score_concordance_result(
+        response,
+        score_columns,
+        score_names or [f"score{idx + 1}" for idx in range(len(score_columns))],
+        weight_values,
+        strata_values,
+        cluster_values,
+        reverse_scores,
+        fix_time,
+        time_weight,
+        lower_bound,
+        upper_bound,
+        influence_value,
+        include_ranks,
     )
 
 
@@ -6394,9 +8596,7 @@ def predict(
         if include_se:
             if linear_se is None:
                 raise AssertionError("se_fit risk predictions require linear SEs")
-            risk_se = [
-                float(se) * math.sqrt(risk) for se, risk in zip(linear_se, risks, strict=True)
-            ]
+            risk_se = [float(se) * risk for se, risk in zip(linear_se, risks, strict=True)]
             return PredictResult(
                 _collapse_prediction_result(risks, collapse),
                 _collapse_prediction_se(risk_se, collapse),
@@ -6413,6 +8613,7 @@ def residuals(
     fit: Any,
     *,
     type: str = "martingale",  # noqa: A002
+    terms: Any | None = None,
     collapse: Any = False,
     weighted: bool | None = None,
     rsigma: bool | None = None,
@@ -6422,6 +8623,8 @@ def residuals(
     weighted_value = _normalize_optional_bool_option(weighted, "weighted")
     rsigma_value = _normalize_optional_bool_option(rsigma, "rsigma")
     if _is_survreg_fit(fit):
+        if terms is not None:
+            raise ValueError("terms is only supported for Cox partial residuals")
         residual_type = _normalize_survreg_residual_type(type)
         if residual_type in {"dfbeta", "dfbetas"}:
             dfbeta_values = _survreg_dfbeta_residuals(fit, residual_type, rsigma=rsigma_value)
@@ -6469,6 +8672,8 @@ def residuals(
         raise AssertionError(f"unhandled survreg residual type {residual_type!r}")
 
     residual_type = _normalize_residual_type(type)
+    if terms is not None and residual_type != "partial":
+        raise ValueError("terms is only supported for Cox partial residuals")
     method_names = {
         "martingale": "martingale_residuals",
         "deviance": "deviance_residuals",
@@ -6510,21 +8715,14 @@ def residuals(
             status = _collapse_residual_result(status, collapse, len(status))
         return _cox_deviance_from_martingale(martingale, status)
 
-    if residual_type == "partial" and (use_weights or not _collapse_is_false(collapse)):
-        martingale_method = getattr(fit, "martingale_residuals", None)
-        if martingale_method is None:
-            raise TypeError("model does not support partial residuals")
-        martingale = [float(value) for value in martingale_method()]
-        if use_weights:
-            martingale = _weight_residual_result(
-                martingale,
-                _model_residual_weights(fit, len(martingale)),
-            )
-        terms = _cox_term_contributions(fit, len(martingale))
-        result = [
-            [martingale[row_idx] + term for term in row_terms]
-            for row_idx, row_terms in enumerate(terms)
-        ]
+    if residual_type == "partial" and (
+        terms is not None or use_weights or not _collapse_is_false(collapse)
+    ):
+        result = _cox_partial_residuals(
+            fit,
+            terms,
+            _model_residual_weights(fit, len(fit.status)) if use_weights else None,
+        )
         if not _collapse_is_false(collapse):
             result = _collapse_residual_result(result, collapse, len(result))
         return result
@@ -6690,25 +8888,52 @@ def coxph(
     method: str | None = None,
     ties: str | None = None,
     robust: Any | None = None,
+    model: Any = False,
+    y: Any = True,
+    tt: Any | None = None,
+    id: Any | None = None,  # noqa: A002
+    istate: Any | None = None,
+    statedata: Any | None = None,
+    singular_ok: Any = True,
+    nocenter: Any = (-1, 0, 1),
     control: Any | None = None,
     **kwargs: Any,
 ):
     """Fit a Cox proportional hazards model from Surv plus covariates."""
 
     na_action = _pop_dotted_keyword(kwargs, "na.action", "na_action", na_action, "fail")
+    singular_ok = _pop_dotted_keyword(
+        kwargs,
+        "singular.ok",
+        "singular_ok",
+        singular_ok,
+        True,
+    )
     if kwargs:
         unexpected = ", ".join(sorted(kwargs))
         raise TypeError(f"coxph got unexpected keyword argument(s): {unexpected}")
 
     method_name = _cox_tie_method(method, ties)
     robust_value = _normalize_optional_bool_option(robust, "robust")
+    keep_model = _normalize_bool_option_with_default(model, "model", False)
+    keep_y = _normalize_bool_option_with_default(y, "y", True)
+    singular_ok_value = _normalize_bool_option_with_default(singular_ok, "singular_ok", True)
+    nocenter_values = _normalize_numeric_sequence_or_none(nocenter, "nocenter")
+    id_arg = id
+    if istate is not None or statedata is not None:
+        raise NotImplementedError("coxph multi-state istate/statedata inputs are not supported")
     if init is not None and initial_beta is not None:
         raise ValueError("use only one of init or initial_beta")
-    max_iter, eps, toler = _apply_coxph_control(control, max_iter, eps, toler)
+    max_iter, eps, toler, fix_time = _apply_coxph_control(control, max_iter, eps, toler)
 
     formula_design: _FormulaDesign | None = None
+    formula_x_matrix: list[list[float]] | None = None
+    formula_model_data: Any | None = None
+    formula_cluster_columns: tuple[str, ...] = ()
     if isinstance(response, str):
         response_spec = _formula_response_spec(response)
+        if _formula_has_time_transform_term(response):
+            raise NotImplementedError("coxph tt time-transform terms are not supported")
         if subset is not None:
             data, aligned = _subset_formula_inputs(
                 response,
@@ -6718,11 +8943,13 @@ def coxph(
                 offset=offset,
                 strata=strata,
                 cluster=cluster,
+                id=id_arg,
             )
             weights = aligned["weights"]
             offset = aligned["offset"]
             strata = aligned["strata"]
             cluster = aligned["cluster"]
+            id_arg = aligned["id"]
             subset = None
         data, aligned = _apply_formula_na_action(
             response,
@@ -6732,14 +8959,19 @@ def coxph(
             offset=offset,
             strata=strata,
             cluster=cluster,
+            id=id_arg,
         )
         weights = aligned["weights"]
         offset = aligned["offset"]
         strata = aligned["strata"]
         cluster = aligned["cluster"]
+        id_arg = aligned["id"]
         na_action = "pass"
+        formula_x = False
         if x is not None:
-            raise ValueError("coxph formula input cannot be combined with x")
+            if not _is_bool_like(x):
+                raise TypeError("x must be True or False for coxph formula input")
+            formula_x = _normalize_bool_option(x, "x")
         response, terms = _parse_formula(response, data)
         if terms.strata:
             if strata is not None:
@@ -6753,8 +8985,11 @@ def coxph(
             if cluster is not None:
                 raise ValueError("use only one of formula cluster(...) or cluster")
             cluster = _combined_columns(data, terms.clusters, len(response))
+            formula_cluster_columns = tuple(terms.clusters)
         formula_design = _fit_formula_design(data, response_spec, terms, len(response))
         x = _design_rows_from_spec(data, formula_design, len(response))
+        formula_x_matrix = [list(row) for row in x] if formula_x else None
+        formula_model_data = data
 
     if not isinstance(response, Surv):
         raise TypeError("coxph response must be a Surv object or formula")
@@ -6766,6 +9001,7 @@ def coxph(
         offset = _subset_optional_sequence(offset, indices, "offset")
         strata = _subset_optional_sequence(strata, indices, "strata")
         cluster = _subset_optional_sequence(cluster, indices, "cluster")
+        id_arg = _subset_optional_sequence(id_arg, indices, "id")
     response, aligned = _apply_surv_na_action(
         response,
         na_action,
@@ -6775,12 +9011,14 @@ def coxph(
         offset=offset,
         strata=strata,
         cluster=cluster,
+        id=id_arg,
     )
     x = aligned["x"]
     weights = aligned["weights"]
     offset = aligned["offset"]
     strata = aligned["strata"]
     cluster = aligned["cluster"]
+    id_arg = aligned["id"]
     if response.type not in {"right", "counting"}:
         raise NotImplementedError(
             "coxph currently supports right-censored and counting Surv responses"
@@ -6791,14 +9029,54 @@ def coxph(
         raise ValueError("x must have the same number of rows as the Surv response")
 
     n = len(response)
+    id_values = _materialize_labels(id_arg, "id") if id_arg is not None else None
+    if id_values is not None and len(id_values) != n:
+        raise ValueError("id must have the same length as the Surv response")
+    fit_strata = _encode_groups(strata, n) if strata is not None else None
+    fit_weights = _optional_float_vector(weights, "weights", n)
+    fit_offset = _optional_float_vector(offset, "offset", n)
+    if not singular_ok_value:
+        _check_cox_design_full_rank(rows, fit_weights, toler if toler is not None else 1e-9)
+    model_frame = None
+    if keep_model:
+        model_frame = (
+            _formula_model_frame(
+                formula_model_data,
+                response,
+                formula_design,
+                extra_columns=formula_cluster_columns,
+                weights=weights,
+                offset=offset,
+                strata=strata,
+                cluster=cluster,
+                id=id_values,
+            )
+            if formula_design is not None
+            else _matrix_model_frame(
+                response,
+                rows,
+                weights=weights,
+                offset=offset,
+                strata=strata,
+                cluster=cluster,
+                id=id_values,
+            )
+        )
+
+    fit_times = list(response.time)
     entry_times = list(response.start) if response.start is not None else None
+    if fix_time:
+        if entry_times is None:
+            fit_times = _survdiff_timefix_values(fit_times, True)
+        else:
+            entry_times, fit_times = _timefix_vectors(entry_times, fit_times)
     fit = _core.coxph_fit(
-        list(response.time),
+        fit_times,
         list(response.event),
         rows,
-        strata=_encode_groups(strata, n) if strata is not None else None,
-        weights=_optional_float_vector(weights, "weights", n),
-        offset=_optional_float_vector(offset, "offset", n),
+        strata=fit_strata,
+        weights=fit_weights,
+        offset=fit_offset,
         initial_beta=(
             _float_vector(initial_beta if initial_beta is not None else init, "init")
             if init is not None or initial_beta is not None
@@ -6809,12 +9087,13 @@ def coxph(
         toler=toler,
         method=method_name,
         entry_times=entry_times,
+        nocenter=nocenter_values,
     )
-    robust_cluster = cluster
+    robust_cluster = cluster if cluster is not None else id_values
     if robust_value is True and robust_cluster is None:
         robust_cluster = list(range(n))
     if robust_value is False and robust_cluster is not None:
-        raise ValueError("cluster cannot be combined with robust=False")
+        raise ValueError("cluster or id cannot be combined with robust=False")
     robust_variance = None
     naive_variance = None
     cluster_values = None
@@ -6823,8 +9102,18 @@ def coxph(
             fit,
             robust_cluster,
         )
-    if formula_design is not None or robust_variance is not None:
-        return _FormulaFit(fit, formula_design, robust_variance, naive_variance, cluster_values)
+    if formula_design is not None or robust_variance is not None or model_frame is not None:
+        return _FormulaFit(
+            fit,
+            formula_design,
+            robust_variance,
+            naive_variance,
+            cluster_values,
+            id_values,
+            x_matrix=formula_x_matrix,
+            y_response=response if formula_design is not None and keep_y else None,
+            model_frame=model_frame,
+        )
     return fit
 
 
@@ -6840,6 +9129,7 @@ def survreg(
     weights: Any | None = None,
     offset: Any | None = None,
     offsets: Any | None = None,
+    init: Any | None = None,
     initial: Any | None = None,
     initial_beta: Any | None = None,
     strata: Any | None = None,
@@ -6847,6 +9137,13 @@ def survreg(
     na_action: str | None = "fail",
     dist: str | None = None,
     distribution: str | None = None,
+    scale: Any = 0.0,
+    parms: Any | None = None,
+    model: Any = False,
+    y: Any = True,
+    robust: Any | None = None,
+    cluster: Any | None = None,
+    score: Any = False,
     max_iter: int | None = None,
     eps: float | None = None,
     tol_chol: float | None = None,
@@ -6862,14 +9159,31 @@ def survreg(
 
     if offset is not None and offsets is not None:
         raise ValueError("use only one of offset or offsets")
-    if initial is not None and initial_beta is not None:
-        raise ValueError("use only one of initial or initial_beta")
+    initial_options = {
+        "init": init,
+        "initial": initial,
+        "initial_beta": initial_beta,
+    }
+    if sum(value is not None for value in initial_options.values()) > 1:
+        raise ValueError("use only one of init, initial, or initial_beta")
     if x is not None and covariates is not None:
         raise ValueError("use only one of x or covariates")
+    scale_value = _finite_float(scale, "scale")
+    if scale_value < 0.0:
+        raise ValueError("scale must be non-negative")
+    if parms is not None:
+        raise NotImplementedError("survreg distribution parameters via parms are not supported")
+    keep_model = _normalize_bool_option_with_default(model, "model", False)
+    keep_y = _normalize_bool_option_with_default(y, "y", True)
+    keep_score = _normalize_bool_option_with_default(score, "score", False)
+    robust_requested = None if robust is None else _normalize_bool_option(robust, "robust")
     max_iter, eps, tol_chol = _apply_survreg_control(control, max_iter, eps, tol_chol)
 
     formula_rows: list[list[float]] | None = None
     formula_design: _FormulaDesign | None = None
+    formula_x_matrix: list[list[float]] | None = None
+    formula_model_data: Any | None = None
+    formula_cluster_columns: tuple[str, ...] = ()
     matrix_input = response is None and time is not None and status is not None
     if matrix_input:
         response_time = _float_vector(time, "time")
@@ -6888,6 +9202,7 @@ def survreg(
             offset = _subset_optional_sequence(offset, indices, "offset")
             offsets = _subset_optional_sequence(offsets, indices, "offsets")
             strata = _subset_optional_sequence(strata, indices, "strata")
+            cluster = _subset_optional_sequence(cluster, indices, "cluster")
             subset = None
         keep = _keep_rows_after_na_action(
             _missing_row_indices(
@@ -6903,6 +9218,7 @@ def survreg(
                             ("offset", offset),
                             ("offsets", offsets),
                             ("strata", strata),
+                            ("cluster", cluster),
                         )
                         if values is not None
                     ),
@@ -6924,6 +9240,7 @@ def survreg(
             offset = _subset_optional_sequence(offset, keep, "offset")
             offsets = _subset_optional_sequence(offsets, keep, "offsets")
             strata = _subset_optional_sequence(strata, keep, "strata")
+            cluster = _subset_optional_sequence(cluster, keep, "cluster")
         response_status = [
             float(value)
             for value in _integer_code_vector(
@@ -6947,11 +9264,13 @@ def survreg(
                     offset=offset,
                     offsets=offsets,
                     strata=strata,
+                    cluster=cluster,
                 )
                 weights = aligned["weights"]
                 offset = aligned["offset"]
                 offsets = aligned["offsets"]
                 strata = aligned["strata"]
+                cluster = aligned["cluster"]
                 subset = None
             data, aligned = _apply_formula_na_action(
                 response,
@@ -6961,16 +9280,22 @@ def survreg(
                 offset=offset,
                 offsets=offsets,
                 strata=strata,
+                cluster=cluster,
             )
             weights = aligned["weights"]
             offset = aligned["offset"]
             offsets = aligned["offsets"]
             strata = aligned["strata"]
+            cluster = aligned["cluster"]
             na_action = "pass"
-            if x is not None or covariates is not None:
+            formula_x = False
+            if x is not None:
+                if not _is_bool_like(x):
+                    raise TypeError("x must be True or False for survreg formula input")
+                formula_x = _normalize_bool_option(x, "x")
+            if covariates is not None:
                 raise ValueError("survreg formula input cannot be combined with x or covariates")
             response, terms = _parse_formula(response, data)
-            _reject_formula_clusters("survreg", terms)
             formula_design = _fit_formula_design(
                 data,
                 response_spec,
@@ -6983,6 +9308,7 @@ def survreg(
                 if terms.covariates or formula_design.intercept
                 else [[] for _ in range(len(response))]
             )
+            formula_x_matrix = [list(row) for row in formula_rows] if formula_x else None
             if terms.strata:
                 if strata is not None:
                     raise ValueError("use only one of formula strata(...) or strata")
@@ -6991,6 +9317,12 @@ def survreg(
                 if offset is not None or offsets is not None:
                     raise ValueError("use only one of formula offset(...) or offset")
                 offsets = _offset_vector(data, terms.offsets, len(response))
+            if terms.clusters:
+                if cluster is not None:
+                    raise ValueError("use only one of formula cluster(...) or cluster")
+                cluster = _combined_columns(data, terms.clusters, len(response))
+                formula_cluster_columns = tuple(terms.clusters)
+            formula_model_data = data
 
         if not isinstance(response, Surv):
             raise TypeError("survreg response must be a Surv object, formula, or time/status input")
@@ -7003,6 +9335,7 @@ def survreg(
             offset = _subset_optional_sequence(offset, indices, "offset")
             offsets = _subset_optional_sequence(offsets, indices, "offsets")
             strata = _subset_optional_sequence(strata, indices, "strata")
+            cluster = _subset_optional_sequence(cluster, indices, "cluster")
         response, aligned = _apply_surv_na_action(
             response,
             na_action,
@@ -7013,6 +9346,7 @@ def survreg(
             offset=offset,
             offsets=offsets,
             strata=strata,
+            cluster=cluster,
         )
         x = aligned["x"]
         covariates = aligned["covariates"]
@@ -7020,6 +9354,7 @@ def survreg(
         offset = aligned["offset"]
         offsets = aligned["offsets"]
         strata = aligned["strata"]
+        cluster = aligned["cluster"]
 
         response_time, response_status, response_time2 = _survreg_response_arrays(response)
         rows = (
@@ -7042,10 +9377,60 @@ def survreg(
     offset_values = _optional_float_vector(offsets if offsets is not None else offset, "offsets", n)
     weight_values = _optional_float_vector(weights, "weights", n)
     strata_values = _encode_groups(strata, n) if strata is not None else None
+    if scale_value > 0.0 and strata_values is not None and len(set(strata_values)) > 1:
+        raise ValueError("cannot have both a fixed scale and strata")
+    cluster_values_for_validation = (
+        _materialize_labels(cluster, "cluster") if cluster is not None else None
+    )
+    if cluster_values_for_validation is not None:
+        if len(cluster_values_for_validation) != n:
+            raise ValueError("cluster must have the same length as the Surv response")
+        _label_levels(cluster_values_for_validation, "cluster")
+    robust_value = (
+        cluster_values_for_validation is not None if robust_requested is None else robust_requested
+    )
+    model_frame = None
+    if keep_model:
+        if formula_design is not None:
+            model_frame = _formula_model_frame(
+                formula_model_data,
+                response,
+                formula_design,
+                extra_columns=formula_cluster_columns,
+                weights=weights,
+                offset=offset,
+                offsets=offsets,
+                strata=strata,
+                cluster=cluster,
+            )
+        elif isinstance(response, Surv):
+            model_frame = _matrix_model_frame(
+                response,
+                rows,
+                weights=weights,
+                offset=offset,
+                offsets=offsets,
+                strata=strata,
+                cluster=cluster,
+            )
+        else:
+            model_frame = _survreg_matrix_model_frame(
+                response_time,
+                response_status,
+                response_time2,
+                rows,
+                weights=weights,
+                offset=offset,
+                offsets=offsets,
+                strata=strata,
+                cluster=cluster,
+            )
+    initial_name, initial_source = next(
+        ((name, value) for name, value in initial_options.items() if value is not None),
+        ("initial", None),
+    )
     initial_values = (
-        _float_vector(initial_beta if initial_beta is not None else initial, "initial")
-        if initial is not None or initial_beta is not None
-        else None
+        _float_vector(initial_source, initial_name) if initial_source is not None else None
     )
 
     fit = _core.survreg(
@@ -7061,5 +9446,37 @@ def survreg(
         eps=eps,
         tol_chol=tol_chol,
         time2=response_time2,
+        fixed_scale=scale_value if scale_value > 0.0 else None,
     )
-    return _FormulaFit(fit, formula_design) if formula_design is not None else fit
+    robust_cluster = cluster_values_for_validation
+    if robust_value and robust_cluster is None:
+        robust_cluster = list(range(n))
+    robust_variance = None
+    naive_variance = None
+    cluster_values = None
+    if robust_cluster is not None and robust_value:
+        robust_variance, naive_variance, cluster_values = _survreg_robust_variance_matrix(
+            fit,
+            robust_cluster,
+        )
+    score_values = list(fit.score_vector) if keep_score else None
+    return (
+        _FormulaFit(
+            fit,
+            formula_design,
+            robust_variance=robust_variance,
+            naive_variance=naive_variance,
+            cluster=cluster_values,
+            x_matrix=formula_x_matrix,
+            y_response=response if keep_y else None,
+            model_frame=model_frame,
+            score_values=score_values,
+        )
+        if (
+            formula_design is not None
+            or robust_variance is not None
+            or model_frame is not None
+            or score_values is not None
+        )
+        else fit
+    )

--- a/python/survival/r_api.pyi
+++ b/python/survival/r_api.pyi
@@ -14,12 +14,21 @@ class Surv:
 def is_surv(value: Any) -> bool: ...
 
 class ConcordanceResult:
-    concordance: float
+    concordance: float | list[float]
     n: int
     n_event: int
     reverse: bool
+    concordant: float | list[float]
+    comparable: float | list[float]
+    ranks: list[dict[str, float]] | list[list[dict[str, float]] | None] | None
+    dfbeta: list[float] | list[list[float] | None] | None
+    influence: list[list[float]] | list[list[list[float]] | None] | None
+    variance: float | list[float | None] | None
+    score_names: list[str] | None
     @property
-    def c_index(self) -> float: ...
+    def c_index(self) -> float | list[float]: ...
+    @property
+    def var(self) -> float | list[float | None] | None: ...
 
 class PredictResult:
     fit: Any
@@ -102,6 +111,7 @@ class CoxSurvfitResult:
     std_chaz: list[list[float]]
     conf_lower: list[list[float]]
     conf_upper: list[list[float]]
+    model: dict[str, Any] | None
     def __iter__(self): ...
     @property
     def curves(self) -> list[list[float]]: ...
@@ -123,6 +133,8 @@ class SurvfitResult:
     conf_upper: list[float]
     cumhaz: list[float]
     std_chaz: list[float]
+    n_enter: list[float] | None
+    model: dict[str, Any] | None
     @property
     def surv(self) -> list[float]: ...
     @property
@@ -130,15 +142,33 @@ class SurvfitResult:
     @property
     def cumulative_hazard_std_err(self) -> list[float]: ...
 
+class TurnbullSurvfitResult:
+    time_points: list[float]
+    survival: list[float]
+    survival_lower: list[float]
+    survival_upper: list[float]
+    n_iter: int
+    converged: bool
+    model: dict[str, Any] | None
+
 def concordance(
     response: Surv | str,
     data: Any | None = None,
     *,
     scores: Any | None = None,
     risk_scores: Any | None = None,
+    weights: Any | None = None,
     subset: Any | None = None,
     na_action: str | None = "fail",
+    cluster: Any | None = None,
+    ymin: Any | None = None,
+    ymax: Any | None = None,
+    timewt: Any = "n",
+    influence: Any = 0,
+    ranks: bool = False,
     reverse: bool = False,
+    timefix: bool = True,
+    keepstrata: Any = 10,
     **kwargs: Any,
 ) -> ConcordanceResult: ...
 def survfit(
@@ -153,6 +183,7 @@ def survfit(
     conf_level: float = 0.95,
     conf_int: Any | None = None,
     conf_type: str | None = "log",
+    se_fit: Any = True,
     start_time: Any | None = None,
     time0: bool = False,
     reverse: bool = False,
@@ -160,6 +191,15 @@ def survfit(
     type: str | None = None,
     stype: int | None = None,
     ctype: int | None = None,
+    id: Any | None = None,
+    cluster: Any | None = None,
+    robust: Any | None = None,
+    istate: Any | None = None,
+    etype: Any | None = None,
+    model: Any = False,
+    error: Any | None = None,
+    entry: Any = False,
+    timefix: bool = True,
     **kwargs: Any,
 ) -> Any: ...
 def survdiff(
@@ -224,6 +264,14 @@ def coxph(
     method: str | None = None,
     ties: str | None = None,
     robust: Any | None = None,
+    model: Any = False,
+    y: Any = True,
+    tt: Any | None = None,
+    id: Any | None = None,
+    istate: Any | None = None,
+    statedata: Any | None = None,
+    singular_ok: Any = True,
+    nocenter: Any = (-1, 0, 1),
     control: Any | None = None,
     **kwargs: Any,
 ) -> Any: ...
@@ -246,6 +294,7 @@ def residuals(
     fit: Any,
     *,
     type: str = "martingale",
+    terms: Any | None = None,
     collapse: Any = False,
     weighted: bool | None = None,
     rsigma: bool | None = None,
@@ -262,6 +311,7 @@ def survreg(
     weights: Any | None = None,
     offset: Any | None = None,
     offsets: Any | None = None,
+    init: Any | None = None,
     initial: Any | None = None,
     initial_beta: Any | None = None,
     strata: Any | None = None,
@@ -269,6 +319,13 @@ def survreg(
     na_action: str | None = "fail",
     dist: str | None = None,
     distribution: str | None = None,
+    scale: Any = 0.0,
+    parms: Any | None = None,
+    model: Any = False,
+    y: Any = True,
+    robust: Any | None = None,
+    cluster: Any | None = None,
+    score: Any = False,
     max_iter: int | None = None,
     eps: float | None = None,
     tol_chol: float | None = None,

--- a/python/tests/test_binding_contract.py
+++ b/python/tests/test_binding_contract.py
@@ -441,6 +441,7 @@ def test_survreg_prediction_bindings_are_typed_to_runtime_surface():
             "eps",
             "tol_chol",
             "time2",
+            "fixed_scale",
         ],
         "predict_survreg": [
             "covariates",
@@ -595,6 +596,7 @@ def test_survreg_prediction_bindings_are_typed_to_runtime_surface():
         1e-5,
         1e-9,
         None,
+        None,
     )
     fit_prediction = fit.predict(covariates[:2], "lp")
     fit_quantiles = fit.predict_quantile(covariates[:2], [0.25, 0.5])
@@ -637,6 +639,7 @@ def test_coxph_fit_detail_bindings_are_typed_to_runtime_surface():
             "toler",
             "method",
             "entry_times",
+            "nocenter",
         ],
         "coxph_detail": [
             "time",
@@ -713,6 +716,7 @@ def test_coxph_fit_detail_bindings_are_typed_to_runtime_surface():
         "covariates",
         "strata",
         "method",
+        "nocenter",
     }
     assert _pyi_class_property_names(stub_path, "CoxphDetailRow") == {
         "stratum",
@@ -7973,29 +7977,48 @@ def test_counting_concordance_binding_is_typed():
     stub_names = _pyi_top_level_names(stub_path)
 
     assert {
+        "concordance_index",
         "concordance_summary",
         "counting_concordance_index",
         "counting_concordance_summary",
     } <= stub_names
+    assert "time" in inspect.signature(core.concordance_index).parameters
     assert "time" in inspect.signature(core.concordance_summary).parameters
     assert "start" in inspect.signature(core.counting_concordance_index).parameters
     assert "start" in inspect.signature(core.counting_concordance_summary).parameters
+    assert "timewt" in inspect.signature(core.concordance_index).parameters
+    assert "timewt" in inspect.signature(core.concordance_summary).parameters
+    assert "timewt" in inspect.signature(core.counting_concordance_index).parameters
+    assert "timewt" in inspect.signature(core.counting_concordance_summary).parameters
+    assert _pyi_function_arg_names(stub_path, "concordance_index") == [
+        "time",
+        "status",
+        "risk_scores",
+        "weights",
+        "timewt",
+    ]
     assert _pyi_function_arg_names(stub_path, "concordance_summary") == [
         "time",
         "status",
         "risk_scores",
+        "weights",
+        "timewt",
     ]
     assert _pyi_function_arg_names(stub_path, "counting_concordance_index") == [
         "start",
         "stop",
         "status",
         "risk_scores",
+        "weights",
+        "timewt",
     ]
     assert _pyi_function_arg_names(stub_path, "counting_concordance_summary") == [
         "start",
         "stop",
         "status",
         "risk_scores",
+        "weights",
+        "timewt",
     ]
 
 
@@ -9962,9 +9985,18 @@ def test_r_api_stub_tracks_concordance_public_signature():
         "data",
         "scores",
         "risk_scores",
+        "weights",
         "subset",
         "na_action",
+        "cluster",
+        "ymin",
+        "ymax",
+        "timewt",
+        "influence",
+        "ranks",
         "reverse",
+        "timefix",
+        "keepstrata",
     ]
     runtime_params = inspect.signature(survival.r_api.concordance).parameters
     assert [
@@ -9993,6 +10025,7 @@ def test_r_api_stub_tracks_survfit_public_signature():
         "conf_level",
         "conf_int",
         "conf_type",
+        "se_fit",
         "start_time",
         "time0",
         "reverse",
@@ -10000,6 +10033,15 @@ def test_r_api_stub_tracks_survfit_public_signature():
         "type",
         "stype",
         "ctype",
+        "id",
+        "cluster",
+        "robust",
+        "istate",
+        "etype",
+        "model",
+        "error",
+        "entry",
+        "timefix",
     ]
     runtime_params = inspect.signature(survival.r_api.survfit).parameters
     assert [
@@ -10051,6 +10093,24 @@ def test_r_api_stub_tracks_predict_public_signature():
     assert predict_node.args.kwarg.arg == "kwargs"
 
 
+def test_r_api_stub_tracks_residuals_public_signature():
+    setup_survival_import()
+    survival = importlib.import_module("survival")
+    stub_path = PACKAGE_ROOT / "r_api.pyi"
+
+    expected = [
+        "fit",
+        "type",
+        "terms",
+        "collapse",
+        "weighted",
+        "rsigma",
+    ]
+    runtime_params = inspect.signature(survival.r_api.residuals).parameters
+    assert list(runtime_params) == expected
+    assert _pyi_function_arg_names(stub_path, "residuals") == expected
+
+
 def test_r_api_stub_tracks_survdiff_public_signature():
     setup_survival_import()
     survival = importlib.import_module("survival")
@@ -10100,6 +10160,14 @@ def test_r_api_stub_tracks_fit_control_public_signatures():
             "method",
             "ties",
             "robust",
+            "model",
+            "y",
+            "tt",
+            "id",
+            "istate",
+            "statedata",
+            "singular_ok",
+            "nocenter",
             "control",
         ],
         "survreg": [
@@ -10113,6 +10181,7 @@ def test_r_api_stub_tracks_fit_control_public_signatures():
             "weights",
             "offset",
             "offsets",
+            "init",
             "initial",
             "initial_beta",
             "strata",
@@ -10120,6 +10189,13 @@ def test_r_api_stub_tracks_fit_control_public_signatures():
             "na_action",
             "dist",
             "distribution",
+            "scale",
+            "parms",
+            "model",
+            "y",
+            "robust",
+            "cluster",
+            "score",
             "max_iter",
             "eps",
             "tol_chol",

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -176,6 +176,23 @@ def _manual_cox_robust_variance(fit, cluster):
     ]
 
 
+def _manual_survreg_robust_variance(fit, cluster):
+    dfbeta = survival.r_api.residuals(
+        fit,
+        type="dfbeta",
+        weighted=True,
+        collapse=cluster,
+        rsigma=True,
+    )
+    width = len(dfbeta[0]) if dfbeta else len(fit.variance_matrix)
+    robust = [[0.0 for _ in range(width)] for _ in range(width)]
+    for row in dfbeta:
+        for left in range(width):
+            for right in range(width):
+                robust[left][right] += row[left] * row[right]
+    return robust
+
+
 def _manual_cox_loglik(
     time,
     status,
@@ -234,33 +251,146 @@ def _manual_cox_loglik(
     return loglik
 
 
-def _manual_counting_concordance(start, stop, status, scores):
-    concordant, comparable = _manual_counting_concordance_counts(start, stop, status, scores)
+def _manual_counting_concordance(start, stop, status, scores, weights=None, timewt="n"):
+    concordant, comparable = _manual_counting_concordance_counts(
+        start,
+        stop,
+        status,
+        scores,
+        weights,
+        timewt,
+    )
     return concordant / comparable if comparable else 0.5
 
 
-def _manual_counting_concordance_counts(start, stop, status, scores):
+def _manual_concordance_time_multiplier(timewt, total_weight, survival, censoring_survival, nrisk):
+    if nrisk <= 0.0:
+        return 0.0
+    if timewt == "S":
+        return total_weight * survival / nrisk
+    if timewt == "S/G":
+        return (
+            total_weight * survival / (censoring_survival * nrisk)
+            if censoring_survival > 0.0
+            else 0.0
+        )
+    if timewt == "n/G2":
+        return 1.0 / (censoring_survival * censoring_survival) if censoring_survival > 0.0 else 0.0
+    if timewt == "I":
+        return 1.0 / nrisk
+    return 1.0
+
+
+def _manual_right_time_multipliers(time, status, weights, timewt):
+    if timewt == "n":
+        return dict.fromkeys(
+            {time[idx] for idx, event in enumerate(status) if event == 1},
+            1.0,
+        )
+    total_weight = float(len(time)) if weights is None else sum(weights)
+    survival = 1.0
+    censoring_survival = 1.0
+    multipliers = {}
+    for event_time in sorted(set(time)):
+        indices = [idx for idx, value in enumerate(time) if value == event_time]
+        nrisk = sum(
+            (1.0 if weights is None else weights[idx])
+            for idx, value in enumerate(time)
+            if value >= event_time
+        )
+        death_weight = sum(
+            (1.0 if weights is None else weights[idx]) for idx in indices if status[idx] == 1
+        )
+        censor_weight = sum(
+            (1.0 if weights is None else weights[idx]) for idx in indices if status[idx] != 1
+        )
+        if death_weight > 0.0:
+            multipliers[event_time] = _manual_concordance_time_multiplier(
+                timewt,
+                total_weight,
+                survival,
+                censoring_survival,
+                nrisk,
+            )
+            if nrisk > 0.0:
+                survival *= max((nrisk - death_weight) / nrisk, 0.0)
+        if censor_weight > 0.0 and nrisk > 0.0:
+            censoring_survival *= max((nrisk - censor_weight) / nrisk, 0.0)
+    return multipliers
+
+
+def _manual_counting_time_multipliers(start, stop, status, weights, timewt):
+    if timewt == "n":
+        return dict.fromkeys(
+            {stop[idx] for idx, event in enumerate(status) if event == 1},
+            1.0,
+        )
+    total_weight = float(len(stop)) if weights is None else sum(weights)
+    survival = 1.0
+    multipliers = {}
+    for event_time in sorted({stop[idx] for idx, event in enumerate(status) if event == 1}):
+        nrisk = sum(
+            (1.0 if weights is None else weights[idx])
+            for idx, (entry, exit_time) in enumerate(zip(start, stop, strict=True))
+            if entry < event_time <= exit_time
+        )
+        multipliers[event_time] = _manual_concordance_time_multiplier(
+            timewt,
+            total_weight,
+            survival,
+            1.0,
+            nrisk,
+        )
+        death_weight = sum(
+            (1.0 if weights is None else weights[idx])
+            for idx, event in enumerate(status)
+            if event == 1 and stop[idx] == event_time
+        )
+        if nrisk > 0.0:
+            survival *= max((nrisk - death_weight) / nrisk, 0.0)
+    return multipliers
+
+
+def _manual_concordance_bounded_times_and_status(time, status, ymin=None, ymax=None):
+    bounded_time = [max(value, ymin) for value in time] if ymin is not None else list(time)
+    bounded_status = [
+        0 if ymax is not None and event == 1 and bounded_time[idx] > ymax else event
+        for idx, event in enumerate(status)
+    ]
+    return bounded_time, bounded_status
+
+
+def _manual_counting_concordance_counts(start, stop, status, scores, weights=None, timewt="n"):
     comparable = 0.0
     concordant = 0.0
+    multipliers = _manual_counting_time_multipliers(start, stop, status, weights, timewt)
     for event_idx, event in enumerate(status):
         if event != 1:
+            continue
+        event_time = stop[event_idx]
+        multiplier = multipliers.get(event_time, 0.0)
+        if multiplier <= 0.0:
             continue
         for risk_idx in range(len(stop)):
             if risk_idx == event_idx:
                 continue
-            if start[risk_idx] < stop[event_idx] and stop[risk_idx] > stop[event_idx]:
-                comparable += 1.0
+            if start[risk_idx] < event_time and stop[risk_idx] > event_time:
+                pair_weight = (
+                    1.0 if weights is None else weights[event_idx] * weights[risk_idx]
+                ) * multiplier
+                comparable += pair_weight
                 diff = scores[event_idx] - scores[risk_idx]
                 if diff > 0.0:
-                    concordant += 1.0
+                    concordant += pair_weight
                 elif abs(diff) < 1e-12:
-                    concordant += 0.5
+                    concordant += 0.5 * pair_weight
     return concordant, comparable
 
 
-def _manual_right_concordance_counts(time, status, scores):
+def _manual_right_concordance_counts(time, status, scores, weights=None, timewt="n"):
     comparable = 0.0
     concordant = 0.0
+    multipliers = _manual_right_time_multipliers(time, status, weights, timewt)
     for left in range(len(time)):
         for right in range(left + 1, len(time)):
             if status[left] == 1 and time[left] < time[right]:
@@ -269,12 +399,16 @@ def _manual_right_concordance_counts(time, status, scores):
                 event_idx, risk_idx = right, left
             else:
                 continue
-            comparable += 1.0
+            multiplier = multipliers.get(time[event_idx], 0.0)
+            pair_weight = (
+                1.0 if weights is None else weights[event_idx] * weights[risk_idx]
+            ) * multiplier
+            comparable += pair_weight
             diff = scores[event_idx] - scores[risk_idx]
             if diff > 0.0:
-                concordant += 1.0
+                concordant += pair_weight
             elif abs(diff) < 1e-12:
-                concordant += 0.5
+                concordant += 0.5 * pair_weight
     return concordant, comparable
 
 
@@ -429,6 +563,50 @@ def test_survfit_honors_non_default_conf_level():
     assert formula_alias.conf_lower == pytest.approx(high_level.conf_lower)
     assert formula_alias.conf_upper == pytest.approx(high_level.conf_upper)
     assert high_level.conf_lower != pytest.approx(default.conf_lower)
+
+
+def test_survfit_accepts_se_fit_false_for_km_outputs():
+    data = _toy_data()
+    response = survival.Surv(data["time"], data["status"])
+
+    default = survival.survfit(response)
+    direct = survival.survfit(response, se_fit=False)
+    dotted = survival.survfit(response, **{"se.fit": False})
+    formula = survival.survfit("Surv(time, status) ~ 1", data=data, se_fit=False)
+    time0 = survival.survfit(response, se_fit=False, time0=True)
+    fh = survival.survfit(response, se_fit=False, type="fleming-harrington")
+    fh_default = survival.survfit(response, type="fleming-harrington")
+
+    assert direct.time == pytest.approx(default.time)
+    assert direct.n_risk == pytest.approx(default.n_risk)
+    assert direct.n_event == pytest.approx(default.n_event)
+    assert direct.n_censor == pytest.approx(default.n_censor)
+    assert direct.estimate == pytest.approx(default.estimate)
+    assert direct.cumhaz == pytest.approx(default.cumhaz)
+    assert direct.std_err == []
+    assert direct.std_chaz == []
+    assert direct.conf_lower == []
+    assert direct.conf_upper == []
+    assert direct.cumulative_hazard_std_err == []
+
+    assert dotted.estimate == pytest.approx(direct.estimate)
+    assert dotted.std_err == []
+    assert formula.estimate == pytest.approx(direct.estimate)
+    assert formula.std_chaz == []
+
+    assert time0.time == pytest.approx([0.0, *default.time])
+    assert time0.estimate[0] == pytest.approx(1.0)
+    assert time0.std_err == []
+    assert time0.std_chaz == []
+    assert time0.conf_lower == []
+    assert time0.conf_upper == []
+
+    assert fh.estimate == pytest.approx(fh_default.estimate)
+    assert fh.cumhaz == pytest.approx(fh_default.cumhaz)
+    assert fh.std_err == []
+    assert fh.std_chaz == []
+    assert fh.conf_lower == []
+    assert fh.conf_upper == []
 
 
 def test_survfit_coxph_accepts_conf_int_alias():
@@ -588,8 +766,12 @@ def test_r_api_bool_options_accept_numpy_bool_scalars():
 
     direct_concordance = survival.concordance(response, scores=scores, reverse=True)
     numpy_concordance = survival.concordance(response, scores=scores, reverse=np.bool_(True))
+    numpy_timefix = survival.concordance(response, scores=scores, timefix=np.bool_(False))
     assert numpy_concordance.concordance == pytest.approx(direct_concordance.concordance)
     assert numpy_concordance.reverse is True
+    assert numpy_timefix.concordance == pytest.approx(
+        survival.concordance(response, scores=scores, timefix=False).concordance
+    )
 
     direct_basehaz = survival.basehaz(fit, centered=False)
     numpy_basehaz = survival.basehaz(fit, centered=np.bool_(False))
@@ -630,6 +812,8 @@ def test_r_api_bool_options_reject_python_truthiness():
         survival.survfit(response, reverse=1)
     with pytest.raises(TypeError, match="reverse"):
         survival.concordance(response, scores=scores, reverse="yes")
+    with pytest.raises(TypeError, match="timefix"):
+        survival.concordance(response, scores=scores, timefix=1)
     with pytest.raises(TypeError, match="centered"):
         survival.basehaz(fit, centered=1)
     with pytest.raises(TypeError, match="terms"):
@@ -638,6 +822,8 @@ def test_r_api_bool_options_reject_python_truthiness():
         survival.cox_zph(fit, singledf="yes")
     with pytest.raises(TypeError, match="global"):
         survival.cox_zph(fit, global_test=1)
+    with pytest.raises(ValueError, match="global_test or global"):
+        survival.cox_zph(fit, global_test=False, **{"global": True})
     with pytest.raises(TypeError, match="se_fit"):
         survival.predict(fit, rows, se_fit=1)
     with pytest.raises(TypeError, match="centered"):
@@ -772,6 +958,227 @@ def test_survfit_reverse_matches_low_level_censoring_distribution():
     assert formula.estimate == pytest.approx(direct.estimate)
 
 
+def test_survfit_accepts_r_style_formula_defaults():
+    data = _toy_data()
+    default = survival.survfit("Surv(time, status) ~ group", data=data)
+    explicit = survival.survfit(
+        "Surv(time, status) ~ group",
+        data=data,
+        id=None,
+        cluster=None,
+        robust=None,
+        istate=None,
+        etype=None,
+        model=False,
+        error=None,
+        entry=False,
+        se_fit=True,
+    )
+    explicit_false_robust = survival.survfit(
+        "Surv(time, status) ~ group",
+        data=data,
+        robust=False,
+    )
+
+    assert set(explicit) == set(default)
+    assert set(explicit_false_robust) == set(default)
+    for label in default:
+        assert explicit[label].time == pytest.approx(default[label].time)
+        assert explicit[label].estimate == pytest.approx(default[label].estimate)
+        assert explicit_false_robust[label].estimate == pytest.approx(default[label].estimate)
+
+    dotted_se = survival.survfit(
+        "Surv(time, status) ~ group",
+        data=data,
+        **{"se.fit": True},
+    )
+    for label in default:
+        assert dotted_se[label].std_err == pytest.approx(default[label].std_err)
+
+
+def test_survfit_model_true_stores_direct_and_formula_inputs():
+    data = _toy_data()
+    response = survival.Surv(data["time"], data["status"])
+    weights = [1.0 + 0.1 * idx for idx in range(len(data["time"]))]
+
+    direct = survival.survfit(response, model=True)
+    grouped = survival.survfit(response, group=data["group"], weights=weights, model=True)
+    formula = survival.survfit("Surv(time, status) ~ group", data=data, model=True)
+
+    assert isinstance(direct, survival.r_api.SurvfitResult)
+    assert direct.model["response"].time == pytest.approx(data["time"])
+    assert direct.model["response"].event == tuple(data["status"])
+
+    assert set(grouped) == {"A", "B"}
+    for curve in grouped.values():
+        assert curve.model["response"].time == pytest.approx(data["time"])
+        assert curve.model["response"].event == tuple(data["status"])
+        assert curve.model["group"] == data["group"]
+        assert curve.model["(weights)"] == pytest.approx(weights)
+
+    for curve in formula.values():
+        assert curve.model["Surv(time, status)"].time == pytest.approx(data["time"])
+        assert curve.model["Surv(time, status)"].event == tuple(data["status"])
+        assert curve.model["time"] == pytest.approx(data["time"])
+        assert curve.model["status"] == data["status"]
+        assert curve.model["group"] == data["group"]
+
+
+def test_survfit_error_argument_is_accepted_as_noop():
+    data = _toy_data()
+    response = survival.Surv(data["time"], data["status"])
+
+    default = survival.survfit(response)
+    direct = survival.survfit(response, error="tsiatis")
+    formula = survival.survfit("Surv(time, status) ~ 1", data=data, error="greenwood")
+    fit = survival.coxph("Surv(time, status) ~ x1 + x2", data=data, max_iter=10)
+    cox_default = survival.survfit(fit, newdata={"x1": [0.5], "x2": [0.8]})
+    cox_error = survival.survfit(fit, newdata={"x1": [0.5], "x2": [0.8]}, error="unused")
+
+    assert direct.time == pytest.approx(default.time)
+    assert direct.estimate == pytest.approx(default.estimate)
+    assert direct.std_err == pytest.approx(default.std_err)
+    assert formula.estimate == pytest.approx(default.estimate)
+    assert cox_error.time == pytest.approx(cox_default.time)
+    for actual, expected in zip(cox_error.surv, cox_default.surv, strict=True):
+        assert actual == pytest.approx(expected)
+    for actual, expected in zip(cox_error.std_err, cox_default.std_err, strict=True):
+        assert actual == pytest.approx(expected)
+
+
+def test_survfit_counting_id_reports_entry_counts_without_artificial_censors():
+    response = survival.Surv(
+        [0.0, 10.0, 25.0, 0.0, 5.0],
+        [10.0, 20.0, 30.0, 15.0, 25.0],
+        [0, 0, 1, 1, 0],
+    )
+    subject = ["a", "a", "a", "b", "c"]
+
+    fit = survival.survfit(response, id=subject, entry=True)
+    weighted = survival.survfit(
+        response,
+        id=subject,
+        weights=[2.0, 2.0, 2.0, 1.0, 3.0],
+        entry=True,
+    )
+    no_entry = survival.survfit(response, id=subject)
+
+    assert fit.time == pytest.approx([0.0, 5.0, 15.0, 20.0, 25.0, 30.0])
+    assert fit.n_risk == pytest.approx([0.0, 2.0, 3.0, 2.0, 1.0, 1.0])
+    assert fit.n_event == pytest.approx([0.0, 0.0, 1.0, 0.0, 0.0, 1.0])
+    assert fit.n_censor == pytest.approx([0.0, 0.0, 0.0, 1.0, 1.0, 0.0])
+    assert fit.n_enter == pytest.approx([2.0, 1.0, 0.0, 0.0, 1.0, 0.0])
+    assert fit.estimate == pytest.approx([1.0, 1.0, 2 / 3, 2 / 3, 2 / 3, 0.0])
+
+    assert no_entry.n_enter is None
+    assert no_entry.time == pytest.approx([10.0, 15.0, 20.0, 25.0, 30.0])
+    assert no_entry.n_censor == pytest.approx([0.0, 0.0, 1.0, 1.0, 0.0])
+    assert no_entry.estimate == pytest.approx([1.0, 2 / 3, 2 / 3, 2 / 3, 0.0])
+
+    assert weighted.n_risk == pytest.approx([0.0, 3.0, 6.0, 5.0, 3.0, 2.0])
+    assert weighted.n_event == pytest.approx([0.0, 0.0, 1.0, 0.0, 0.0, 2.0])
+    assert weighted.n_censor == pytest.approx([0.0, 0.0, 0.0, 2.0, 3.0, 0.0])
+    assert weighted.n_enter == pytest.approx([3.0, 3.0, 0.0, 0.0, 2.0, 0.0])
+    assert weighted.estimate == pytest.approx([1.0, 1.0, 5 / 6, 5 / 6, 5 / 6, 0.0])
+
+
+def test_survfit_formula_counting_id_aligns_groups_and_model_frame():
+    data = {
+        "start": [0.0, 10.0, 25.0, 0.0, 5.0, 5.0],
+        "stop": [10.0, 20.0, 30.0, 15.0, 25.0, 18.0],
+        "status": [0, 0, 1, 1, 0, 1],
+        "subject": ["a", "a", "a", "b", "c", "d"],
+        "arm": ["A", "A", "A", "A", "B", "B"],
+    }
+
+    grouped = survival.survfit(
+        "Surv(start, stop, status) ~ arm",
+        data=data,
+        id="subject",
+        entry=True,
+        model=True,
+    )
+    direct_a = survival.survfit(
+        survival.Surv([0.0, 10.0, 25.0, 0.0], [10.0, 20.0, 30.0, 15.0], [0, 0, 1, 1]),
+        id=["a", "a", "a", "b"],
+        entry=True,
+    )
+    direct_b = survival.survfit(
+        survival.Surv([5.0, 5.0], [25.0, 18.0], [0, 1]),
+        id=["c", "d"],
+        entry=True,
+    )
+
+    assert list(grouped) == ["A", "B"]
+    assert grouped["A"].time == pytest.approx(direct_a.time)
+    assert grouped["A"].n_enter == pytest.approx(direct_a.n_enter)
+    assert grouped["A"].n_censor == pytest.approx(direct_a.n_censor)
+    assert grouped["A"].estimate == pytest.approx(direct_a.estimate)
+    assert grouped["B"].time == pytest.approx(direct_b.time)
+    assert grouped["B"].n_enter == pytest.approx(direct_b.n_enter)
+    assert grouped["B"].estimate == pytest.approx(direct_b.estimate)
+
+    for curve in grouped.values():
+        assert curve.model["(id)"] == data["subject"]
+        assert curve.model["subject"] == data["subject"]
+
+
+def test_survfit_grouped_formula_accepts_se_fit_false():
+    data = _toy_data()
+
+    default = survival.survfit("Surv(time, status) ~ group", data=data)
+    grouped = survival.survfit("Surv(time, status) ~ group", data=data, se_fit=False)
+    dotted = survival.survfit("Surv(time, status) ~ group", data=data, **{"se.fit": False})
+
+    assert set(grouped) == set(default)
+    assert set(dotted) == set(default)
+    for label in default:
+        assert grouped[label].time == pytest.approx(default[label].time)
+        assert grouped[label].estimate == pytest.approx(default[label].estimate)
+        assert grouped[label].cumhaz == pytest.approx(default[label].cumhaz)
+        assert grouped[label].std_err == []
+        assert grouped[label].std_chaz == []
+        assert grouped[label].conf_lower == []
+        assert grouped[label].conf_upper == []
+        assert dotted[label].estimate == pytest.approx(grouped[label].estimate)
+        assert dotted[label].std_err == []
+
+
+def test_survfit_timefix_false_uses_exact_event_times():
+    times = [1.0, 1.0 + 5e-10, 2.0]
+    status = [1, 1, 0]
+    response = survival.Surv(times, status)
+
+    default = survival.survfit(response)
+    exact = survival.survfit(response, timefix=False)
+    exact_dotted = survival.survfit(
+        "Surv(time, status) ~ 1",
+        data={"time": times, "status": status},
+        **{"time.fix": False},
+    )
+    exact_fh2 = survival.survfit(response, timefix=False, type="fh2")
+
+    assert default.time == pytest.approx([1.0, 2.0])
+    assert default.n_risk == pytest.approx([3.0, 1.0])
+    assert default.n_event == pytest.approx([2.0, 0.0])
+    assert default.estimate == pytest.approx([1.0 / 3.0, 1.0 / 3.0])
+
+    assert exact.time == pytest.approx(times)
+    assert exact.n_risk == pytest.approx([3.0, 2.0, 1.0])
+    assert exact.n_event == pytest.approx([1.0, 1.0, 0.0])
+    assert exact.estimate == pytest.approx([2.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0])
+    assert exact.std_err == pytest.approx(
+        [
+            (2.0 / 3.0) * math.sqrt(1.0 / 6.0),
+            (1.0 / 3.0) * math.sqrt(2.0 / 3.0),
+            (1.0 / 3.0) * math.sqrt(2.0 / 3.0),
+        ]
+    )
+    assert exact_dotted.time == pytest.approx(exact.time)
+    assert exact_dotted.estimate == pytest.approx(exact.estimate)
+    assert exact_fh2.cumhaz == pytest.approx([1.0 / 3.0, 5.0 / 6.0, 5.0 / 6.0])
+
+
 def test_survfit_counting_process_uses_delayed_entry():
     data = {
         "start": [0.0, 0.0, 1.0, 2.0, 3.0],
@@ -799,6 +1206,35 @@ def test_survfit_counting_process_uses_delayed_entry():
     assert direct.std_chaz == pytest.approx(low_level.std_chaz)
     assert formula.estimate == pytest.approx(direct.estimate)
     assert low_level.estimate == pytest.approx(direct.estimate)
+
+
+def test_survfit_counting_process_timefix_false_uses_exact_risk_sets():
+    data = {
+        "start": [0.0, 0.0, 1.0, 1.0 + 5e-10],
+        "stop": [1.0, 1.0 + 5e-10, 2.0, 2.0],
+        "status": [1, 1, 0, 0],
+    }
+    response = survival.Surv(data["start"], data["stop"], data["status"])
+
+    default = survival.survfit(response)
+    exact = survival.survfit(response, timefix=False)
+    exact_formula = survival.survfit(
+        "Surv(start, stop, status) ~ 1",
+        data=data,
+        timefix=False,
+    )
+
+    assert default.time == pytest.approx([1.0, 2.0])
+    assert default.n_risk == pytest.approx([2.0, 2.0])
+    assert default.n_event == pytest.approx([2.0, 0.0])
+    assert default.estimate == pytest.approx([0.0, 0.0])
+
+    assert exact.time == pytest.approx([1.0, 1.0 + 5e-10, 2.0])
+    assert exact.n_risk == pytest.approx([2.0, 2.0, 2.0])
+    assert exact.n_event == pytest.approx([1.0, 1.0, 0.0])
+    assert exact.n_censor == pytest.approx([0.0, 0.0, 2.0])
+    assert exact.estimate == pytest.approx([0.5, 0.25, 0.25])
+    assert exact_formula.estimate == pytest.approx(exact.estimate)
 
 
 def test_survfit_start_time_conditions_counting_process_curve():
@@ -922,6 +1358,13 @@ def test_survfit_left_censored_response_uses_turnbull_estimator():
     assert high_level.time_points == pytest.approx(low_level.time_points)
     assert high_level.survival == pytest.approx(low_level.survival)
 
+    with_model = survival.survfit(response, model=True)
+    assert isinstance(with_model, survival.r_api.TurnbullSurvfitResult)
+    assert with_model.time_points == pytest.approx(low_level.time_points)
+    assert with_model.survival == pytest.approx(low_level.survival)
+    assert with_model.model["response"].type == "left"
+    assert with_model.model["response"].status == response.status
+
 
 def test_turnbull_weights_match_replicated_rows():
     weighted = survival.turnbull_estimator(
@@ -956,6 +1399,14 @@ def test_survfit_interval_weights_use_weighted_turnbull_estimator():
 
     assert high_level.time_points == pytest.approx(low_level.time_points)
     assert high_level.survival == pytest.approx(low_level.survival)
+
+    with_model = survival.survfit(response, weights=weights, model=True)
+    assert isinstance(with_model, survival.r_api.TurnbullSurvfitResult)
+    assert with_model.time_points == pytest.approx(low_level.time_points)
+    assert with_model.survival == pytest.approx(low_level.survival)
+    assert with_model.model["response"].type == "interval"
+    assert with_model.model["response"].status == response.status
+    assert with_model.model["(weights)"] == pytest.approx(weights)
 
 
 def test_survfit_formula_accepts_left_censored_surv_type():
@@ -1010,6 +1461,16 @@ def test_survfit_formula_splits_interval_weights_by_group():
     assert grouped["A"].survival == pytest.approx(expected_a.survival)
     assert grouped["B"].time_points == pytest.approx(expected_b.time_points)
     assert grouped["B"].survival == pytest.approx(expected_b.survival)
+
+    grouped_with_model = survival.survfit(
+        "Surv(left, right, status, type='interval') ~ arm",
+        data=data,
+        weights=data["weights"],
+        model=True,
+    )
+    assert grouped_with_model["A"].survival == pytest.approx(expected_a.survival)
+    assert grouped_with_model["B"].survival == pytest.approx(expected_b.survival)
+    assert grouped_with_model["A"].model["(weights)"] == pytest.approx(data["weights"])
 
 
 def test_survfit_interval_response_uses_turnbull_estimator():
@@ -1453,12 +1914,15 @@ def test_concordance_direct_surv_uses_rust_c_index():
     scores = [8.0 - value for value in data["time"]]
     result = survival.concordance(survival.Surv(data["time"], data["status"]), scores=scores)
     low_level = survival.concordance_index(data["time"], data["status"], scores)
+    summary = survival.core.concordance_summary(data["time"], data["status"], scores)
 
     assert result.concordance == pytest.approx(low_level)
     assert result.c_index == pytest.approx(result.concordance)
     assert result.n == len(data["time"])
     assert result.n_event == sum(data["status"])
     assert result.reverse is False
+    assert result.concordant == pytest.approx(summary["concordant"])
+    assert result.comparable == pytest.approx(summary["comparable"])
 
     reversed_result = survival.concordance(
         survival.Surv(data["time"], data["status"]),
@@ -1469,6 +1933,458 @@ def test_concordance_direct_surv_uses_rust_c_index():
         survival.concordance_index(data["time"], data["status"], [-value for value in scores])
     )
     assert reversed_result.reverse is True
+
+
+def test_concordance_timefix_false_uses_exact_event_times():
+    times = [1.0, 1.0 + 5e-10, 2.0]
+    status = [1, 1, 0]
+    scores = [0.9, 0.1, 0.5]
+    response = survival.Surv(times, status)
+
+    default = survival.concordance(response, scores=scores)
+    exact = survival.concordance(response, scores=scores, timefix=False)
+    exact_dotted = survival.concordance(
+        "Surv(time, status) ~ score",
+        data={"time": times, "status": status, "score": scores},
+        **{"time.fix": False},
+    )
+    fixed_times = [1.0, 1.0, 2.0]
+    fixed_concordant, fixed_comparable = _manual_right_concordance_counts(
+        fixed_times,
+        status,
+        scores,
+    )
+    exact_concordant, exact_comparable = _manual_right_concordance_counts(
+        times,
+        status,
+        scores,
+    )
+
+    assert default.concordance == pytest.approx(fixed_concordant / fixed_comparable)
+    assert exact.concordance == pytest.approx(exact_concordant / exact_comparable)
+    assert exact_dotted.concordance == pytest.approx(exact.concordance)
+    assert default.concordant == pytest.approx(fixed_concordant)
+    assert default.comparable == pytest.approx(fixed_comparable)
+    assert exact.concordant == pytest.approx(exact_concordant)
+    assert exact.comparable == pytest.approx(exact_comparable)
+    assert default.concordance != pytest.approx(exact.concordance)
+    assert default.n_event == exact.n_event == sum(status)
+
+
+def test_concordance_accepts_r_style_defaults():
+    data = {
+        "time": [1.0, 2.0, 3.0, 4.0],
+        "status": [1, 1, 0, 1],
+        "score": [0.8, 0.6, 0.2, 0.1],
+    }
+
+    default = survival.concordance("Surv(time, status) ~ score", data=data)
+    explicit = survival.concordance(
+        "Surv(time, status) ~ score",
+        data=data,
+        weights=None,
+        subset=None,
+        cluster=None,
+        ymin=None,
+        ymax=None,
+        timewt="n",
+        influence=0,
+        ranks=False,
+        reverse=False,
+        timefix=True,
+        keepstrata=10,
+    )
+    r_default_timewt = survival.concordance(
+        "Surv(time, status) ~ score",
+        data=data,
+        timewt=("n", "S", "S/G", "n/G2", "I"),
+        influence=None,
+        ranks=None,
+        keepstrata=None,
+    )
+
+    assert explicit.concordance == pytest.approx(default.concordance)
+    assert explicit.concordant == pytest.approx(default.concordant)
+    assert explicit.comparable == pytest.approx(default.comparable)
+    assert r_default_timewt.concordance == pytest.approx(default.concordance)
+
+
+def test_concordance_ranks_return_weighted_event_contributions():
+    data = {
+        "time": [1.0, 2.0, 3.0, 4.0],
+        "status": [1, 1, 1, 0],
+        "score": [0.9, 0.6, 0.4, 0.1],
+        "wt": [2.0, 1.0, 3.0, 1.0],
+    }
+    response = survival.Surv(data["time"], data["status"])
+
+    default = survival.concordance(response, scores=data["score"], weights=data["wt"])
+    ranked = survival.concordance(response, scores=data["score"], weights=data["wt"], ranks=True)
+    formula_ranked = survival.concordance(
+        "Surv(time, status) ~ score",
+        data=data,
+        weights="wt",
+        ranks=True,
+    )
+    reversed_ranked = survival.concordance(
+        response,
+        scores=data["score"],
+        weights=data["wt"],
+        ranks=True,
+        reverse=True,
+    )
+
+    assert default.ranks is None
+    assert ranked.ranks is not None
+    assert [row["time"] for row in ranked.ranks] == pytest.approx([1.0, 2.0, 3.0])
+    assert [row["casewt"] for row in ranked.ranks] == pytest.approx([2.0, 1.0, 3.0])
+    assert [row["timewt"] for row in ranked.ranks] == pytest.approx([7.0, 5.0, 4.0])
+    assert [row["rank"] for row in ranked.ranks] == pytest.approx([5.0 / 7.0, 4.0 / 5.0, 0.25])
+    assert ranked.concordance == pytest.approx(default.concordance)
+    assert formula_ranked.ranks is not None
+    for formula_row, direct_row in zip(formula_ranked.ranks, ranked.ranks, strict=True):
+        assert formula_row.keys() == direct_row.keys()
+        for key in direct_row:
+            assert formula_row[key] == pytest.approx(direct_row[key])
+    assert sum(row["rank"] * row["timewt"] * row["casewt"] for row in ranked.ranks) == (
+        pytest.approx(2.0 * ranked.concordant - ranked.comparable)
+    )
+    assert sum(
+        row["rank"] * row["timewt"] * row["casewt"] for row in reversed_ranked.ranks
+    ) == pytest.approx(2.0 * reversed_ranked.concordant - reversed_ranked.comparable)
+    assert reversed_ranked.concordance == pytest.approx(1.0 - ranked.concordance)
+
+
+def test_concordance_influence_modes_return_r_style_diagnostics():
+    data = {
+        "time": [1.0, 2.0, 3.0, 4.0],
+        "status": [1, 1, 1, 0],
+        "score": [0.9, 0.1, 0.4, 0.2],
+        "wt": [2.0, 1.0, 3.0, 1.0],
+    }
+    response = survival.Surv(data["time"], data["status"])
+
+    dfbeta_only = survival.concordance(
+        response,
+        scores=data["score"],
+        weights=data["wt"],
+        influence=1,
+    )
+    influence_only = survival.concordance(
+        response,
+        scores=data["score"],
+        weights=data["wt"],
+        influence=2,
+    )
+    both = survival.concordance(
+        response,
+        scores=data["score"],
+        weights=data["wt"],
+        influence=3,
+    )
+    bool_alias = survival.concordance(
+        response,
+        scores=data["score"],
+        weights=data["wt"],
+        influence=True,
+    )
+    reversed_both = survival.concordance(
+        response,
+        scores=data["score"],
+        weights=data["wt"],
+        influence=3,
+        reverse=True,
+    )
+
+    assert dfbeta_only.dfbeta is not None
+    assert dfbeta_only.influence is None
+    assert influence_only.dfbeta is None
+    assert influence_only.influence is not None
+    assert both.dfbeta == pytest.approx(dfbeta_only.dfbeta)
+    assert bool_alias.dfbeta == pytest.approx(dfbeta_only.dfbeta)
+    assert both.influence is not None
+    assert influence_only.influence is not None
+    for both_row, influence_row in zip(both.influence, influence_only.influence, strict=True):
+        assert both_row == pytest.approx(influence_row)
+    assert both.variance == pytest.approx(sum(value * value for value in both.dfbeta))
+    assert both.var == pytest.approx(both.variance)
+    assert [sum(row[col] for row in both.influence) for col in range(5)] == pytest.approx(
+        [both.concordant, both.comparable - both.concordant, 0.0, 0.0, 0.0]
+    )
+    assert sum(both.dfbeta) == pytest.approx(0.0)
+    assert reversed_both.concordance == pytest.approx(1.0 - both.concordance)
+    assert reversed_both.dfbeta == pytest.approx([-value for value in both.dfbeta])
+    assert [sum(row[col] for row in reversed_both.influence) for col in range(5)] == pytest.approx(
+        [both.comparable - both.concordant, both.concordant, 0.0, 0.0, 0.0]
+    )
+
+
+def test_concordance_cluster_collapses_dfbeta_for_robust_variance():
+    data = {
+        "time": [1.0, 2.0, 3.0, 4.0],
+        "status": [1, 1, 1, 0],
+        "score": [0.9, 0.1, 0.4, 0.2],
+        "wt": [2.0, 1.0, 3.0, 1.0],
+        "cluster": ["a", "a", "b", "c"],
+    }
+    response = survival.Surv(data["time"], data["status"])
+
+    unclustered = survival.concordance(
+        response,
+        scores=data["score"],
+        weights=data["wt"],
+        influence=3,
+    )
+    clustered = survival.concordance(
+        response,
+        scores=data["score"],
+        weights=data["wt"],
+        cluster=data["cluster"],
+        influence=3,
+    )
+    formula_clustered = survival.concordance(
+        "Surv(time, status) ~ score",
+        data=data,
+        weights="wt",
+        cluster="cluster",
+        influence=1,
+    )
+    formula_term_clustered = survival.concordance(
+        "Surv(time, status) ~ score + cluster(cluster)",
+        data=data,
+        weights="wt",
+        influence=1,
+    )
+    variance_only = survival.concordance(
+        response,
+        scores=data["score"],
+        weights=data["wt"],
+        cluster=data["cluster"],
+    )
+
+    expected_dfbeta = [
+        unclustered.dfbeta[0] + unclustered.dfbeta[1],
+        unclustered.dfbeta[2],
+        unclustered.dfbeta[3],
+    ]
+    assert clustered.dfbeta == pytest.approx(expected_dfbeta)
+    assert formula_clustered.dfbeta == pytest.approx(expected_dfbeta)
+    assert formula_term_clustered.dfbeta == pytest.approx(expected_dfbeta)
+    assert clustered.variance == pytest.approx(sum(value * value for value in expected_dfbeta))
+    assert formula_clustered.variance == pytest.approx(clustered.variance)
+    assert formula_term_clustered.variance == pytest.approx(clustered.variance)
+    assert variance_only.dfbeta is None
+    assert variance_only.influence is None
+    assert variance_only.variance == pytest.approx(clustered.variance)
+    for clustered_row, unclustered_row in zip(
+        clustered.influence,
+        unclustered.influence,
+        strict=True,
+    ):
+        assert clustered_row == pytest.approx(unclustered_row)
+
+
+def test_concordance_accepts_case_weights():
+    data = {
+        "time": [1.0, 2.0, 3.0, 4.0],
+        "status": [1, 1, 1, 0],
+        "score": [0.4, 0.9, 0.2, 0.1],
+        "wt": [5.0, 1.0, 2.0, 1.0],
+    }
+    response = survival.Surv(data["time"], data["status"])
+    expected_concordant, expected_comparable = _manual_right_concordance_counts(
+        data["time"],
+        data["status"],
+        data["score"],
+        data["wt"],
+    )
+
+    direct = survival.concordance(response, scores=data["score"], weights=data["wt"])
+    formula = survival.concordance("Surv(time, status) ~ score", data=data, weights="wt")
+    formula_vector = survival.concordance(
+        "Surv(time, status) ~ score",
+        data=data,
+        weights=data["wt"],
+    )
+    low_level = survival.core.concordance_summary(
+        data["time"],
+        data["status"],
+        data["score"],
+        weights=data["wt"],
+    )
+
+    assert direct.concordance == pytest.approx(expected_concordant / expected_comparable)
+    assert formula.concordance == pytest.approx(direct.concordance)
+    assert formula_vector.concordance == pytest.approx(direct.concordance)
+    assert direct.concordant == pytest.approx(expected_concordant)
+    assert direct.comparable == pytest.approx(expected_comparable)
+    assert low_level["concordance"] == pytest.approx(direct.concordance)
+    assert low_level["concordant"] == pytest.approx(expected_concordant)
+    assert low_level["comparable"] == pytest.approx(expected_comparable)
+    assert survival.concordance(response, scores=data["score"]).concordance != pytest.approx(
+        direct.concordance
+    )
+    assert survival.concordance_index(
+        data["time"],
+        data["status"],
+        data["score"],
+        weights=data["wt"],
+    ) == pytest.approx(direct.concordance)
+
+
+def test_concordance_accepts_identity_time_weight():
+    data = {
+        "time": [1.0, 2.0, 3.0, 4.0],
+        "status": [1, 1, 1, 0],
+        "score": [0.1, 0.9, 0.8, 0.0],
+        "wt": [2.0, 1.0, 3.0, 1.0],
+    }
+    response = survival.Surv(data["time"], data["status"])
+    concordant, comparable = _manual_right_concordance_counts(
+        data["time"],
+        data["status"],
+        data["score"],
+        data["wt"],
+        timewt="I",
+    )
+    default = survival.concordance(response, scores=data["score"], weights=data["wt"])
+    direct = survival.concordance(
+        response,
+        scores=data["score"],
+        weights=data["wt"],
+        timewt="I",
+    )
+    formula = survival.concordance(
+        "Surv(time, status) ~ score",
+        data=data,
+        weights="wt",
+        timewt="I",
+    )
+    summary = survival.core.concordance_summary(
+        data["time"],
+        data["status"],
+        data["score"],
+        weights=data["wt"],
+        timewt="I",
+    )
+
+    assert direct.concordance == pytest.approx(concordant / comparable)
+    assert direct.concordant == pytest.approx(concordant)
+    assert direct.comparable == pytest.approx(comparable)
+    assert formula.concordance == pytest.approx(direct.concordance)
+    assert summary["concordance"] == pytest.approx(direct.concordance)
+    assert summary["concordant"] == pytest.approx(concordant)
+    assert summary["comparable"] == pytest.approx(comparable)
+    assert survival.concordance_index(
+        data["time"],
+        data["status"],
+        data["score"],
+        weights=data["wt"],
+        timewt="I",
+    ) == pytest.approx(direct.concordance)
+    assert direct.concordance != pytest.approx(default.concordance)
+
+
+@pytest.mark.parametrize("timewt", ["S", "S/G", "n/G2"])
+def test_concordance_accepts_km_time_weights(timewt):
+    data = {
+        "time": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+        "status": [1, 0, 1, 0, 1, 1],
+        "score": [0.1, 0.9, 0.2, 0.3, 0.8, 0.4],
+        "wt": [1.0, 2.0, 1.5, 0.5, 3.0, 1.0],
+    }
+    response = survival.Surv(data["time"], data["status"])
+    concordant, comparable = _manual_right_concordance_counts(
+        data["time"],
+        data["status"],
+        data["score"],
+        data["wt"],
+        timewt=timewt,
+    )
+
+    direct = survival.concordance(
+        response,
+        scores=data["score"],
+        weights=data["wt"],
+        timewt=timewt,
+    )
+    formula = survival.concordance(
+        "Surv(time, status) ~ score",
+        data=data,
+        weights="wt",
+        timewt=timewt,
+    )
+    summary = survival.core.concordance_summary(
+        data["time"],
+        data["status"],
+        data["score"],
+        weights=data["wt"],
+        timewt=timewt,
+    )
+
+    assert direct.concordance == pytest.approx(concordant / comparable)
+    assert direct.concordant == pytest.approx(concordant)
+    assert direct.comparable == pytest.approx(comparable)
+    assert formula.concordance == pytest.approx(direct.concordance)
+    assert summary["concordance"] == pytest.approx(direct.concordance)
+    assert summary["concordant"] == pytest.approx(concordant)
+    assert summary["comparable"] == pytest.approx(comparable)
+    assert survival.concordance_index(
+        data["time"],
+        data["status"],
+        data["score"],
+        weights=data["wt"],
+        timewt=timewt,
+    ) == pytest.approx(direct.concordance)
+
+
+def test_concordance_accepts_time_window_restrictions():
+    data = {
+        "time": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+        "status": [1, 1, 0, 1, 1, 0],
+        "score": [0.2, 0.9, 0.1, 0.8, 0.3, 0.4],
+        "wt": [1.0, 2.0, 1.5, 0.5, 3.0, 1.0],
+    }
+    ymin = 2.5
+    ymax = 4.0
+    bounded_time, bounded_status = _manual_concordance_bounded_times_and_status(
+        data["time"],
+        data["status"],
+        ymin=ymin,
+        ymax=ymax,
+    )
+    concordant, comparable = _manual_right_concordance_counts(
+        bounded_time,
+        bounded_status,
+        data["score"],
+        data["wt"],
+        timewt="S",
+    )
+    response = survival.Surv(data["time"], data["status"])
+
+    direct = survival.concordance(
+        response,
+        scores=data["score"],
+        weights=data["wt"],
+        ymin=ymin,
+        ymax=ymax,
+        timewt="S",
+    )
+    formula = survival.concordance(
+        "Surv(time, status) ~ score",
+        data=data,
+        weights="wt",
+        ymin=ymin,
+        ymax=ymax,
+        timewt="S",
+    )
+
+    assert direct.concordance == pytest.approx(concordant / comparable)
+    assert direct.concordant == pytest.approx(concordant)
+    assert direct.comparable == pytest.approx(comparable)
+    assert direct.n_event == sum(bounded_status)
+    assert formula.concordance == pytest.approx(direct.concordance)
+    assert formula.n_event == direct.n_event
 
 
 def test_concordance_formula_applies_subset_and_na_action():
@@ -1547,6 +2463,63 @@ def test_concordance_formula_accepts_offset_only_predictor():
     assert result.n == len(data["time"])
 
 
+def test_concordance_formula_returns_one_result_per_score_column():
+    data = {
+        "time": [1.0, 2.0, 3.0, 4.0, 5.0],
+        "status": [1, 1, 0, 1, 1],
+        "x1": [0.8, 0.6, 0.4, 0.2, 0.1],
+        "x2": [0.1, 0.5, 0.2, 0.7, 0.3],
+    }
+    result = survival.concordance("Surv(time, status) ~ x1 + x2", data=data)
+    x1 = survival.core.concordance_summary(data["time"], data["status"], data["x1"])
+    x2 = survival.core.concordance_summary(data["time"], data["status"], data["x2"])
+
+    assert result.score_names == ["x1", "x2"]
+    assert result.concordance == pytest.approx([x1["concordance"], x2["concordance"]])
+    assert result.concordant == pytest.approx([x1["concordant"], x2["concordant"]])
+    assert result.comparable == pytest.approx([x1["comparable"], x2["comparable"]])
+    assert result.n == len(data["time"])
+    assert result.n_event == sum(data["status"])
+
+
+def test_concordance_matrix_scores_return_parallel_cluster_variances():
+    data = {
+        "time": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+        "status": [1, 1, 0, 1, 1, 0],
+        "x1": [0.8, 0.6, 0.4, 0.2, 0.1, 0.3],
+        "x2": [0.1, 0.5, 0.2, 0.7, 0.3, 0.9],
+        "wt": [1.0, 2.0, 1.0, 0.5, 1.5, 1.0],
+        "cluster": ["a", "a", "b", "b", "c", "c"],
+    }
+    response = survival.Surv(data["time"], data["status"])
+    scores = [[x1, x2] for x1, x2 in zip(data["x1"], data["x2"], strict=True)]
+
+    result = survival.concordance(
+        response,
+        scores=scores,
+        weights=data["wt"],
+        cluster=data["cluster"],
+    )
+    x1 = survival.concordance(
+        response,
+        scores=data["x1"],
+        weights=data["wt"],
+        cluster=data["cluster"],
+    )
+    x2 = survival.concordance(
+        response,
+        scores=data["x2"],
+        weights=data["wt"],
+        cluster=data["cluster"],
+    )
+
+    assert result.score_names == ["score1", "score2"]
+    assert result.concordance == pytest.approx([x1.concordance, x2.concordance])
+    assert result.concordant == pytest.approx([x1.concordant, x2.concordant])
+    assert result.comparable == pytest.approx([x1.comparable, x2.comparable])
+    assert result.variance == pytest.approx([x1.variance, x2.variance])
+
+
 def test_concordance_summary_low_level_reports_pair_counts():
     data = _toy_data()
     scores = [8.0 - value for value in data["time"]]
@@ -1578,9 +2551,27 @@ def test_concordance_formula_accepts_strata_wrapper():
         "Surv(time, status) ~ score + strata(group)",
         data=data,
     )
+    collapsed = survival.concordance(
+        "Surv(time, status) ~ score + strata(group)",
+        data=data,
+        keepstrata=False,
+    )
+    thresholded = survival.concordance(
+        "Surv(time, status) ~ score + strata(group)",
+        data=data,
+        keepstrata=0,
+    )
+    retained = survival.concordance(
+        "Surv(time, status) ~ score + strata(group)",
+        data=data,
+        keepstrata=True,
+    )
     unstratified = survival.concordance("Surv(time, status) ~ score", data=data)
 
     assert stratified.concordance == pytest.approx(1.0)
+    assert collapsed.concordance == pytest.approx(stratified.concordance)
+    assert thresholded.concordance == pytest.approx(stratified.concordance)
+    assert retained.concordance == pytest.approx(stratified.concordance)
     assert unstratified.concordance < stratified.concordance
     assert stratified.n == len(data["time"])
     assert stratified.n_event == sum(data["status"])
@@ -1609,8 +2600,119 @@ def test_concordance_counting_process_uses_delayed_entry_risk_sets():
     assert result.concordance == pytest.approx(expected)
     assert result.n == len(data["stop"])
     assert result.n_event == sum(data["status"])
+    concordant, comparable = _manual_counting_concordance_counts(
+        data["start"],
+        data["stop"],
+        data["status"],
+        scores,
+    )
+    assert result.concordant == pytest.approx(concordant)
+    assert result.comparable == pytest.approx(comparable)
     assert reversed_result.concordance == pytest.approx(reversed_expected)
     assert reversed_result.reverse is True
+
+
+def test_concordance_counting_process_ranks_use_delayed_entry_risk_sets():
+    data = {
+        "start": [0.0, 0.0, 0.5, 1.5],
+        "stop": [1.0, 2.0, 3.0, 4.0],
+        "status": [1, 1, 1, 0],
+    }
+    scores = [0.9, 0.7, 0.4, 0.1]
+    response = survival.Surv(data["start"], data["stop"], data["status"])
+
+    ranked = survival.concordance(response, scores=scores, ranks=True)
+    exact_ranked = survival.concordance(response, scores=scores, ranks=True, timefix=False)
+    formula_ranked = survival.concordance(
+        "Surv(start, stop, status) ~ score",
+        data={**data, "score": scores},
+        ranks=True,
+    )
+
+    assert ranked.ranks is not None
+    assert exact_ranked.ranks is not None
+    assert formula_ranked.ranks is not None
+    assert [row["time"] for row in ranked.ranks] == pytest.approx(
+        sorted(data["stop"][idx] for idx, event in enumerate(data["status"]) if event == 1)
+    )
+    assert sum(row["rank"] * row["timewt"] * row["casewt"] for row in ranked.ranks) == (
+        pytest.approx(2.0 * ranked.concordant - ranked.comparable)
+    )
+    assert sum(row["rank"] * row["timewt"] * row["casewt"] for row in exact_ranked.ranks) == (
+        pytest.approx(2.0 * exact_ranked.concordant - exact_ranked.comparable)
+    )
+    for formula_row, direct_row in zip(formula_ranked.ranks, ranked.ranks, strict=True):
+        assert formula_row.keys() == direct_row.keys()
+        for key in direct_row:
+            assert formula_row[key] == pytest.approx(direct_row[key])
+
+
+def test_concordance_counting_process_influence_uses_delayed_entry_risk_sets():
+    data = {
+        "start": [0.0, 0.0, 0.5, 1.5],
+        "stop": [1.0, 2.0, 3.0, 4.0],
+        "status": [1, 1, 1, 0],
+        "score": [0.9, 0.1, 0.4, 0.2],
+    }
+    response = survival.Surv(data["start"], data["stop"], data["status"])
+
+    result = survival.concordance(response, scores=data["score"], influence=3)
+    exact = survival.concordance(response, scores=data["score"], influence=3, timefix=False)
+    formula = survival.concordance(
+        "Surv(start, stop, status) ~ score",
+        data=data,
+        influence=3,
+    )
+
+    assert result.dfbeta is not None
+    assert result.influence is not None
+    assert exact.dfbeta is not None
+    assert exact.influence is not None
+    assert formula.dfbeta == pytest.approx(result.dfbeta)
+    assert formula.influence is not None
+    assert result.influence is not None
+    for formula_row, result_row in zip(formula.influence, result.influence, strict=True):
+        assert formula_row == pytest.approx(result_row)
+    assert [sum(row[col] for row in result.influence) for col in range(5)] == pytest.approx(
+        [result.concordant, result.comparable - result.concordant, 0.0, 0.0, 0.0]
+    )
+    assert result.variance == pytest.approx(sum(value * value for value in result.dfbeta))
+    assert exact.variance == pytest.approx(sum(value * value for value in exact.dfbeta))
+
+
+def test_concordance_counting_process_timefix_false_uses_exact_risk_sets():
+    data = {
+        "start": [0.0, 0.0, 0.0],
+        "stop": [1.0, 1.0 + 5e-10, 2.0],
+        "status": [1, 0, 0],
+        "score": [0.5, 0.9, 0.1],
+    }
+    response = survival.Surv(data["start"], data["stop"], data["status"])
+
+    default = survival.concordance(response, scores=data["score"])
+    exact = survival.concordance(response, scores=data["score"], timefix=False)
+    exact_formula = survival.concordance(
+        "Surv(start, stop, status) ~ score",
+        data=data,
+        timefix=False,
+    )
+    fixed_expected = _manual_counting_concordance(
+        data["start"],
+        [1.0, 1.0, 2.0],
+        data["status"],
+        data["score"],
+    )
+    exact_expected = _manual_counting_concordance(
+        data["start"],
+        data["stop"],
+        data["status"],
+        data["score"],
+    )
+
+    assert default.concordance == pytest.approx(fixed_expected)
+    assert exact.concordance == pytest.approx(exact_expected)
+    assert exact_formula.concordance == pytest.approx(exact.concordance)
+    assert default.concordance != pytest.approx(exact.concordance)
 
 
 def test_counting_concordance_low_level_matches_manual_risk_sets():
@@ -1645,6 +2747,240 @@ def test_counting_concordance_low_level_matches_manual_risk_sets():
         survival.counting_concordance_index([0.0], [1.0, 2.0], [1], [0.5])
 
 
+def test_counting_concordance_accepts_case_weights():
+    data = _counting_cox_data()
+    data["score"] = [0.9, 0.2, 0.7, 0.1, 0.5, 0.4]
+    data["wt"] = [2.0, 1.0, 3.0, 1.5, 0.5, 4.0]
+    response = survival.Surv(data["start"], data["stop"], data["status"])
+    concordant, comparable = _manual_counting_concordance_counts(
+        data["start"],
+        data["stop"],
+        data["status"],
+        data["score"],
+        data["wt"],
+    )
+    expected = concordant / comparable
+
+    direct = survival.concordance(response, scores=data["score"], weights=data["wt"])
+    formula = survival.concordance(
+        "Surv(start, stop, status) ~ score",
+        data=data,
+        weights="wt",
+    )
+    low_level = survival.core.counting_concordance_summary(
+        data["start"],
+        data["stop"],
+        data["status"],
+        data["score"],
+        weights=data["wt"],
+    )
+
+    assert direct.concordance == pytest.approx(expected)
+    assert formula.concordance == pytest.approx(expected)
+    assert direct.concordant == pytest.approx(concordant)
+    assert direct.comparable == pytest.approx(comparable)
+    assert low_level["concordance"] == pytest.approx(expected)
+    assert low_level["concordant"] == pytest.approx(concordant)
+    assert low_level["comparable"] == pytest.approx(comparable)
+    assert survival.counting_concordance_index(
+        data["start"],
+        data["stop"],
+        data["status"],
+        data["score"],
+        weights=data["wt"],
+    ) == pytest.approx(expected)
+
+
+def test_counting_concordance_accepts_identity_time_weight():
+    data = {
+        "start": [0.0, 0.0, 0.0, 1.0],
+        "stop": [1.0, 2.0, 3.0, 4.0],
+        "status": [1, 1, 1, 0],
+        "score": [0.1, 0.9, 0.8, 0.0],
+        "wt": [2.0, 1.0, 3.0, 1.0],
+    }
+    response = survival.Surv(data["start"], data["stop"], data["status"])
+    concordant, comparable = _manual_counting_concordance_counts(
+        data["start"],
+        data["stop"],
+        data["status"],
+        data["score"],
+        data["wt"],
+        timewt="I",
+    )
+    default = survival.concordance(response, scores=data["score"], weights=data["wt"])
+    direct = survival.concordance(
+        response,
+        scores=data["score"],
+        weights=data["wt"],
+        timewt="I",
+    )
+    exact = survival.concordance(
+        response,
+        scores=data["score"],
+        weights=data["wt"],
+        timewt="I",
+        timefix=False,
+    )
+    formula = survival.concordance(
+        "Surv(start, stop, status) ~ score",
+        data=data,
+        weights="wt",
+        timewt="I",
+    )
+    summary = survival.core.counting_concordance_summary(
+        data["start"],
+        data["stop"],
+        data["status"],
+        data["score"],
+        weights=data["wt"],
+        timewt="I",
+    )
+
+    assert direct.concordance == pytest.approx(concordant / comparable)
+    assert direct.concordant == pytest.approx(concordant)
+    assert direct.comparable == pytest.approx(comparable)
+    assert exact.concordance == pytest.approx(direct.concordance)
+    assert formula.concordance == pytest.approx(direct.concordance)
+    assert summary["concordance"] == pytest.approx(direct.concordance)
+    assert summary["concordant"] == pytest.approx(concordant)
+    assert summary["comparable"] == pytest.approx(comparable)
+    assert survival.counting_concordance_index(
+        data["start"],
+        data["stop"],
+        data["status"],
+        data["score"],
+        weights=data["wt"],
+        timewt="I",
+    ) == pytest.approx(direct.concordance)
+    assert direct.concordance != pytest.approx(default.concordance)
+
+
+def test_counting_concordance_accepts_survival_time_weight():
+    data = {
+        "start": [0.0, 0.0, 0.0, 1.0],
+        "stop": [1.0, 2.0, 3.0, 4.0],
+        "status": [1, 1, 1, 0],
+        "score": [0.1, 0.9, 0.8, 0.0],
+        "wt": [2.0, 1.0, 3.0, 1.0],
+    }
+    response = survival.Surv(data["start"], data["stop"], data["status"])
+    concordant, comparable = _manual_counting_concordance_counts(
+        data["start"],
+        data["stop"],
+        data["status"],
+        data["score"],
+        data["wt"],
+        timewt="S",
+    )
+
+    direct = survival.concordance(
+        response,
+        scores=data["score"],
+        weights=data["wt"],
+        timewt="S",
+    )
+    exact = survival.concordance(
+        response,
+        scores=data["score"],
+        weights=data["wt"],
+        timewt="S",
+        timefix=False,
+    )
+    formula = survival.concordance(
+        "Surv(start, stop, status) ~ score",
+        data=data,
+        weights="wt",
+        timewt="S",
+    )
+    summary = survival.core.counting_concordance_summary(
+        data["start"],
+        data["stop"],
+        data["status"],
+        data["score"],
+        weights=data["wt"],
+        timewt="S",
+    )
+
+    assert direct.concordance == pytest.approx(concordant / comparable)
+    assert direct.concordant == pytest.approx(concordant)
+    assert direct.comparable == pytest.approx(comparable)
+    assert exact.concordance == pytest.approx(direct.concordance)
+    assert formula.concordance == pytest.approx(direct.concordance)
+    assert summary["concordance"] == pytest.approx(direct.concordance)
+    assert summary["concordant"] == pytest.approx(concordant)
+    assert summary["comparable"] == pytest.approx(comparable)
+    assert survival.counting_concordance_index(
+        data["start"],
+        data["stop"],
+        data["status"],
+        data["score"],
+        weights=data["wt"],
+        timewt="S",
+    ) == pytest.approx(direct.concordance)
+
+
+def test_counting_concordance_accepts_time_window_restrictions():
+    data = {
+        "start": [0.0, 0.0, 0.5, 1.0, 2.5],
+        "stop": [1.0, 2.0, 3.0, 4.0, 5.0],
+        "status": [1, 1, 1, 1, 0],
+        "score": [0.1, 0.9, 0.8, 0.0, 0.4],
+        "wt": [2.0, 1.0, 3.0, 1.0, 0.5],
+    }
+    ymin = 1.5
+    ymax = 3.0
+    bounded_stop, bounded_status = _manual_concordance_bounded_times_and_status(
+        data["stop"],
+        data["status"],
+        ymin=ymin,
+        ymax=ymax,
+    )
+    concordant, comparable = _manual_counting_concordance_counts(
+        data["start"],
+        bounded_stop,
+        bounded_status,
+        data["score"],
+        data["wt"],
+        timewt="S",
+    )
+    response = survival.Surv(data["start"], data["stop"], data["status"])
+
+    direct = survival.concordance(
+        response,
+        scores=data["score"],
+        weights=data["wt"],
+        ymin=ymin,
+        ymax=ymax,
+        timewt="S",
+    )
+    exact = survival.concordance(
+        response,
+        scores=data["score"],
+        weights=data["wt"],
+        ymin=ymin,
+        ymax=ymax,
+        timewt="S",
+        timefix=False,
+    )
+    formula = survival.concordance(
+        "Surv(start, stop, status) ~ score",
+        data=data,
+        weights="wt",
+        ymin=ymin,
+        ymax=ymax,
+        timewt="S",
+    )
+
+    assert direct.concordance == pytest.approx(concordant / comparable)
+    assert direct.concordant == pytest.approx(concordant)
+    assert direct.comparable == pytest.approx(comparable)
+    assert direct.n_event == sum(bounded_status)
+    assert exact.concordance == pytest.approx(direct.concordance)
+    assert formula.concordance == pytest.approx(direct.concordance)
+    assert formula.n_event == direct.n_event
+
+
 def test_concordance_formula_strata_supports_counting_process_response():
     data = _counting_cox_data()
     data["score"] = [0.9, 0.2, 0.7, 0.1, 0.5, 0.4]
@@ -1668,6 +3004,8 @@ def test_concordance_formula_strata_supports_counting_process_response():
         total_comparable += comparable
 
     assert result.concordance == pytest.approx(total_concordant / total_comparable)
+    assert result.concordant == pytest.approx(total_concordant)
+    assert result.comparable == pytest.approx(total_comparable)
     assert result.n_event == sum(data["status"])
 
 
@@ -1740,6 +3078,138 @@ def test_survdiff_counting_process_uses_delayed_entry():
     assert fh.statistic == pytest.approx(fh_low_level.statistic)
 
 
+def test_survdiff_counting_process_timefix_false_uses_exact_event_times():
+    start = [0.0, 0.0, 0.0, 0.0]
+    stop = [1.0, 1.0 + 5e-10, 2.0, 3.0]
+    status = [1, 1, 0, 1]
+    group = ["control", "treated", "control", "treated"]
+    group_codes = [0, 1, 0, 1]
+    response = survival.Surv(start, stop, status)
+
+    def manual_exact(rho=0.0):
+        observed = [0.0, 0.0]
+        expected = [0.0, 0.0]
+        variance = 0.0
+        km_survival = 1.0
+        for event_time in sorted({time for time, event in zip(stop, status, strict=True) if event}):
+            at_risk = [0.0, 0.0]
+            events = [0.0, 0.0]
+            total_events = 0.0
+            for row_idx, stop_time in enumerate(stop):
+                group_idx = group_codes[row_idx]
+                if start[row_idx] < event_time <= stop_time:
+                    at_risk[group_idx] += 1.0
+                if status[row_idx] == 1 and stop_time == event_time:
+                    events[group_idx] += 1.0
+                    total_events += 1.0
+            total_at_risk = sum(at_risk)
+            weight = km_survival**rho
+            for group_idx in range(2):
+                observed[group_idx] += weight * events[group_idx]
+                expected[group_idx] += weight * total_events * at_risk[group_idx] / total_at_risk
+            if total_at_risk > 1.0:
+                variance += (
+                    weight
+                    * weight
+                    * total_events
+                    * (total_at_risk - total_events)
+                    / (total_at_risk * total_at_risk * (total_at_risk - 1.0))
+                    * at_risk[0]
+                    * at_risk[1]
+                )
+            km_survival *= 1.0 - total_events / total_at_risk
+        statistic = (observed[0] - expected[0]) ** 2 / variance
+        return observed, expected, variance, statistic
+
+    default = survival.survdiff(response, group=group)
+    exact = survival.survdiff(response, group=group, timefix=False)
+    exact_dotted = survival.survdiff(response, group=group, **{"time.fix": False})
+    fh_exact = survival.survdiff(response, group=group, rho=0.5, timefix=False)
+    observed, expected, variance, statistic = manual_exact()
+    fh_observed, fh_expected, fh_variance, fh_statistic = manual_exact(0.5)
+
+    assert exact.observed == pytest.approx(observed)
+    assert exact.expected == pytest.approx(expected)
+    assert exact.variance == pytest.approx(variance)
+    assert exact.statistic == pytest.approx(statistic)
+    assert exact_dotted.observed == pytest.approx(exact.observed)
+    assert exact_dotted.expected == pytest.approx(exact.expected)
+    assert exact_dotted.statistic == pytest.approx(exact.statistic)
+    assert exact.statistic != pytest.approx(default.statistic)
+    assert fh_exact.observed == pytest.approx(fh_observed)
+    assert fh_exact.expected == pytest.approx(fh_expected)
+    assert fh_exact.variance == pytest.approx(fh_variance)
+    assert fh_exact.statistic == pytest.approx(fh_statistic)
+
+
+def test_survdiff_counting_process_formula_strata_combines_delayed_entry_components():
+    data = {
+        "start": [0.0, 0.0, 1.0, 2.0, 0.0, 1.0],
+        "stop": [2.0, 4.0, 3.0, 5.0, 2.5, 4.5],
+        "status": [1, 0, 1, 1, 1, 0],
+        "group": ["treated", "control", "treated", "control", "treated", "control"],
+        "site": ["x", "x", "x", "x", "y", "y"],
+    }
+    group_codes = [0 if value == "treated" else 1 for value in data["group"]]
+
+    def combine(rho=0.0):
+        observed = [0.0, 0.0]
+        expected = [0.0, 0.0]
+        variance = 0.0
+        for site in ("x", "y"):
+            indices = [idx for idx, value in enumerate(data["site"]) if value == site]
+            if rho == 0.0:
+                result = survival.logrank_test(
+                    [data["stop"][idx] for idx in indices],
+                    [data["status"][idx] for idx in indices],
+                    [group_codes[idx] for idx in indices],
+                    entry_times=[data["start"][idx] for idx in indices],
+                )
+            else:
+                result = survival.fleming_harrington_test(
+                    [data["stop"][idx] for idx in indices],
+                    [data["status"][idx] for idx in indices],
+                    [group_codes[idx] for idx in indices],
+                    rho,
+                    0.0,
+                    entry_times=[data["start"][idx] for idx in indices],
+                )
+            for group_idx in range(2):
+                observed[group_idx] += result.observed[group_idx]
+                expected[group_idx] += result.expected[group_idx]
+            variance += result.variance
+        statistic = (observed[0] - expected[0]) ** 2 / variance
+        return observed, expected, variance, statistic
+
+    observed, expected, variance, statistic = combine()
+    fh_observed, fh_expected, fh_variance, fh_statistic = combine(0.5)
+
+    result = survival.survdiff("Surv(start, stop, status) ~ group + strata(site)", data=data)
+    fh = survival.survdiff(
+        "Surv(start, stop, status) ~ group + strata(site)",
+        data=data,
+        rho=0.5,
+    )
+    exact = survival.survdiff(
+        "Surv(start, stop, status) ~ group + strata(site)",
+        data=data,
+        timefix=False,
+    )
+
+    assert result.observed == pytest.approx(observed)
+    assert result.expected == pytest.approx(expected)
+    assert result.variance == pytest.approx(variance)
+    assert result.statistic == pytest.approx(statistic)
+    assert fh.observed == pytest.approx(fh_observed)
+    assert fh.expected == pytest.approx(fh_expected)
+    assert fh.variance == pytest.approx(fh_variance)
+    assert fh.statistic == pytest.approx(fh_statistic)
+    assert exact.observed == pytest.approx(observed)
+    assert exact.expected == pytest.approx(expected)
+    assert exact.variance == pytest.approx(variance)
+    assert exact.statistic == pytest.approx(statistic)
+
+
 def test_survdiff_timefix_false_uses_exact_event_times():
     times = [1.0, 1.0 + 5e-10, 2.0, 3.0]
     status = [0, 0, 1, 1]
@@ -1748,12 +3218,18 @@ def test_survdiff_timefix_false_uses_exact_event_times():
 
     default = survival.survdiff(response, group=groups)
     exact = survival.survdiff(response, group=groups, timefix=False)
+    exact_formula = survival.survdiff(
+        "Surv(time, status) ~ group",
+        data={"time": times, "status": status, "group": groups},
+        **{"time.fix": False},
+    )
     low_level = survival.survdiff2(times, status, [1, 1, 1, 2], None, None)
 
     assert default.statistic == pytest.approx(1.0)
     assert exact.statistic == pytest.approx(low_level.chi_squared)
     assert exact.statistic == pytest.approx(0.5)
     assert exact.statistic != pytest.approx(default.statistic)
+    assert exact_formula.statistic == pytest.approx(exact.statistic)
     assert exact.observed == pytest.approx(low_level.observed)
     assert exact.expected == pytest.approx(low_level.expected)
 
@@ -1998,11 +3474,38 @@ def test_coxph_formula_cluster_computes_robust_variance():
         max_iter=10,
         eps=1e-5,
     )
+    id_cluster = survival.coxph(
+        "Surv(time, status) ~ x1 + x2",
+        data=data,
+        id=data["subject"],
+        max_iter=10,
+        eps=1e-5,
+    )
+    id_model = survival.coxph(
+        "Surv(time, status) ~ x1 + x2",
+        data=data,
+        id=data["subject"],
+        model=True,
+        max_iter=10,
+        eps=1e-5,
+    )
+    matrix_id = survival.coxph(
+        survival.Surv(data["time"], data["status"]),
+        x=[[data["x1"][idx], data["x2"][idx]] for idx in range(len(data["time"]))],
+        id=data["subject"],
+        max_iter=10,
+        eps=1e-5,
+    )
     expected_robust = _manual_cox_robust_variance(plain, data["subject"])
 
     assert clustered.robust is True
     assert clustered.cluster == data["subject"]
+    assert id_cluster.robust is True
+    assert id_cluster.id == data["subject"]
+    assert id_cluster.cluster == data["subject"]
+    assert id_model.model["(id)"] == data["subject"]
     assert clustered.coefficients[0] == pytest.approx(plain.coefficients[0])
+    assert id_cluster.coefficients[0] == pytest.approx(plain.coefficients[0])
     assert len(clustered.covariates[0]) == 2
     for actual, expected in zip(
         clustered.naive_information_matrix, plain.information_matrix, strict=True
@@ -2016,6 +3519,47 @@ def test_coxph_formula_cluster_computes_robust_variance():
         assert actual == pytest.approx(expected)
     for actual, expected in zip(explicit_cluster.information_matrix, expected_robust, strict=True):
         assert actual == pytest.approx(expected)
+    for actual, expected in zip(id_cluster.information_matrix, expected_robust, strict=True):
+        assert actual == pytest.approx(expected)
+    for actual, expected in zip(matrix_id.information_matrix, expected_robust, strict=True):
+        assert actual == pytest.approx(expected)
+
+    score = clustered.score_residuals()
+    expected_dfbeta = [
+        [
+            sum(expected_robust[col_idx][inner_idx] * row[inner_idx] for inner_idx in range(2))
+            for col_idx in range(2)
+        ]
+        for row in score
+    ]
+    expected_dfbetas = [
+        [
+            row[col_idx]
+            / max(
+                math.sqrt(abs(expected_robust[col_idx][col_idx])),
+                survival.r_api._COX_DFBETAS_SCALE_FLOOR,
+            )
+            for col_idx in range(2)
+        ]
+        for row in expected_dfbeta
+    ]
+    for actual, expected in zip(clustered.dfbeta(), expected_dfbeta, strict=True):
+        assert actual == pytest.approx(expected)
+    for actual, expected in zip(clustered.dfbetas(), expected_dfbetas, strict=True):
+        assert actual == pytest.approx(expected)
+    for actual, expected in zip(
+        survival.r_api.residuals(clustered, type="dfbeta", weighted=False),
+        expected_dfbeta,
+        strict=True,
+    ):
+        assert actual == pytest.approx(expected)
+    for actual, expected in zip(
+        survival.r_api.residuals(clustered, type="dfbetas", weighted=False),
+        expected_dfbetas,
+        strict=True,
+    ):
+        assert actual == pytest.approx(expected)
+    assert clustered.dfbeta()[3] != pytest.approx(clustered.fit.dfbeta()[3])
 
     row = [0.5, 0.8]
     robust_prediction = survival.predict(clustered, [row], reference="zero", se_fit=True)
@@ -2268,6 +3812,8 @@ def test_survfit_accepts_simple_coxph_model():
     result = survival.survfit(fit, newdata=[[0.5, 0.8]])
     event_only = survival.survfit(fit, newdata=[[0.5, 0.8]], censor=False)
     no_conf = survival.survfit(fit, newdata=[[0.5, 0.8]], conf_type="none")
+    no_se = survival.survfit(fit, newdata=[[0.5, 0.8]], se_fit=False)
+    with_model = survival.survfit(fit, newdata=[[0.5, 0.8]], model=True)
     plain = survival.survfit(fit, newdata=[[0.5, 0.8]], conf_type="plain")
     direct_times, direct_curves = fit.survival_curve([[0.5, 0.8]])
     times, curves = result
@@ -2301,6 +3847,17 @@ def test_survfit_accepts_simple_coxph_model():
     assert no_conf.cumhaz[0] == pytest.approx(result.cumhaz[0])
     assert no_conf.conf_lower == []
     assert no_conf.conf_upper == []
+    assert no_se.time == pytest.approx(result.time)
+    assert no_se.surv[0] == pytest.approx(result.surv[0])
+    assert no_se.cumhaz[0] == pytest.approx(result.cumhaz[0])
+    assert no_se.std_err == []
+    assert no_se.std_chaz == []
+    assert no_se.conf_lower == []
+    assert no_se.conf_upper == []
+    assert with_model.time == pytest.approx(result.time)
+    assert with_model.surv[0] == pytest.approx(result.surv[0])
+    assert with_model.model["fit"] is fit
+    assert with_model.model["newdata"] == [[0.5, 0.8]]
     assert result.curves[0] == pytest.approx(curves[0])
     assert result.estimate[0] == pytest.approx(curves[0])
     assert result.cumulative_hazard[0] == pytest.approx(result.cumhaz[0])
@@ -2509,7 +4066,7 @@ def test_predict_coxph_r_style_generic_types():
     risk_with_se = survival.predict(fit, rows, type="risk", se_fit=True)
     assert risk_with_se.fit == pytest.approx(risk)
     assert risk_with_se.se_fit == pytest.approx(
-        [se * math.sqrt(value) for se, value in zip(expected_lp_se, risk, strict=True)]
+        [se * value for se, value in zip(expected_lp_se, risk, strict=True)]
     )
     zero_se = [
         math.sqrt(
@@ -2872,8 +4429,10 @@ def test_predict_expected_and_residuals_share_martingale_identity():
 def test_cox_zph_rank_transform_matches_low_level_ph_test():
     fit = survival.coxph("Surv(time, status) ~ x1 + x2", data=_toy_data(), max_iter=10, eps=1e-5)
     raw = fit.schoenfeld_residuals()
+    scaled = fit.scaled_schoenfeld_residuals()
     ranks = list(range(1, len(raw) + 1))
-    low_level = survival.ph_test(raw, ranks, None)
+    low_level = survival.ph_test(scaled, ranks, None)
+    raw_level = survival.ph_test(raw, ranks, None)
 
     result = survival.cox_zph(fit, transform="rank", terms=False)
 
@@ -2886,9 +4445,42 @@ def test_cox_zph_rank_transform_matches_low_level_ph_test():
     assert result.global_chi2 == pytest.approx(low_level.global_chi2)
     assert result.global_df == low_level.global_df
     assert result.global_p_value == pytest.approx(low_level.global_p_value)
-    for actual, expected in zip(result.y, fit.scaled_schoenfeld_residuals(), strict=True):
+    assert result.global_chi2 != pytest.approx(raw_level.global_chi2)
+    for actual, expected in zip(result.y, scaled, strict=True):
         assert actual == pytest.approx(expected)
     assert result.table[-1]["name"] == "GLOBAL"
+
+
+def test_cox_zph_clustered_fit_uses_robust_scaled_schoenfeld_residuals():
+    data = {**_toy_data(), "subject": ["a", "a", "b", "b", "c", "c", "d", "d"]}
+    fit = survival.coxph(
+        "Surv(time, status) ~ x1 + x2 + cluster(subject)",
+        data=data,
+        max_iter=10,
+        eps=1e-5,
+    )
+    raw = fit.schoenfeld_residuals()
+    robust_scaled = survival.r_api.residuals(fit, type="scaledsch")
+    naive_scaled = fit.fit.scaled_schoenfeld_residuals()
+    ranks = list(range(1, len(raw) + 1))
+    low_level = survival.ph_test(robust_scaled, ranks, None)
+    naive_level = survival.ph_test(naive_scaled, ranks, None)
+
+    result = survival.cox_zph(fit, transform="rank", terms=False)
+
+    assert result.variable_names == ["x1", "x2"]
+    assert result.x == pytest.approx(ranks)
+    assert result.chi2_values == pytest.approx(low_level.chi2_values)
+    assert result.p_values == pytest.approx(low_level.p_values)
+    assert result.global_chi2 == pytest.approx(low_level.global_chi2)
+    assert result.global_df == low_level.global_df
+    assert result.global_p_value == pytest.approx(low_level.global_p_value)
+    assert result.global_chi2 != pytest.approx(naive_level.global_chi2)
+    for actual, expected in zip(fit.scaled_schoenfeld_residuals(), robust_scaled, strict=True):
+        assert actual == pytest.approx(expected)
+    assert fit.scaled_schoenfeld_residuals()[0] != pytest.approx(naive_scaled[0])
+    for actual, expected in zip(result.y, robust_scaled, strict=True):
+        assert actual == pytest.approx(expected)
 
 
 def test_cox_zph_identity_and_km_transforms_expose_r_style_time_axes():
@@ -2961,6 +4553,7 @@ def test_cox_zph_formula_terms_group_multi_column_factors():
     assert len(by_column.y[0]) == 3
     assert by_term.table[-1]["name"] == "GLOBAL"
     assert survival.cox_zph(fit, global_test=False).table[-1]["name"] != "GLOBAL"
+    assert survival.cox_zph(fit, **{"global": False}).table[-1]["name"] != "GLOBAL"
 
 
 def test_coxph_partial_residuals_add_terms_to_martingales():
@@ -2985,6 +4578,16 @@ def test_coxph_partial_residuals_add_terms_to_martingales():
             strict=True,
         ):
             assert actual == pytest.approx(expected_row)
+
+    selected_x2 = survival.r_api.residuals(fit, type="partial", terms="x2")
+    selected_by_index = survival.r_api.residuals(fit, type="partial", terms=[2, 1])
+    for row_idx, actual in enumerate(selected_x2):
+        assert actual == pytest.approx([expected[row_idx][1]])
+    for row_idx, actual in enumerate(selected_by_index):
+        assert actual == pytest.approx([expected[row_idx][1], expected[row_idx][0]])
+
+    with pytest.raises(ValueError, match="unknown model term"):
+        survival.r_api.residuals(fit, type="partial", terms="missing")
 
 
 def test_coxph_counting_process_partial_residuals_keep_training_row_order():
@@ -3567,6 +5170,27 @@ def test_coxph_accepts_r_style_ties_alias():
     assert matching_aliases.log_likelihood == pytest.approx(by_method.log_likelihood)
 
 
+def test_coxph_accepts_unused_tt_argument_without_time_transform_terms():
+    data = _toy_data()
+    baseline = survival.coxph(
+        "Surv(time, status) ~ x1 + x2",
+        data=data,
+        max_iter=10,
+        eps=1e-5,
+    )
+    unused_tt = survival.coxph(
+        "Surv(time, status) ~ x1 + x2",
+        data=data,
+        tt=lambda value, *_args: value,
+        max_iter=10,
+        eps=1e-5,
+    )
+
+    for actual, expected in zip(unused_tt.coefficients, baseline.coefficients, strict=True):
+        assert actual == pytest.approx(expected)
+    assert unused_tt.log_likelihood == pytest.approx(baseline.log_likelihood)
+
+
 def test_coxph_accepts_r_style_control_mapping():
     data = _tied_cox_data()
     explicit = survival.coxph(
@@ -3594,6 +5218,329 @@ def test_coxph_accepts_r_style_control_mapping():
     assert controlled.coefficients[0] == pytest.approx(explicit.coefficients[0])
     assert controlled.log_likelihood == pytest.approx(explicit.log_likelihood)
     assert controlled.risk_scores == pytest.approx(explicit.risk_scores)
+
+    nondefault_ignored = survival.coxph(
+        "Surv(time, status) ~ x1",
+        data=data,
+        method="breslow",
+        control={
+            "iter.max": 15,
+            "eps": 1e-5,
+            "toler.chol": 1e-8,
+            "toler.inf": 0.25,
+            "outer.max": 2,
+        },
+    )
+
+    assert nondefault_ignored.coefficients[0] == pytest.approx(explicit.coefficients[0])
+    assert nondefault_ignored.log_likelihood == pytest.approx(explicit.log_likelihood)
+    assert nondefault_ignored.risk_scores == pytest.approx(explicit.risk_scores)
+
+
+def test_coxph_accepts_r_style_formula_storage_flags():
+    data = _toy_data()
+    default = survival.coxph(
+        "Surv(time, status) ~ x1 + x2",
+        data=data,
+        max_iter=10,
+        eps=1e-5,
+    )
+    explicit_defaults = survival.coxph(
+        "Surv(time, status) ~ x1 + x2",
+        data=data,
+        x=False,
+        y=True,
+        model=False,
+        tt=None,
+        id=None,
+        istate=None,
+        statedata=None,
+        singular_ok=True,
+        nocenter=[-1, 0, 1],
+        max_iter=10,
+        eps=1e-5,
+    )
+    strict_singular = survival.coxph(
+        "Surv(time, status) ~ x1 + x2",
+        data=data,
+        singular_ok=False,
+        max_iter=10,
+        eps=1e-5,
+    )
+    with_model = survival.coxph(
+        "Surv(time, status) ~ x1 + x2 + offset(offset) + strata(group)",
+        data=data,
+        model=True,
+        x=True,
+        max_iter=10,
+        eps=1e-5,
+    )
+
+    for actual, expected in zip(explicit_defaults.coefficients, default.coefficients, strict=True):
+        assert actual == pytest.approx(expected)
+    for actual, expected in zip(strict_singular.coefficients, default.coefficients, strict=True):
+        assert actual == pytest.approx(expected)
+    assert explicit_defaults.log_likelihood == pytest.approx(default.log_likelihood)
+    assert strict_singular.log_likelihood == pytest.approx(default.log_likelihood)
+    assert explicit_defaults.y.time == pytest.approx(data["time"])
+    assert explicit_defaults.y.event == tuple(data["status"])
+    assert not hasattr(explicit_defaults, "x")
+    assert not hasattr(explicit_defaults, "model")
+
+    model_frame = with_model.model
+    assert model_frame["Surv(time, status)"].time == pytest.approx(data["time"])
+    assert model_frame["Surv(time, status)"].event == tuple(data["status"])
+    assert model_frame["time"] == pytest.approx(data["time"])
+    assert model_frame["status"] == data["status"]
+    assert model_frame["x1"] == pytest.approx(data["x1"])
+    assert model_frame["x2"] == pytest.approx(data["x2"])
+    assert model_frame["offset"] == pytest.approx(data["offset"])
+    assert model_frame["group"] == data["group"]
+    assert model_frame["(offset)"] == pytest.approx(data["offset"])
+    assert model_frame["(strata)"] == data["group"]
+
+    with_x = survival.coxph(
+        "Surv(time, status) ~ x1 + x2",
+        data=data,
+        x=True,
+        y=False,
+        max_iter=10,
+        eps=1e-5,
+    )
+    expected_x = [[data["x1"][idx], data["x2"][idx]] for idx in range(len(data["time"]))]
+    for actual, expected in zip(with_x.x, expected_x, strict=True):
+        assert actual == pytest.approx(expected)
+    assert not hasattr(with_x, "y")
+
+    dotted_singular = survival.coxph(
+        "Surv(time, status) ~ x1 + x2",
+        data=data,
+        max_iter=10,
+        eps=1e-5,
+        **{"singular.ok": True},
+    )
+    for actual, expected in zip(dotted_singular.coefficients, default.coefficients, strict=True):
+        assert actual == pytest.approx(expected)
+    assert dotted_singular.log_likelihood == pytest.approx(default.log_likelihood)
+
+
+def test_coxph_nocenter_controls_r_style_column_centering():
+    data = {
+        "time": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+        "status": [1, 1, 0, 1, 0, 1],
+        "dummy": [0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
+        "x": [0.2, 1.3, 0.7, 1.8, 1.1, 2.2],
+    }
+
+    default = survival.coxph(
+        "Surv(time, status) ~ dummy + x",
+        data=data,
+        max_iter=20,
+        eps=1e-9,
+    )
+    center_all = survival.coxph(
+        "Surv(time, status) ~ dummy + x",
+        data=data,
+        nocenter=[],
+        max_iter=20,
+        eps=1e-9,
+    )
+    scalar = survival.coxph(
+        "Surv(time, status) ~ dummy + x",
+        data=data,
+        nocenter=0,
+        max_iter=20,
+        eps=1e-9,
+    )
+
+    assert default.nocenter == pytest.approx([-1.0, 0.0, 1.0])
+    assert center_all.nocenter == []
+    assert scalar.nocenter == pytest.approx([0.0])
+    assert default.coefficients[0] == pytest.approx(center_all.coefficients[0])
+    assert default.log_likelihood == pytest.approx(center_all.log_likelihood)
+    assert default.means[0] == pytest.approx(0.0)
+    assert center_all.means[0] == pytest.approx(sum(data["dummy"]) / len(data["dummy"]))
+    assert scalar.means[0] == pytest.approx(center_all.means[0])
+
+    default_lp = survival.predict(default, reference="sample")
+    center_all_lp = survival.predict(center_all, reference="sample")
+    shift = center_all.means[0] * center_all.coefficients[0][0]
+    assert center_all_lp == pytest.approx([value - shift for value in default_lp])
+    assert survival.predict(default, reference="zero") == pytest.approx(
+        survival.predict(center_all, reference="zero")
+    )
+
+
+def test_coxph_model_true_stores_matrix_inputs():
+    data = _toy_data()
+    response = survival.Surv(data["time"], data["status"])
+    rows = [[data["x1"][idx], data["x2"][idx]] for idx in range(len(data["time"]))]
+
+    fit = survival.coxph(response, x=rows, model=True, y=False, max_iter=10, eps=1e-5)
+
+    assert fit.model["response"].time == pytest.approx(data["time"])
+    assert fit.model["response"].event == tuple(data["status"])
+    for actual, expected in zip(fit.model["x"], rows, strict=True):
+        assert actual == pytest.approx(expected)
+    assert not hasattr(fit, "y")
+
+
+def test_coxph_singular_ok_false_rejects_dependent_designs():
+    data = _toy_data()
+    singular_data = {
+        **data,
+        "constant": [1.0] * len(data["time"]),
+        "x_duplicate": [2.0 * value + 1.0 for value in data["x1"]],
+    }
+    response = survival.Surv(data["time"], data["status"])
+
+    with pytest.raises(ValueError, match="singular.*singular_ok=True"):
+        survival.coxph(
+            "Surv(time, status) ~ x1 + x_duplicate",
+            data=singular_data,
+            singular_ok=False,
+        )
+
+    with pytest.raises(ValueError, match="singular.*singular_ok=True"):
+        survival.coxph(
+            "Surv(time, status) ~ constant",
+            data=singular_data,
+            singular_ok=False,
+        )
+
+    with pytest.raises(ValueError, match="singular.*singular_ok=True"):
+        survival.coxph(
+            response,
+            x=[[value, 2.0 * value + 1.0] for value in data["x1"]],
+            singular_ok=False,
+        )
+
+    intercept_only = survival.coxph(
+        "Surv(time, status) ~ 1",
+        data=data,
+        singular_ok=False,
+        max_iter=0,
+    )
+    assert intercept_only.coefficients == [[]]
+
+
+def test_coxph_control_timefix_matches_r_near_tie_behavior():
+    data = {
+        "time": [1.0, 1.0 + 5e-10, 2.0, 3.0],
+        "status": [1, 1, 0, 1],
+        "x1": [0.0, 1.0, 0.5, 1.5],
+    }
+    fixed_times = [1.0, 1.0, 2.0, 3.0]
+    rows = [[value] for value in data["x1"]]
+    fixed_low_level = survival.regression.coxph_fit(
+        fixed_times,
+        data["status"],
+        rows,
+        max_iter=20,
+        eps=1e-9,
+        method="efron",
+    )
+    exact_low_level = survival.regression.coxph_fit(
+        data["time"],
+        data["status"],
+        rows,
+        max_iter=20,
+        eps=1e-9,
+        method="efron",
+    )
+
+    default = survival.coxph(
+        "Surv(time, status) ~ x1",
+        data=data,
+        max_iter=20,
+        eps=1e-9,
+        method="efron",
+    )
+    explicit_true = survival.coxph(
+        "Surv(time, status) ~ x1",
+        data=data,
+        max_iter=20,
+        eps=1e-9,
+        method="efron",
+        control={"timefix": True},
+    )
+    exact = survival.coxph(
+        "Surv(time, status) ~ x1",
+        data=data,
+        max_iter=20,
+        eps=1e-9,
+        method="efron",
+        control={"timefix": False},
+    )
+    exact_dotted = survival.coxph(
+        "Surv(time, status) ~ x1",
+        data=data,
+        max_iter=20,
+        eps=1e-9,
+        method="efron",
+        control={"time.fix": False},
+    )
+
+    assert default.coefficients[0] == pytest.approx(fixed_low_level.coefficients[0])
+    assert default.log_likelihood == pytest.approx(fixed_low_level.log_likelihood)
+    assert explicit_true.coefficients[0] == pytest.approx(default.coefficients[0])
+    assert exact.coefficients[0] == pytest.approx(exact_low_level.coefficients[0])
+    assert exact.log_likelihood == pytest.approx(exact_low_level.log_likelihood)
+    assert exact_dotted.coefficients[0] == pytest.approx(exact.coefficients[0])
+    assert exact.coefficients[0] != pytest.approx(default.coefficients[0])
+
+    with pytest.raises(ValueError, match=r"control\.timefix or control\.time\.fix"):
+        survival.coxph(
+            "Surv(time, status) ~ x1",
+            data=data,
+            control={"timefix": False, "time.fix": True},
+        )
+
+
+def test_coxph_control_timefix_applies_to_counting_process_endpoints():
+    start = [0.0, 0.0, 0.5, 1.0 + 5e-10, 0.0]
+    stop = [1.0, 1.0 + 5e-10, 2.0, 3.0, 4.0]
+    status = [1, 1, 0, 1, 0]
+    rows = [[value] for value in [0.0, 1.0, 0.5, 1.5, 0.2]]
+    fixed_start, fixed_stop = survival.r_api._timefix_vectors(
+        [float(value) for value in start],
+        [float(value) for value in stop],
+    )
+    fixed_low_level = survival.regression.coxph_fit(
+        fixed_stop,
+        status,
+        rows,
+        entry_times=fixed_start,
+        max_iter=20,
+        eps=1e-9,
+        method="efron",
+    )
+    exact_low_level = survival.regression.coxph_fit(
+        stop,
+        status,
+        rows,
+        entry_times=start,
+        max_iter=20,
+        eps=1e-9,
+        method="efron",
+    )
+    response = survival.Surv(start, stop, status)
+
+    default = survival.coxph(response, x=rows, max_iter=20, eps=1e-9, method="efron")
+    exact = survival.coxph(
+        response,
+        x=rows,
+        max_iter=20,
+        eps=1e-9,
+        method="efron",
+        control={"timefix": False},
+    )
+
+    assert default.coefficients[0] == pytest.approx(fixed_low_level.coefficients[0])
+    assert default.log_likelihood == pytest.approx(fixed_low_level.log_likelihood)
+    assert exact.coefficients[0] == pytest.approx(exact_low_level.coefficients[0])
+    assert exact.log_likelihood == pytest.approx(exact_low_level.log_likelihood)
+    assert exact.coefficients[0] != pytest.approx(default.coefficients[0])
 
 
 def test_coxph_exact_ties_alias_accepts_data_without_tied_events():
@@ -3698,6 +5645,49 @@ def test_low_level_coxph_accepts_zero_column_null_model():
     assert len(curves) == 1
 
 
+def test_low_level_coxph_nocenter_disables_column_scaling():
+    data = {
+        "time": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+        "status": [1, 1, 0, 1, 0, 1],
+        "dummy": [0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
+        "x": [0.2, 1.3, 0.7, 1.8, 1.1, 2.2],
+    }
+    rows = [[dummy, x] for dummy, x in zip(data["dummy"], data["x"], strict=True)]
+
+    centered = survival.regression.coxph_fit(
+        data["time"],
+        data["status"],
+        rows,
+        max_iter=20,
+        eps=1e-9,
+    )
+    default = survival.regression.coxph_fit(
+        data["time"],
+        data["status"],
+        rows,
+        max_iter=20,
+        eps=1e-9,
+        nocenter=[-1.0, 0.0, 1.0],
+    )
+    zero_only = survival.regression.coxph_fit(
+        data["time"],
+        data["status"],
+        rows,
+        max_iter=20,
+        eps=1e-9,
+        nocenter=[0.0],
+    )
+
+    assert centered.nocenter == []
+    assert default.nocenter == pytest.approx([-1.0, 0.0, 1.0])
+    assert centered.coefficients[0] == pytest.approx(default.coefficients[0])
+    assert centered.log_likelihood == pytest.approx(default.log_likelihood)
+    assert centered.means[0] == pytest.approx(sum(data["dummy"]) / len(data["dummy"]))
+    assert default.means[0] == pytest.approx(0.0)
+    assert default.means[1] != pytest.approx(0.0)
+    assert zero_only.means[0] == pytest.approx(centered.means[0])
+
+
 def test_low_level_coxph_rejects_invalid_numeric_inputs():
     data = _toy_data()
     kwargs = {
@@ -3737,6 +5727,9 @@ def test_low_level_coxph_rejects_invalid_numeric_inputs():
 
     with pytest.raises(ValueError, match="initial_beta contains non-finite"):
         survival.regression.coxph_fit(**{**kwargs, "initial_beta": [float("nan")]})
+
+    with pytest.raises(ValueError, match="nocenter contains non-finite"):
+        survival.regression.coxph_fit(**{**kwargs, "nocenter": [0.0, float("nan")]})
 
     with pytest.raises(ValueError, match="eps must be a finite positive value"):
         survival.regression.coxph_fit(**{**kwargs, "eps": 0.0})
@@ -4348,8 +6341,50 @@ def test_predict_coxph_expected_accepts_counting_newdata_response():
         expected.append(stop_hazard - start_hazard)
 
     actual = survival.predict(fit, newdata, type="expected")
+    actual_with_se = survival.predict(fit, newdata, type="expected", se_fit=True)
+    baseline = survival.r_api._cox_expected_baseline_by_stratum(fit)[0]
+    variance = fit.information_matrix
+    means = fit.means
+    linear_predictors = survival.predict(
+        fit,
+        [[value] for value in newdata["x1"]],
+        reference="zero",
+    )
+    expected_se = []
+    for start, stop, x1, linear_predictor in zip(
+        newdata["start"],
+        newdata["stop"],
+        newdata["x1"],
+        linear_predictors,
+        strict=True,
+    ):
+        start_hazard, start_varhaz, start_xbar = survival.r_api._cox_expected_baseline_at(
+            baseline,
+            start,
+            1,
+        )
+        stop_hazard, stop_varhaz, stop_xbar = survival.r_api._cox_expected_baseline_at(
+            baseline,
+            stop,
+            1,
+        )
+        centered_x = x1 - means[0]
+        start_delta = start_hazard * centered_x - start_xbar[0]
+        stop_delta = stop_hazard * centered_x - stop_xbar[0]
+        interval_delta = stop_delta - start_delta
+        expected_var = stop_varhaz - start_varhaz + interval_delta * variance[0][0] * interval_delta
+        expected_se.append(math.sqrt(max(expected_var, 0.0)) * math.exp(linear_predictor))
+    conditioned = survival.survfit(
+        fit,
+        newdata={"x1": [newdata["x1"][1]]},
+        start_time=newdata["start"][1],
+        conf_type="none",
+    )
 
     assert actual == pytest.approx(expected)
+    assert actual_with_se.fit == pytest.approx(expected)
+    assert actual_with_se.se_fit == pytest.approx(expected_se)
+    assert conditioned.std_chaz[0][-1] == pytest.approx(expected_se[1])
     assert survival.predict(fit, newdata, type="survival") == pytest.approx(
         [math.exp(-value) for value in expected]
     )
@@ -4896,6 +6931,186 @@ def test_survreg_formula_matches_low_level_binding():
     assert fit.log_likelihood == pytest.approx(low_level.log_likelihood)
 
 
+def test_survreg_fixed_scale_matches_low_level_binding():
+    data = _toy_data()
+    fit = survival.survreg(
+        "Surv(time, status) ~ x1 + x2",
+        data=data,
+        scale=1.25,
+        dist="weibull",
+        max_iter=10,
+        eps=1e-5,
+    )
+    low_level = survival.regression.survreg(
+        time=data["time"],
+        status=[float(value) for value in data["status"]],
+        covariates=_with_intercept(
+            [[data["x1"][idx], data["x2"][idx]] for idx in range(len(data["time"]))]
+        ),
+        distribution="weibull",
+        fixed_scale=1.25,
+        max_iter=10,
+        eps=1e-5,
+    )
+
+    assert fit.coefficients == pytest.approx(low_level.coefficients)
+    assert fit.location_coefficients == pytest.approx(low_level.location_coefficients)
+    assert fit.log_likelihood == pytest.approx(low_level.log_likelihood)
+    assert fit.scale == pytest.approx(1.25)
+    assert fit.scales == pytest.approx([1.25])
+    assert len(fit.variance_matrix) == len(fit.coefficients)
+    assert all(len(row) == len(fit.coefficients) for row in fit.variance_matrix)
+    assert len(fit.score_vector) == len(fit.coefficients)
+
+
+def test_survreg_score_true_exposes_score_vector_alias():
+    data = _toy_data()
+    formula_fit = survival.survreg(
+        "Surv(time, status) ~ x1 + x2",
+        data=data,
+        dist="weibull",
+        score=True,
+        max_iter=10,
+        eps=1e-5,
+    )
+    formula_low_level = survival.regression.survreg(
+        time=data["time"],
+        status=[float(value) for value in data["status"]],
+        covariates=_with_intercept(
+            [[data["x1"][idx], data["x2"][idx]] for idx in range(len(data["time"]))]
+        ),
+        distribution="weibull",
+        max_iter=10,
+        eps=1e-5,
+    )
+
+    assert formula_fit.score == pytest.approx(formula_low_level.score_vector)
+    assert formula_fit.score_vector == pytest.approx(formula_low_level.score_vector)
+
+    no_score = survival.survreg(
+        "Surv(time, status) ~ x1 + x2",
+        data=data,
+        dist="weibull",
+        score=False,
+        max_iter=10,
+        eps=1e-5,
+    )
+    assert not hasattr(no_score, "score")
+
+    rows = [[data["x1"][idx], data["x2"][idx]] for idx in range(len(data["time"]))]
+    matrix_fit = survival.survreg(
+        time=data["time"],
+        status=data["status"],
+        covariates=rows,
+        distribution="weibull",
+        score=True,
+        max_iter=10,
+        eps=1e-5,
+    )
+    matrix_low_level = survival.regression.survreg(
+        time=data["time"],
+        status=[float(value) for value in data["status"]],
+        covariates=rows,
+        distribution="weibull",
+        max_iter=10,
+        eps=1e-5,
+    )
+
+    assert matrix_fit.score == pytest.approx(matrix_low_level.score_vector)
+    assert matrix_fit.score_vector == pytest.approx(matrix_low_level.score_vector)
+
+
+def test_survreg_cluster_computes_robust_variance():
+    data = {**_toy_data(), "subject": ["a", "a", "b", "b", "c", "c", "d", "d"]}
+    rows = [[data["x1"][idx], data["x2"][idx]] for idx in range(len(data["time"]))]
+    plain = survival.survreg(
+        "Surv(time, status) ~ x1 + x2",
+        data=data,
+        dist="weibull",
+        max_iter=10,
+        eps=1e-5,
+    )
+    formula_clustered = survival.survreg(
+        "Surv(time, status) ~ x1 + x2 + cluster(subject)",
+        data=data,
+        dist="weibull",
+        model=True,
+        x=True,
+        max_iter=10,
+        eps=1e-5,
+    )
+    explicit_cluster = survival.survreg(
+        "Surv(time, status) ~ x1 + x2",
+        data=data,
+        dist="weibull",
+        cluster=data["subject"],
+        max_iter=10,
+        eps=1e-5,
+    )
+    matrix_cluster = survival.survreg(
+        time=data["time"],
+        status=data["status"],
+        covariates=_with_intercept(rows),
+        distribution="weibull",
+        cluster=data["subject"],
+        max_iter=10,
+        eps=1e-5,
+    )
+    singleton_robust = survival.survreg(
+        "Surv(time, status) ~ x1 + x2",
+        data=data,
+        dist="weibull",
+        robust=True,
+        max_iter=10,
+        eps=1e-5,
+    )
+    nonrobust_cluster = survival.survreg(
+        "Surv(time, status) ~ x1 + x2",
+        data=data,
+        dist="weibull",
+        cluster=data["subject"],
+        robust=False,
+        max_iter=10,
+        eps=1e-5,
+    )
+
+    expected_robust = _manual_survreg_robust_variance(plain, data["subject"])
+    singleton_expected = _manual_survreg_robust_variance(plain, list(range(len(data["time"]))))
+
+    assert formula_clustered.robust is True
+    assert formula_clustered.cluster == data["subject"]
+    assert formula_clustered.coefficients == pytest.approx(plain.coefficients)
+    assert explicit_cluster.coefficients == pytest.approx(plain.coefficients)
+    assert matrix_cluster.coefficients == pytest.approx(plain.coefficients)
+    assert formula_clustered.model["subject"] == data["subject"]
+    assert formula_clustered.model["(cluster)"] == data["subject"]
+    for actual, expected in zip(formula_clustered.x, _with_intercept(rows), strict=True):
+        assert actual == pytest.approx(expected)
+
+    for actual, expected in zip(
+        formula_clustered.naive_variance,
+        plain.variance_matrix,
+        strict=True,
+    ):
+        assert actual == pytest.approx(expected)
+    for actual, expected in zip(formula_clustered.variance_matrix, expected_robust, strict=True):
+        assert actual == pytest.approx(expected)
+    for actual, expected in zip(explicit_cluster.variance_matrix, expected_robust, strict=True):
+        assert actual == pytest.approx(expected)
+    for actual, expected in zip(matrix_cluster.variance_matrix, expected_robust, strict=True):
+        assert actual == pytest.approx(expected)
+    for actual, expected in zip(singleton_robust.variance_matrix, singleton_expected, strict=True):
+        assert actual == pytest.approx(expected)
+
+    assert nonrobust_cluster.robust is False
+    for actual, expected in zip(
+        nonrobust_cluster.variance_matrix,
+        plain.variance_matrix,
+        strict=True,
+    ):
+        assert actual == pytest.approx(expected)
+
+
 def test_survreg_accepts_r_style_control_mapping():
     data = _toy_data()
     explicit = survival.survreg(
@@ -4910,6 +7125,8 @@ def test_survreg_accepts_r_style_control_mapping():
         "Surv(time, status) ~ x1 + x2",
         data=data,
         dist="weibull",
+        scale=0,
+        parms=None,
         control={
             "maxiter": 10,
             "rel.tolerance": 1e-5,
@@ -4921,6 +7138,173 @@ def test_survreg_accepts_r_style_control_mapping():
 
     assert controlled.coefficients == pytest.approx(explicit.coefficients)
     assert controlled.log_likelihood == pytest.approx(explicit.log_likelihood)
+
+    nondefault_ignored = survival.survreg(
+        "Surv(time, status) ~ x1 + x2",
+        data=data,
+        dist="weibull",
+        scale=0,
+        control={
+            "maxiter": 10,
+            "rel.tolerance": 1e-5,
+            "toler.chol": 1e-8,
+            "debug": 1,
+            "outer.max": 2,
+        },
+    )
+
+    assert nondefault_ignored.coefficients == pytest.approx(explicit.coefficients)
+    assert nondefault_ignored.log_likelihood == pytest.approx(explicit.log_likelihood)
+
+    matrix_controlled = survival.survreg(
+        time=data["time"],
+        status=data["status"],
+        covariates=[[data["x1"][idx], data["x2"][idx]] for idx in range(len(data["time"]))],
+        distribution="weibull",
+        scale=0.0,
+        control={"maxiter": 10, "rel.tolerance": 1e-5, "toler.chol": 1e-8},
+    )
+    matrix_explicit = survival.survreg(
+        time=data["time"],
+        status=data["status"],
+        covariates=[[data["x1"][idx], data["x2"][idx]] for idx in range(len(data["time"]))],
+        distribution="weibull",
+        max_iter=10,
+        eps=1e-5,
+        tol_chol=1e-8,
+    )
+
+    assert matrix_controlled.coefficients == pytest.approx(matrix_explicit.coefficients)
+    assert matrix_controlled.log_likelihood == pytest.approx(matrix_explicit.log_likelihood)
+
+
+def test_survreg_accepts_r_style_formula_storage_flags():
+    data = _toy_data()
+    default = survival.survreg(
+        "Surv(time, status) ~ x1 + x2",
+        data=data,
+        dist="weibull",
+        max_iter=10,
+        eps=1e-5,
+    )
+    explicit_defaults = survival.survreg(
+        "Surv(time, status) ~ x1 + x2",
+        data=data,
+        dist="weibull",
+        model=False,
+        x=False,
+        y=True,
+        robust=False,
+        cluster=None,
+        score=False,
+        max_iter=10,
+        eps=1e-5,
+    )
+    with_model = survival.survreg(
+        "Surv(time, status) ~ x1 + x2 + offset(offset)",
+        data=data,
+        dist="weibull",
+        model=True,
+        x=True,
+        max_iter=10,
+        eps=1e-5,
+    )
+
+    assert explicit_defaults.coefficients == pytest.approx(default.coefficients)
+    assert explicit_defaults.log_likelihood == pytest.approx(default.log_likelihood)
+    assert explicit_defaults.y.time == pytest.approx(data["time"])
+    assert explicit_defaults.y.event == tuple(data["status"])
+    assert not hasattr(explicit_defaults, "x")
+    assert not hasattr(explicit_defaults, "model")
+    assert not hasattr(explicit_defaults, "score")
+
+    model_frame = with_model.model
+    assert model_frame["Surv(time, status)"].time == pytest.approx(data["time"])
+    assert model_frame["Surv(time, status)"].event == tuple(data["status"])
+    assert model_frame["time"] == pytest.approx(data["time"])
+    assert model_frame["status"] == data["status"]
+    assert model_frame["x1"] == pytest.approx(data["x1"])
+    assert model_frame["x2"] == pytest.approx(data["x2"])
+    assert model_frame["offset"] == pytest.approx(data["offset"])
+    assert model_frame["(offset)"] == pytest.approx(data["offset"])
+
+    with_x = survival.survreg(
+        "Surv(time, status) ~ x1 + x2",
+        data=data,
+        dist="weibull",
+        x=True,
+        y=False,
+        max_iter=10,
+        eps=1e-5,
+    )
+    expected_x = _with_intercept(
+        [[data["x1"][idx], data["x2"][idx]] for idx in range(len(data["time"]))]
+    )
+    for actual, expected in zip(with_x.x, expected_x, strict=True):
+        assert actual == pytest.approx(expected)
+    assert not hasattr(with_x, "y")
+
+
+def test_survreg_model_true_stores_matrix_inputs():
+    data = _toy_data()
+    rows = [[data["x1"][idx], data["x2"][idx]] for idx in range(len(data["time"]))]
+
+    fit = survival.survreg(
+        time=data["time"],
+        status=data["status"],
+        covariates=rows,
+        model=True,
+        max_iter=10,
+        eps=1e-5,
+    )
+
+    assert fit.model["time"] == pytest.approx(data["time"])
+    assert fit.model["status"] == pytest.approx([float(value) for value in data["status"]])
+    for actual, expected in zip(fit.model["x"], rows, strict=True):
+        assert actual == pytest.approx(expected)
+
+
+def test_survreg_accepts_r_style_init_alias():
+    data = _toy_data()
+    initial = [0.15, -0.1, 0.05, 0.0]
+    alias = survival.survreg(
+        "Surv(time, status) ~ x1 + x2",
+        data=data,
+        dist="weibull",
+        init=initial,
+        max_iter=0,
+    )
+    explicit = survival.survreg(
+        "Surv(time, status) ~ x1 + x2",
+        data=data,
+        dist="weibull",
+        initial_beta=initial,
+        max_iter=0,
+    )
+
+    assert alias.coefficients == pytest.approx(explicit.coefficients)
+    assert alias.log_likelihood == pytest.approx(explicit.log_likelihood)
+
+    rows = [[data["x1"][idx], data["x2"][idx]] for idx in range(len(data["time"]))]
+    matrix_alias = survival.survreg(
+        time=data["time"],
+        status=data["status"],
+        covariates=rows,
+        distribution="weibull",
+        init=initial[1:],
+        max_iter=0,
+    )
+    matrix_explicit = survival.survreg(
+        time=data["time"],
+        status=data["status"],
+        covariates=rows,
+        distribution="weibull",
+        initial=initial[1:],
+        max_iter=0,
+    )
+
+    assert matrix_alias.coefficients == pytest.approx(matrix_explicit.coefficients)
+    assert matrix_alias.log_likelihood == pytest.approx(matrix_explicit.log_likelihood)
 
 
 def test_survreg_distribution_accepts_r_style_prefixes_and_aliases():
@@ -5021,6 +7405,20 @@ def test_low_level_survreg_rejects_invalid_numeric_inputs():
 
     with pytest.raises(ValueError, match="initial_beta contains non-finite"):
         survival.regression.survreg(**{**kwargs, "initial_beta": [0.0, 0.0, float("nan")]})
+
+    with pytest.raises(ValueError, match="fixed_scale must be a finite positive value"):
+        survival.regression.survreg(**{**kwargs, "fixed_scale": 0.0})
+
+    with pytest.raises(ValueError, match="fixed_scale must be a finite positive value"):
+        survival.regression.survreg(**{**kwargs, "fixed_scale": float("nan")})
+
+    with pytest.raises(ValueError, match="cannot have both a fixed scale and strata"):
+        survival.regression.survreg(**{**kwargs, "strata": [0, 1, 1], "fixed_scale": 1.0})
+
+    with pytest.raises(ValueError, match="initial_beta has 3 values but model expects 2"):
+        survival.regression.survreg(
+            **{**kwargs, "initial_beta": [0.0, 0.0, 0.0], "fixed_scale": 1.0}
+        )
 
     with pytest.raises(ValueError, match="eps must be a finite positive value"):
         survival.regression.survreg(**{**kwargs, "eps": 0.0})
@@ -5428,6 +7826,10 @@ def test_survreg_fit_exposes_prediction_metadata_and_methods():
     assert fit.scales == pytest.approx([fit.scale])
     assert fit.location_coefficients == pytest.approx(fit.coefficients[:3])
     assert fit.linear_predictors == pytest.approx(training_lp)
+    for actual, expected in zip(fit.information_matrix, fit.fit.variance_matrix, strict=True):
+        assert actual == pytest.approx(expected)
+    for actual, expected in zip(fit.variance_matrix, fit.fit.variance_matrix, strict=True):
+        assert actual == pytest.approx(expected)
 
     lp = fit.predict(design_rows, "lp")
     response = fit.predict(design_rows)
@@ -5527,7 +7929,7 @@ def test_predict_survreg_r_style_generic_types():
         assert actual == pytest.approx(expected)
     expected_terms_se = [
         [
-            abs((row[col_idx] - means[col_idx]) * fit.location_coefficients[col_idx])
+            abs(row[col_idx] - means[col_idx])
             * math.sqrt(max(location_vcov[col_idx][col_idx], 0.0))
             for col_idx in range(1, fit.n_covariates)
         ]
@@ -5556,7 +7958,7 @@ def test_predict_survreg_r_style_generic_types():
     ]
     expected_training_terms_se = [
         [
-            abs((row[col_idx] - means[col_idx]) * fit.location_coefficients[col_idx])
+            abs(row[col_idx] - means[col_idx])
             * math.sqrt(max(location_vcov[col_idx][col_idx], 0.0))
             for col_idx in range(1, fit.n_covariates)
         ]
@@ -6840,14 +9242,8 @@ def test_survreg_formula_treatment_codes_categorical_covariates():
     for actual, expected in zip(
         term_se.se_fit,
         [
-            [
-                abs((1.0 - group_mean) * fit.location_coefficients[1])
-                * math.sqrt(max(group_var, 0.0))
-            ],
-            [
-                abs((0.0 - group_mean) * fit.location_coefficients[1])
-                * math.sqrt(max(group_var, 0.0))
-            ],
+            [abs(1.0 - group_mean) * math.sqrt(max(group_var, 0.0))],
+            [abs(0.0 - group_mean) * math.sqrt(max(group_var, 0.0))],
         ],
         strict=True,
     ):
@@ -6975,8 +9371,6 @@ def test_r_api_rejects_unsupported_formula_features():
     for function in (
         survival.survfit,
         survival.survdiff,
-        survival.concordance,
-        survival.survreg,
     ):
         with pytest.raises(ValueError, match=r"cluster\(\)"):
             function("Surv(time, status) ~ x1 + cluster(group)", data=_toy_data())
@@ -6991,6 +9385,127 @@ def test_r_api_rejects_unsupported_formula_features():
 
     with pytest.raises(ValueError, match="ambiguous"):
         survival.coxph("Surv(time, status) ~ x1", data=_toy_data(), ties="e")
+
+    with pytest.raises(TypeError, match="y"):
+        survival.coxph("Surv(time, status) ~ x1", data=_toy_data(), y=1)
+
+    with pytest.raises(TypeError, match="x"):
+        survival.coxph("Surv(time, status) ~ x1", data=_toy_data(), x=1)
+
+    with pytest.raises(ValueError, match=r"singular_ok or singular\.ok"):
+        survival.coxph(
+            "Surv(time, status) ~ x1",
+            data=_toy_data(),
+            singular_ok=False,
+            **{"singular.ok": True},
+        )
+
+    with pytest.raises(NotImplementedError, match="tt"):
+        survival.coxph(
+            "Surv(time, status) ~ x1 + tt(x2)",
+            data=_toy_data(),
+            tt=lambda value, *_args: value,
+        )
+
+    with pytest.raises(ValueError, match="id must have length"):
+        survival.coxph("Surv(time, status) ~ x1", data=_toy_data(), id=["a"])
+
+    with pytest.raises(ValueError, match="cluster or id"):
+        survival.coxph(
+            "Surv(time, status) ~ x1",
+            data=_toy_data(),
+            id=_toy_data()["group"],
+            robust=False,
+        )
+
+    with pytest.raises(NotImplementedError, match="istate"):
+        survival.coxph("Surv(time, status) ~ x1", data=_toy_data(), istate=_toy_data()["status"])
+
+    with pytest.raises(NotImplementedError, match="statedata"):
+        survival.coxph("Surv(time, status) ~ x1", data=_toy_data(), statedata={"states": [1]})
+
+    with pytest.raises(ValueError, match="nocenter"):
+        survival.coxph("Surv(time, status) ~ x1", data=_toy_data(), nocenter=[0.0, float("nan")])
+
+    with pytest.raises(ValueError, match="fixed scale and strata"):
+        survival.survreg("Surv(time, status) ~ x1 + strata(group)", data=_toy_data(), scale=1.0)
+
+    with pytest.raises(NotImplementedError, match="parms"):
+        survival.survreg("Surv(time, status) ~ x1", data=_toy_data(), parms=[1.0])
+
+    concordance_data = _toy_data()
+    with pytest.raises(ValueError, match="weights must be non-negative"):
+        survival.concordance(
+            "Surv(time, status) ~ x1",
+            data=concordance_data,
+            weights=[1.0, -1.0, *([1.0] * (len(concordance_data["time"]) - 2))],
+        )
+
+    with pytest.raises(ValueError, match="cluster must have"):
+        survival.concordance(
+            "Surv(time, status) ~ x1",
+            data=concordance_data,
+            cluster=["a"],
+        )
+
+    with pytest.raises(ValueError, match="formula cluster"):
+        survival.concordance(
+            "Surv(time, status) ~ x1 + cluster(group)",
+            data=concordance_data,
+            cluster=concordance_data["group"],
+        )
+
+    with pytest.raises(TypeError, match="ymin"):
+        survival.concordance(
+            "Surv(time, status) ~ x1",
+            data=concordance_data,
+            ymin=object(),
+        )
+
+    counting_concordance_data = _counting_cox_data()
+    counting_concordance_data["score"] = [0.9, 0.2, 0.7, 0.1, 0.5, 0.4]
+    with pytest.raises(ValueError, match="counting-process"):
+        survival.concordance(
+            "Surv(start, stop, status) ~ score",
+            data=counting_concordance_data,
+            timewt="S/G",
+        )
+
+    with pytest.raises(ValueError, match="influence"):
+        survival.concordance(
+            "Surv(time, status) ~ x1",
+            data=concordance_data,
+            influence=4,
+        )
+
+    with pytest.raises(TypeError, match="ranks"):
+        survival.concordance(
+            "Surv(time, status) ~ x1",
+            data=concordance_data,
+            ranks=1,
+        )
+
+    with pytest.raises(TypeError, match="keepstrata"):
+        survival.concordance(
+            "Surv(time, status) ~ x1",
+            data=concordance_data,
+            keepstrata=object(),
+        )
+
+    with pytest.raises(TypeError, match="y"):
+        survival.survreg("Surv(time, status) ~ x1", data=_toy_data(), y=1)
+
+    with pytest.raises(TypeError, match="x"):
+        survival.survreg("Surv(time, status) ~ x1", data=_toy_data(), x=1)
+
+    with pytest.raises(ValueError, match="cluster must have"):
+        survival.survreg("Surv(time, status) ~ x1", data=_toy_data(), cluster=["a"])
+
+    with pytest.raises(ValueError, match="scale must be non-negative"):
+        survival.survreg("Surv(time, status) ~ x1", data=_toy_data(), scale=-1.0)
+
+    with pytest.raises(ValueError, match="scale must be finite"):
+        survival.survreg("Surv(time, status) ~ x1", data=_toy_data(), scale=float("nan"))
 
     with pytest.raises(ValueError, match="time="):
         survival.basehaz(survival.coxph("Surv(time, status) ~ x1", data=_toy_data()), time=[1.0])
@@ -7075,6 +9590,9 @@ def test_r_api_rejects_unsupported_formula_features():
     with pytest.raises(ValueError, match="ambiguous"):
         survival.r_api.residuals(fit, type="d")
 
+    with pytest.raises(ValueError, match="Cox partial residuals"):
+        survival.r_api.residuals(fit, type="score", terms="x1")
+
     data = _numeric_data()
     data["x1"][2] = float("nan")
     with pytest.raises(ValueError, match="missing values"):
@@ -7107,8 +9625,14 @@ def test_r_api_rejects_unsupported_formula_features():
             **{"conf.type": "logit"},
         )
 
-    with pytest.raises(TypeError, match="unexpected keyword"):
-        survival.survfit(survival.Surv([1.0, 2.0], [1, 0]), **{"time.fix": True})
+    dotted_timefix = survival.survfit(
+        survival.Surv([1.0, 1.0 + 5e-10, 2.0], [1, 1, 0]),
+        **{"time.fix": False},
+    )
+    assert dotted_timefix.time == pytest.approx([1.0, 1.0 + 5e-10, 2.0])
+
+    with pytest.raises(TypeError, match="timefix"):
+        survival.survfit(survival.Surv([1.0, 2.0], [1, 0]), timefix=1)
 
     with pytest.raises(ValueError, match=r"se_fit or se\.fit"):
         survival.predict(fit, [[0.5, 0.8]], se_fit=True, **{"se.fit": False})
@@ -7124,11 +9648,18 @@ def test_r_api_rejects_unsupported_formula_features():
             control={"iter.max": 10},
         )
 
-    with pytest.raises(NotImplementedError, match="outer\\.max"):
+    with pytest.raises(ValueError, match="outer\\.max"):
         survival.coxph(
             "Surv(time, status) ~ x1 + x2",
             data=_toy_data(),
-            control={"outer.max": 2},
+            control={"outer.max": 0},
+        )
+
+    with pytest.raises(ValueError, match="toler\\.inf"):
+        survival.coxph(
+            "Surv(time, status) ~ x1 + x2",
+            data=_toy_data(),
+            control={"toler.inf": 0},
         )
 
     with pytest.raises(ValueError, match=r"eps or control\.rel\.tolerance"):
@@ -7139,12 +9670,36 @@ def test_r_api_rejects_unsupported_formula_features():
             control={"rel.tolerance": 1e-6},
         )
 
-    with pytest.raises(NotImplementedError, match="debug"):
+    with pytest.raises(ValueError, match="debug"):
         survival.survreg(
             "Surv(time, status) ~ x1 + x2",
             data=_toy_data(),
-            control={"debug": 1},
+            control={"debug": math.nan},
         )
+
+    with pytest.raises(ValueError, match="outer\\.max"):
+        survival.survreg(
+            "Surv(time, status) ~ x1 + x2",
+            data=_toy_data(),
+            control={"outer.max": 0},
+        )
+
+    with pytest.raises(ValueError, match="only one of init"):
+        survival.survreg(
+            "Surv(time, status) ~ x1 + x2",
+            data=_toy_data(),
+            init=[0.0, 0.0, 0.0],
+            initial=[0.0, 0.0, 0.0],
+        )
+
+    aft = survival.survreg(
+        "Surv(time, status) ~ x1",
+        data=_toy_data(),
+        max_iter=5,
+        eps=1e-5,
+    )
+    with pytest.raises(ValueError, match="Cox partial residuals"):
+        survival.r_api.residuals(aft, type="response", terms="x1")
 
     with pytest.raises(ValueError, match="conf_level"):
         survival.survfit(
@@ -7181,6 +9736,44 @@ def test_r_api_rejects_unsupported_formula_features():
 
     with pytest.raises(ValueError, match="ctype"):
         survival.survfit(survival.Surv([1.0, 2.0], [1, 0]), ctype=0)
+
+    left_model = survival.survfit(survival.Surv([1.0, 2.0], [0, 1], type="left"), model=True)
+    assert isinstance(left_model, survival.r_api.TurnbullSurvfitResult)
+    assert left_model.model["response"].type == "left"
+
+    with pytest.raises(ValueError, match="entry=TRUE"):
+        survival.survfit(survival.Surv([1.0, 2.0], [1, 0]), entry=True)
+
+    with pytest.raises(ValueError, match="entry=TRUE"):
+        survival.survfit(survival.Surv([1.0, 2.0], [1, 0]), id=["a", "b"], entry=True)
+
+    with pytest.raises(ValueError, match=r"se_fit or se\.fit"):
+        survival.survfit(
+            survival.Surv([1.0, 2.0], [1, 0]),
+            se_fit=False,
+            **{"se.fit": True},
+        )
+
+    with pytest.raises(ValueError, match="id must have"):
+        survival.survfit(
+            survival.Surv([0.0, 0.0], [1.0, 2.0], [1, 0]),
+            id=["a"],
+        )
+
+    with pytest.raises(NotImplementedError, match="cluster"):
+        survival.survfit(survival.Surv([1.0, 2.0], [1, 0]), cluster=["a", "b"])
+
+    with pytest.raises(NotImplementedError, match="robust variance"):
+        survival.survfit(survival.Surv([1.0, 2.0], [1, 0]), robust=True)
+
+    with pytest.raises(NotImplementedError, match="istate"):
+        survival.survfit(survival.Surv([1.0, 2.0], [1, 0]), istate=[0, 1])
+
+    with pytest.raises(NotImplementedError, match="etype"):
+        survival.survfit(survival.Surv([1.0, 2.0], [1, 0]), etype=[1, 2])
+
+    with pytest.raises(TypeError, match="entry"):
+        survival.survfit(survival.Surv([1.0, 2.0], [1, 0]), entry=1)
 
     with pytest.raises(ValueError, match=r"start\[0\] must be less than stop\[0\]"):
         survival.Surv([1.0, 1.0], [1.0, 2.0], [1, 0])
@@ -7264,30 +9857,19 @@ def test_r_api_rejects_unsupported_formula_features():
             group=["A", "B"],
         )
 
-    with pytest.raises(NotImplementedError, match="right-censored Surv"):
-        survival.survdiff(
-            "Surv(start, stop, status) ~ group + strata(site)",
-            data={
-                "start": [0.0, 0.0, 1.0, 1.0],
-                "stop": [1.0, 2.0, 3.0, 4.0],
-                "status": [1, 0, 1, 1],
-                "group": ["A", "B", "A", "B"],
-                "site": ["x", "x", "y", "y"],
-            },
-        )
-
-    with pytest.raises(NotImplementedError, match="timefix=False"):
-        survival.survdiff(
-            survival.Surv([0.0, 0.0], [1.0, 2.0], [1, 1]),
-            group=["A", "B"],
-            timefix=False,
-        )
-
     with pytest.raises(TypeError, match="timefix"):
         survival.survdiff(
             survival.Surv([1.0, 2.0], [1, 0]),
             group=["A", "B"],
             timefix=1,
+        )
+
+    with pytest.raises(ValueError, match=r"timefix or time\.fix"):
+        survival.survdiff(
+            survival.Surv([1.0, 1.0 + 5e-10, 2.0], [1, 1, 0]),
+            group=["A", "A", "B"],
+            timefix=False,
+            **{"time.fix": True},
         )
 
     with pytest.raises(ValueError, match="right endpoint"):

--- a/src/causal/double_ml.rs
+++ b/src/causal/double_ml.rs
@@ -1,5 +1,6 @@
 use pyo3::prelude::*;
 
+use crate::constants::{DIVISION_FLOOR, normal_ci_95};
 use crate::internal::statistical::normal_cdf;
 
 #[derive(Debug, Clone)]
@@ -305,11 +306,10 @@ pub fn double_ml_survival(
         all_scores.iter().map(|&s| (s - ate).powi(2)).sum::<f64>() / (all_scores.len() - 1) as f64;
     let se = (var / all_scores.len() as f64).sqrt();
 
-    let z = ate / se.max(crate::constants::DIVISION_FLOOR);
+    let z = ate / se.max(DIVISION_FLOOR);
     let pvalue = 2.0 * (1.0 - normal_cdf(z.abs()));
 
-    let ci_lower = ate - 1.96 * se;
-    let ci_upper = ate + 1.96 * se;
+    let (ci_lower, ci_upper) = normal_ci_95(ate, se);
 
     Ok(DoubleMLResult {
         ate,

--- a/src/causal/g_computation.rs
+++ b/src/causal/g_computation.rs
@@ -1,6 +1,8 @@
 use pyo3::prelude::*;
 use rayon::prelude::*;
 
+use crate::constants::normal_ci_95;
+
 #[derive(Debug, Clone)]
 #[pyclass(from_py_object)]
 pub struct GComputationResult {
@@ -206,9 +208,7 @@ pub fn g_computation(
         n_boot,
     );
 
-    let z = 1.96;
-    let ate_ci_lower = ate - z * ate_se;
-    let ate_ci_upper = ate + z * ate_se;
+    let (ate_ci_lower, ate_ci_upper) = normal_ci_95(ate, ate_se);
 
     Ok(GComputationResult {
         ate,

--- a/src/causal/instrumental_variable/mod.rs
+++ b/src/causal/instrumental_variable/mod.rs
@@ -1,5 +1,6 @@
 use pyo3::prelude::*;
 
+use crate::constants::{DIVISION_FLOOR, normal_ci_95};
 use crate::internal::statistical::{chi2_cdf, normal_cdf};
 
 include!("iv_cox.rs");

--- a/src/causal/instrumental_variable/rd_survival.rs
+++ b/src/causal/instrumental_variable/rd_survival.rs
@@ -151,7 +151,7 @@ pub fn rd_survival(
     let se_right = (survival_right * (1.0 - survival_right) / n_right as f64).sqrt();
     let se = (se_left.powi(2) + se_right.powi(2)).sqrt();
 
-    let z_score = if se > crate::constants::DIVISION_FLOOR {
+    let z_score = if se > DIVISION_FLOOR {
         treatment_effect / se
     } else {
         0.0
@@ -159,8 +159,7 @@ pub fn rd_survival(
 
     let p_value = 2.0 * (1.0 - normal_cdf(z_score.abs()));
 
-    let ci_lower = treatment_effect - 1.96 * se;
-    let ci_upper = treatment_effect + 1.96 * se;
+    let (ci_lower, ci_upper) = normal_ci_95(treatment_effect, se);
 
     Ok(RDSurvivalResult {
         treatment_effect,

--- a/src/causal/ipcw.rs
+++ b/src/causal/ipcw.rs
@@ -1,5 +1,7 @@
 use pyo3::prelude::*;
 
+use crate::constants::{DIVISION_FLOOR, Z_SCORE_95, normal_ci_95, same_time};
+
 #[derive(Debug, Clone)]
 #[pyclass(from_py_object)]
 pub struct IPCWInput {
@@ -139,7 +141,7 @@ fn fit_logistic_model(
 
         let mut max_change: f64 = 0.0;
         for j in 0..p {
-            if hessian_diag[j].abs() > crate::constants::DIVISION_FLOOR {
+            if hessian_diag[j].abs() > DIVISION_FLOOR {
                 let update = gradient[j] / hessian_diag[j];
                 beta[j] += update;
                 max_change = max_change.max(update.abs());
@@ -206,7 +208,7 @@ fn compute_ipcw_weights_typed(input: &IPCWInput, config: &IPCWConfig) -> PyResul
         let mut y_risk = Vec::with_capacity(at_risk.len());
         let mut has_events = false;
         for &i in at_risk {
-            let yi = if (time[i] - t).abs() < crate::constants::DIVISION_FLOOR && censored[i] == 1 {
+            let yi = if (time[i] - t).abs() < DIVISION_FLOOR && censored[i] == 1 {
                 1
             } else {
                 0
@@ -289,7 +291,7 @@ fn compute_km_censoring(time: &[f64], status: &[i32], n: usize) -> Vec<f64> {
         let mut censored_count = 0;
 
         let start_i = i;
-        while i < n && (time[indices[i]] - current_time).abs() < crate::constants::TIME_EPSILON {
+        while i < n && same_time(time[indices[i]], current_time) {
             if status[indices[i]] == 0 {
                 censored_count += 1;
             }
@@ -373,9 +375,7 @@ fn ipcw_treatment_effect_typed(input: IPCWTreatmentInput) -> PyResult<IPCWResult
     }
 
     let std_error = (var_sum / (n_treated + n_control).powi(2)).sqrt();
-    let z = 1.96;
-    let ci_lower = treatment_effect - z * std_error;
-    let ci_upper = treatment_effect + z * std_error;
+    let (ci_lower, ci_upper) = normal_ci_95(treatment_effect, std_error);
 
     Ok(IPCWResult {
         weights: ipcw.weights,
@@ -457,7 +457,7 @@ pub fn ipcw_kaplan_meier(
         variance.push(var);
     }
 
-    let ci_width: Vec<f64> = variance.iter().map(|&v| 1.96 * v.sqrt()).collect();
+    let ci_width: Vec<f64> = variance.iter().map(|&v| Z_SCORE_95 * v.sqrt()).collect();
 
     Ok((time_points, survival, ci_width))
 }

--- a/src/causal/msm.rs
+++ b/src/causal/msm.rs
@@ -1,5 +1,7 @@
 use pyo3::prelude::*;
 
+use crate::constants::exp_ci_bounds_95;
+
 #[derive(Debug, Clone)]
 #[pyclass(from_py_object)]
 pub struct MSMResult {
@@ -279,18 +281,7 @@ pub fn marginal_structural_model(
 
     let hazard_ratios: Vec<f64> = coefficients.iter().map(|&b| b.exp()).collect();
 
-    let z = 1.96;
-    let hr_ci_lower: Vec<f64> = coefficients
-        .iter()
-        .zip(std_errors.iter())
-        .map(|(&b, &se)| (b - z * se).exp())
-        .collect();
-
-    let hr_ci_upper: Vec<f64> = coefficients
-        .iter()
-        .zip(std_errors.iter())
-        .map(|(&b, &se)| (b + z * se).exp())
-        .collect();
+    let (hr_ci_lower, hr_ci_upper) = exp_ci_bounds_95(&coefficients, &std_errors);
 
     Ok(MSMResult {
         coefficients,

--- a/src/causal/target_trial.rs
+++ b/src/causal/target_trial.rs
@@ -1,6 +1,8 @@
 use pyo3::prelude::*;
 use rayon::prelude::*;
 
+use crate::constants::{exp_ci_95, normal_ci_95};
+
 #[derive(Debug, Clone)]
 #[pyclass(from_py_object)]
 pub struct TargetTrialResult {
@@ -310,11 +312,8 @@ pub fn target_trial_emulation(
         config,
     );
 
-    let z = 1.96;
-    let hr_ci_lower = (hazard_ratio.ln() - z * hr_se).exp();
-    let hr_ci_upper = (hazard_ratio.ln() + z * hr_se).exp();
-    let rd_ci_lower = risk_difference - z * rd_se;
-    let rd_ci_upper = risk_difference + z * rd_se;
+    let (hr_ci_lower, hr_ci_upper) = exp_ci_95(hazard_ratio.ln(), hr_se);
+    let (rd_ci_lower, rd_ci_upper) = normal_ci_95(risk_difference, rd_se);
 
     let weights: Vec<f64> = all_clones.iter().map(|c| c.weight).collect();
 

--- a/src/causal/tmle.rs
+++ b/src/causal/tmle.rs
@@ -1,5 +1,6 @@
 use pyo3::prelude::*;
 
+use crate::constants::{DIVISION_FLOOR, normal_ci_95};
 use crate::internal::statistical::normal_cdf;
 
 #[derive(Debug, Clone)]
@@ -288,11 +289,10 @@ pub fn tmle_ate(
         / (n * (n - 1)) as f64;
     let se = var.sqrt();
 
-    let z = ate / se.max(crate::constants::DIVISION_FLOOR);
+    let z = ate / se.max(DIVISION_FLOOR);
     let pvalue = 2.0 * (1.0 - normal_cdf(z.abs()));
 
-    let ci_lower = ate - 1.96 * se;
-    let ci_upper = ate + 1.96 * se;
+    let (ci_lower, ci_upper) = normal_ci_95(ate, se);
 
     Ok(TMLEResult {
         ate,
@@ -453,8 +453,9 @@ pub fn tmle_survival(
 
         survival_diff.push(diff);
         se_vec.push(se);
-        ci_lower.push(diff - 1.96 * se);
-        ci_upper.push(diff + 1.96 * se);
+        let (lower, upper) = normal_ci_95(diff, se);
+        ci_lower.push(lower);
+        ci_upper.push(upper);
     }
 
     let mut rmst_diff = 0.0;

--- a/src/concordance/basic.rs
+++ b/src/concordance/basic.rs
@@ -1,30 +1,24 @@
 use crate::constants::{CONCORDANCE_COUNT_SIZE, PARALLEL_THRESHOLD_LARGE, TIME_EPSILON};
 use crate::internal::statistical::{
-    ConcordanceSummary, concordance_index_with_horizon, concordance_summary_with_horizon,
-    counting_process_concordance_index, counting_process_concordance_summary,
+    ConcordanceSummary, ConcordanceTimeWeight, concordance_index_with_horizon,
+    concordance_summary_with_horizon, concordance_summary_with_horizon_and_weights,
+    concordance_summary_with_horizon_weights_and_time_weight, counting_process_concordance_index,
+    counting_process_concordance_summary, counting_process_concordance_summary_with_weights,
+    counting_process_concordance_summary_with_weights_and_time_weight,
 };
-use crate::internal::validation::{validate_finite, validate_no_nan, validate_non_negative};
+use crate::internal::validation::{
+    validate_binary_i32, validate_finite, validate_no_nan, validate_non_negative,
+};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use rayon::prelude::*;
 
-fn validate_binary_status(status: &[i32]) -> PyResult<()> {
-    for (idx, &value) in status.iter().enumerate() {
-        if value != 0 && value != 1 {
-            return Err(PyValueError::new_err(format!(
-                "status must contain only 0/1 values; found {} at observation {}",
-                value, idx
-            )));
-        }
-    }
-    Ok(())
-}
-
 fn validate_right_concordance_inputs(
     time: &[f64],
     status: &[i32],
     risk_scores: &[f64],
+    weights: Option<&[f64]>,
 ) -> PyResult<()> {
     if time.len() != status.len() || time.len() != risk_scores.len() {
         return Err(PyValueError::new_err(
@@ -36,7 +30,17 @@ fn validate_right_concordance_inputs(
     validate_non_negative(time, "time")?;
     validate_no_nan(risk_scores, "risk_scores")?;
     validate_finite(risk_scores, "risk_scores")?;
-    validate_binary_status(status)?;
+    validate_binary_i32(status, "status")?;
+    if let Some(values) = weights {
+        if values.len() != time.len() {
+            return Err(PyValueError::new_err(
+                "weights must have the same length as time",
+            ));
+        }
+        validate_no_nan(values, "weights")?;
+        validate_finite(values, "weights")?;
+        validate_non_negative(values, "weights")?;
+    }
     Ok(())
 }
 
@@ -45,6 +49,7 @@ fn validate_counting_concordance_inputs(
     stop: &[f64],
     status: &[i32],
     risk_scores: &[f64],
+    weights: Option<&[f64]>,
 ) -> PyResult<()> {
     if start.len() != stop.len() || start.len() != status.len() || start.len() != risk_scores.len()
     {
@@ -60,7 +65,17 @@ fn validate_counting_concordance_inputs(
     validate_non_negative(stop, "stop")?;
     validate_no_nan(risk_scores, "risk_scores")?;
     validate_finite(risk_scores, "risk_scores")?;
-    validate_binary_status(status)?;
+    validate_binary_i32(status, "status")?;
+    if let Some(values) = weights {
+        if values.len() != start.len() {
+            return Err(PyValueError::new_err(
+                "weights must have the same length as start",
+            ));
+        }
+        validate_no_nan(values, "weights")?;
+        validate_finite(values, "weights")?;
+        validate_non_negative(values, "weights")?;
+    }
 
     for (idx, (&entry, &exit)) in start.iter().zip(stop.iter()).enumerate() {
         if entry >= exit - TIME_EPSILON {
@@ -73,17 +88,58 @@ fn validate_counting_concordance_inputs(
     Ok(())
 }
 
+fn parse_concordance_time_weight(timewt: &str) -> PyResult<ConcordanceTimeWeight> {
+    match timewt {
+        "n" => Ok(ConcordanceTimeWeight::N),
+        "S" => Ok(ConcordanceTimeWeight::S),
+        "S/G" => Ok(ConcordanceTimeWeight::SOverG),
+        "n/G2" => Ok(ConcordanceTimeWeight::NOverG2),
+        "I" => Ok(ConcordanceTimeWeight::I),
+        _ => Err(PyValueError::new_err(
+            "timewt must be one of 'n', 'S', 'S/G', 'n/G2', 'I'",
+        )),
+    }
+}
+
+fn parse_counting_concordance_time_weight(timewt: &str) -> PyResult<ConcordanceTimeWeight> {
+    match parse_concordance_time_weight(timewt)? {
+        ConcordanceTimeWeight::SOverG | ConcordanceTimeWeight::NOverG2 => {
+            Err(PyValueError::new_err(
+                "S/G and n/G2 timewt options are not supported for counting-process data",
+            ))
+        }
+        value => Ok(value),
+    }
+}
+
 /// Compute Harrell's concordance index for survival predictions.
 #[pyfunction]
-pub fn concordance_index(time: Vec<f64>, status: Vec<i32>, risk_scores: Vec<f64>) -> PyResult<f64> {
-    validate_right_concordance_inputs(&time, &status, &risk_scores)?;
+#[pyo3(signature = (time, status, risk_scores, weights=None, timewt="n".to_string()))]
+pub fn concordance_index(
+    time: Vec<f64>,
+    status: Vec<i32>,
+    risk_scores: Vec<f64>,
+    weights: Option<Vec<f64>>,
+    timewt: String,
+) -> PyResult<f64> {
+    validate_right_concordance_inputs(&time, &status, &risk_scores, weights.as_deref())?;
+    let time_weight = parse_concordance_time_weight(&timewt)?;
 
-    Ok(concordance_index_with_horizon(
-        &risk_scores,
-        &time,
-        &status,
-        None,
-    ))
+    Ok(
+        if time_weight == ConcordanceTimeWeight::N && weights.is_none() {
+            concordance_index_with_horizon(&risk_scores, &time, &status, None)
+        } else {
+            concordance_summary_with_horizon_weights_and_time_weight(
+                &risk_scores,
+                &time,
+                &status,
+                weights.as_deref(),
+                None,
+                time_weight,
+            )
+            .c_index()
+        },
+    )
 }
 
 fn build_concordance_summary_dict(summary: ConcordanceSummary) -> PyResult<Py<PyDict>> {
@@ -98,55 +154,106 @@ fn build_concordance_summary_dict(summary: ConcordanceSummary) -> PyResult<Py<Py
 
 /// Compute Harrell's concordance index and pair counts for survival predictions.
 #[pyfunction]
+#[pyo3(signature = (time, status, risk_scores, weights=None, timewt="n".to_string()))]
 pub fn concordance_summary(
     time: Vec<f64>,
     status: Vec<i32>,
     risk_scores: Vec<f64>,
+    weights: Option<Vec<f64>>,
+    timewt: String,
 ) -> PyResult<Py<PyDict>> {
-    validate_right_concordance_inputs(&time, &status, &risk_scores)?;
+    validate_right_concordance_inputs(&time, &status, &risk_scores, weights.as_deref())?;
+    let time_weight = parse_concordance_time_weight(&timewt)?;
 
-    build_concordance_summary_dict(concordance_summary_with_horizon(
-        &risk_scores,
-        &time,
-        &status,
-        None,
-    ))
+    build_concordance_summary_dict(if time_weight == ConcordanceTimeWeight::N {
+        match weights.as_deref() {
+            Some(values) => concordance_summary_with_horizon_and_weights(
+                &risk_scores,
+                &time,
+                &status,
+                Some(values),
+                None,
+            ),
+            None => concordance_summary_with_horizon(&risk_scores, &time, &status, None),
+        }
+    } else {
+        concordance_summary_with_horizon_weights_and_time_weight(
+            &risk_scores,
+            &time,
+            &status,
+            weights.as_deref(),
+            None,
+            time_weight,
+        )
+    })
 }
 
 /// Compute Harrell's concordance index for counting-process survival data.
 #[pyfunction]
+#[pyo3(signature = (start, stop, status, risk_scores, weights=None, timewt="n".to_string()))]
 pub fn counting_concordance_index(
     start: Vec<f64>,
     stop: Vec<f64>,
     status: Vec<i32>,
     risk_scores: Vec<f64>,
+    weights: Option<Vec<f64>>,
+    timewt: String,
 ) -> PyResult<f64> {
-    validate_counting_concordance_inputs(&start, &stop, &status, &risk_scores)?;
+    validate_counting_concordance_inputs(&start, &stop, &status, &risk_scores, weights.as_deref())?;
+    let time_weight = parse_counting_concordance_time_weight(&timewt)?;
 
-    Ok(counting_process_concordance_index(
-        &risk_scores,
-        &start,
-        &stop,
-        &status,
-    ))
+    Ok(
+        if time_weight == ConcordanceTimeWeight::N && weights.is_none() {
+            counting_process_concordance_index(&risk_scores, &start, &stop, &status)
+        } else {
+            counting_process_concordance_summary_with_weights_and_time_weight(
+                &risk_scores,
+                &start,
+                &stop,
+                &status,
+                weights.as_deref(),
+                time_weight,
+            )
+            .c_index()
+        },
+    )
 }
 
 /// Compute Harrell's concordance index and pair counts for counting-process data.
 #[pyfunction]
+#[pyo3(signature = (start, stop, status, risk_scores, weights=None, timewt="n".to_string()))]
 pub fn counting_concordance_summary(
     start: Vec<f64>,
     stop: Vec<f64>,
     status: Vec<i32>,
     risk_scores: Vec<f64>,
+    weights: Option<Vec<f64>>,
+    timewt: String,
 ) -> PyResult<Py<PyDict>> {
-    validate_counting_concordance_inputs(&start, &stop, &status, &risk_scores)?;
+    validate_counting_concordance_inputs(&start, &stop, &status, &risk_scores, weights.as_deref())?;
+    let time_weight = parse_counting_concordance_time_weight(&timewt)?;
 
-    build_concordance_summary_dict(counting_process_concordance_summary(
-        &risk_scores,
-        &start,
-        &stop,
-        &status,
-    ))
+    build_concordance_summary_dict(if time_weight == ConcordanceTimeWeight::N {
+        match weights.as_deref() {
+            Some(values) => counting_process_concordance_summary_with_weights(
+                &risk_scores,
+                &start,
+                &stop,
+                &status,
+                Some(values),
+            ),
+            None => counting_process_concordance_summary(&risk_scores, &start, &stop, &status),
+        }
+    } else {
+        counting_process_concordance_summary_with_weights_and_time_weight(
+            &risk_scores,
+            &start,
+            &stop,
+            &status,
+            weights.as_deref(),
+            time_weight,
+        )
+    })
 }
 
 /// Compute concordance statistics for survival predictions.
@@ -283,7 +390,7 @@ mod tests {
     fn validate_right_concordance_rejects_malformed_inputs() {
         initialize_python();
 
-        let status_err = validate_right_concordance_inputs(&[1.0, 2.0], &[1, 2], &[0.4, 0.1])
+        let status_err = validate_right_concordance_inputs(&[1.0, 2.0], &[1, 2], &[0.4, 0.1], None)
             .expect_err("non-binary status should be rejected");
         assert!(
             status_err
@@ -292,31 +399,61 @@ mod tests {
         );
 
         let time_err =
-            validate_right_concordance_inputs(&[1.0, f64::INFINITY], &[1, 0], &[0.4, 0.1])
+            validate_right_concordance_inputs(&[1.0, f64::INFINITY], &[1, 0], &[0.4, 0.1], None)
                 .expect_err("non-finite time should be rejected");
         assert!(time_err.to_string().contains("time contains non-finite"));
 
-        let risk_err = validate_right_concordance_inputs(&[1.0, 2.0], &[1, 0], &[0.4, f64::NAN])
-            .expect_err("NaN risk score should be rejected");
+        let risk_err =
+            validate_right_concordance_inputs(&[1.0, 2.0], &[1, 0], &[0.4, f64::NAN], None)
+                .expect_err("NaN risk score should be rejected");
         assert!(risk_err.to_string().contains("risk_scores contains NaN"));
+
+        let weight_err = validate_right_concordance_inputs(
+            &[1.0, 2.0],
+            &[1, 0],
+            &[0.4, 0.1],
+            Some(&[1.0, -1.0]),
+        )
+        .expect_err("negative weights should be rejected");
+        assert!(weight_err.to_string().contains("weights contains negative"));
     }
 
     #[test]
     fn validate_counting_concordance_rejects_malformed_inputs() {
         initialize_python();
 
-        let interval_err =
-            validate_counting_concordance_inputs(&[0.0, 2.0], &[1.0, 2.0], &[1, 0], &[0.4, 0.1])
-                .expect_err("zero-width counting interval should be rejected");
+        let interval_err = validate_counting_concordance_inputs(
+            &[0.0, 2.0],
+            &[1.0, 2.0],
+            &[1, 0],
+            &[0.4, 0.1],
+            None,
+        )
+        .expect_err("zero-width counting interval should be rejected");
         assert!(
             interval_err
                 .to_string()
                 .contains("start must be less than stop")
         );
 
-        let start_err =
-            validate_counting_concordance_inputs(&[-0.1, 0.0], &[1.0, 2.0], &[1, 0], &[0.4, 0.1])
-                .expect_err("negative start time should be rejected");
+        let start_err = validate_counting_concordance_inputs(
+            &[-0.1, 0.0],
+            &[1.0, 2.0],
+            &[1, 0],
+            &[0.4, 0.1],
+            None,
+        )
+        .expect_err("negative start time should be rejected");
         assert!(start_err.to_string().contains("start contains negative"));
+
+        let weight_err = validate_counting_concordance_inputs(
+            &[0.0, 0.0],
+            &[1.0, 2.0],
+            &[1, 0],
+            &[0.4, 0.1],
+            Some(&[1.0, f64::NAN]),
+        )
+        .expect_err("NaN weights should be rejected");
+        assert!(weight_err.to_string().contains("weights contains NaN"));
     }
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -35,6 +35,130 @@ pub fn z_score_for_confidence(confidence_level: f64) -> f64 {
     }
 }
 
+#[inline]
+pub fn normal_ci(estimate: f64, standard_error: f64, z_score: f64) -> (f64, f64) {
+    (
+        estimate - z_score * standard_error,
+        estimate + z_score * standard_error,
+    )
+}
+
+#[inline]
+pub fn clamped_normal_ci(
+    estimate: f64,
+    standard_error: f64,
+    z_score: f64,
+    lower_bound: f64,
+    upper_bound: f64,
+) -> (f64, f64) {
+    let (lower, upper) = normal_ci(estimate, standard_error, z_score);
+    (
+        lower.clamp(lower_bound, upper_bound),
+        upper.clamp(lower_bound, upper_bound),
+    )
+}
+
+#[inline]
+pub fn normal_ci_95(estimate: f64, standard_error: f64) -> (f64, f64) {
+    normal_ci(estimate, standard_error, Z_SCORE_95)
+}
+
+#[inline]
+pub fn clamped_normal_ci_95(
+    estimate: f64,
+    standard_error: f64,
+    lower_bound: f64,
+    upper_bound: f64,
+) -> (f64, f64) {
+    clamped_normal_ci(
+        estimate,
+        standard_error,
+        Z_SCORE_95,
+        lower_bound,
+        upper_bound,
+    )
+}
+
+#[inline]
+pub fn exp_ci(log_estimate: f64, standard_error: f64, z_score: f64) -> (f64, f64) {
+    let (lower, upper) = normal_ci(log_estimate, standard_error, z_score);
+    (lower.exp(), upper.exp())
+}
+
+#[inline]
+pub fn exp_ci_95(log_estimate: f64, standard_error: f64) -> (f64, f64) {
+    exp_ci(log_estimate, standard_error, Z_SCORE_95)
+}
+
+#[inline]
+pub fn normal_ci_bounds_95(estimates: &[f64], standard_errors: &[f64]) -> (Vec<f64>, Vec<f64>) {
+    normal_ci_bounds(estimates, standard_errors, Z_SCORE_95)
+}
+
+#[inline]
+pub fn normal_ci_bounds(
+    estimates: &[f64],
+    standard_errors: &[f64],
+    z_score: f64,
+) -> (Vec<f64>, Vec<f64>) {
+    estimates
+        .iter()
+        .zip(standard_errors.iter())
+        .map(|(&estimate, &standard_error)| normal_ci(estimate, standard_error, z_score))
+        .unzip()
+}
+
+#[inline]
+pub fn clamped_normal_ci_bounds_95(
+    estimates: &[f64],
+    standard_errors: &[f64],
+    lower_bound: f64,
+    upper_bound: f64,
+) -> (Vec<f64>, Vec<f64>) {
+    clamped_normal_ci_bounds(
+        estimates,
+        standard_errors,
+        Z_SCORE_95,
+        lower_bound,
+        upper_bound,
+    )
+}
+
+#[inline]
+pub fn clamped_normal_ci_bounds(
+    estimates: &[f64],
+    standard_errors: &[f64],
+    z_score: f64,
+    lower_bound: f64,
+    upper_bound: f64,
+) -> (Vec<f64>, Vec<f64>) {
+    estimates
+        .iter()
+        .zip(standard_errors.iter())
+        .map(|(&estimate, &standard_error)| {
+            clamped_normal_ci(estimate, standard_error, z_score, lower_bound, upper_bound)
+        })
+        .unzip()
+}
+
+#[inline]
+pub fn exp_ci_bounds_95(log_estimates: &[f64], standard_errors: &[f64]) -> (Vec<f64>, Vec<f64>) {
+    exp_ci_bounds(log_estimates, standard_errors, Z_SCORE_95)
+}
+
+#[inline]
+pub fn exp_ci_bounds(
+    log_estimates: &[f64],
+    standard_errors: &[f64],
+    z_score: f64,
+) -> (Vec<f64>, Vec<f64>) {
+    log_estimates
+        .iter()
+        .zip(standard_errors.iter())
+        .map(|(&log_estimate, &standard_error)| exp_ci(log_estimate, standard_error, z_score))
+        .unzip()
+}
+
 pub const PARALLEL_THRESHOLD_SMALL: usize = 100;
 pub const PARALLEL_THRESHOLD_MEDIUM: usize = 500;
 pub const PARALLEL_THRESHOLD_LARGE: usize = 1000;
@@ -47,6 +171,17 @@ pub const LINEAR_PRED_CLAMP_MAX: f64 = 20.0;
 
 pub const EXP_CLAMP_MIN: f64 = -100.0;
 pub const EXP_CLAMP_MAX: f64 = 100.0;
+
+#[inline]
+pub fn exp_clamped(value: f64) -> f64 {
+    value.clamp(EXP_CLAMP_MIN, EXP_CLAMP_MAX).exp()
+}
+
+#[inline]
+pub fn exp_clamped_ci(log_estimate: f64, standard_error: f64, z_score: f64) -> (f64, f64) {
+    let (lower, upper) = normal_ci(log_estimate, standard_error, z_score);
+    (exp_clamped(lower), exp_clamped(upper))
+}
 
 pub const CONVERGENCE_FLAG: i32 = 1000;
 
@@ -82,3 +217,8 @@ pub const HARTLEY_B5: f64 = 1.330274;
 
 pub const ROYSTON_KAPPA_FACTOR: f64 = 8.0;
 pub const ROYSTON_VARIANCE_FACTOR: f64 = 6.0;
+
+#[inline]
+pub fn same_time(left: f64, right: f64) -> bool {
+    (left - right).abs() < TIME_EPSILON
+}

--- a/src/core/coxcount1.rs
+++ b/src/core/coxcount1.rs
@@ -1,5 +1,7 @@
 use pyo3::prelude::*;
 
+use crate::internal::validation::validate_binary_f64;
+
 fn value_error(message: impl Into<String>) -> PyErr {
     pyo3::exceptions::PyValueError::new_err(message.into())
 }
@@ -18,17 +20,6 @@ fn validate_finite(values: &[f64], name: &str) -> PyResult<()> {
         if !value.is_finite() {
             return Err(value_error(format!(
                 "{name} must contain only finite values; got {value} at index {idx}"
-            )));
-        }
-    }
-    Ok(())
-}
-
-fn validate_binary_status(values: &[f64]) -> PyResult<()> {
-    for (idx, &value) in values.iter().enumerate() {
-        if value != 0.0 && value != 1.0 {
-            return Err(value_error(format!(
-                "status values must be 0 or 1; got {value} at index {idx}"
             )));
         }
     }
@@ -67,7 +58,7 @@ fn validate_coxcount1_inputs(time: &[f64], status: &[f64], strata: &[i32]) -> Py
     validate_same_length(n, status.len(), "status")?;
     validate_same_length(n, strata.len(), "strata")?;
     validate_finite(time, "time")?;
-    validate_binary_status(status)?;
+    validate_binary_f64(status, "status")?;
     validate_strata_markers(strata, n)
 }
 
@@ -87,7 +78,7 @@ fn validate_coxcount2_inputs(
     validate_same_length(n, strata.len(), "strata")?;
     validate_finite(time1, "time1")?;
     validate_finite(time2, "time2")?;
-    validate_binary_status(status)?;
+    validate_binary_f64(status, "status")?;
     validate_strata_markers(strata, n)?;
     validate_sort_indices(sort1, n, "sort1")?;
     validate_sort_indices(sort2, n, "sort2")
@@ -350,7 +341,7 @@ mod tests {
             Err(err) => err,
         };
 
-        assert!(err.to_string().contains("status values must be 0 or 1"));
+        assert!(err.to_string().contains("status must contain only 0/1"));
     }
 
     #[test]

--- a/src/data_prep/rttright.rs
+++ b/src/data_prep/rttright.rs
@@ -2,7 +2,9 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use std::collections::BTreeMap;
 
-use crate::internal::validation::{validate_finite, validate_no_nan, validate_non_negative};
+use crate::internal::validation::{
+    validate_binary_i32, validate_finite, validate_no_nan, validate_non_negative,
+};
 
 /// Result of redistribute-to-the-right weight calculation
 #[derive(Debug, Clone)]
@@ -93,14 +95,7 @@ fn validate_rttright_inputs(time: &[f64], status: &[i32], weights: &[f64]) -> Py
     validate_finite(weights, "weights")?;
     validate_non_negative(weights, "weights")?;
 
-    for (index, &status_value) in status.iter().enumerate() {
-        if status_value != 0 && status_value != 1 {
-            return Err(PyValueError::new_err(format!(
-                "status must contain only 0/1 values; got {} at index {}",
-                status_value, index
-            )));
-        }
-    }
+    validate_binary_i32(status, "status")?;
 
     Ok(())
 }

--- a/src/data_prep/surv2data.rs
+++ b/src/data_prep/surv2data.rs
@@ -8,7 +8,7 @@ use pyo3::prelude::*;
 use std::collections::HashMap;
 
 use crate::constants::TIME_EPSILON;
-use crate::internal::validation::{validate_finite, validate_no_nan};
+use crate::internal::validation::{validate_binary_i32, validate_finite, validate_no_nan};
 
 /// Result of converting timecourse data to interval format
 #[pyclass(from_py_object)]
@@ -86,7 +86,7 @@ pub fn surv2data(
         validate_finite(etimes, "event_time")?;
     }
     if let Some(estatus) = &event_status {
-        validate_binary_status("event_status", estatus)?;
+        validate_binary_i32(estatus, "event_status")?;
     }
 
     if n == 0 {
@@ -190,18 +190,6 @@ pub fn surv2data(
     }
 
     Ok(result)
-}
-
-fn validate_binary_status(field: &str, status: &[i32]) -> PyResult<()> {
-    for (index, &status_value) in status.iter().enumerate() {
-        if status_value != 0 && status_value != 1 {
-            return Err(PyValueError::new_err(format!(
-                "{} must contain only 0/1 values; got {} at index {}",
-                field, status_value, index
-            )));
-        }
-    }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/src/data_prep/survcondense.rs
+++ b/src/data_prep/survcondense.rs
@@ -7,7 +7,7 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
 use crate::constants::TIME_EPSILON;
-use crate::internal::validation::{validate_finite, validate_no_nan};
+use crate::internal::validation::{validate_binary_i32, validate_finite, validate_no_nan};
 
 /// Result of condensing survival data
 #[pyclass(from_py_object)]
@@ -74,7 +74,7 @@ pub fn survcondense(
     validate_finite(&time1, "time1")?;
     validate_no_nan(&time2, "time2")?;
     validate_finite(&time2, "time2")?;
-    validate_binary_status("status", &status)?;
+    validate_binary_i32(&status, "status")?;
     for (index, (&start, &stop)) in time1.iter().zip(time2.iter()).enumerate() {
         if start > stop + TIME_EPSILON {
             return Err(PyValueError::new_err(format!(
@@ -150,18 +150,6 @@ pub fn survcondense(
     }
 
     Ok(result)
-}
-
-fn validate_binary_status(field: &str, status: &[i32]) -> PyResult<()> {
-    for (index, &status_value) in status.iter().enumerate() {
-        if status_value != 0 && status_value != 1 {
-            return Err(PyValueError::new_err(format!(
-                "{} must contain only 0/1 values; got {} at index {}",
-                field, status_value, index
-            )));
-        }
-    }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/src/internal/statistical.rs
+++ b/src/internal/statistical.rs
@@ -11,6 +11,15 @@ pub(crate) struct ConcordanceSummary {
     pub(crate) comparable: f64,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ConcordanceTimeWeight {
+    N,
+    S,
+    SOverG,
+    NOverG2,
+    I,
+}
+
 impl ConcordanceSummary {
     #[inline]
     pub(crate) fn c_index(self) -> f64 {
@@ -76,8 +85,39 @@ pub(crate) fn concordance_summary_with_horizon(
     event: &[i32],
     horizon: Option<f64>,
 ) -> ConcordanceSummary {
+    concordance_summary_with_horizon_and_weights(risk_scores, time, event, None, horizon)
+}
+
+pub(crate) fn concordance_summary_with_horizon_and_weights(
+    risk_scores: &[f64],
+    time: &[f64],
+    event: &[i32],
+    weights: Option<&[f64]>,
+    horizon: Option<f64>,
+) -> ConcordanceSummary {
+    concordance_summary_with_horizon_weights_and_time_weight(
+        risk_scores,
+        time,
+        event,
+        weights,
+        horizon,
+        ConcordanceTimeWeight::N,
+    )
+}
+
+pub(crate) fn concordance_summary_with_horizon_weights_and_time_weight(
+    risk_scores: &[f64],
+    time: &[f64],
+    event: &[i32],
+    weights: Option<&[f64]>,
+    horizon: Option<f64>,
+    time_weight: ConcordanceTimeWeight,
+) -> ConcordanceSummary {
     let n = risk_scores.len();
     if n < 2 || time.len() != n || event.len() != n {
+        return ConcordanceSummary::default();
+    }
+    if weights.is_some_and(|values| values.len() != n) {
         return ConcordanceSummary::default();
     }
 
@@ -85,10 +125,17 @@ pub(crate) fn concordance_summary_with_horizon(
         || risk_scores.iter().any(|value| !value.is_finite())
         || horizon.is_some_and(|value| !value.is_finite())
     {
-        return concordance_summary_quadratic(risk_scores, time, event, horizon);
+        return concordance_summary_quadratic(
+            risk_scores,
+            time,
+            event,
+            weights,
+            horizon,
+            time_weight,
+        );
     }
 
-    concordance_summary_ranked(risk_scores, time, event, horizon)
+    concordance_summary_ranked(risk_scores, time, event, weights, horizon, time_weight)
 }
 
 pub(crate) fn counting_process_concordance_index(
@@ -106,8 +153,39 @@ pub(crate) fn counting_process_concordance_summary(
     stop: &[f64],
     event: &[i32],
 ) -> ConcordanceSummary {
+    counting_process_concordance_summary_with_weights(risk_scores, start, stop, event, None)
+}
+
+pub(crate) fn counting_process_concordance_summary_with_weights(
+    risk_scores: &[f64],
+    start: &[f64],
+    stop: &[f64],
+    event: &[i32],
+    weights: Option<&[f64]>,
+) -> ConcordanceSummary {
+    counting_process_concordance_summary_with_weights_and_time_weight(
+        risk_scores,
+        start,
+        stop,
+        event,
+        weights,
+        ConcordanceTimeWeight::N,
+    )
+}
+
+pub(crate) fn counting_process_concordance_summary_with_weights_and_time_weight(
+    risk_scores: &[f64],
+    start: &[f64],
+    stop: &[f64],
+    event: &[i32],
+    weights: Option<&[f64]>,
+    time_weight: ConcordanceTimeWeight,
+) -> ConcordanceSummary {
     let n = risk_scores.len();
     if n < 2 || start.len() != n || stop.len() != n || event.len() != n {
+        return ConcordanceSummary::default();
+    }
+    if weights.is_some_and(|values| values.len() != n) {
         return ConcordanceSummary::default();
     }
 
@@ -115,7 +193,14 @@ pub(crate) fn counting_process_concordance_summary(
         || stop.iter().any(|value| !value.is_finite())
         || risk_scores.iter().any(|value| !value.is_finite())
     {
-        return counting_process_concordance_summary_quadratic(risk_scores, start, stop, event);
+        return counting_process_concordance_summary_quadratic(
+            risk_scores,
+            start,
+            stop,
+            event,
+            weights,
+            time_weight,
+        );
     }
 
     let mut risk_levels = risk_scores.to_vec();
@@ -134,6 +219,12 @@ pub(crate) fn counting_process_concordance_summary(
     event_times.sort_by(f64::total_cmp);
     event_times.dedup();
 
+    let event_time_multipliers = if time_weight == ConcordanceTimeWeight::N {
+        Vec::new()
+    } else {
+        counting_process_time_weight_multipliers(start, stop, event, weights, time_weight)
+    };
+
     let mut at_risk = FenwickTree::new(risk_levels.len());
     let mut active = vec![false; n];
     let mut start_cursor = 0usize;
@@ -146,31 +237,48 @@ pub(crate) fn counting_process_concordance_summary(
             let idx = start_order[start_cursor];
             if !active[idx] {
                 let rank = risk_levels.partition_point(|&risk| risk < risk_scores[idx]);
-                at_risk.update(rank, 1.0);
+                at_risk.update(rank, observation_weight(weights, idx));
                 active[idx] = true;
             }
             start_cursor += 1;
         }
 
+        while stop_cursor < n && stop[stop_order[stop_cursor]] < event_time {
+            let idx = stop_order[stop_cursor];
+            if active[idx] {
+                let rank = risk_levels.partition_point(|&risk| risk < risk_scores[idx]);
+                at_risk.update(rank, -observation_weight(weights, idx));
+                active[idx] = false;
+            }
+            stop_cursor += 1;
+        }
+
+        let event_time_multiplier = if time_weight == ConcordanceTimeWeight::N {
+            1.0
+        } else {
+            event_time_multiplier_at(&event_time_multipliers, event_time)
+        };
+
         while stop_cursor < n && stop[stop_order[stop_cursor]] <= event_time {
             let idx = stop_order[stop_cursor];
             if active[idx] {
                 let rank = risk_levels.partition_point(|&risk| risk < risk_scores[idx]);
-                at_risk.update(rank, -1.0);
+                at_risk.update(rank, -observation_weight(weights, idx));
                 active[idx] = false;
             }
             stop_cursor += 1;
         }
 
         let at_risk_total = at_risk.total();
-        if at_risk_total <= 0.0 {
+        if at_risk_total <= 0.0 || event_time_multiplier <= 0.0 {
             continue;
         }
         for idx in 0..n {
             if event[idx] == 1 && stop[idx] == event_time {
-                comparable += at_risk_total;
-                concordant +=
-                    concordance_contribution_for_rank(&at_risk, &risk_levels, risk_scores[idx]);
+                let event_weight = observation_weight(weights, idx) * event_time_multiplier;
+                comparable += event_weight * at_risk_total;
+                concordant += event_weight
+                    * concordance_contribution_for_rank(&at_risk, &risk_levels, risk_scores[idx]);
             }
         }
     }
@@ -188,7 +296,15 @@ fn counting_process_concordance_quadratic(
     stop: &[f64],
     event: &[i32],
 ) -> f64 {
-    counting_process_concordance_summary_quadratic(risk_scores, start, stop, event).c_index()
+    counting_process_concordance_summary_quadratic(
+        risk_scores,
+        start,
+        stop,
+        event,
+        None,
+        ConcordanceTimeWeight::N,
+    )
+    .c_index()
 }
 
 fn counting_process_concordance_summary_quadratic(
@@ -196,27 +312,45 @@ fn counting_process_concordance_summary_quadratic(
     start: &[f64],
     stop: &[f64],
     event: &[i32],
+    weights: Option<&[f64]>,
+    time_weight: ConcordanceTimeWeight,
 ) -> ConcordanceSummary {
     let n = risk_scores.len();
     let mut concordant = 0.0;
     let mut comparable = 0.0;
+    let event_time_multipliers = if time_weight == ConcordanceTimeWeight::N {
+        Vec::new()
+    } else {
+        counting_process_time_weight_multipliers(start, stop, event, weights, time_weight)
+    };
 
     for event_idx in 0..n {
         if event[event_idx] != 1 {
             continue;
         }
         let event_time = stop[event_idx];
+        let event_time_multiplier = if time_weight == ConcordanceTimeWeight::N {
+            1.0
+        } else {
+            event_time_multiplier_at(&event_time_multipliers, event_time)
+        };
+        if event_time_multiplier <= 0.0 {
+            continue;
+        }
         for risk_idx in 0..n {
             if risk_idx == event_idx {
                 continue;
             }
             if start[risk_idx] < event_time && stop[risk_idx] > event_time {
-                comparable += 1.0;
+                let pair_weight = observation_weight(weights, event_idx)
+                    * observation_weight(weights, risk_idx)
+                    * event_time_multiplier;
+                comparable += pair_weight;
                 let diff = risk_scores[event_idx] - risk_scores[risk_idx];
                 if diff > 0.0 {
-                    concordant += 1.0;
+                    concordant += pair_weight;
                 } else if diff.abs() < DIVISION_FLOOR {
-                    concordant += TIED_PAIR_WEIGHT;
+                    concordant += TIED_PAIR_WEIGHT * pair_weight;
                 }
             }
         }
@@ -235,18 +369,33 @@ fn concordance_index_quadratic(
     event: &[i32],
     horizon: Option<f64>,
 ) -> f64 {
-    concordance_summary_quadratic(risk_scores, time, event, horizon).c_index()
+    concordance_summary_quadratic(
+        risk_scores,
+        time,
+        event,
+        None,
+        horizon,
+        ConcordanceTimeWeight::N,
+    )
+    .c_index()
 }
 
 fn concordance_summary_quadratic(
     risk_scores: &[f64],
     time: &[f64],
     event: &[i32],
+    weights: Option<&[f64]>,
     horizon: Option<f64>,
+    time_weight: ConcordanceTimeWeight,
 ) -> ConcordanceSummary {
     let n = risk_scores.len();
     let mut concordant = 0.0;
     let mut comparable = 0.0;
+    let event_time_multipliers = if time_weight == ConcordanceTimeWeight::N {
+        Vec::new()
+    } else {
+        right_censored_time_weight_multipliers(time, event, weights, time_weight)
+    };
 
     for i in 0..n {
         for j in (i + 1)..n {
@@ -264,18 +413,34 @@ fn concordance_summary_quadratic(
                 };
 
             if i_comparable {
-                comparable += 1.0;
+                let event_time_multiplier = if time_weight == ConcordanceTimeWeight::N {
+                    1.0
+                } else {
+                    event_time_multiplier_at(&event_time_multipliers, time[i])
+                };
+                let pair_weight = observation_weight(weights, i)
+                    * observation_weight(weights, j)
+                    * event_time_multiplier;
+                comparable += pair_weight;
                 if risk_scores[i] > risk_scores[j] {
-                    concordant += 1.0;
+                    concordant += pair_weight;
                 } else if (risk_scores[i] - risk_scores[j]).abs() < DIVISION_FLOOR {
-                    concordant += TIED_PAIR_WEIGHT;
+                    concordant += TIED_PAIR_WEIGHT * pair_weight;
                 }
             } else if j_comparable {
-                comparable += 1.0;
+                let event_time_multiplier = if time_weight == ConcordanceTimeWeight::N {
+                    1.0
+                } else {
+                    event_time_multiplier_at(&event_time_multipliers, time[j])
+                };
+                let pair_weight = observation_weight(weights, j)
+                    * observation_weight(weights, i)
+                    * event_time_multiplier;
+                comparable += pair_weight;
                 if risk_scores[j] > risk_scores[i] {
-                    concordant += 1.0;
+                    concordant += pair_weight;
                 } else if (risk_scores[i] - risk_scores[j]).abs() < DIVISION_FLOOR {
-                    concordant += TIED_PAIR_WEIGHT;
+                    concordant += TIED_PAIR_WEIGHT * pair_weight;
                 }
             }
         }
@@ -294,14 +459,24 @@ fn concordance_index_ranked(
     event: &[i32],
     horizon: Option<f64>,
 ) -> f64 {
-    concordance_summary_ranked(risk_scores, time, event, horizon).c_index()
+    concordance_summary_ranked(
+        risk_scores,
+        time,
+        event,
+        None,
+        horizon,
+        ConcordanceTimeWeight::N,
+    )
+    .c_index()
 }
 
 fn concordance_summary_ranked(
     risk_scores: &[f64],
     time: &[f64],
     event: &[i32],
+    weights: Option<&[f64]>,
     horizon: Option<f64>,
+    time_weight: ConcordanceTimeWeight,
 ) -> ConcordanceSummary {
     let n = risk_scores.len();
     let mut time_order: Vec<usize> = (0..n).collect();
@@ -315,6 +490,11 @@ fn concordance_summary_ranked(
     let mut concordant = 0.0;
     let mut comparable = 0.0;
     let mut group_start = 0;
+    let event_time_multipliers = if time_weight == ConcordanceTimeWeight::N {
+        Vec::new()
+    } else {
+        right_censored_time_weight_multipliers(time, event, weights, time_weight)
+    };
 
     while group_start < n {
         let current_time = time[time_order[group_start]];
@@ -324,21 +504,27 @@ fn concordance_summary_ranked(
         }
 
         let at_risk_total = at_risk.total();
-        if at_risk_total > 0.0 {
+        let event_time_multiplier = if time_weight == ConcordanceTimeWeight::N {
+            1.0
+        } else {
+            event_time_multiplier_at(&event_time_multipliers, current_time)
+        };
+        if at_risk_total > 0.0 && event_time_multiplier > 0.0 {
             for &idx in &time_order[group_start..group_end] {
                 if event[idx] != 1 || horizon.is_some_and(|h| time[idx] > h) {
                     continue;
                 }
 
-                comparable += at_risk_total;
-                concordant +=
-                    concordance_contribution_for_rank(&at_risk, &risk_levels, risk_scores[idx]);
+                let event_weight = observation_weight(weights, idx) * event_time_multiplier;
+                comparable += event_weight * at_risk_total;
+                concordant += event_weight
+                    * concordance_contribution_for_rank(&at_risk, &risk_levels, risk_scores[idx]);
             }
         }
 
         for &idx in &time_order[group_start..group_end] {
             let rank = risk_levels.partition_point(|&risk| risk < risk_scores[idx]);
-            at_risk.update(rank, 1.0);
+            at_risk.update(rank, observation_weight(weights, idx));
         }
 
         group_start = group_end;
@@ -348,6 +534,178 @@ fn concordance_summary_ranked(
         concordant,
         comparable,
     }
+}
+
+#[inline]
+fn observation_weight(weights: Option<&[f64]>, idx: usize) -> f64 {
+    weights.map_or(1.0, |values| values[idx])
+}
+
+fn event_time_multiplier_at(event_time_multipliers: &[(f64, f64)], event_time: f64) -> f64 {
+    event_time_multipliers
+        .binary_search_by(|&(time, _)| time.total_cmp(&event_time))
+        .map_or(0.0, |idx| event_time_multipliers[idx].1)
+}
+
+fn time_weight_multiplier_from_components(
+    time_weight: ConcordanceTimeWeight,
+    total_weight: f64,
+    survival: f64,
+    censoring_survival: f64,
+    nrisk: f64,
+) -> f64 {
+    if nrisk <= 0.0 {
+        return 0.0;
+    }
+    match time_weight {
+        ConcordanceTimeWeight::N => 1.0,
+        ConcordanceTimeWeight::S => total_weight * survival / nrisk,
+        ConcordanceTimeWeight::SOverG => {
+            if censoring_survival > 0.0 {
+                total_weight * survival / (censoring_survival * nrisk)
+            } else {
+                0.0
+            }
+        }
+        ConcordanceTimeWeight::NOverG2 => {
+            if censoring_survival > 0.0 {
+                1.0 / (censoring_survival * censoring_survival)
+            } else {
+                0.0
+            }
+        }
+        ConcordanceTimeWeight::I => 1.0 / nrisk,
+    }
+}
+
+fn right_censored_time_weight_multipliers(
+    time: &[f64],
+    event: &[i32],
+    weights: Option<&[f64]>,
+    time_weight: ConcordanceTimeWeight,
+) -> Vec<(f64, f64)> {
+    if time_weight == ConcordanceTimeWeight::N {
+        return Vec::new();
+    }
+
+    let n = time.len();
+    let total_weight: f64 = (0..n).map(|idx| observation_weight(weights, idx)).sum();
+    let mut time_order: Vec<usize> = (0..n).collect();
+    time_order.sort_by(|&a, &b| time[a].total_cmp(&time[b]));
+
+    let mut nrisk = total_weight;
+    let mut survival = 1.0;
+    let mut censoring_survival = 1.0;
+    let mut multipliers = Vec::new();
+    let mut group_start = 0usize;
+
+    while group_start < n {
+        let current_time = time[time_order[group_start]];
+        let mut group_end = group_start + 1;
+        while group_end < n && time[time_order[group_end]] == current_time {
+            group_end += 1;
+        }
+
+        let mut death_weight = 0.0;
+        let mut censor_weight = 0.0;
+        let mut group_weight = 0.0;
+        for &idx in &time_order[group_start..group_end] {
+            let weight = observation_weight(weights, idx);
+            group_weight += weight;
+            if event[idx] == 1 {
+                death_weight += weight;
+            } else {
+                censor_weight += weight;
+            }
+        }
+
+        if death_weight > 0.0 {
+            multipliers.push((
+                current_time,
+                time_weight_multiplier_from_components(
+                    time_weight,
+                    total_weight,
+                    survival,
+                    censoring_survival,
+                    nrisk,
+                ),
+            ));
+            if nrisk > 0.0 {
+                survival *= ((nrisk - death_weight) / nrisk).max(0.0);
+            }
+        }
+        if censor_weight > 0.0 && nrisk > 0.0 {
+            censoring_survival *= ((nrisk - censor_weight) / nrisk).max(0.0);
+        }
+        nrisk -= group_weight;
+        group_start = group_end;
+    }
+
+    multipliers
+}
+
+fn counting_process_time_weight_multipliers(
+    start: &[f64],
+    stop: &[f64],
+    event: &[i32],
+    weights: Option<&[f64]>,
+    time_weight: ConcordanceTimeWeight,
+) -> Vec<(f64, f64)> {
+    if time_weight == ConcordanceTimeWeight::N {
+        return Vec::new();
+    }
+
+    let n = start.len();
+    let total_weight: f64 = (0..n).map(|idx| observation_weight(weights, idx)).sum();
+    let mut event_times: Vec<f64> = (0..n)
+        .filter(|&idx| event[idx] == 1)
+        .map(|idx| stop[idx])
+        .collect();
+    event_times.sort_by(f64::total_cmp);
+    event_times.dedup();
+
+    let mut start_order: Vec<usize> = (0..n).collect();
+    start_order.sort_by(|&a, &b| start[a].total_cmp(&start[b]));
+    let mut stop_order: Vec<usize> = (0..n).collect();
+    stop_order.sort_by(|&a, &b| stop[a].total_cmp(&stop[b]));
+
+    let mut active_weight = 0.0;
+    let mut start_cursor = 0usize;
+    let mut stop_cursor = 0usize;
+    let mut survival = 1.0;
+    let mut multipliers = Vec::with_capacity(event_times.len());
+
+    for event_time in event_times {
+        while start_cursor < n && start[start_order[start_cursor]] < event_time {
+            active_weight += observation_weight(weights, start_order[start_cursor]);
+            start_cursor += 1;
+        }
+        while stop_cursor < n && stop[stop_order[stop_cursor]] < event_time {
+            active_weight -= observation_weight(weights, stop_order[stop_cursor]);
+            stop_cursor += 1;
+        }
+
+        let death_weight = (0..n)
+            .filter(|&idx| event[idx] == 1 && stop[idx] == event_time)
+            .map(|idx| observation_weight(weights, idx))
+            .sum::<f64>();
+
+        multipliers.push((
+            event_time,
+            time_weight_multiplier_from_components(
+                time_weight,
+                total_weight,
+                survival,
+                1.0,
+                active_weight,
+            ),
+        ));
+        if active_weight > 0.0 {
+            survival *= ((active_weight - death_weight) / active_weight).max(0.0);
+        }
+    }
+
+    multipliers
 }
 
 #[inline]
@@ -710,6 +1068,128 @@ mod tests {
         );
     }
 
+    fn assert_weighted_ranked_matches_quadratic(
+        risk_scores: &[f64],
+        time: &[f64],
+        event: &[i32],
+        weights: &[f64],
+        horizon: Option<f64>,
+    ) {
+        let ranked = concordance_summary_ranked(
+            risk_scores,
+            time,
+            event,
+            Some(weights),
+            horizon,
+            ConcordanceTimeWeight::N,
+        )
+        .c_index();
+        let quadratic = concordance_summary_quadratic(
+            risk_scores,
+            time,
+            event,
+            Some(weights),
+            horizon,
+            ConcordanceTimeWeight::N,
+        )
+        .c_index();
+
+        assert!(
+            (ranked - quadratic).abs() < 1e-12,
+            "weighted ranked {ranked} differed from quadratic {quadratic}"
+        );
+    }
+
+    fn assert_time_weighted_ranked_matches_quadratic(
+        risk_scores: &[f64],
+        time: &[f64],
+        event: &[i32],
+        weights: &[f64],
+        time_weight: ConcordanceTimeWeight,
+    ) {
+        let ranked =
+            concordance_summary_ranked(risk_scores, time, event, Some(weights), None, time_weight)
+                .c_index();
+        let quadratic = concordance_summary_quadratic(
+            risk_scores,
+            time,
+            event,
+            Some(weights),
+            None,
+            time_weight,
+        )
+        .c_index();
+
+        assert!(
+            (ranked - quadratic).abs() < 1e-12,
+            "time-weighted ranked {ranked} differed from quadratic {quadratic}"
+        );
+    }
+
+    fn assert_weighted_counting_ranked_matches_quadratic(
+        risk_scores: &[f64],
+        start: &[f64],
+        stop: &[f64],
+        event: &[i32],
+        weights: &[f64],
+    ) {
+        let ranked = counting_process_concordance_summary_with_weights(
+            risk_scores,
+            start,
+            stop,
+            event,
+            Some(weights),
+        )
+        .c_index();
+        let quadratic = counting_process_concordance_summary_quadratic(
+            risk_scores,
+            start,
+            stop,
+            event,
+            Some(weights),
+            ConcordanceTimeWeight::N,
+        )
+        .c_index();
+
+        assert!(
+            (ranked - quadratic).abs() < 1e-12,
+            "weighted counting ranked {ranked} differed from quadratic {quadratic}"
+        );
+    }
+
+    fn assert_time_weighted_counting_ranked_matches_quadratic(
+        risk_scores: &[f64],
+        start: &[f64],
+        stop: &[f64],
+        event: &[i32],
+        weights: &[f64],
+        time_weight: ConcordanceTimeWeight,
+    ) {
+        let ranked = counting_process_concordance_summary_with_weights_and_time_weight(
+            risk_scores,
+            start,
+            stop,
+            event,
+            Some(weights),
+            time_weight,
+        )
+        .c_index();
+        let quadratic = counting_process_concordance_summary_quadratic(
+            risk_scores,
+            start,
+            stop,
+            event,
+            Some(weights),
+            time_weight,
+        )
+        .c_index();
+
+        assert!(
+            (ranked - quadratic).abs() < 1e-12,
+            "time-weighted counting ranked {ranked} differed from quadratic {quadratic}"
+        );
+    }
+
     #[test]
     fn test_ranked_concordance_matches_quadratic_for_common_cases() {
         let time = [5.0, 2.0, 7.0, 3.0, 3.0, 9.0, 1.0];
@@ -761,6 +1241,80 @@ mod tests {
     }
 
     #[test]
+    fn test_weighted_ranked_concordance_matches_quadratic() {
+        for n in 2..40 {
+            let time: Vec<f64> = (0..n).map(|i| ((i * 7 + n * 3) % 11) as f64).collect();
+            let event: Vec<i32> = (0..n)
+                .map(|i| if (i + n) % 4 == 0 { 0 } else { 1 })
+                .collect();
+            let risk: Vec<f64> = (0..n)
+                .map(|i| {
+                    if i % 6 == 0 {
+                        0.25
+                    } else {
+                        ((i * 11 + n * 5) % 17) as f64 / 10.0
+                    }
+                })
+                .collect();
+            let weights: Vec<f64> = (0..n)
+                .map(|i| {
+                    if i % 9 == 0 {
+                        0.0
+                    } else {
+                        0.5 + (i % 5) as f64
+                    }
+                })
+                .collect();
+
+            assert_weighted_ranked_matches_quadratic(&risk, &time, &event, &weights, None);
+            assert_weighted_ranked_matches_quadratic(&risk, &time, &event, &weights, Some(5.0));
+        }
+    }
+
+    #[test]
+    fn test_time_weighted_ranked_concordance_matches_quadratic() {
+        for n in 2..40 {
+            let time: Vec<f64> = (0..n).map(|i| ((i * 5 + n * 2) % 13) as f64).collect();
+            let event: Vec<i32> = (0..n)
+                .map(|i| if (i + n) % 5 == 0 { 0 } else { 1 })
+                .collect();
+            let risk: Vec<f64> = (0..n)
+                .map(|i| {
+                    if i % 7 == 0 {
+                        0.15
+                    } else {
+                        ((i * 17 + n * 3) % 23) as f64 / 10.0
+                    }
+                })
+                .collect();
+            let weights: Vec<f64> = (0..n)
+                .map(|i| {
+                    if i % 10 == 0 {
+                        0.0
+                    } else {
+                        0.25 + (i % 7) as f64
+                    }
+                })
+                .collect();
+
+            for time_weight in [
+                ConcordanceTimeWeight::S,
+                ConcordanceTimeWeight::SOverG,
+                ConcordanceTimeWeight::NOverG2,
+                ConcordanceTimeWeight::I,
+            ] {
+                assert_time_weighted_ranked_matches_quadratic(
+                    &risk,
+                    &time,
+                    &event,
+                    &weights,
+                    time_weight,
+                );
+            }
+        }
+    }
+
+    #[test]
     fn test_concordance_falls_back_for_non_finite_values() {
         let time = [1.0, f64::NAN, 3.0];
         let event = [1, 1, 1];
@@ -805,6 +1359,87 @@ mod tests {
                 .collect();
 
             assert_counting_ranked_matches_quadratic(&risk, &start, &stop, &event);
+        }
+    }
+
+    #[test]
+    fn test_weighted_counting_concordance_matches_quadratic() {
+        for n in 2..40 {
+            let start: Vec<f64> = (0..n).map(|i| (i % 5) as f64 * 0.5).collect();
+            let stop: Vec<f64> = start
+                .iter()
+                .enumerate()
+                .map(|(i, &value)| value + 0.5 + ((i * 7 + n) % 6) as f64 * 0.25)
+                .collect();
+            let event: Vec<i32> = (0..n)
+                .map(|i| if (i + n) % 5 == 0 { 0 } else { 1 })
+                .collect();
+            let risk: Vec<f64> = (0..n)
+                .map(|i| {
+                    if i % 7 == 0 {
+                        0.35
+                    } else {
+                        ((i * 13 + n * 3) % 19) as f64 / 10.0
+                    }
+                })
+                .collect();
+            let weights: Vec<f64> = (0..n)
+                .map(|i| {
+                    if i % 8 == 0 {
+                        0.0
+                    } else {
+                        0.25 + (i % 6) as f64
+                    }
+                })
+                .collect();
+
+            assert_weighted_counting_ranked_matches_quadratic(
+                &risk, &start, &stop, &event, &weights,
+            );
+        }
+    }
+
+    #[test]
+    fn test_time_weighted_counting_concordance_matches_quadratic() {
+        for n in 2..40 {
+            let start: Vec<f64> = (0..n).map(|i| (i % 6) as f64 * 0.25).collect();
+            let stop: Vec<f64> = start
+                .iter()
+                .enumerate()
+                .map(|(i, &value)| value + 0.5 + ((i * 5 + n) % 7) as f64 * 0.2)
+                .collect();
+            let event: Vec<i32> = (0..n)
+                .map(|i| if (i + n) % 6 == 0 { 0 } else { 1 })
+                .collect();
+            let risk: Vec<f64> = (0..n)
+                .map(|i| {
+                    if i % 8 == 0 {
+                        0.45
+                    } else {
+                        ((i * 19 + n * 2) % 29) as f64 / 10.0
+                    }
+                })
+                .collect();
+            let weights: Vec<f64> = (0..n)
+                .map(|i| {
+                    if i % 9 == 0 {
+                        0.0
+                    } else {
+                        0.5 + (i % 5) as f64
+                    }
+                })
+                .collect();
+
+            for time_weight in [ConcordanceTimeWeight::S, ConcordanceTimeWeight::I] {
+                assert_time_weighted_counting_ranked_matches_quadratic(
+                    &risk,
+                    &start,
+                    &stop,
+                    &event,
+                    &weights,
+                    time_weight,
+                );
+            }
         }
     }
 

--- a/src/internal/validation.rs
+++ b/src/internal/validation.rs
@@ -56,6 +56,11 @@ pub enum ValidationError {
         index: usize,
         value: f64,
     },
+    NonBinaryValue {
+        field: &'static str,
+        index: usize,
+        value: String,
+    },
 }
 impl fmt::Display for ValidationError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -90,6 +95,15 @@ impl fmt::Display for ValidationError {
                 f,
                 "{} contains non-finite value {} at index {}",
                 field, value, index
+            ),
+            ValidationError::NonBinaryValue {
+                field,
+                index,
+                value,
+            } => write!(
+                f,
+                "{} values must be 0 or 1; {} must contain only 0/1 values; got {} at index {}",
+                field, field, value, index
             ),
         }
     }
@@ -158,6 +172,39 @@ pub(crate) fn validate_finite(slice: &[f64], field: &'static str) -> Result<(), 
     }
     Ok(())
 }
+
+pub(crate) fn validate_binary_i32(
+    slice: &[i32],
+    field: &'static str,
+) -> Result<(), ValidationError> {
+    for (index, &value) in slice.iter().enumerate() {
+        if value != 0 && value != 1 {
+            return Err(ValidationError::NonBinaryValue {
+                field,
+                index,
+                value: value.to_string(),
+            });
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_binary_f64(
+    slice: &[f64],
+    field: &'static str,
+) -> Result<(), ValidationError> {
+    for (index, &value) in slice.iter().enumerate() {
+        if value != 0.0 && value != 1.0 {
+            return Err(ValidationError::NonBinaryValue {
+                field,
+                index,
+                value: value.to_string(),
+            });
+        }
+    }
+    Ok(())
+}
+
 pub(crate) fn clamp_probability(value: f64) -> f64 {
     value.clamp(0.0, 1.0)
 }

--- a/src/interval/interval_censoring.rs
+++ b/src/interval/interval_censoring.rs
@@ -1,3 +1,4 @@
+use crate::constants::clamped_normal_ci_bounds_95;
 use crate::internal::statistical::erf;
 use pyo3::prelude::*;
 
@@ -499,18 +500,7 @@ pub fn turnbull_estimator(
         .map(|&prob| (prob * (1.0 - prob) / total_weight).sqrt())
         .collect();
 
-    let z = 1.96;
-    let survival_lower: Vec<f64> = survival
-        .iter()
-        .zip(se.iter())
-        .map(|(&s, &se)| (s - z * se).max(0.0))
-        .collect();
-
-    let survival_upper: Vec<f64> = survival
-        .iter()
-        .zip(se.iter())
-        .map(|(&s, &se)| (s + z * se).min(1.0))
-        .collect();
+    let (survival_lower, survival_upper) = clamped_normal_ci_bounds_95(&survival, &se, 0.0, 1.0);
 
     Ok(TurnbullResult {
         time_points: all_points,

--- a/src/joint/dynamic_prediction/discrimination.rs
+++ b/src/joint/dynamic_prediction/discrimination.rs
@@ -223,8 +223,9 @@ pub fn time_varying_auc(
         auc_values.push(auc);
 
         let se = (auc * (1.0 - auc) / cases.len().min(controls.len()) as f64).sqrt();
-        auc_lower.push((auc - 1.96 * se).max(0.0));
-        auc_upper.push((auc + 1.96 * se).min(1.0));
+        let (lower, upper) = clamped_normal_ci_95(auc, se, 0.0, 1.0);
+        auc_lower.push(lower);
+        auc_upper.push(upper);
     }
 
     let integrated_auc = if eval_times.len() > 1 {
@@ -351,8 +352,7 @@ pub fn dynamic_c_index(
         0.0
     };
 
-    let lower = (c_index - 1.96 * se).max(0.0);
-    let upper = (c_index + 1.96 * se).min(1.0);
+    let (lower, upper) = clamped_normal_ci_95(c_index, se, 0.0, 1.0);
 
     let default_times: Vec<f64> = {
         let min_t = event_time

--- a/src/joint/dynamic_prediction/mod.rs
+++ b/src/joint/dynamic_prediction/mod.rs
@@ -1,3 +1,4 @@
+use crate::constants::clamped_normal_ci_95;
 use crate::internal::statistical::{concordance_index_with_horizon, sample_normal};
 use pyo3::prelude::*;
 use rayon::prelude::*;

--- a/src/missing/multiple_imputation.rs
+++ b/src/missing/multiple_imputation.rs
@@ -1,6 +1,8 @@
 use pyo3::prelude::*;
 use rayon::prelude::*;
 
+use crate::constants::normal_ci_bounds_95;
+
 #[derive(Debug, Clone)]
 #[pyclass(from_py_object)]
 pub struct MultipleImputationResult {
@@ -537,18 +539,7 @@ fn rubin_rules(results: &[Vec<f64>], n_vars: usize) -> MultipleImputationResult 
 
     let pooled_se: Vec<f64> = total_var.iter().map(|&v| v.sqrt()).collect();
 
-    let z = 1.96;
-    let pooled_ci_lower: Vec<f64> = pooled_coef
-        .iter()
-        .zip(pooled_se.iter())
-        .map(|(&c, &se)| c - z * se)
-        .collect();
-
-    let pooled_ci_upper: Vec<f64> = pooled_coef
-        .iter()
-        .zip(pooled_se.iter())
-        .map(|(&c, &se)| c + z * se)
-        .collect();
+    let (pooled_ci_lower, pooled_ci_upper) = normal_ci_bounds_95(&pooled_coef, &pooled_se);
 
     let fmi: Vec<f64> = (0..n_vars)
         .map(|j| {

--- a/src/missing/pattern_mixture.rs
+++ b/src/missing/pattern_mixture.rs
@@ -1,5 +1,7 @@
 use pyo3::prelude::*;
 
+use crate::constants::normal_ci_bounds_95;
+
 type CoxEstimate = (Vec<f64>, Vec<f64>);
 type SensitivityResult = (f64, Vec<f64>, Vec<f64>);
 
@@ -160,18 +162,7 @@ pub fn pattern_mixture_model(
 
     let averaged_se: Vec<f64> = averaged_var.iter().map(|&v| v.sqrt()).collect();
 
-    let z = 1.96;
-    let averaged_ci_lower: Vec<f64> = averaged_coef
-        .iter()
-        .zip(averaged_se.iter())
-        .map(|(&c, &se)| c - z * se)
-        .collect();
-
-    let averaged_ci_upper: Vec<f64> = averaged_coef
-        .iter()
-        .zip(averaged_se.iter())
-        .map(|(&c, &se)| c + z * se)
-        .collect();
+    let (averaged_ci_lower, averaged_ci_upper) = normal_ci_bounds_95(&averaged_coef, &averaged_se);
 
     Ok(PatternMixtureResult {
         pattern_coefficients,

--- a/src/recurrent/gap_time.rs
+++ b/src/recurrent/gap_time.rs
@@ -1,5 +1,7 @@
 use pyo3::prelude::*;
 
+use crate::constants::exp_ci_bounds_95;
+
 #[derive(Debug, Clone)]
 #[pyclass(from_py_object)]
 pub struct GapTimeResult {
@@ -195,18 +197,7 @@ pub fn gap_time_model(
 
     let hazard_ratios: Vec<f64> = beta.iter().map(|&b| b.exp()).collect();
 
-    let z = 1.96;
-    let hr_ci_lower: Vec<f64> = beta
-        .iter()
-        .zip(std_errors.iter())
-        .map(|(&b, &se)| (b - z * se).exp())
-        .collect();
-
-    let hr_ci_upper: Vec<f64> = beta
-        .iter()
-        .zip(std_errors.iter())
-        .map(|(&b, &se)| (b + z * se).exp())
-        .collect();
+    let (hr_ci_lower, hr_ci_upper) = exp_ci_bounds_95(&beta, &std_errors);
 
     let mut unique_times: Vec<f64> = gap_times.clone();
     unique_times.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));

--- a/src/recurrent/marginal_models.rs
+++ b/src/recurrent/marginal_models.rs
@@ -1,5 +1,7 @@
 use pyo3::prelude::*;
 
+use crate::constants::exp_ci_bounds_95;
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[pyclass(from_py_object)]
 pub enum MarginalMethod {
@@ -188,18 +190,7 @@ pub fn marginal_recurrent_model(
 
     let hazard_ratios: Vec<f64> = beta.iter().map(|&b| b.exp()).collect();
 
-    let z = 1.96;
-    let hr_ci_lower: Vec<f64> = beta
-        .iter()
-        .zip(robust_se.iter())
-        .map(|(&b, &se)| (b - z * se).exp())
-        .collect();
-
-    let hr_ci_upper: Vec<f64> = beta
-        .iter()
-        .zip(robust_se.iter())
-        .map(|(&b, &se)| (b + z * se).exp())
-        .collect();
+    let (hr_ci_lower, hr_ci_upper) = exp_ci_bounds_95(&beta, &robust_se);
 
     let score_test: f64 = beta
         .iter()

--- a/src/regression/aareg.rs
+++ b/src/regression/aareg.rs
@@ -1,3 +1,4 @@
+use crate::constants::normal_ci_95;
 use crate::internal::matrix::lu_solve;
 use crate::internal::statistical::normal_cdf;
 use ndarray::{Array1, Array2, Axis};
@@ -593,10 +594,10 @@ fn perform_aalen_regression(
         .iter()
         .zip(standard_errors.iter())
         .map(|(&coef, &se)| {
-            let margin = 1.96 * se;
+            let (lower_bound, upper_bound) = normal_ci_95(coef, se);
             AaregConfidenceInterval {
-                lower_bound: coef - margin,
-                upper_bound: coef + margin,
+                lower_bound,
+                upper_bound,
             }
         })
         .collect();

--- a/src/regression/agfit5.rs
+++ b/src/regression/agfit5.rs
@@ -1,3 +1,4 @@
+use crate::constants::normal_ci_95;
 use crate::internal::matrix::{lu_solve, matrix_inverse};
 use crate::internal::statistical::normal_cdf;
 use ndarray::{Array1, Array2};
@@ -350,7 +351,7 @@ pub(crate) fn agfit5(
         .map(|i| {
             let se = standard_errors[i];
             let coef = beta[i];
-            (coef - 1.96 * se, coef + 1.96 * se)
+            normal_ci_95(coef, se)
         })
         .collect();
     let score: f64 = u.iter().map(|&x| x * x).sum();

--- a/src/regression/cause_specific_cox.rs
+++ b/src/regression/cause_specific_cox.rs
@@ -1,3 +1,4 @@
+use crate::constants::{exp_ci_bounds_95, same_time};
 use crate::internal::matrix::invert_matrix;
 use pyo3::prelude::*;
 use rayon::prelude::*;
@@ -351,9 +352,7 @@ fn compute_baseline_hazard(
         let current_time = time[idx];
 
         let mut n_events = 0.0;
-        while i < n
-            && (time[sorted_indices[i]] - current_time).abs() < crate::constants::TIME_EPSILON
-        {
+        while i < n && same_time(time[sorted_indices[i]], current_time) {
             if cause[sorted_indices[i]] == cause_of_interest {
                 n_events += weights[sorted_indices[i]];
             }
@@ -483,17 +482,7 @@ pub fn cause_specific_cox(
 
     let hazard_ratios: Vec<f64> = beta.iter().map(|&b| b.exp()).collect();
 
-    let z = 1.96;
-    let hr_ci_lower: Vec<f64> = beta
-        .iter()
-        .zip(std_errors.iter())
-        .map(|(&b, &se)| (b - z * se).exp())
-        .collect();
-    let hr_ci_upper: Vec<f64> = beta
-        .iter()
-        .zip(std_errors.iter())
-        .map(|(&b, &se)| (b + z * se).exp())
-        .collect();
+    let (hr_ci_lower, hr_ci_upper) = exp_ci_bounds_95(&beta, &std_errors);
 
     let exp_eta: Vec<f64> = (0..n_obs)
         .map(|i| {

--- a/src/regression/clogit.rs
+++ b/src/regression/clogit.rs
@@ -1,15 +1,10 @@
 use std::collections::BTreeMap;
 
-use crate::constants::{EXP_CLAMP_MAX, EXP_CLAMP_MIN};
+use crate::constants::exp_clamped;
 use pyo3::prelude::*;
 
 fn value_error(message: impl Into<String>) -> PyErr {
     pyo3::exceptions::PyValueError::new_err(message.into())
-}
-
-#[inline]
-fn exp_clamped(value: f64) -> f64 {
-    value.clamp(EXP_CLAMP_MIN, EXP_CLAMP_MAX).exp()
 }
 
 #[pyclass(from_py_object)]

--- a/src/regression/coxph.rs
+++ b/src/regression/coxph.rs
@@ -1,4 +1,5 @@
 use crate::constants::{EXP_CLAMP_MAX, EXP_CLAMP_MIN, TIME_EPSILON};
+use crate::internal::validation::validate_binary_i32;
 use crate::regression::cox_optimizer::{CoxFit, Method as CoxMethod};
 pub use crate::regression::coxph_model::{CoxPHModel, Subject};
 use crate::regression::coxph_support::{ActiveRiskSet, CoxSweepRow, StratifiedBaselineLookup};
@@ -74,6 +75,8 @@ pub struct CoxPHFit {
     pub strata: Vec<i32>,
     #[pyo3(get)]
     pub method: String,
+    #[pyo3(get)]
+    pub nocenter: Vec<f64>,
 }
 
 impl CoxPHFit {
@@ -476,18 +479,6 @@ fn validate_finite_values(name: &str, values: &[f64]) -> PyResult<()> {
     Ok(())
 }
 
-fn validate_binary_status(status: &[i32]) -> PyResult<()> {
-    for (idx, &value) in status.iter().enumerate() {
-        if value != 0 && value != 1 {
-            return Err(pyo3::exceptions::PyValueError::new_err(format!(
-                "status must contain only 0/1 values; got {} at index {}",
-                value, idx
-            )));
-        }
-    }
-    Ok(())
-}
-
 fn validate_case_weights(weights: &[f64]) -> PyResult<()> {
     validate_finite_values("weights", weights)?;
     for (idx, &value) in weights.iter().enumerate() {
@@ -507,7 +498,7 @@ fn validate_case_weights(weights: &[f64]) -> PyResult<()> {
 }
 
 #[pyfunction]
-#[pyo3(signature = (time, status, covariates, strata=None, weights=None, offset=None, initial_beta=None, max_iter=None, eps=None, toler=None, method=None, entry_times=None))]
+#[pyo3(signature = (time, status, covariates, strata=None, weights=None, offset=None, initial_beta=None, max_iter=None, eps=None, toler=None, method=None, entry_times=None, nocenter=None))]
 #[allow(clippy::too_many_arguments)]
 pub fn coxph_fit(
     time: Vec<f64>,
@@ -522,6 +513,7 @@ pub fn coxph_fit(
     toler: Option<f64>,
     method: Option<&str>,
     entry_times: Option<Vec<f64>>,
+    nocenter: Option<Vec<f64>>,
 ) -> PyResult<CoxPHFit> {
     let event_times = time.clone();
     let status_values = status.clone();
@@ -553,7 +545,7 @@ pub fn coxph_fit(
         ));
     }
     validate_finite_values("time", &time)?;
-    validate_binary_status(&status)?;
+    validate_binary_i32(&status, "status")?;
     for (idx, row) in covariates.iter().enumerate() {
         validate_finite_values(&format!("covariates[{}]", idx), row)?;
     }
@@ -590,6 +582,9 @@ pub fn coxph_fit(
                 )));
             }
         }
+    }
+    if let Some(values) = nocenter.as_ref() {
+        validate_finite_values("nocenter", values)?;
     }
     if let Some(values) = initial_beta.as_ref()
         && values.len() != nvar
@@ -629,6 +624,18 @@ pub fn coxph_fit(
     let weights_vec = weights.unwrap_or_else(|| vec![1.0; n]);
     let strata_values = strata.unwrap_or_else(|| vec![0; n]);
     let original_strata_values = strata_values.clone();
+    let nocenter_values = nocenter.unwrap_or_default();
+    let doscale: Vec<bool> = if nocenter_values.is_empty() {
+        vec![true; nvar]
+    } else {
+        (0..nvar)
+            .map(|col_idx| {
+                !covariates
+                    .iter()
+                    .all(|row| nocenter_values.iter().any(|value| row[col_idx] == *value))
+            })
+            .collect()
+    };
     let mut order: Vec<usize> = (0..n).collect();
     order.sort_by(|&lhs, &rhs| {
         strata_values[lhs]
@@ -669,7 +676,7 @@ pub fn coxph_fit(
         max_iter.unwrap_or(20),
         eps.unwrap_or(1e-5),
         toler.unwrap_or(1e-9),
-        vec![true; nvar],
+        doscale,
         initial_beta.unwrap_or_else(|| vec![0.0; nvar]),
     )
     .map_err(|e| {
@@ -718,6 +725,7 @@ pub fn coxph_fit(
         covariates,
         strata: original_strata_values,
         method: method_name,
+        nocenter: nocenter_values,
     })
 }
 
@@ -751,6 +759,7 @@ mod tests {
             ],
             strata: vec![1, 1, 1, 2, 2, 2],
             method: method.to_string(),
+            nocenter: vec![-1.0, 0.0, 1.0],
         }
     }
 
@@ -922,6 +931,7 @@ mod tests {
             covariates: vec![vec![1.0], vec![709.0 / 710.0], vec![708.0 / 710.0]],
             strata: vec![0, 0, 0],
             method: "breslow".to_string(),
+            nocenter: Vec::new(),
         };
 
         let (times, hazards, strata) = fit.basehaz_with_strata_internal(false).unwrap();

--- a/src/regression/coxph_detail.rs
+++ b/src/regression/coxph_detail.rs
@@ -1,4 +1,5 @@
 use crate::constants::TIME_EPSILON;
+use crate::internal::validation::validate_binary_i32;
 use pyo3::prelude::*;
 
 #[derive(Debug, Clone)]
@@ -502,14 +503,7 @@ pub fn coxph_detail(
             )));
         }
     }
-    for (idx, value) in status.iter().enumerate() {
-        if *value != 0 && *value != 1 {
-            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                "status must contain only 0/1 values; got {} at index {}",
-                value, idx
-            )));
-        }
-    }
+    validate_binary_i32(&status, "status")?;
     for (row_idx, row) in covariates.iter().enumerate() {
         if row.len() != coefficients.len() {
             return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(

--- a/src/regression/coxph_model.rs
+++ b/src/regression/coxph_model.rs
@@ -1,5 +1,6 @@
 use crate::constants::{
-    DIVISION_FLOOR, EXP_CLAMP_MAX, EXP_CLAMP_MIN, TIME_EPSILON, z_score_for_confidence,
+    DIVISION_FLOOR, EXP_CLAMP_MIN, TIME_EPSILON, exp_clamped, exp_clamped_ci,
+    z_score_for_confidence,
 };
 use crate::internal::matrix::invert_matrix;
 use crate::regression::cox_optimizer::{CoxFitBuilder, Method as CoxMethod};
@@ -16,10 +17,6 @@ struct CoxModelRiskSetCache {
 
 fn value_error(message: impl Into<String>) -> PyErr {
     pyo3::exceptions::PyValueError::new_err(message.into())
-}
-
-fn exp_clamped(value: f64) -> f64 {
-    value.clamp(EXP_CLAMP_MIN, EXP_CLAMP_MAX).exp()
 }
 
 fn validate_finite_values(name: &str, values: &[f64]) -> PyResult<()> {
@@ -584,8 +581,9 @@ impl CoxPHModel {
         for (i, &beta) in coefs.iter().enumerate() {
             let se_i = se.get(i).copied().unwrap_or(0.1);
             hr.push(exp_clamped(beta));
-            ci_lower.push(exp_clamped(beta - z * se_i));
-            ci_upper.push(exp_clamped(beta + z * se_i));
+            let (lower, upper) = exp_clamped_ci(beta, se_i, z);
+            ci_lower.push(lower);
+            ci_upper.push(upper);
         }
         (hr, ci_lower, ci_upper)
     }

--- a/src/regression/elastic_net.rs
+++ b/src/regression/elastic_net.rs
@@ -324,10 +324,6 @@ fn shifted_exp_eta(eta: &[f64], weights: &[f64]) -> Vec<f64> {
     eta.iter().map(|&eta_i| (eta_i - shift).exp()).collect()
 }
 
-fn same_elastic_net_time(left: f64, right: f64) -> bool {
-    (left - right).abs() < crate::constants::TIME_EPSILON
-}
-
 #[allow(clippy::needless_range_loop)]
 fn precompute_risk_set_cumsum(
     x: &[f64],
@@ -368,7 +364,7 @@ fn precompute_risk_set_cumsum(
     while start < n {
         let current_time = time[indices[start]];
         let mut end = start + 1;
-        while end < n && same_elastic_net_time(time[indices[end]], current_time) {
+        while end < n && crate::constants::same_time(time[indices[end]], current_time) {
             end += 1;
         }
 

--- a/src/regression/fast_cox/core.rs
+++ b/src/regression/fast_cox/core.rs
@@ -101,7 +101,7 @@ fn precompute_risk_set_cumsum(
     while start < n {
         let current_time = time[sorted_indices[start]];
         let mut end = start + 1;
-        while end < n && same_fast_cox_time(time[sorted_indices[end]], current_time) {
+        while end < n && crate::constants::same_time(time[sorted_indices[end]], current_time) {
             end += 1;
         }
 
@@ -154,10 +154,6 @@ fn shifted_exp_eta(eta: &[f64], weights: &[f64]) -> Vec<f64> {
     eta.iter()
         .map(|&eta_i| (eta_i - risk_shift).exp())
         .collect()
-}
-
-fn same_fast_cox_time(left: f64, right: f64) -> bool {
-    (left - right).abs() < crate::constants::TIME_EPSILON
 }
 
 #[allow(clippy::needless_range_loop)]

--- a/src/regression/finegray_regression.rs
+++ b/src/regression/finegray_regression.rs
@@ -3,18 +3,14 @@ use rayon::prelude::*;
 use std::fmt;
 
 use crate::constants::{
-    EXP_CLAMP_MAX, EXP_CLAMP_MIN, IPCW_SURVIVAL_FLOOR, PARALLEL_THRESHOLD_LARGE,
+    IPCW_SURVIVAL_FLOOR, PARALLEL_THRESHOLD_LARGE, Z_SCORE_90, Z_SCORE_95, Z_SCORE_99,
+    clamped_normal_ci_bounds, exp_clamped, normal_ci_bounds_95, same_time,
 };
 use crate::internal::matrix::invert_matrix;
 use crate::internal::statistical::{compute_censoring_km, km_step_prob_at, normal_cdf};
 
 fn value_error(message: impl Into<String>) -> PyErr {
     pyo3::exceptions::PyValueError::new_err(message.into())
-}
-
-#[inline]
-fn exp_clamped(value: f64) -> f64 {
-    value.clamp(EXP_CLAMP_MIN, EXP_CLAMP_MAX).exp()
 }
 
 #[derive(Debug, Clone)]
@@ -344,17 +340,7 @@ pub(crate) fn finegray_regression_core(
         .map(|&z| 2.0 * (1.0 - normal_cdf(z.abs())))
         .collect();
 
-    let z_crit = 1.96;
-    let ci_lower: Vec<f64> = beta
-        .iter()
-        .zip(std_errors.iter())
-        .map(|(&b, &se)| b - z_crit * se)
-        .collect();
-    let ci_upper: Vec<f64> = beta
-        .iter()
-        .zip(std_errors.iter())
-        .map(|(&b, &se)| b + z_crit * se)
-        .collect();
+    let (ci_lower, ci_upper) = normal_ci_bounds_95(&beta, &std_errors);
 
     FineGrayResult {
         coefficients: beta,
@@ -600,7 +586,7 @@ pub(crate) fn competing_risks_cif_core(
         let mut n_other_events = 0;
         let mut total_at_time = 0;
 
-        while i < n && (time[indices[i]] - current_time).abs() < crate::constants::TIME_EPSILON {
+        while i < n && same_time(time[indices[i]], current_time) {
             let s = status[indices[i]];
             if s == event_type {
                 n_event_type += 1;
@@ -638,23 +624,14 @@ pub(crate) fn competing_risks_cif_core(
     }
 
     let z = match confidence_level {
-        x if (x - 0.90).abs() < 0.01 => 1.645,
-        x if (x - 0.95).abs() < 0.01 => 1.96,
-        x if (x - 0.99).abs() < 0.01 => 2.576,
-        _ => 1.96,
+        x if (x - 0.90).abs() < 0.01 => Z_SCORE_90,
+        x if (x - 0.95).abs() < 0.01 => Z_SCORE_95,
+        x if (x - 0.99).abs() < 0.01 => Z_SCORE_99,
+        _ => Z_SCORE_95,
     };
 
-    let ci_lower: Vec<f64> = cif_values
-        .iter()
-        .zip(variance_values.iter())
-        .map(|(&c, &v)| (c - z * v.sqrt()).max(0.0))
-        .collect();
-
-    let ci_upper: Vec<f64> = cif_values
-        .iter()
-        .zip(variance_values.iter())
-        .map(|(&c, &v)| (c + z * v.sqrt()).min(1.0))
-        .collect();
+    let cif_se: Vec<f64> = variance_values.iter().map(|&v| v.sqrt()).collect();
+    let (ci_lower, ci_upper) = clamped_normal_ci_bounds(&cif_values, &cif_se, z, 0.0, 1.0);
 
     CompetingRisksCIF {
         times: unique_times,

--- a/src/regression/functional_survival.rs
+++ b/src/regression/functional_survival.rs
@@ -1,6 +1,7 @@
 use pyo3::prelude::*;
 use rayon::prelude::*;
 
+use crate::constants::exp_ci_bounds_95;
 use crate::internal::statistical::normal_cdf;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -426,17 +427,7 @@ pub fn functional_cox(
 
     let hazard_ratio: Vec<f64> = coefficients.par_iter().map(|&c| c.exp()).collect();
 
-    let ci_lower: Vec<f64> = coefficients
-        .par_iter()
-        .zip(coefficient_se.par_iter())
-        .map(|(c, se): (&f64, &f64)| (c - 1.96 * se).exp())
-        .collect();
-
-    let ci_upper: Vec<f64> = coefficients
-        .par_iter()
-        .zip(coefficient_se.par_iter())
-        .map(|(c, se): (&f64, &f64)| (c + 1.96 * se).exp())
-        .collect();
+    let (ci_lower, ci_upper) = exp_ci_bounds_95(&coefficients, &coefficient_se);
 
     let p_values: Vec<f64> = coefficients
         .par_iter()

--- a/src/regression/joint_competing.rs
+++ b/src/regression/joint_competing.rs
@@ -1,3 +1,4 @@
+use crate::constants::same_time;
 use crate::internal::matrix::invert_matrix;
 use pyo3::prelude::*;
 use rayon::prelude::*;
@@ -464,9 +465,7 @@ fn compute_baseline_hazard(
         let current_time = time[idx];
         let mut n_events = 0.0;
 
-        while i < n
-            && (time[sorted_indices[i]] - current_time).abs() < crate::constants::TIME_EPSILON
-        {
+        while i < n && same_time(time[sorted_indices[i]], current_time) {
             if cause[sorted_indices[i]] == cause_of_interest {
                 n_events += weights[sorted_indices[i]];
             }

--- a/src/regression/longitudinal_survival.rs
+++ b/src/regression/longitudinal_survival.rs
@@ -1,6 +1,8 @@
 use pyo3::prelude::*;
 use rayon::prelude::*;
 
+use crate::constants::{clamped_normal_ci_95, same_time};
+
 #[derive(Debug, Clone)]
 #[pyclass(from_py_object)]
 pub struct JointModelConfig {
@@ -610,8 +612,9 @@ pub fn longitudinal_dynamic_pred(
         survival_probabilities.push(surv_prob);
 
         let se = 0.05;
-        confidence_lower.push((surv_prob - 1.96 * se).clamp(0.0, 1.0));
-        confidence_upper.push((surv_prob + 1.96 * se).clamp(0.0, 1.0));
+        let (lower, upper) = clamped_normal_ci_95(surv_prob, se, 0.0, 1.0);
+        confidence_lower.push(lower);
+        confidence_upper.push(upper);
     }
 
     Ok(LongDynamicPredResult {
@@ -734,9 +737,7 @@ pub fn time_varying_cox(
             let mut gradient = vec![0.0; n_features];
 
             for &i in at_risk.iter() {
-                if event[i] == 1
-                    && (stop_time[i] - time_point).abs() < crate::constants::TIME_EPSILON
-                {
+                if event[i] == 1 && same_time(stop_time[i], time_point) {
                     for (j, &xij) in covariates[i].iter().enumerate() {
                         let weighted_mean: f64 = at_risk
                             .iter()
@@ -769,7 +770,7 @@ pub fn time_varying_cox(
         let risk_sum: f64 = exp_lp.iter().sum();
 
         for (idx, &i) in at_risk.iter().enumerate() {
-            if event[i] == 1 && (stop_time[i] - time_point).abs() < crate::constants::TIME_EPSILON {
+            if event[i] == 1 && same_time(stop_time[i], time_point) {
                 total_ll += linear_pred[idx] - risk_sum.ln();
             }
         }

--- a/src/regression/parametric_survival.rs
+++ b/src/regression/parametric_survival.rs
@@ -787,13 +787,15 @@ pub enum DistributionType {
 ///     Cholesky tolerance (default crate::constants::DIVISION_FLOOR).
 /// time2 : array-like, optional
 ///     Interval upper-bound times. Required for rows with status=3.
+/// fixed_scale : float, optional
+///     Fixed scale parameter. When supplied, the scale is not estimated.
 ///
 /// Returns
 /// -------
 /// SurvivalFit
 ///     Object with: coefficients, std_errors, variance_matrix, log_likelihood, convergence info.
 #[pyfunction]
-#[pyo3(signature = (time, status, covariates, weights=None, offsets=None, initial_beta=None, strata=None, distribution=None, max_iter=None, eps=None, tol_chol=None, time2=None))]
+#[pyo3(signature = (time, status, covariates, weights=None, offsets=None, initial_beta=None, strata=None, distribution=None, max_iter=None, eps=None, tol_chol=None, time2=None, fixed_scale=None))]
 #[allow(clippy::too_many_arguments)]
 pub fn survreg(
     time: Vec<f64>,
@@ -808,6 +810,7 @@ pub fn survreg(
     eps: Option<f64>,
     tol_chol: Option<f64>,
     time2: Option<Vec<f64>>,
+    fixed_scale: Option<f64>,
 ) -> PyResult<SurvivalFit> {
     let dist_type = parse_distribution_type(distribution)?;
     let config = SurvregConfig::create(Some(dist_type), max_iter, eps, tol_chol);
@@ -865,19 +868,33 @@ pub fn survreg(
     } else {
         1
     };
+    if let Some(scale) = fixed_scale {
+        if !scale.is_finite() || scale <= 0.0 {
+            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                "fixed_scale must be a finite positive value",
+            ));
+        }
+        if nstrat > 1 {
+            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                "cannot have both a fixed scale and strata",
+            ));
+        }
+    }
+    let estimated_scale_count = if fixed_scale.is_some() { 0 } else { nstrat };
+    let expected_initial_len = nvar + estimated_scale_count;
     if let Some(values) = initial_beta.as_ref()
-        && values.len() != nvar + nstrat
+        && values.len() != expected_initial_len
     {
         return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
             "initial_beta has {} values but model expects {}",
             values.len(),
-            nvar + nstrat
+            expected_initial_len
         )));
     }
     if let Some(values) = initial_beta.as_ref() {
         validate_finite_values("initial_beta", values)?;
     }
-    let initial_beta = initial_beta.unwrap_or_else(|| vec![0.0; nvar + nstrat]);
+    let initial_beta = initial_beta.unwrap_or_else(|| vec![0.0; expected_initial_len]);
     let y = {
         if let Some(time2) = time2_values.as_ref() {
             let mut y_data = Vec::with_capacity(n * 3);
@@ -925,6 +942,7 @@ pub fn survreg(
         eps: config.eps,
         tol_chol: config.tol_chol,
         distribution: distribution_type,
+        fixed_scale,
     })
     .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("{}", e)))?;
     let variance_matrix = result
@@ -933,10 +951,14 @@ pub fn survreg(
         .map(|row| row.iter().copied().collect())
         .collect();
     let location_coefficients = result.coefficients[..nvar].to_vec();
-    let scales: Vec<f64> = result.coefficients[nvar..nvar + nstrat]
-        .iter()
-        .map(|value| value.exp())
-        .collect();
+    let scales: Vec<f64> = if let Some(scale) = fixed_scale {
+        vec![scale]
+    } else {
+        result.coefficients[nvar..nvar + nstrat]
+            .iter()
+            .map(|value| value.exp())
+            .collect()
+    };
     let linear_predictors =
         compute_linear_predictor(&covariate_rows, &location_coefficients, Some(&offsets_vec));
     let status_values: Vec<i32> = status.iter().map(|&value| value as i32).collect();
@@ -946,7 +968,11 @@ pub fn survreg(
         covariate_rows
     };
     Ok(SurvivalFit {
-        coefficients: result.coefficients,
+        coefficients: if fixed_scale.is_some() {
+            location_coefficients.clone()
+        } else {
+            result.coefficients
+        },
         location_coefficients,
         scale: scales.first().copied().unwrap_or(1.0),
         scales,
@@ -977,19 +1003,28 @@ fn compute_survreg(
         covariates,
         weights,
         offsets,
-        mut beta,
+        beta,
         nstrat,
         strata,
         eps,
         tol_chol,
         distribution,
+        fixed_scale,
     } = input;
     let n = y.nrows();
     let ny = y.ncols();
-    let nvar2 = nvar + nstrat;
+    let estimated_scale_count = if fixed_scale.is_some() { 0 } else { nstrat };
+    let nvar2 = nvar + estimated_scale_count;
     let mut imat = Array2::zeros((nvar2, nvar2));
     let mut jj = Array2::zeros((nvar2, nvar2));
     let mut u = Array1::zeros(nvar2);
+    let mut beta = if let Some(scale) = fixed_scale {
+        let mut values = beta;
+        values.push(scale.ln());
+        values
+    } else {
+        beta
+    };
     let mut newbeta = beta.clone();
     let mut usave = Array1::zeros(nvar2);
     let time1_vec: Vec<f64> = y.column(0).iter().map(|&t| t.ln()).collect();
@@ -1012,7 +1047,7 @@ fn compute_survreg(
     let input = LikelihoodInput {
         n,
         nvar,
-        nstrat,
+        nstrat: estimated_scale_count,
         beta: &beta,
         distribution: &distribution,
         strata,
@@ -1043,11 +1078,11 @@ fn compute_survreg(
             .iter_mut()
             .zip(beta.iter().zip(delta.iter()))
             .for_each(|(nb, (b, d))| *nb = b + d * step_factor);
-        adjust_strata(&mut newbeta, &beta, nvar, nstrat);
+        adjust_strata(&mut newbeta, &beta, nvar, estimated_scale_count);
         let new_input = LikelihoodInput {
             n,
             nvar,
-            nstrat,
+            nstrat: estimated_scale_count,
             beta: &newbeta,
             distribution: &distribution,
             strata,
@@ -1120,6 +1155,7 @@ struct ComputeSurvregInput<'a> {
     eps: f64,
     tol_chol: f64,
     distribution: DistributionType,
+    fixed_scale: Option<f64>,
 }
 
 #[cfg(test)]
@@ -1229,6 +1265,7 @@ mod tests {
             eps: 1e-6,
             tol_chol: 1e-10,
             distribution: DistributionType::Weibull,
+            fixed_scale: None,
         });
 
         assert!(result.is_ok());
@@ -1263,6 +1300,7 @@ mod tests {
             eps: 1e-6,
             tol_chol: 1e-10,
             distribution: DistributionType::Weibull,
+            fixed_scale: None,
         });
 
         assert!(result.is_ok());
@@ -1297,6 +1335,7 @@ mod tests {
             eps: 1e-6,
             tol_chol: 1e-10,
             distribution: DistributionType::LogNormal,
+            fixed_scale: None,
         });
 
         assert!(result.is_ok());
@@ -1330,6 +1369,7 @@ mod tests {
             eps: 1e-6,
             tol_chol: 1e-10,
             distribution: DistributionType::LogLogistic,
+            fixed_scale: None,
         });
 
         assert!(result.is_ok());
@@ -1368,6 +1408,7 @@ mod tests {
             eps: 1e-6,
             tol_chol: 1e-10,
             distribution: DistributionType::Weibull,
+            fixed_scale: None,
         });
 
         assert!(result.is_ok());
@@ -1405,11 +1446,50 @@ mod tests {
             eps: 1e-6,
             tol_chol: 1e-10,
             distribution: DistributionType::Weibull,
+            fixed_scale: None,
         });
 
         assert!(result.is_ok());
         let fit = result.unwrap();
         assert_eq!(fit.coefficients.len(), nvar + 1);
+    }
+
+    #[test]
+    fn test_compute_survreg_fixed_scale_uses_location_variance() {
+        let n = 20;
+        let nvar = 1;
+        let times: Vec<f64> = (1..=n).map(|i| (i as f64) * 0.4 + 0.5).collect();
+        let y_data: Vec<f64> = times.iter().flat_map(|&t| vec![t, 1.0]).collect();
+        let y = Array2::from_shape_vec((n, 2), y_data).unwrap();
+        let covariates = Array2::from_shape_vec((nvar, n), vec![1.0; n]).unwrap();
+        let weights = Array1::from_vec(vec![1.0; n]);
+        let offsets = Array1::from_vec(vec![0.0; n]);
+        let beta = vec![0.0; nvar];
+        let strata = vec![0; n];
+
+        let result = compute_survreg(ComputeSurvregInput {
+            max_iter: 20,
+            nvar,
+            y: &y,
+            covariates: &covariates,
+            weights: &weights,
+            offsets: &offsets,
+            beta,
+            nstrat: 1,
+            strata: &strata,
+            eps: 1e-6,
+            tol_chol: 1e-10,
+            distribution: DistributionType::Weibull,
+            fixed_scale: Some(1.25),
+        });
+
+        assert!(result.is_ok());
+        let fit = result.unwrap();
+        assert_eq!(fit.coefficients.len(), nvar + 1);
+        assert_eq!(fit.score_vector.len(), nvar);
+        assert_eq!(fit.variance_matrix.shape(), &[nvar, nvar]);
+        assert_eq!(fit.coefficients[nvar], 1.25f64.ln());
+        assert!(fit.log_likelihood.is_finite());
     }
 
     #[test]

--- a/src/regression/recurrent_events/anderson_gill.rs
+++ b/src/regression/recurrent_events/anderson_gill.rs
@@ -11,29 +11,11 @@ pub fn anderson_gill_model(
     tol: f64,
 ) -> PyResult<AndersonGillResult> {
     let n = id.len();
-    if start.len() != n || stop.len() != n || event.len() != n {
-        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-            "All input vectors must have the same length",
-        ));
-    }
+    validate_recurrent_lengths(n, &[start.len(), stop.len(), event.len()])?;
 
-    let p = if covariates.is_empty() {
-        1
-    } else {
-        covariates.len() / n
-    };
-    let x_mat = if covariates.is_empty() {
-        vec![1.0; n]
-    } else {
-        covariates.clone()
-    };
+    let (p, x_mat) = covariate_matrix_or_intercept(covariates, n);
 
-    let unique_ids: Vec<i32> = {
-        let mut ids = id.clone();
-        ids.sort();
-        ids.dedup();
-        ids
-    };
+    let unique_ids = sorted_unique_i32(&id);
     let n_subjects = unique_ids.len();
 
     let n_events_total = event.iter().filter(|&&e| e == 1).count();
@@ -41,11 +23,7 @@ pub fn anderson_gill_model(
     let total_time: f64 = stop.iter().zip(start.iter()).map(|(&s, &st)| s - st).sum();
     let mean_event_rate = n_events_total as f64 / total_time;
 
-    let id_to_idx: std::collections::HashMap<i32, usize> = unique_ids
-        .iter()
-        .enumerate()
-        .map(|(idx, &id_val)| (id_val, idx))
-        .collect();
+    let id_to_idx = index_by_i32(&unique_ids);
 
     let mut beta = vec![0.0; p];
     let mut converged = false;
@@ -102,7 +80,7 @@ pub fn anderson_gill_model(
                 }
             }
 
-            if risk_sum > crate::constants::DIVISION_FLOOR {
+            if risk_sum > DIVISION_FLOOR {
                 loglik += eta_i - risk_sum.ln();
 
                 for j in 0..p {
@@ -121,7 +99,7 @@ pub fn anderson_gill_model(
         }
 
         for j in 0..p {
-            if hessian[j][j].abs() > crate::constants::DIVISION_FLOOR {
+            if hessian[j][j].abs() > DIVISION_FLOOR {
                 beta[j] += gradient[j] / hessian[j][j];
                 beta[j] = beta[j].clamp(-10.0, 10.0);
             }
@@ -167,7 +145,7 @@ pub fn anderson_gill_model(
             }
         }
 
-        if risk_sum > crate::constants::DIVISION_FLOOR {
+        if risk_sum > DIVISION_FLOOR {
             for j1 in 0..p {
                 let x_bar1 = risk_x_sum[j1] / risk_sum;
                 for j2 in 0..p {
@@ -187,7 +165,7 @@ pub fn anderson_gill_model(
 
     let std_errors: Vec<f64> = (0..p)
         .map(|j| {
-            if info_matrix[j][j] > crate::constants::DIVISION_FLOOR {
+            if info_matrix[j][j] > DIVISION_FLOOR {
                 (1.0 / info_matrix[j][j]).sqrt()
             } else {
                 f64::INFINITY
@@ -206,7 +184,7 @@ pub fn anderson_gill_model(
 
     let robust_std_errors: Vec<f64> = (0..p)
         .map(|j| {
-            let inv_info = if info_matrix[j][j] > crate::constants::DIVISION_FLOOR {
+            let inv_info = if info_matrix[j][j] > DIVISION_FLOOR {
                 1.0 / info_matrix[j][j]
             } else {
                 0.0
@@ -219,7 +197,7 @@ pub fn anderson_gill_model(
         .iter()
         .zip(robust_std_errors.iter())
         .map(|(&b, &se)| {
-            if se > crate::constants::DIVISION_FLOOR {
+            if se > DIVISION_FLOOR {
                 b / se
             } else {
                 0.0
@@ -234,17 +212,7 @@ pub fn anderson_gill_model(
 
     let hazard_ratios: Vec<f64> = beta.iter().map(|&b| b.exp()).collect();
 
-    let hr_lower: Vec<f64> = beta
-        .iter()
-        .zip(robust_std_errors.iter())
-        .map(|(&b, &se)| (b - 1.96 * se).exp())
-        .collect();
-
-    let hr_upper: Vec<f64> = beta
-        .iter()
-        .zip(robust_std_errors.iter())
-        .map(|(&b, &se)| (b + 1.96 * se).exp())
-        .collect();
+    let (hr_lower, hr_upper) = exp_ci_bounds_95(&beta, &robust_std_errors);
 
     Ok(AndersonGillResult {
         coef: beta,
@@ -263,4 +231,3 @@ pub fn anderson_gill_model(
         mean_event_rate,
     })
 }
-

--- a/src/regression/recurrent_events/mod.rs
+++ b/src/regression/recurrent_events/mod.rs
@@ -1,7 +1,40 @@
 use pyo3::prelude::*;
 use rayon::prelude::*;
 
+use crate::constants::{DIVISION_FLOOR, exp_ci_bounds_95};
 use crate::internal::statistical::{chi2_cdf, ln_gamma, normal_cdf};
+
+fn covariate_matrix_or_intercept(covariates: Vec<f64>, n: usize) -> (usize, Vec<f64>) {
+    if covariates.is_empty() {
+        (1, vec![1.0; n])
+    } else {
+        (covariates.len() / n, covariates)
+    }
+}
+
+fn sorted_unique_i32(values: &[i32]) -> Vec<i32> {
+    let mut unique_values = values.to_vec();
+    unique_values.sort_unstable();
+    unique_values.dedup();
+    unique_values
+}
+
+fn index_by_i32(values: &[i32]) -> std::collections::HashMap<i32, usize> {
+    values
+        .iter()
+        .enumerate()
+        .map(|(idx, &value)| (value, idx))
+        .collect()
+}
+
+fn validate_recurrent_lengths(n: usize, lengths: &[usize]) -> PyResult<()> {
+    if lengths.iter().any(|&len| len != n) {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "All input vectors must have the same length",
+        ));
+    }
+    Ok(())
+}
 
 include!("pwp.rs");
 include!("wlw.rs");

--- a/src/regression/recurrent_events/negative_binomial.rs
+++ b/src/regression/recurrent_events/negative_binomial.rs
@@ -75,42 +75,20 @@ pub fn negative_binomial_frailty(
     config: &NegativeBinomialFrailtyConfig,
 ) -> PyResult<NegativeBinomialFrailtyResult> {
     let n = id.len();
-    if time.len() != n || event.len() != n {
-        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-            "All input vectors must have the same length",
-        ));
-    }
+    validate_recurrent_lengths(n, &[time.len(), event.len()])?;
 
-    let p = if covariates.is_empty() {
-        1
-    } else {
-        covariates.len() / n
-    };
-    let x_mat = if covariates.is_empty() {
-        vec![1.0; n]
-    } else {
-        covariates.clone()
-    };
+    let (p, x_mat) = covariate_matrix_or_intercept(covariates, n);
 
     let offset_vec = offset.unwrap_or_else(|| {
         time.iter()
-            .map(|&t| t.max(crate::constants::DIVISION_FLOOR).ln())
+            .map(|&t| t.max(DIVISION_FLOOR).ln())
             .collect()
     });
 
-    let unique_ids: Vec<i32> = {
-        let mut ids = id.clone();
-        ids.sort();
-        ids.dedup();
-        ids
-    };
+    let unique_ids = sorted_unique_i32(&id);
     let n_subjects = unique_ids.len();
 
-    let id_to_idx: std::collections::HashMap<i32, usize> = unique_ids
-        .iter()
-        .enumerate()
-        .map(|(idx, &id_val)| (id_val, idx))
-        .collect();
+    let id_to_idx = index_by_i32(&unique_ids);
 
     let mut subject_events: Vec<i32> = vec![0; n_subjects];
     let mut subject_exposure: Vec<f64> = vec![0.0; n_subjects];
@@ -197,7 +175,7 @@ pub fn negative_binomial_frailty(
 
             let mut max_change: f64 = 0.0;
             for j in 0..p {
-                if hessian_diag[j].abs() > crate::constants::DIVISION_FLOOR {
+                if hessian_diag[j].abs() > DIVISION_FLOOR {
                     let delta = gradient[j] / (hessian_diag[j] + 1e-6);
                     beta[j] += delta;
                     beta[j] = beta[j].clamp(-10.0, 10.0);
@@ -286,7 +264,7 @@ pub fn negative_binomial_frailty(
     let std_errors: Vec<f64> = info_matrix
         .par_iter()
         .map(|&info| {
-            if info > crate::constants::DIVISION_FLOOR {
+            if info > DIVISION_FLOOR {
                 (1.0 / info).sqrt()
             } else {
                 f64::INFINITY
@@ -298,7 +276,7 @@ pub fn negative_binomial_frailty(
         .par_iter()
         .zip(std_errors.par_iter())
         .map(|(&b, &se)| {
-            if se > crate::constants::DIVISION_FLOOR && se.is_finite() {
+            if se > DIVISION_FLOOR && se.is_finite() {
                 b / se
             } else {
                 0.0
@@ -313,17 +291,7 @@ pub fn negative_binomial_frailty(
 
     let rate_ratios: Vec<f64> = beta.par_iter().map(|&b| b.exp()).collect();
 
-    let rr_lower: Vec<f64> = beta
-        .par_iter()
-        .zip(std_errors.par_iter())
-        .map(|(&b, &se)| (b - 1.96 * se).exp())
-        .collect();
-
-    let rr_upper: Vec<f64> = beta
-        .par_iter()
-        .zip(std_errors.par_iter())
-        .map(|(&b, &se)| (b + 1.96 * se).exp())
-        .collect();
+    let (rr_lower, rr_upper) = exp_ci_bounds_95(&beta, &std_errors);
 
     let theta_se = (theta.powi(2) * 2.0 / n_subjects as f64).sqrt();
     let frailty_variance = theta;

--- a/src/regression/recurrent_events/pwp.rs
+++ b/src/regression/recurrent_events/pwp.rs
@@ -105,29 +105,11 @@ pub fn pwp_model(
     config: &PWPConfig,
 ) -> PyResult<PWPResult> {
     let n = id.len();
-    if start.len() != n || stop.len() != n || event.len() != n || event_number.len() != n {
-        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-            "All input vectors must have the same length",
-        ));
-    }
+    validate_recurrent_lengths(n, &[start.len(), stop.len(), event.len(), event_number.len()])?;
 
-    let p = if covariates.is_empty() {
-        1
-    } else {
-        covariates.len() / n
-    };
-    let x_mat = if covariates.is_empty() {
-        vec![1.0; n]
-    } else {
-        covariates.clone()
-    };
+    let (p, x_mat) = covariate_matrix_or_intercept(covariates, n);
 
-    let unique_ids: Vec<i32> = {
-        let mut ids = id.clone();
-        ids.sort();
-        ids.dedup();
-        ids
-    };
+    let unique_ids = sorted_unique_i32(&id);
     let n_subjects = unique_ids.len();
     let n_events_total = event.iter().filter(|&&e| e == 1).count();
 
@@ -205,7 +187,7 @@ pub fn pwp_model(
                 }
             }
 
-            if risk_sum > crate::constants::DIVISION_FLOOR {
+            if risk_sum > DIVISION_FLOOR {
                 loglik += eta_i - risk_sum.ln();
 
                 for j in 0..p {
@@ -225,7 +207,7 @@ pub fn pwp_model(
 
         let mut inv_hess = vec![vec![0.0; p]; p];
         for j in 0..p {
-            inv_hess[j][j] = if hessian[j][j].abs() > crate::constants::DIVISION_FLOOR {
+            inv_hess[j][j] = if hessian[j][j].abs() > DIVISION_FLOOR {
                 1.0 / hessian[j][j]
             } else {
                 0.0
@@ -247,11 +229,7 @@ pub fn pwp_model(
     let mut info_matrix = vec![vec![0.0; p]; p];
     let mut score_residuals: Vec<Vec<f64>> = unique_ids.iter().map(|_| vec![0.0; p]).collect();
 
-    let id_to_idx: std::collections::HashMap<i32, usize> = unique_ids
-        .iter()
-        .enumerate()
-        .map(|(idx, &id_val)| (id_val, idx))
-        .collect();
+    let id_to_idx = index_by_i32(&unique_ids);
 
     let mut sorted_indices: Vec<usize> = (0..n).collect();
     sorted_indices.sort_by(|&a, &b| {
@@ -298,7 +276,7 @@ pub fn pwp_model(
             }
         }
 
-        if risk_sum > crate::constants::DIVISION_FLOOR {
+        if risk_sum > DIVISION_FLOOR {
             for j1 in 0..p {
                 let x_bar1 = risk_x_sum[j1] / risk_sum;
                 for j2 in 0..p {
@@ -318,7 +296,7 @@ pub fn pwp_model(
 
     let std_errors: Vec<f64> = (0..p)
         .map(|j| {
-            if info_matrix[j][j] > crate::constants::DIVISION_FLOOR {
+            if info_matrix[j][j] > DIVISION_FLOOR {
                 (1.0 / info_matrix[j][j]).sqrt()
             } else {
                 f64::INFINITY
@@ -337,7 +315,7 @@ pub fn pwp_model(
 
     let robust_std_errors: Vec<f64> = (0..p)
         .map(|j| {
-            let inv_info = if info_matrix[j][j] > crate::constants::DIVISION_FLOOR {
+            let inv_info = if info_matrix[j][j] > DIVISION_FLOOR {
                 1.0 / info_matrix[j][j]
             } else {
                 0.0
@@ -356,7 +334,7 @@ pub fn pwp_model(
         .iter()
         .zip(se_to_use.iter())
         .map(|(&b, &se)| {
-            if se > crate::constants::DIVISION_FLOOR {
+            if se > DIVISION_FLOOR {
                 b / se
             } else {
                 0.0
@@ -371,17 +349,7 @@ pub fn pwp_model(
 
     let hazard_ratios: Vec<f64> = beta.iter().map(|&b| b.exp()).collect();
 
-    let hr_lower: Vec<f64> = beta
-        .iter()
-        .zip(se_to_use.iter())
-        .map(|(&b, &se)| (b - 1.96 * se).exp())
-        .collect();
-
-    let hr_upper: Vec<f64> = beta
-        .iter()
-        .zip(se_to_use.iter())
-        .map(|(&b, &se)| (b + 1.96 * se).exp())
-        .collect();
+    let (hr_lower, hr_upper) = exp_ci_bounds_95(&beta, se_to_use);
 
     let event_specific_coef: Vec<Vec<f64>> = (1..=max_event_num).map(|_| beta.clone()).collect();
 

--- a/src/regression/recurrent_events/wlw.rs
+++ b/src/regression/recurrent_events/wlw.rs
@@ -76,46 +76,19 @@ pub fn wlw_model(
     config: &WLWConfig,
 ) -> PyResult<WLWResult> {
     let n = id.len();
-    if time.len() != n || event.len() != n || stratum.len() != n {
-        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-            "All input vectors must have the same length",
-        ));
-    }
+    validate_recurrent_lengths(n, &[time.len(), event.len(), stratum.len()])?;
 
-    let p = if covariates.is_empty() {
-        1
-    } else {
-        covariates.len() / n
-    };
-    let x_mat = if covariates.is_empty() {
-        vec![1.0; n]
-    } else {
-        covariates.clone()
-    };
+    let (p, x_mat) = covariate_matrix_or_intercept(covariates, n);
 
-    let unique_ids: Vec<i32> = {
-        let mut ids = id.clone();
-        ids.sort();
-        ids.dedup();
-        ids
-    };
+    let unique_ids = sorted_unique_i32(&id);
     let n_subjects = unique_ids.len();
 
-    let unique_strata: Vec<i32> = {
-        let mut strata = stratum.clone();
-        strata.sort();
-        strata.dedup();
-        strata
-    };
+    let unique_strata = sorted_unique_i32(&stratum);
     let n_strata = unique_strata.len();
 
     let n_events_total = event.iter().filter(|&&e| e == 1).count();
 
-    let id_to_idx: std::collections::HashMap<i32, usize> = unique_ids
-        .iter()
-        .enumerate()
-        .map(|(idx, &id_val)| (id_val, idx))
-        .collect();
+    let id_to_idx = index_by_i32(&unique_ids);
 
     let mut beta = vec![0.0; p];
     let mut converged = false;
@@ -174,7 +147,7 @@ pub fn wlw_model(
                     }
                 }
 
-                if risk_sum > crate::constants::DIVISION_FLOOR {
+                if risk_sum > DIVISION_FLOOR {
                     loglik += eta_i - risk_sum.ln();
 
                     for j in 0..p {
@@ -194,7 +167,7 @@ pub fn wlw_model(
         }
 
         for j in 0..p {
-            if hessian[j][j].abs() > crate::constants::DIVISION_FLOOR {
+            if hessian[j][j].abs() > DIVISION_FLOOR {
                 beta[j] += gradient[j] / hessian[j][j];
                 beta[j] = beta[j].clamp(-10.0, 10.0);
             }
@@ -249,7 +222,7 @@ pub fn wlw_model(
                 }
             }
 
-            if risk_sum > crate::constants::DIVISION_FLOOR {
+            if risk_sum > DIVISION_FLOOR {
                 for j1 in 0..p {
                     let x_bar1 = risk_x_sum[j1] / risk_sum;
                     for j2 in 0..p {
@@ -270,7 +243,7 @@ pub fn wlw_model(
 
     let std_errors: Vec<f64> = (0..p)
         .map(|j| {
-            if info_matrix[j][j] > crate::constants::DIVISION_FLOOR {
+            if info_matrix[j][j] > DIVISION_FLOOR {
                 (1.0 / info_matrix[j][j]).sqrt()
             } else {
                 f64::INFINITY
@@ -289,7 +262,7 @@ pub fn wlw_model(
 
     let robust_std_errors: Vec<f64> = (0..p)
         .map(|j| {
-            let inv_info = if info_matrix[j][j] > crate::constants::DIVISION_FLOOR {
+            let inv_info = if info_matrix[j][j] > DIVISION_FLOOR {
                 1.0 / info_matrix[j][j]
             } else {
                 0.0
@@ -308,7 +281,7 @@ pub fn wlw_model(
         .iter()
         .zip(se_to_use.iter())
         .map(|(&b, &se)| {
-            if se > crate::constants::DIVISION_FLOOR {
+            if se > DIVISION_FLOOR {
                 b / se
             } else {
                 0.0
@@ -323,17 +296,7 @@ pub fn wlw_model(
 
     let hazard_ratios: Vec<f64> = beta.iter().map(|&b| b.exp()).collect();
 
-    let hr_lower: Vec<f64> = beta
-        .iter()
-        .zip(se_to_use.iter())
-        .map(|(&b, &se)| (b - 1.96 * se).exp())
-        .collect();
-
-    let hr_upper: Vec<f64> = beta
-        .iter()
-        .zip(se_to_use.iter())
-        .map(|(&b, &se)| (b + 1.96 * se).exp())
-        .collect();
+    let (hr_lower, hr_upper) = exp_ci_bounds_95(&beta, se_to_use);
 
     let stratum_coef: Vec<Vec<f64>> = unique_strata.iter().map(|_| beta.clone()).collect();
 

--- a/src/regression/ridge.rs
+++ b/src/regression/ridge.rs
@@ -1,6 +1,7 @@
-use crate::constants::{DIVISION_FLOOR, TIME_EPSILON};
+use crate::constants::{DIVISION_FLOOR, same_time};
 use crate::internal::validation::{
-    validate_finite, validate_no_nan, validate_non_empty, validate_non_negative,
+    validate_binary_i32, validate_finite, validate_no_nan, validate_non_empty,
+    validate_non_negative,
 };
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
@@ -249,18 +250,6 @@ fn scale_predictors(x: &[f64], n_obs: usize, n_vars: usize) -> (Vec<f64>, Option
     (scaled, Some(scale_factors))
 }
 
-fn validate_ridge_status(status: &[i32]) -> PyResult<()> {
-    for (idx, &value) in status.iter().enumerate() {
-        if value != 0 && value != 1 {
-            return Err(PyValueError::new_err(format!(
-                "status must contain only 0/1 values; got {} at index {}",
-                value, idx
-            )));
-        }
-    }
-    Ok(())
-}
-
 fn validate_ridge_penalty(penalty: &RidgePenalty) -> PyResult<()> {
     if !penalty.theta.is_finite() || penalty.theta < 0.0 {
         return Err(PyValueError::new_err(
@@ -302,7 +291,7 @@ fn validate_ridge_inputs(
     validate_no_nan(time, "time")?;
     validate_finite(time, "time")?;
     validate_non_negative(time, "time")?;
-    validate_ridge_status(status)?;
+    validate_binary_i32(status, "status")?;
 
     if let Some(weights) = weights {
         if weights.len() != n_obs {
@@ -314,10 +303,6 @@ fn validate_ridge_inputs(
     }
 
     Ok(())
-}
-
-fn same_ridge_time(left: f64, right: f64) -> bool {
-    (left - right).abs() < TIME_EPSILON
 }
 
 /// Fit unpenalized model (simplified)
@@ -373,7 +358,7 @@ fn fit_unpenalized(
     while start < n_obs {
         let current_time = time[indices[start]];
         let mut end = start + 1;
-        while end < n_obs && same_ridge_time(time[indices[end]], current_time) {
+        while end < n_obs && same_time(time[indices[end]], current_time) {
             end += 1;
         }
         for &idx in &indices[start..end] {
@@ -530,6 +515,7 @@ pub fn ridge_cv(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::constants::TIME_EPSILON;
 
     #[test]
     fn test_ridge_penalty_new() {

--- a/src/regression/spline_hazard.rs
+++ b/src/regression/spline_hazard.rs
@@ -1,5 +1,7 @@
 use pyo3::prelude::*;
 
+use crate::constants::clamped_normal_ci_bounds_95;
+
 #[pyclass(from_py_object)]
 #[derive(Clone, Debug)]
 pub struct SplineConfig {
@@ -517,16 +519,9 @@ pub fn predict_hazard_spline(
         survival[i] = (-cumulative_hazard[i]).exp();
     }
 
-    let z = 1.96;
     let se_factor = 0.1;
-    let lower_ci: Vec<f64> = survival
-        .iter()
-        .map(|s| (s - z * s * se_factor).clamp(0.0, 1.0))
-        .collect();
-    let upper_ci: Vec<f64> = survival
-        .iter()
-        .map(|s| (s + z * s * se_factor).clamp(0.0, 1.0))
-        .collect();
+    let survival_se: Vec<f64> = survival.iter().map(|&s| s * se_factor).collect();
+    let (lower_ci, upper_ci) = clamped_normal_ci_bounds_95(&survival, &survival_se, 0.0, 1.0);
 
     Ok(HazardSplineResult {
         time_points: eval_times,

--- a/src/relative/net_survival.rs
+++ b/src/relative/net_survival.rs
@@ -2,6 +2,8 @@
 
 use pyo3::prelude::*;
 
+use crate::constants::clamped_normal_ci_bounds_95;
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[pyclass(from_py_object)]
 pub enum NetSurvivalMethod {
@@ -164,18 +166,8 @@ fn pohar_perme_estimator(
         at_risk_set.retain(|&i| time[i] > t);
     }
 
-    let z = 1.96;
-    let net_survival_lower: Vec<f64> = net_survival
-        .iter()
-        .zip(net_survival_se.iter())
-        .map(|(&s, &se)| (s - z * se).max(0.0))
-        .collect();
-
-    let net_survival_upper: Vec<f64> = net_survival
-        .iter()
-        .zip(net_survival_se.iter())
-        .map(|(&s, &se)| (s + z * se).min(1.0))
-        .collect();
+    let (net_survival_lower, net_survival_upper) =
+        clamped_normal_ci_bounds_95(&net_survival, &net_survival_se, 0.0, 1.0);
 
     Ok(NetSurvivalResult {
         time_points: unique_times.to_vec(),
@@ -261,18 +253,8 @@ fn ederer_ii_estimator(
         at_risk -= d;
     }
 
-    let z = 1.96;
-    let net_survival_lower: Vec<f64> = net_survival
-        .iter()
-        .zip(net_survival_se.iter())
-        .map(|(&s, &se)| (s - z * se).max(0.0))
-        .collect();
-
-    let net_survival_upper: Vec<f64> = net_survival
-        .iter()
-        .zip(net_survival_se.iter())
-        .map(|(&s, &se)| (s + z * se).min(1.0))
-        .collect();
+    let (net_survival_lower, net_survival_upper) =
+        clamped_normal_ci_bounds_95(&net_survival, &net_survival_se, 0.0, 1.0);
 
     Ok(NetSurvivalResult {
         time_points: unique_times.to_vec(),
@@ -355,18 +337,8 @@ fn ederer_i_estimator(
         at_risk -= d;
     }
 
-    let z = 1.96;
-    let net_survival_lower: Vec<f64> = net_survival
-        .iter()
-        .zip(net_survival_se.iter())
-        .map(|(&s, &se)| (s - z * se).max(0.0))
-        .collect();
-
-    let net_survival_upper: Vec<f64> = net_survival
-        .iter()
-        .zip(net_survival_se.iter())
-        .map(|(&s, &se)| (s + z * se).min(1.0))
-        .collect();
+    let (net_survival_lower, net_survival_upper) =
+        clamped_normal_ci_bounds_95(&net_survival, &net_survival_se, 0.0, 1.0);
 
     Ok(NetSurvivalResult {
         time_points: unique_times.to_vec(),

--- a/src/relative/relative_survival.rs
+++ b/src/relative/relative_survival.rs
@@ -2,6 +2,8 @@
 
 use pyo3::prelude::*;
 
+use crate::constants::exp_ci_bounds_95;
+
 #[derive(Debug, Clone)]
 #[pyclass(from_py_object)]
 pub struct RelativeSurvivalResult {
@@ -296,18 +298,7 @@ pub fn excess_hazard_regression(
     let std_errors = vec![0.1; n_vars];
     let excess_hazard_ratio: Vec<f64> = beta.iter().map(|&b| b.exp()).collect();
 
-    let z = 1.96;
-    let ehr_ci_lower: Vec<f64> = beta
-        .iter()
-        .zip(std_errors.iter())
-        .map(|(&b, &se)| (b - z * se).exp())
-        .collect();
-
-    let ehr_ci_upper: Vec<f64> = beta
-        .iter()
-        .zip(std_errors.iter())
-        .map(|(&b, &se)| (b + z * se).exp())
-        .collect();
+    let (ehr_ci_lower, ehr_ci_upper) = exp_ci_bounds_95(&beta, &std_errors);
 
     let mut unique_times: Vec<f64> = time.clone();
     unique_times.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));

--- a/src/reliability/core.rs
+++ b/src/reliability/core.rs
@@ -1,3 +1,4 @@
+use crate::constants::normal_ci;
 use crate::internal::statistical::{normal_cdf, normal_inverse_cdf};
 use pyo3::prelude::*;
 
@@ -178,16 +179,17 @@ pub fn reliability(
 
             let (new_se, l, u) = match scale_enum {
                 ReliabilityScale::Surv => {
-                    let l = (s - z * se_val).max(0.0);
-                    let u = (s + z * se_val).min(1.0);
+                    let (l, u) = normal_ci(s, se_val, z);
+                    let l = l.max(0.0);
+                    let u = u.min(1.0);
                     (se_val, l, u)
                 }
                 ReliabilityScale::Cumhaz => {
                     if s > 0.0 && se_val > 0.0 {
                         let h = -s.ln();
                         let se_h = se_val / s;
-                        let l = (h - z * se_h).max(0.0);
-                        let u = h + z * se_h;
+                        let (l, u) = normal_ci(h, se_h, z);
+                        let l = l.max(0.0);
                         (se_h, l, u)
                     } else {
                         (f64::NAN, f64::NAN, f64::NAN)
@@ -198,8 +200,7 @@ pub fn reliability(
                         let h = -s.ln();
                         let se_cll = se_val / (s * h);
                         let cll = h.ln();
-                        let l = cll - z * se_cll;
-                        let u = cll + z * se_cll;
+                        let (l, u) = normal_ci(cll, se_cll, z);
                         (se_cll, l, u)
                     } else {
                         (f64::NAN, f64::NAN, f64::NAN)
@@ -209,8 +210,7 @@ pub fn reliability(
                     if s > 0.0 && s < 1.0 && se_val > 0.0 {
                         let se_logit = se_val / (s * (1.0 - s));
                         let logit = ((1.0 - s) / s).ln();
-                        let l = logit - z * se_logit;
-                        let u = logit + z * se_logit;
+                        let (l, u) = normal_ci(logit, se_logit, z);
                         (se_logit, l, u)
                     } else {
                         (f64::NAN, f64::NAN, f64::NAN)
@@ -223,8 +223,7 @@ pub fn reliability(
                         let phi =
                             (-0.5 * z_val.powi(2)).exp() / (2.0 * std::f64::consts::PI).sqrt();
                         let se_probit = se_val / phi;
-                        let l = z_val - z * se_probit;
-                        let u = z_val + z * se_probit;
+                        let (l, u) = normal_ci(z_val, se_probit, z);
                         (se_probit, l, u)
                     } else {
                         (f64::NAN, f64::NAN, f64::NAN)

--- a/src/residuals/survfit_resid.rs
+++ b/src/residuals/survfit_resid.rs
@@ -1,5 +1,6 @@
+use crate::constants::DIVISION_FLOOR;
 use crate::internal::statistical::normal_inverse_cdf;
-use crate::internal::validation::validate_finite;
+use crate::internal::validation::{validate_binary_i32, validate_finite};
 use pyo3::prelude::*;
 
 #[derive(Debug, Clone)]
@@ -56,7 +57,7 @@ pub(crate) fn compute_deviance_survfit(
         .map(|(&m, &d)| {
             let sign = if m >= 0.0 { 1.0 } else { -1.0 };
             let abs_term = if d == 1 {
-                -2.0 * (m - 1.0 + (1.0 - m).max(1e-10).ln())
+                -2.0 * (m - 1.0 + (1.0 - m).max(DIVISION_FLOOR).ln())
             } else {
                 -2.0 * m
             };
@@ -119,15 +120,6 @@ fn get_surv_at_time(t: f64, surv_time: &[f64], surv: &[f64]) -> f64 {
     1.0
 }
 
-fn validate_binary_status(status: &[i32]) -> PyResult<()> {
-    if status.iter().any(|&value| value != 0 && value != 1) {
-        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-            "status must contain only 0/1 values",
-        ));
-    }
-    Ok(())
-}
-
 fn validate_survival_probabilities(surv: &[f64]) -> PyResult<()> {
     validate_finite(surv, "surv")?;
     for (index, &value) in surv.iter().enumerate() {
@@ -148,7 +140,7 @@ fn validate_survfit_residual_inputs(
     surv: &[f64],
 ) -> PyResult<()> {
     validate_finite(time, "time")?;
-    validate_binary_status(status)?;
+    validate_binary_i32(status, "status")?;
     validate_finite(surv_time, "surv_time")?;
     validate_survival_probabilities(surv)?;
 

--- a/src/spatial/network_survival/centrality.rs
+++ b/src/spatial/network_survival/centrality.rs
@@ -275,17 +275,8 @@ pub fn network_survival_model(
     );
 
     let hazard_ratios: Vec<f64> = beta[..n_covariates].iter().map(|&b| b.exp()).collect();
-    let z = 1.96;
-    let hr_ci_lower: Vec<f64> = beta[..n_covariates]
-        .iter()
-        .zip(se[..n_covariates].iter())
-        .map(|(&b, &s)| (b - z * s).exp())
-        .collect();
-    let hr_ci_upper: Vec<f64> = beta[..n_covariates]
-        .iter()
-        .zip(se[..n_covariates].iter())
-        .map(|(&b, &s)| (b + z * s).exp())
-        .collect();
+    let (hr_ci_lower, hr_ci_upper) =
+        exp_ci_bounds_95(&beta[..n_covariates], &se[..n_covariates]);
 
     let mut idx = n_covariates;
     let (peer_effect, peer_effect_se) = if config.include_peer_effects {

--- a/src/spatial/network_survival/mod.rs
+++ b/src/spatial/network_survival/mod.rs
@@ -1,4 +1,4 @@
-use crate::constants::PARALLEL_THRESHOLD_MEDIUM;
+use crate::constants::{PARALLEL_THRESHOLD_MEDIUM, exp_ci_bounds_95};
 use crate::internal::sorting::descending_time_indices;
 use pyo3::prelude::*;
 use rayon::prelude::*;

--- a/src/spatial/spatial_frailty.rs
+++ b/src/spatial/spatial_frailty.rs
@@ -1,4 +1,4 @@
-use crate::constants::PARALLEL_THRESHOLD_MEDIUM;
+use crate::constants::{PARALLEL_THRESHOLD_MEDIUM, exp_ci_bounds_95};
 use crate::internal::matrix::invert_flat_square_matrix_with_fallback;
 use crate::internal::sorting::descending_time_indices;
 use crate::internal::statistical::normal_cdf;
@@ -166,18 +166,7 @@ pub fn spatial_frailty_model(
 
     let hazard_ratios: Vec<f64> = beta.iter().map(|&b| b.exp()).collect();
 
-    let z = 1.96;
-    let hr_ci_lower: Vec<f64> = beta
-        .iter()
-        .zip(se.iter())
-        .map(|(&b, &se)| (b - z * se).exp())
-        .collect();
-
-    let hr_ci_upper: Vec<f64> = beta
-        .iter()
-        .zip(se.iter())
-        .map(|(&b, &se)| (b + z * se).exp())
-        .collect();
+    let (hr_ci_lower, hr_ci_upper) = exp_ci_bounds_95(&beta, &se);
 
     let p_d = 2.0 * (log_lik - compute_saturated_loglik(&time, &status));
     let dic = -2.0 * log_lik + 2.0 * p_d;

--- a/src/surv_analysis/aggregate_survfit.rs
+++ b/src/surv_analysis/aggregate_survfit.rs
@@ -1,4 +1,4 @@
-use crate::constants::TIME_EPSILON;
+use crate::constants::{TIME_EPSILON, clamped_normal_ci_bounds};
 use crate::internal::statistical::normal_inverse_cdf;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
@@ -246,17 +246,7 @@ pub fn aggregate_survfit(
         agg_se[j] = agg_se[j].sqrt();
     }
 
-    let lower: Vec<f64> = agg_surv
-        .iter()
-        .zip(agg_se.iter())
-        .map(|(&s, &se)| (s - z * se).max(0.0))
-        .collect();
-
-    let upper: Vec<f64> = agg_surv
-        .iter()
-        .zip(agg_se.iter())
-        .map(|(&s, &se)| (s + z * se).min(1.0))
-        .collect();
+    let (lower, upper) = clamped_normal_ci_bounds(&agg_surv, &agg_se, z, 0.0, 1.0);
 
     Ok(AggregateSurvfitResult {
         time: all_times,

--- a/src/surv_analysis/illness_death.rs
+++ b/src/surv_analysis/illness_death.rs
@@ -1,7 +1,7 @@
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
-use crate::constants::TIME_EPSILON;
+use crate::constants::{TIME_EPSILON, exp_ci_95, same_time};
 use crate::internal::statistical::normal_cdf;
 use crate::internal::validation::{validate_finite, validate_no_nan, validate_non_negative};
 
@@ -356,7 +356,7 @@ pub fn fit_illness_death(
                     let events_at_t = times
                         .iter()
                         .zip(events.iter())
-                        .filter(|&(ti, e)| same_illness_time(*ti, t) && *e)
+                        .filter(|&(ti, e)| same_time(*ti, t) && *e)
                         .count() as f64;
                     if at_risk > 0.0 {
                         events_at_t / at_risk
@@ -388,14 +388,15 @@ pub fn fit_illness_death(
         let hr = coef.exp();
         let z = if se > 1e-10 { coef / se } else { 0.0 };
         let p_value = 2.0 * (1.0 - normal_cdf(z.abs()));
+        let (ci_lower, ci_upper) = exp_ci_95(coef, se);
         TransitionHazard {
             from_state: from.to_string(),
             to_state: to.to_string(),
             coefficient: coef,
             se,
             hazard_ratio: hr,
-            ci_lower: (coef - 1.96 * se).exp(),
-            ci_upper: (coef + 1.96 * se).exp(),
+            ci_lower,
+            ci_upper,
             p_value,
             baseline_hazard: bh,
             baseline_times: bt,
@@ -516,14 +517,10 @@ pub fn fit_illness_death(
     })
 }
 
-fn same_illness_time(left: f64, right: f64) -> bool {
-    (left - right).abs() < TIME_EPSILON
-}
-
 fn unique_illness_times(times: &[f64]) -> Vec<f64> {
     let mut unique_times = times.to_vec();
     unique_times.sort_by(|a, b| a.total_cmp(b));
-    unique_times.dedup_by(|a, b| same_illness_time(*a, *b));
+    unique_times.dedup_by(|a, b| same_time(*a, *b));
     unique_times
 }
 

--- a/src/surv_analysis/logrank_components.rs
+++ b/src/surv_analysis/logrank_components.rs
@@ -1,5 +1,5 @@
 use crate::internal::validation::{
-    validate_finite, validate_length, validate_no_nan, validate_non_negative,
+    validate_binary_i32, validate_finite, validate_length, validate_no_nan, validate_non_negative,
 };
 use pyo3::prelude::*;
 
@@ -39,7 +39,7 @@ pub fn compute_logrank_components(
     validate_no_nan(&time, "time")?;
     validate_finite(&time, "time")?;
     validate_non_negative(&time, "time")?;
-    validate_binary_status(&status)?;
+    validate_binary_i32(&status, "status")?;
     validate_group_codes(&group, n)?;
     let strata_vec = strata.unwrap_or_else(|| vec![0; n]);
     validate_length(n, strata_vec.len(), "strata")?;
@@ -113,17 +113,6 @@ pub fn compute_logrank_components(
         chi_squared: chi_sq,
         degrees_of_freedom: df,
     })
-}
-
-fn validate_binary_status(values: &[i32]) -> PyResult<()> {
-    for (idx, &value) in values.iter().enumerate() {
-        if value != 0 && value != 1 {
-            return Err(value_error(format!(
-                "status values must be 0 or 1; got {value} at index {idx}"
-            )));
-        }
-    }
-    Ok(())
 }
 
 fn validate_group_codes(values: &[i32], n: usize) -> PyResult<()> {
@@ -329,7 +318,7 @@ mod tests {
         let err = compute_logrank_components(vec![1.0], vec![2], vec![1], None, None)
             .expect_err("non-binary status should fail");
 
-        assert!(err.to_string().contains("status values must be 0 or 1"));
+        assert!(err.to_string().contains("status must contain only 0/1"));
     }
 
     #[test]

--- a/src/surv_analysis/nelson_aalen.rs
+++ b/src/surv_analysis/nelson_aalen.rs
@@ -1,7 +1,9 @@
-use crate::constants::{PARALLEL_THRESHOLD_XLARGE, TIME_EPSILON, z_score_for_confidence};
+use crate::constants::{
+    PARALLEL_THRESHOLD_XLARGE, clamped_normal_ci, normal_ci, same_time, z_score_for_confidence,
+};
 use crate::internal::simd::sum_f64;
 use crate::internal::validation::{
-    validate_finite, validate_length, validate_no_nan, validate_non_negative,
+    validate_binary_i32, validate_finite, validate_length, validate_no_nan, validate_non_negative,
 };
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
@@ -60,18 +62,6 @@ fn validate_confidence_level(confidence_level: f64) -> PyResult<()> {
     Ok(())
 }
 
-fn validate_binary_status(status: &[i32]) -> PyResult<()> {
-    for (idx, &value) in status.iter().enumerate() {
-        if value != 0 && value != 1 {
-            return Err(PyValueError::new_err(format!(
-                "status must contain only 0/1 values; found {} at observation {}",
-                value, idx
-            )));
-        }
-    }
-    Ok(())
-}
-
 fn validate_survival_inputs(
     time: &[f64],
     status: &[i32],
@@ -82,7 +72,7 @@ fn validate_survival_inputs(
     validate_no_nan(time, "time")?;
     validate_finite(time, "time")?;
     validate_non_negative(time, "time")?;
-    validate_binary_status(status)?;
+    validate_binary_i32(status, "status")?;
     if let Some(weights) = weights {
         validate_length(time.len(), weights.len(), "weights")?;
         validate_no_nan(weights, "weights")?;
@@ -101,10 +91,6 @@ fn sorted_indices_by_time(time: &[f64]) -> Vec<usize> {
         indices.sort_by(|&a, &b| time[a].total_cmp(&time[b]).then_with(|| a.cmp(&b)));
     }
     indices
-}
-
-fn same_time(left: f64, right: f64) -> bool {
-    (left - right).abs() < TIME_EPSILON
 }
 
 pub fn nelson_aalen(
@@ -183,8 +169,9 @@ pub fn nelson_aalen(
     let mut ci_upper = Vec::with_capacity(m);
     for j in 0..m {
         let se = variance[j].sqrt();
-        ci_lower.push((cumulative_hazard[j] - z * se).max(0.0));
-        ci_upper.push(cumulative_hazard[j] + z * se);
+        let (lower, upper) = normal_ci(cumulative_hazard[j], se, z);
+        ci_lower.push(lower.max(0.0));
+        ci_upper.push(upper);
     }
     NelsonAalenResult {
         time: unique_times,
@@ -416,8 +403,9 @@ fn kaplan_meier(
     let mut ci_upper = Vec::with_capacity(m);
     for j in 0..m {
         let se = greenwood_var[j].sqrt();
-        ci_lower.push((survival[j] - z * se).clamp(0.0, 1.0));
-        ci_upper.push((survival[j] + z * se).clamp(0.0, 1.0));
+        let (lower, upper) = clamped_normal_ci(survival[j], se, z, 0.0, 1.0);
+        ci_lower.push(lower);
+        ci_upper.push(upper);
     }
     KMResult {
         time: unique_times,
@@ -445,6 +433,7 @@ pub fn stratified_kaplan_meier(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::constants::TIME_EPSILON;
 
     #[test]
     fn nelson_aalen_empty_input() {

--- a/src/surv_analysis/norisk.rs
+++ b/src/surv_analysis/norisk.rs
@@ -1,5 +1,7 @@
 use pyo3::prelude::*;
 
+use crate::internal::validation::validate_binary_i32;
+
 fn value_error(message: impl Into<String>) -> PyErr {
     pyo3::exceptions::PyValueError::new_err(message.into())
 }
@@ -18,17 +20,6 @@ fn validate_finite(values: &[f64], name: &str) -> PyResult<()> {
         if !value.is_finite() {
             return Err(value_error(format!(
                 "{name} must contain only finite values; got {value} at index {idx}"
-            )));
-        }
-    }
-    Ok(())
-}
-
-fn validate_binary_status(values: &[i32]) -> PyResult<()> {
-    for (idx, &value) in values.iter().enumerate() {
-        if value != 0 && value != 1 {
-            return Err(value_error(format!(
-                "status values must be 0 or 1; got {value} at index {idx}"
             )));
         }
     }
@@ -72,7 +63,7 @@ fn validate_norisk_inputs(
     validate_same_length(n, sort2.len(), "sort2")?;
     validate_finite(time1, "time1")?;
     validate_finite(time2, "time2")?;
-    validate_binary_status(status)?;
+    validate_binary_i32(status, "status")?;
     validate_sort_indices(sort1, n, "sort1")?;
     validate_sort_indices(sort2, n, "sort2")?;
     validate_strata_boundaries(strata, n)
@@ -169,6 +160,6 @@ mod tests {
             Err(err) => err,
         };
 
-        assert!(err.to_string().contains("status values must be 0 or 1"));
+        assert!(err.to_string().contains("status must contain only 0/1"));
     }
 }

--- a/src/surv_analysis/pseudo.rs
+++ b/src/surv_analysis/pseudo.rs
@@ -1,9 +1,11 @@
 use pyo3::prelude::*;
 use rayon::prelude::*;
 
-use crate::constants::TIME_EPSILON;
+use crate::constants::{DIVISION_FLOOR, TIME_EPSILON, normal_ci_95, same_time};
 use crate::internal::statistical::normal_cdf;
-use crate::internal::validation::{validate_finite, validate_no_nan, validate_non_negative};
+use crate::internal::validation::{
+    validate_binary_i32, validate_finite, validate_no_nan, validate_non_negative,
+};
 use pyo3::exceptions::PyValueError;
 
 /// Result of pseudo-value computation
@@ -128,18 +130,6 @@ fn validate_pseudo_type(type_: Option<&str>) -> PyResult<&'static str> {
     }
 }
 
-fn validate_binary_status(status: &[i32]) -> PyResult<()> {
-    for (idx, &value) in status.iter().enumerate() {
-        if value != 0 && value != 1 {
-            return Err(PyValueError::new_err(format!(
-                "status must contain only 0/1 values; got {} at index {}",
-                value, idx
-            )));
-        }
-    }
-    Ok(())
-}
-
 fn validate_pseudo_inputs(
     time: &[f64],
     status: &[i32],
@@ -154,7 +144,7 @@ fn validate_pseudo_inputs(
     validate_no_nan(time, "time")?;
     validate_finite(time, "time")?;
     validate_non_negative(time, "time")?;
-    validate_binary_status(status)?;
+    validate_binary_i32(status, "status")?;
 
     if let Some(eval_times) = eval_times {
         validate_no_nan(eval_times, "eval_times")?;
@@ -165,10 +155,6 @@ fn validate_pseudo_inputs(
     Ok(())
 }
 
-fn same_pseudo_time(left: f64, right: f64) -> bool {
-    (left - right).abs() < TIME_EPSILON
-}
-
 fn default_event_times(time: &[f64], status: &[i32]) -> Vec<f64> {
     let mut event_times: Vec<f64> = time
         .iter()
@@ -177,7 +163,7 @@ fn default_event_times(time: &[f64], status: &[i32]) -> Vec<f64> {
         .map(|(t, _)| *t)
         .collect();
     event_times.sort_by(|a, b| a.total_cmp(b));
-    event_times.dedup_by(|a, b| same_pseudo_time(*a, *b));
+    event_times.dedup_by(|a, b| same_time(*a, *b));
     event_times
 }
 
@@ -208,7 +194,7 @@ fn compute_km(time: &[f64], status: &[i32], eval_times: &[f64], type_: &str) -> 
     while start < n {
         let current_time = time[indices[start]];
         let mut end = start + 1;
-        while end < n && same_pseudo_time(time[indices[end]], current_time) {
+        while end < n && same_time(time[indices[end]], current_time) {
             end += 1;
         }
 
@@ -668,7 +654,7 @@ pub fn pseudo_gee_regression(
     let confidence_intervals: Vec<(f64, f64)> = beta
         .iter()
         .zip(std_errors.iter())
-        .map(|(b, se)| (b - 1.96 * se, b + 1.96 * se))
+        .map(|(&beta, &std_error)| normal_ci_95(beta, std_error))
         .collect();
 
     let rss: f64 = residuals.iter().map(|r| r * r).sum();
@@ -801,15 +787,15 @@ fn apply_link_inverse(eta: &[f64], link: &str) -> Vec<f64> {
 fn compute_link_derivative(mu: &[f64], link: &str) -> Vec<f64> {
     match link {
         "identity" => vec![1.0; mu.len()],
-        "log" => mu.iter().map(|m| 1.0 / m.max(1e-10)).collect(),
+        "log" => mu.iter().map(|m| 1.0 / m.max(DIVISION_FLOOR)).collect(),
         "logit" => mu
             .iter()
-            .map(|m| 1.0 / (m.max(1e-10) * (1.0 - m).max(1e-10)))
+            .map(|m| 1.0 / (m.max(DIVISION_FLOOR) * (1.0 - m).max(DIVISION_FLOOR)))
             .collect(),
         "cloglog" => mu
             .iter()
             .map(|m| {
-                let m = m.clamp(1e-10, 1.0 - 1e-10);
+                let m = m.clamp(DIVISION_FLOOR, 1.0 - DIVISION_FLOOR);
                 1.0 / ((1.0 - m) * (-(1.0 - m).ln()))
             })
             .collect(),
@@ -898,7 +884,7 @@ fn invert_matrix(m: &[Vec<f64>]) -> Vec<Vec<f64>> {
         aug.swap(i, max_row);
 
         let pivot = aug[i][i];
-        if pivot.abs() < 1e-10 {
+        if pivot.abs() < DIVISION_FLOOR {
             continue;
         }
 

--- a/src/surv_analysis/survfit_matrix.rs
+++ b/src/surv_analysis/survfit_matrix.rs
@@ -1,6 +1,8 @@
 use pyo3::exceptions::{PyIndexError, PyValueError};
 use pyo3::prelude::*;
 
+use crate::constants::same_time;
+
 fn value_error(message: impl Into<String>) -> PyErr {
     PyErr::new::<PyValueError, _>(message.into())
 }
@@ -656,7 +658,7 @@ pub fn basehaz(
             .filter_map(|(&event_time, &event)| (event == 1).then_some(event_time))
             .collect();
         event_times.sort_by(|a, b| a.total_cmp(b));
-        event_times.dedup_by(|a, b| (*a - *b).abs() < crate::constants::TIME_EPSILON);
+        event_times.dedup_by(|a, b| same_time(*a, *b));
 
         let mut hazard = Vec::with_capacity(event_times.len());
         let mut cum_hazard = 0.0;
@@ -666,8 +668,7 @@ pub fn basehaz(
                 .zip(status.iter())
                 .zip(weights.iter())
                 .filter_map(|((&stop, &event), &weight)| {
-                    (event == 1 && (stop - event_time).abs() < crate::constants::TIME_EPSILON)
-                        .then_some(weight)
+                    (event == 1 && same_time(stop, *event_time)).then_some(weight)
                 })
                 .sum::<f64>();
             let risk_sum: f64 = (0..n)
@@ -707,7 +708,7 @@ pub fn basehaz(
         let mut events = 0.0;
         let start_i = i;
 
-        while i < n && (time[indices[i]] - current_time).abs() < crate::constants::TIME_EPSILON {
+        while i < n && same_time(time[indices[i]], current_time) {
             if status[indices[i]] == 1 {
                 events += weights[indices[i]];
             }

--- a/src/surv_analysis/survfitaj_extended.rs
+++ b/src/surv_analysis/survfitaj_extended.rs
@@ -1,9 +1,13 @@
 use pyo3::prelude::*;
 use rayon::prelude::*;
 
-use crate::constants::TIME_EPSILON;
+use crate::constants::{
+    TIME_EPSILON, Z_SCORE_90, Z_SCORE_95, Z_SCORE_99, clamped_normal_ci_bounds, same_time,
+};
 use crate::internal::validation::{validate_finite, validate_no_nan, validate_non_negative};
 use pyo3::exceptions::PyValueError;
+
+type StateProbabilityCube = Vec<Vec<Vec<f64>>>;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[pyclass(from_py_object)]
@@ -212,7 +216,7 @@ fn compute_transition_matrix(
     let mut n_at_risk = vec![0usize; n_states];
 
     for (i, &t) in time.iter().enumerate() {
-        if same_transition_time(t, event_time) {
+        if same_time(t, event_time) {
             let from = from_state[i];
             let to = to_state[i];
             if from < n_states && to < n_states {
@@ -431,14 +435,10 @@ fn compute_expected_sojourn(
     sojourn
 }
 
-fn same_transition_time(left: f64, right: f64) -> bool {
-    (left - right).abs() < TIME_EPSILON
-}
-
 fn unique_transition_times(time: &[f64]) -> Vec<f64> {
     let mut unique_times = time.to_vec();
     unique_times.sort_by(|a, b| a.total_cmp(b));
-    unique_times.dedup_by(|a, b| same_transition_time(*a, *b));
+    unique_times.dedup_by(|a, b| same_time(*a, *b));
     unique_times
 }
 
@@ -551,45 +551,27 @@ pub fn survfitaj_extended(
     };
 
     let z = match config.confidence_level {
-        c if c >= 0.99 => 2.576,
-        c if c >= 0.95 => 1.96,
-        c if c >= 0.90 => 1.645,
-        _ => 1.96,
+        c if c >= 0.99 => Z_SCORE_99,
+        c if c >= 0.95 => Z_SCORE_95,
+        c if c >= 0.90 => Z_SCORE_90,
+        _ => Z_SCORE_95,
     };
 
-    let ci_lower: Vec<Vec<Vec<f64>>> = variance
+    let (ci_lower, ci_upper): (StateProbabilityCube, StateProbabilityCube) = variance
         .iter()
         .zip(state_probs.iter())
         .map(|(var, probs)| {
-            var.iter()
+            let row_intervals: Vec<(Vec<f64>, Vec<f64>)> = var
+                .iter()
                 .zip(probs.iter())
                 .map(|(var_row, prob_row)| {
-                    var_row
-                        .iter()
-                        .zip(prob_row.iter())
-                        .map(|(&v, &p)| (p - z * v.sqrt()).clamp(0.0, 1.0))
-                        .collect()
+                    let std_errors: Vec<f64> = var_row.iter().map(|&v| v.sqrt()).collect();
+                    clamped_normal_ci_bounds(prob_row, &std_errors, z, 0.0, 1.0)
                 })
-                .collect()
+                .collect();
+            row_intervals.into_iter().unzip()
         })
-        .collect();
-
-    let ci_upper: Vec<Vec<Vec<f64>>> = variance
-        .iter()
-        .zip(state_probs.iter())
-        .map(|(var, probs)| {
-            var.iter()
-                .zip(probs.iter())
-                .map(|(var_row, prob_row)| {
-                    var_row
-                        .iter()
-                        .zip(prob_row.iter())
-                        .map(|(&v, &p)| (p + z * v.sqrt()).clamp(0.0, 1.0))
-                        .collect()
-                })
-                .collect()
-        })
-        .collect();
+        .unzip();
 
     let cumulative_incidence: Vec<Vec<f64>> = (0..n_states)
         .map(|j| state_probs.iter().map(|p| p[0][j]).collect())

--- a/src/surv_analysis/survfitkm.rs
+++ b/src/surv_analysis/survfitkm.rs
@@ -1,11 +1,13 @@
-use crate::constants::{DEFAULT_CONFIDENCE_LEVEL, PARALLEL_THRESHOLD_XLARGE, TIME_EPSILON};
+use crate::constants::{
+    DEFAULT_CONFIDENCE_LEVEL, PARALLEL_THRESHOLD_XLARGE, TIME_EPSILON, exp_ci, normal_ci,
+};
 use crate::internal::numpy_utils::{
     extract_optional_vec_f64, extract_optional_vec_i32, extract_vec_f64,
 };
 use crate::internal::statistical::normal_inverse_cdf;
 use crate::internal::validation::{
-    clamp_probability, validate_finite, validate_length, validate_no_nan, validate_non_empty,
-    validate_non_negative,
+    clamp_probability, validate_binary_f64, validate_finite, validate_length, validate_no_nan,
+    validate_non_empty, validate_non_negative,
 };
 use pyo3::prelude::*;
 use rayon::prelude::*;
@@ -187,17 +189,15 @@ fn compute_confidence_interval(survival: f64, std_err: f64, z: f64, conf_type: &
     }
 
     match conf_type {
-        "plain" => (
-            clamp_probability(survival - z * std_err),
-            clamp_probability(survival + z * std_err),
-        ),
+        "plain" => {
+            let (lower, upper) = normal_ci(survival, std_err, z);
+            (clamp_probability(lower), clamp_probability(upper))
+        }
         "log" => {
             let log_survival = survival.ln();
             let log_std_err = std_err / survival;
-            (
-                clamp_probability((log_survival - z * log_std_err).exp()),
-                clamp_probability((log_survival + z * log_std_err).exp()),
-            )
+            let (lower, upper) = exp_ci(log_survival, log_std_err, z);
+            (clamp_probability(lower), clamp_probability(upper))
         }
         "log-log" => {
             let log_survival = survival.ln();
@@ -244,18 +244,6 @@ fn validate_entry_times(time: &[f64], entry_times: &[f64]) -> PyResult<()> {
             return Err(pyo3::exceptions::PyValueError::new_err(format!(
                 "entry_times must be less than time for observation {}",
                 idx
-            )));
-        }
-    }
-    Ok(())
-}
-
-fn validate_binary_status(status: &[f64]) -> PyResult<()> {
-    for (idx, &value) in status.iter().enumerate() {
-        if value != 0.0 && value != 1.0 {
-            return Err(pyo3::exceptions::PyValueError::new_err(format!(
-                "status must contain only 0/1 values; found {} at observation {}",
-                value, idx
             )));
         }
     }
@@ -378,7 +366,7 @@ pub fn survfitkm(
     validate_non_negative(&time, "time")?;
     validate_no_nan(&status, "status")?;
     validate_finite(&status, "status")?;
-    validate_binary_status(&status)?;
+    validate_binary_f64(&status, "status")?;
     let weights = match weights_opt {
         Some(w) => {
             validate_length(time.len(), w.len(), "weights")?;
@@ -535,7 +523,7 @@ pub fn survfitkm_with_options(
     validate_non_negative(&time, "time")?;
     validate_no_nan(&status, "status")?;
     validate_finite(&status, "status")?;
-    validate_binary_status(&status)?;
+    validate_binary_f64(&status, "status")?;
     let weights = match opts.weights {
         Some(w) => {
             validate_length(time.len(), w.len(), "weights")?;
@@ -643,10 +631,10 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_binary_status_rejects_non_binary_values() {
+    fn test_validate_binary_f64_rejects_non_binary_values() {
         pyo3::Python::initialize();
 
-        let err = validate_binary_status(&[0.0, 0.5, 1.0])
+        let err = validate_binary_f64(&[0.0, 0.5, 1.0], "status")
             .expect_err("non-binary status should be rejected");
 
         assert!(err.to_string().contains("status must contain only 0/1"));

--- a/src/validation/bootstrap.rs
+++ b/src/validation/bootstrap.rs
@@ -329,6 +329,7 @@ pub(crate) fn bootstrap_survreg(
         Some(1e-5),
         Some(1e-9),
         None,
+        None,
     )?;
     let seed = config.seed.unwrap_or(crate::constants::DEFAULT_RANDOM_SEED);
     let bootstrap_coefs: Vec<Vec<f64>> = (0..config.n_bootstrap)
@@ -351,6 +352,7 @@ pub(crate) fn bootstrap_survreg(
                 Some(COX_MAX_ITER),
                 Some(1e-5),
                 Some(1e-9),
+                None,
                 None,
             ) {
                 Ok(result) => Some(result.coefficients),

--- a/src/validation/cipoisson.rs
+++ b/src/validation/cipoisson.rs
@@ -1,3 +1,4 @@
+use crate::constants::normal_ci;
 use crate::internal::statistical::{gamma_inverse_cdf, normal_inverse_cdf};
 use pyo3::prelude::*;
 
@@ -32,8 +33,7 @@ pub fn cipoisson_anscombe(k: u32, time: f64, p: f64) -> PyResult<(f64, f64)> {
     let transformed_k = (k as f64 + 3.0 / 8.0).sqrt();
     let z = normal_inverse_cdf(p / 2.0);
     let variance: f64 = 1.0 / 4.0;
-    let lower_bound = transformed_k - z * (variance.sqrt());
-    let upper_bound = transformed_k + z * (variance.sqrt());
+    let (lower_bound, upper_bound) = normal_ci(transformed_k, variance.sqrt(), z);
     let lower_bound_poisson = (lower_bound.powi(2) - 3.0 / 8.0).max(0.0) / time;
     let upper_bound_poisson = (upper_bound.powi(2) - 3.0 / 8.0) / time;
     Ok((lower_bound_poisson, upper_bound_poisson))

--- a/src/validation/conformal/base.rs
+++ b/src/validation/conformal/base.rs
@@ -162,9 +162,8 @@ pub fn conformal_coverage_test(
     let expected_coverage = coverage;
 
     let se = (empirical_coverage * (1.0 - empirical_coverage) / total_count as f64).sqrt();
-    let z = 1.96;
-    let coverage_ci_lower = (empirical_coverage - z * se).max(0.0);
-    let coverage_ci_upper = (empirical_coverage + z * se).min(1.0);
+    let (coverage_ci_lower, coverage_ci_upper) =
+        clamped_normal_ci_95(empirical_coverage, se, 0.0, 1.0);
 
     let mut sorted_lpb: Vec<f64> = lpb.clone();
     sorted_lpb.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));

--- a/src/validation/conformal/distribution/diagnostics.rs
+++ b/src/validation/conformal/distribution/diagnostics.rs
@@ -95,11 +95,11 @@ pub fn conformal_calibration_plot(
             0.0
         };
         let se = (emp_cov * (1.0 - emp_cov) / total.max(1) as f64).sqrt();
-        let z = 1.96;
+        let (lower, upper) = clamped_normal_ci_95(emp_cov, se, 0.0, 1.0);
 
         empirical_coverages.push(emp_cov);
-        ci_lower.push((emp_cov - z * se).max(0.0));
-        ci_upper.push((emp_cov + z * se).min(1.0));
+        ci_lower.push(lower);
+        ci_upper.push(upper);
     }
 
     Ok(ConformalCalibrationPlot {

--- a/src/validation/conformal/doubly_robust.rs
+++ b/src/validation/conformal/doubly_robust.rs
@@ -54,8 +54,7 @@ impl CensoringModel {
             let mut censored_count = 0;
             let mut event_count = 0;
 
-            while i < n && (time[indices[i]] - current_time).abs() < crate::constants::TIME_EPSILON
-            {
+            while i < n && same_time(time[indices[i]], current_time) {
                 if status[indices[i]] == 0 {
                     censored_count += 1;
                 } else {

--- a/src/validation/conformal/mod.rs
+++ b/src/validation/conformal/mod.rs
@@ -3,7 +3,7 @@ use rayon::prelude::*;
 
 use crate::constants::{
     DEFAULT_CONFORMAL_COVERAGE, DEFAULT_IPCW_TRIM, DEFAULT_MIN_GROUP_SIZE, DEFAULT_WEIGHT_TRIM,
-    MAX_WEIGHT_RATIO,
+    MAX_WEIGHT_RATIO, clamped_normal_ci_95, same_time,
 };
 
 mod base;

--- a/src/validation/conformal/shared.rs
+++ b/src/validation/conformal/shared.rs
@@ -107,7 +107,7 @@ pub(super) fn compute_km_censoring_survival(time: &[f64], status: &[i32]) -> Vec
         let mut censored_count = 0;
 
         let start_i = i;
-        while i < n && (time[indices[i]] - current_time).abs() < crate::constants::TIME_EPSILON {
+        while i < n && same_time(time[indices[i]], current_time) {
             if status[indices[i]] == 0 {
                 censored_count += 1;
             }

--- a/src/validation/crossval.rs
+++ b/src/validation/crossval.rs
@@ -299,6 +299,7 @@ pub(crate) fn cv_survreg(
                 Some(1e-5),
                 Some(1e-9),
                 None,
+                None,
             )
             .ok()?;
             let test_time: Vec<f64> = test_indices.iter().map(|&i| time[i]).collect();
@@ -317,6 +318,7 @@ pub(crate) fn cv_survreg(
                 Some(1),
                 Some(1e-5),
                 Some(1e-9),
+                None,
                 None,
             )
             .ok()?;

--- a/src/validation/d_calibration/mod.rs
+++ b/src/validation/d_calibration/mod.rs
@@ -1,3 +1,4 @@
+use crate::constants::clamped_normal_ci_95;
 use crate::internal::statistical::chi2_sf;
 use crate::simd_ops::{dot_product_simd, mean_simd, subtract_scalar_simd, sum_of_squares_simd};
 use pyo3::prelude::*;

--- a/src/validation/d_calibration/plot.rs
+++ b/src/validation/d_calibration/plot.rs
@@ -122,9 +122,7 @@ pub(crate) fn calibration_plot_data_core(
             0.0
         };
 
-        let z = 1.96;
-        let lower = (obs_surv - z * se).max(0.0);
-        let upper = (obs_surv + z * se).min(1.0);
+        let (lower, upper) = clamped_normal_ci_95(obs_surv, se, 0.0, 1.0);
 
         predicted.push(mean_pred);
         observed.push(obs_surv);

--- a/src/validation/d_calibration/smoothed.rs
+++ b/src/validation/d_calibration/smoothed.rs
@@ -147,11 +147,11 @@ pub(crate) fn smoothed_calibration_core(
         };
 
         let se = (variance / weight_sum.max(1.0)).sqrt();
-        let z = 1.96;
+        let (lower, upper) = clamped_normal_ci_95(smoothed, se, 0.0, 1.0);
 
         smoothed_observed.push(smoothed);
-        ci_lower.push((smoothed - z * se).clamp(0.0, 1.0));
-        ci_upper.push((smoothed + z * se).clamp(0.0, 1.0));
+        ci_lower.push(lower);
+        ci_upper.push(upper);
     }
 
     SmoothedCalibrationCurve {
@@ -196,4 +196,3 @@ pub fn smoothed_calibration(
         bandwidth,
     ))
 }
-

--- a/src/validation/hyperparameter.rs
+++ b/src/validation/hyperparameter.rs
@@ -1,4 +1,4 @@
-use crate::constants::{DEFAULT_CONCORDANCE, DIVISION_FLOOR};
+use crate::constants::{DEFAULT_CONCORDANCE, DIVISION_FLOOR, Z_SCORE_95};
 use crate::internal::statistical::concordance_index_with_horizon;
 use pyo3::prelude::*;
 use rayon::prelude::*;
@@ -410,8 +410,7 @@ impl NestedCVResult {
     }
 
     fn confidence_interval(&self, _alpha: f64) -> (f64, f64) {
-        let z = 1.96;
-        let margin = z * self.std_score / (self.outer_scores.len() as f64).sqrt();
+        let margin = Z_SCORE_95 * self.std_score / (self.outer_scores.len() as f64).sqrt();
         (self.mean_score - margin, self.mean_score + margin)
     }
 }

--- a/src/validation/landmark.rs
+++ b/src/validation/landmark.rs
@@ -1,4 +1,6 @@
-use crate::constants::{PARALLEL_THRESHOLD_SMALL, z_score_for_confidence};
+use crate::constants::{
+    PARALLEL_THRESHOLD_SMALL, clamped_normal_ci, exp_ci, z_score_for_confidence,
+};
 use crate::internal::statistical::normal_cdf as norm_cdf;
 use pyo3::prelude::*;
 use rayon::prelude::*;
@@ -201,8 +203,7 @@ pub(crate) fn compute_conditional_survival(
         0.0
     };
     let se = var_conditional.sqrt();
-    let ci_lower = (conditional - z * se).clamp(0.0, 1.0);
-    let ci_upper = (conditional + z * se).clamp(0.0, 1.0);
+    let (ci_lower, ci_upper) = clamped_normal_ci(conditional, se, z, 0.0, 1.0);
     ConditionalSurvivalResult {
         given_time,
         target_time,
@@ -360,17 +361,8 @@ pub(crate) fn compute_hazard_ratio(
     } else {
         0.0
     };
-    let z: f64 = if confidence_level >= 0.99 {
-        2.576
-    } else if confidence_level >= 0.95 {
-        1.96
-    } else if confidence_level >= 0.90 {
-        1.645
-    } else {
-        1.28
-    };
-    let ci_lower = (log_hr - z * se_log_hr).exp();
-    let ci_upper = (log_hr + z * se_log_hr).exp();
+    let z = z_score_for_confidence(confidence_level);
+    let (ci_lower, ci_upper) = exp_ci(log_hr, se_log_hr, z);
     let z_statistic: f64 = if se_log_hr > 0.0 {
         log_hr / se_log_hr
     } else {
@@ -534,8 +526,7 @@ pub(crate) fn compute_survival_at_times(
                     }
                 };
                 let se = var.sqrt();
-                let ci_lower = (survival - z * se).clamp(0.0, 1.0);
-                let ci_upper = (survival + z * se).clamp(0.0, 1.0);
+                let (ci_lower, ci_upper) = clamped_normal_ci(survival, se, z, 0.0, 1.0);
                 SurvivalAtTimeResult {
                     time: t,
                     survival,
@@ -565,8 +556,7 @@ pub(crate) fn compute_survival_at_times(
                 }
             };
             let se = var.sqrt();
-            let ci_lower = (survival - z * se).clamp(0.0, 1.0);
-            let ci_upper = (survival + z * se).clamp(0.0, 1.0);
+            let (ci_lower, ci_upper) = clamped_normal_ci(survival, se, z, 0.0, 1.0);
             results.push(SurvivalAtTimeResult {
                 time: t,
                 survival,

--- a/src/validation/logrank.rs
+++ b/src/validation/logrank.rs
@@ -1,8 +1,8 @@
-use crate::constants::TIME_EPSILON;
+use crate::constants::{TIME_EPSILON, same_time};
 use crate::internal::numpy_utils::{extract_optional_vec_f64, extract_vec_f64, extract_vec_i32};
 use crate::internal::statistical::chi2_sf;
 use crate::internal::validation::{
-    validate_finite, validate_length, validate_no_nan, validate_non_negative,
+    validate_binary_i32, validate_finite, validate_length, validate_no_nan, validate_non_negative,
 };
 use pyo3::prelude::*;
 use std::collections::HashMap;
@@ -208,7 +208,7 @@ fn validate_logrank_inputs(
 ) -> PyResult<()> {
     validate_length(time.len(), status.len(), "status")?;
     validate_length(time.len(), group.len(), "group")?;
-    validate_binary_status(status)?;
+    validate_binary_i32(status, "status")?;
     validate_no_nan(time, "time")?;
     validate_finite(time, "time")?;
     validate_non_negative(time, "time")?;
@@ -224,18 +224,6 @@ fn validate_logrank_inputs(
                     idx
                 )));
             }
-        }
-    }
-    Ok(())
-}
-
-fn validate_binary_status(status: &[i32]) -> PyResult<()> {
-    for (idx, &value) in status.iter().enumerate() {
-        if value != 0 && value != 1 {
-            return Err(pyo3::exceptions::PyValueError::new_err(format!(
-                "status must contain only 0/1 values; got {} at index {}",
-                value, idx
-            )));
         }
     }
     Ok(())
@@ -263,7 +251,7 @@ fn validate_logrank_trend_inputs(
 ) -> PyResult<()> {
     validate_length(time.len(), status.len(), "status")?;
     validate_length(time.len(), group.len(), "group")?;
-    validate_binary_status(status)?;
+    validate_binary_i32(status, "status")?;
     validate_no_nan(time, "time")?;
     validate_finite(time, "time")?;
     validate_non_negative(time, "time")?;
@@ -276,10 +264,6 @@ fn validate_logrank_trend_inputs(
         validate_finite(values, "scores")?;
     }
     Ok(())
-}
-
-fn same_time(left: f64, right: f64) -> bool {
-    (left - right).abs() < TIME_EPSILON
 }
 
 fn weight_name(weight_type: &WeightType) -> String {

--- a/src/validation/meta_analysis.rs
+++ b/src/validation/meta_analysis.rs
@@ -1,6 +1,13 @@
 use pyo3::prelude::*;
 
+use crate::constants::{
+    DEFAULT_CONFIDENCE_LEVEL, DIVISION_FLOOR, Z_SCORE_95, normal_ci, normal_ci_bounds,
+    z_score_for_confidence,
+};
 use crate::internal::statistical::normal_cdf;
+
+const REML_MAX_ITERATIONS: usize = 100;
+const REML_TOLERANCE: f64 = 1e-8;
 
 #[pyclass(from_py_object)]
 #[derive(Clone, Debug)]
@@ -105,8 +112,13 @@ pub fn survival_meta_analysis(
     std_errors: Vec<f64>,
     config: Option<MetaAnalysisConfig>,
 ) -> PyResult<MetaAnalysisResult> {
-    let config = config
-        .unwrap_or_else(|| MetaAnalysisConfig::new("random".to_string(), 0.95, "dl".to_string()));
+    let config = config.unwrap_or_else(|| {
+        MetaAnalysisConfig::new(
+            "random".to_string(),
+            DEFAULT_CONFIDENCE_LEVEL,
+            "dl".to_string(),
+        )
+    });
 
     let k = effects.len();
     if k < 2 || std_errors.len() != k {
@@ -133,9 +145,8 @@ pub fn survival_meta_analysis(
         _ => compute_random_effects(&effects, &variances, tau_squared),
     };
 
-    let z = 1.96;
-    let lower_ci = pooled_effect - z * pooled_se;
-    let upper_ci = pooled_effect + z * pooled_se;
+    let z = z_score_for_confidence(config.confidence_level);
+    let (lower_ci, upper_ci) = normal_ci(pooled_effect, pooled_se, z);
 
     let z_value = if pooled_se > 0.0 {
         pooled_effect / pooled_se
@@ -216,7 +227,7 @@ fn compute_tau_squared_reml(effects: &[f64], variances: &[f64]) -> f64 {
     let k = effects.len();
     let mut tau2: f64 = 0.0;
 
-    for _ in 0..100 {
+    for _ in 0..REML_MAX_ITERATIONS {
         let weights: Vec<f64> = variances.iter().map(|v| 1.0 / (v + tau2)).collect();
         let sum_w: f64 = weights.iter().sum();
         let weighted_mean: f64 = effects
@@ -238,7 +249,7 @@ fn compute_tau_squared_reml(effects: &[f64], variances: &[f64]) -> f64 {
         let tau2_new = (q - (k as f64 - 1.0)) / c;
         let tau2_new = tau2_new.max(0.0);
 
-        if (tau2_new - tau2).abs() < 1e-8 {
+        if (tau2_new - tau2).abs() < REML_TOLERANCE {
             break;
         }
         tau2 = tau2_new;
@@ -332,7 +343,7 @@ fn t_distribution_quantile(_p: f64, df: usize) -> f64 {
     if df <= 30 {
         return 2.04;
     }
-    1.96
+    Z_SCORE_95
 }
 
 #[pyclass(from_py_object)]
@@ -402,19 +413,17 @@ pub fn generate_forest_plot_data(
         ));
     }
 
-    let z = 1.96;
-    let lower_ci: Vec<f64> = effects
-        .iter()
-        .zip(std_errors.iter())
-        .map(|(e, se)| e - z * se)
-        .collect();
-    let upper_ci: Vec<f64> = effects
-        .iter()
-        .zip(std_errors.iter())
-        .map(|(e, se)| e + z * se)
-        .collect();
+    let config = config.unwrap_or_else(|| {
+        MetaAnalysisConfig::new(
+            "random".to_string(),
+            DEFAULT_CONFIDENCE_LEVEL,
+            "dl".to_string(),
+        )
+    });
+    let z = z_score_for_confidence(config.confidence_level);
+    let (lower_ci, upper_ci) = normal_ci_bounds(&effects, &std_errors, z);
 
-    let meta_result = survival_meta_analysis(effects.clone(), std_errors.clone(), config)?;
+    let meta_result = survival_meta_analysis(effects.clone(), std_errors.clone(), Some(config))?;
 
     Ok(MetaForestPlotData {
         study_names,
@@ -529,7 +538,7 @@ fn weighted_regression(x: &[f64], y: &[f64]) -> (f64, f64, f64) {
     let sum_xx: f64 = x.iter().map(|xi| xi * xi).sum();
 
     let denom = n * sum_xx - sum_x * sum_x;
-    if denom.abs() < 1e-10 {
+    if denom.abs() < DIVISION_FLOOR {
         return (0.0, 0.0, f64::INFINITY);
     }
 

--- a/src/validation/model_selection.rs
+++ b/src/validation/model_selection.rs
@@ -1,6 +1,7 @@
 use pyo3::prelude::*;
 use rayon::prelude::*;
 
+use crate::constants::Z_SCORE_95;
 use crate::internal::statistical::chi2_cdf;
 
 type LikelihoodRatioTest = (String, String, f64, f64, f64);
@@ -341,8 +342,7 @@ impl CrossValidatedScore {
     }
 
     fn confidence_interval(&self, _alpha: f64) -> (f64, f64) {
-        let z = 1.96;
-        let margin = z * self.std_score / (self.n_folds as f64).sqrt();
+        let margin = Z_SCORE_95 * self.std_score / (self.n_folds as f64).sqrt();
         (self.mean_score - margin, self.mean_score + margin)
     }
 }

--- a/src/validation/reporting.rs
+++ b/src/validation/reporting.rs
@@ -1,6 +1,13 @@
 use pyo3::prelude::*;
 
+use crate::constants::{
+    DIVISION_FLOOR, Z_SCORE_95, exp_ci, exp_ci_bounds, same_time, z_score_for_confidence,
+};
 use crate::internal::statistical::{lower_incomplete_gamma, normal_cdf};
+
+const MEDIAN_CI_LOWER_FACTOR: f64 = 0.8;
+const MEDIAN_CI_UPPER_FACTOR: f64 = 1.2;
+const DEFAULT_LANDMARK_FRACTIONS: [f64; 4] = [0.25, 0.5, 0.75, 1.0];
 
 #[derive(Debug, Clone)]
 #[pyclass(from_py_object)]
@@ -74,11 +81,7 @@ pub fn km_plot_data(
     unique_times.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
     unique_times.dedup();
 
-    let z = match confidence_level {
-        c if (c - 0.90).abs() < 0.01 => 1.645,
-        c if (c - 0.99).abs() < 0.01 => 2.576,
-        _ => 1.96,
-    };
+    let z = z_score_for_confidence(confidence_level);
 
     let mut time_points = vec![0.0];
     let mut survival_prob = vec![1.0];
@@ -96,12 +99,12 @@ pub fn km_plot_data(
         let event_count = time
             .iter()
             .zip(event.iter())
-            .filter(|&(&ti, &ei)| (ti - t).abs() < 1e-10 && ei == 1)
+            .filter(|&(&ti, &ei)| same_time(ti, t) && ei == 1)
             .count();
         let censored_count = time
             .iter()
             .zip(event.iter())
-            .filter(|&(&ti, &ei)| (ti - t).abs() < 1e-10 && ei == 0)
+            .filter(|&(&ti, &ei)| same_time(ti, t) && ei == 0)
             .count();
 
         if risk_count > 0 {
@@ -114,11 +117,13 @@ pub fn km_plot_data(
             }
 
             let se = surv * var_sum.sqrt();
-            let log_surv = surv.max(1e-10).ln();
-            let log_se = se / surv.max(1e-10);
+            let bounded_surv = surv.max(DIVISION_FLOOR);
+            let log_surv = bounded_surv.ln();
+            let log_se = se / bounded_surv;
 
-            let lower = (log_surv - z * log_se).exp().clamp(0.0, 1.0);
-            let upper = (log_surv + z * log_se).exp().clamp(0.0, 1.0);
+            let (lower, upper) = exp_ci(log_surv, log_se, z);
+            let lower = lower.clamp(0.0, 1.0);
+            let upper = upper.clamp(0.0, 1.0);
 
             time_points.push(t);
             survival_prob.push(surv);
@@ -190,23 +195,10 @@ pub fn forest_plot_data(
         ));
     }
 
-    let z = match confidence_level {
-        c if (c - 0.90).abs() < 0.01 => 1.645,
-        c if (c - 0.99).abs() < 0.01 => 2.576,
-        _ => 1.96,
-    };
+    let z = z_score_for_confidence(confidence_level);
 
     let hazard_ratios: Vec<f64> = coefficients.iter().map(|&c| c.exp()).collect();
-    let lower_ci: Vec<f64> = coefficients
-        .iter()
-        .zip(standard_errors.iter())
-        .map(|(&c, &se)| (c - z * se).exp())
-        .collect();
-    let upper_ci: Vec<f64> = coefficients
-        .iter()
-        .zip(standard_errors.iter())
-        .map(|(&c, &se)| (c + z * se).exp())
-        .collect();
+    let (lower_ci, upper_ci) = exp_ci_bounds(&coefficients, &standard_errors, z);
     let p_values: Vec<f64> = coefficients
         .iter()
         .zip(standard_errors.iter())
@@ -312,7 +304,8 @@ pub fn calibration_plot_data(
         let expected = bin_n as f64 * pred_mean;
         let obs_events = bin_indices.iter().map(|&j| observed[j] as f64).sum::<f64>();
         if expected > 0.0 && expected < bin_n as f64 {
-            hl_stat += (obs_events - expected).powi(2) / (expected * (1.0 - pred_mean)).max(1e-10);
+            hl_stat += (obs_events - expected).powi(2)
+                / (expected * (1.0 - pred_mean)).max(DIVISION_FLOOR);
         }
     }
     bin_boundaries.push(1.0);
@@ -480,7 +473,7 @@ pub fn generate_survival_report(
         let event_count = time
             .iter()
             .zip(event.iter())
-            .filter(|&(&ti, &ei)| (ti - t).abs() < 1e-10 && ei == 1)
+            .filter(|&(&ti, &ei)| same_time(ti, t) && ei == 1)
             .count();
 
         if risk_count > 0 {
@@ -493,10 +486,12 @@ pub fn generate_survival_report(
             }
 
             let se = surv * var_sum.sqrt();
-            let log_surv = surv.max(1e-10).ln();
-            let log_se = se / surv.max(1e-10);
-            let lower = (log_surv - 1.96 * log_se).exp().clamp(0.0, 1.0);
-            let upper = (log_surv + 1.96 * log_se).exp().clamp(0.0, 1.0);
+            let bounded_surv = surv.max(DIVISION_FLOOR);
+            let log_surv = bounded_surv.ln();
+            let log_se = se / bounded_surv;
+            let (lower, upper) = exp_ci(log_surv, log_se, Z_SCORE_95);
+            let lower = lower.clamp(0.0, 1.0);
+            let upper = upper.clamp(0.0, 1.0);
 
             survival_at_times.push((t, surv, lower, upper));
 
@@ -506,11 +501,15 @@ pub fn generate_survival_report(
         }
     }
 
-    let median_ci = median_survival.map(|m| (m * 0.8, m * 1.2));
+    let median_ci =
+        median_survival.map(|m| (m * MEDIAN_CI_LOWER_FACTOR, m * MEDIAN_CI_UPPER_FACTOR));
 
     let landmarks = landmark_times.unwrap_or_else(|| {
         let max_time = sorted_times.last().cloned().unwrap_or(1.0);
-        vec![max_time * 0.25, max_time * 0.5, max_time * 0.75, max_time]
+        DEFAULT_LANDMARK_FRACTIONS
+            .iter()
+            .map(|fraction| max_time * *fraction)
+            .collect()
     });
 
     let survival_rates: Vec<(f64, f64, f64, f64)> = landmarks

--- a/src/validation/rmst/core.rs
+++ b/src/validation/rmst/core.rs
@@ -186,8 +186,8 @@ pub fn compute_rmst(time: &[f64], status: &[i32], tau: f64, confidence_level: f6
     }
     let se = variance.sqrt();
     let z = z_score_for_confidence(confidence_level);
-    let ci_lower = (rmst - z * se).max(0.0);
-    let ci_upper = rmst + z * se;
+    let (ci_lower, ci_upper) = normal_ci(rmst, se, z);
+    let ci_lower = ci_lower.max(0.0);
     RMSTResult {
         rmst,
         variance,
@@ -245,8 +245,7 @@ pub(crate) fn compare_rmst(
     let diff_var = rmst1.variance + rmst2.variance;
     let diff_se = diff_var.sqrt();
     let z = z_score_for_confidence(confidence_level);
-    let diff_ci_lower = diff - z * diff_se;
-    let diff_ci_upper = diff + z * diff_se;
+    let (diff_ci_lower, diff_ci_upper) = normal_ci(diff, diff_se, z);
     let ratio = if rmst2.rmst > 0.0 {
         rmst1.rmst / rmst2.rmst
     } else {
@@ -257,10 +256,7 @@ pub(crate) fn compare_rmst(
         let log_ratio_var =
             rmst1.variance / (rmst1.rmst * rmst1.rmst) + rmst2.variance / (rmst2.rmst * rmst2.rmst);
         let log_ratio_se = log_ratio_var.sqrt();
-        (
-            (log_ratio - z * log_ratio_se).exp(),
-            (log_ratio + z * log_ratio_se).exp(),
-        )
+        exp_ci(log_ratio, log_ratio_se, z)
     } else {
         (0.0, f64::INFINITY)
     };

--- a/src/validation/rmst/mod.rs
+++ b/src/validation/rmst/mod.rs
@@ -1,5 +1,6 @@
 use crate::constants::{
-    DEFAULT_CONFIDENCE_LEVEL, PARALLEL_THRESHOLD_XLARGE, z_score_for_confidence,
+    DEFAULT_CONFIDENCE_LEVEL, PARALLEL_THRESHOLD_XLARGE, clamped_normal_ci, exp_ci, normal_ci,
+    z_score_for_confidence,
 };
 use crate::internal::statistical::{chi2_cdf, normal_cdf as norm_cdf};
 use pyo3::prelude::*;

--- a/src/validation/rmst/quantiles.rs
+++ b/src/validation/rmst/quantiles.rs
@@ -74,8 +74,7 @@ pub(crate) fn compute_survival_quantile(
                 var_sum += events / (total_at_risk * (total_at_risk - events));
             }
             let se = surv * var_sum.sqrt();
-            let lower = (surv - z * se).clamp(0.0, 1.0);
-            let upper = (surv + z * se).clamp(0.0, 1.0);
+            let (lower, upper) = clamped_normal_ci(surv, se, z, 0.0, 1.0);
             unique_times.push(current_time);
             survival.push(surv);
             ci_lower_vec.push(lower);
@@ -295,8 +294,7 @@ pub(crate) fn compute_nnt(
     let arr = risk2 - risk1;
     let z = z_score_for_confidence(confidence_level);
     let arr_se = (surv1.1 + surv2.1).sqrt();
-    let arr_ci_lower = arr - z * arr_se;
-    let arr_ci_upper = arr + z * arr_se;
+    let (arr_ci_lower, arr_ci_upper) = normal_ci(arr, arr_se, z);
     let nnt = if arr.abs() > 1e-10 {
         1.0 / arr
     } else {

--- a/src/validation/survobrien.rs
+++ b/src/validation/survobrien.rs
@@ -7,24 +7,11 @@
 use crate::internal::numpy_utils::{extract_vec_f64, extract_vec_i32};
 use crate::internal::statistical::chi2_sf;
 use crate::internal::validation::{
-    validate_finite, validate_length, validate_no_nan, validate_non_negative,
+    validate_binary_i32, validate_finite, validate_length, validate_no_nan, validate_non_negative,
 };
 use pyo3::prelude::*;
 
-fn value_error(message: impl Into<String>) -> PyErr {
-    pyo3::exceptions::PyValueError::new_err(message.into())
-}
-
-fn validate_binary_status(status: &[i32]) -> PyResult<()> {
-    for (idx, &value) in status.iter().enumerate() {
-        if value != 0 && value != 1 {
-            return Err(value_error(format!(
-                "status must contain only 0/1 values; found {value} at observation {idx}"
-            )));
-        }
-    }
-    Ok(())
-}
+const RANK_TIE_TOLERANCE: f64 = 1e-10;
 
 fn validate_survobrien_inputs(
     time: &[f64],
@@ -38,7 +25,7 @@ fn validate_survobrien_inputs(
     validate_no_nan(time, "time")?;
     validate_finite(time, "time")?;
     validate_non_negative(time, "time")?;
-    validate_binary_status(status)?;
+    validate_binary_i32(status, "status")?;
     validate_no_nan(covariate, "covariate")?;
     validate_finite(covariate, "covariate")?;
     Ok(())
@@ -213,7 +200,8 @@ fn compute_survobrien(
                         let mut rank_sum = (k + 1) as f64;
 
                         while k + tie_count < n_at_risk
-                            && (at_risk_values[k + tie_count].1 - current_value).abs() < 1e-10
+                            && (at_risk_values[k + tie_count].1 - current_value).abs()
+                                < RANK_TIE_TOLERANCE
                         {
                             rank_sum += (k + tie_count + 1) as f64;
                             tie_count += 1;

--- a/src/validation/time_dependent_auc.rs
+++ b/src/validation/time_dependent_auc.rs
@@ -1,8 +1,12 @@
-use crate::constants::{IPCW_SURVIVAL_FLOOR, PARALLEL_THRESHOLD_LARGE};
+use crate::constants::{
+    DIVISION_FLOOR, IPCW_SURVIVAL_FLOOR, PARALLEL_THRESHOLD_LARGE, clamped_normal_ci_95,
+};
 use crate::internal::statistical::{compute_censoring_km, km_step_prob_at};
 use pyo3::prelude::*;
 use rayon::prelude::*;
 use std::fmt;
+
+const TIED_MARKER_TOLERANCE: f64 = DIVISION_FLOOR;
 
 #[derive(Debug, Clone)]
 #[pyclass(str, get_all, from_py_object)]
@@ -155,7 +159,7 @@ pub fn time_dependent_auc_core(
 
             let indicator = if m_case > m_ctrl {
                 1.0
-            } else if (m_case - m_ctrl).abs() < 1e-10 {
+            } else if (m_case - m_ctrl).abs() < TIED_MARKER_TOLERANCE {
                 0.5
             } else {
                 0.0
@@ -204,9 +208,7 @@ pub fn time_dependent_auc_core(
         0.0
     };
     let std_error = var_auc.sqrt();
-    let z = 1.96;
-    let ci_lower = (auc - z * std_error).clamp(0.0, 1.0);
-    let ci_upper = (auc + z * std_error).clamp(0.0, 1.0);
+    let (ci_lower, ci_upper) = clamped_normal_ci_95(auc, std_error, 0.0, 1.0);
 
     TimeDepAUCResult {
         auc,

--- a/src/validation/uncertainty/dropout.rs
+++ b/src/validation/uncertainty/dropout.rs
@@ -1,8 +1,7 @@
-
+const NORMAL_CI_Z_SCORE: f64 = crate::constants::Z_SCORE_95;
 
 #[derive(Debug, Clone)]
 #[pyclass(from_py_object)]
-
 pub struct MCDropoutConfig {
     #[pyo3(get, set)]
     pub n_samples: usize,
@@ -130,7 +129,7 @@ pub fn mc_dropout_uncertainty(predictions: Vec<Vec<Vec<f64>>>) -> PyResult<Uncer
         .map(|(m, s)| {
             m.iter()
                 .zip(s.iter())
-                .map(|(&mi, &si)| (mi - 1.96 * si).clamp(0.0, 1.0))
+                .map(|(&mi, &si)| (mi - NORMAL_CI_Z_SCORE * si).clamp(0.0, 1.0))
                 .collect()
         })
         .collect();
@@ -141,7 +140,7 @@ pub fn mc_dropout_uncertainty(predictions: Vec<Vec<Vec<f64>>>) -> PyResult<Uncer
         .map(|(m, s)| {
             m.iter()
                 .zip(s.iter())
-                .map(|(&mi, &si)| (mi + 1.96 * si).clamp(0.0, 1.0))
+                .map(|(&mi, &si)| (mi + NORMAL_CI_Z_SCORE * si).clamp(0.0, 1.0))
                 .collect()
         })
         .collect();

--- a/src/validation/uncertainty/mod.rs
+++ b/src/validation/uncertainty/mod.rs
@@ -2,6 +2,8 @@ use pyo3::prelude::*;
 use rayon::prelude::*;
 use std::collections::HashMap;
 
+use crate::constants::{Z_SCORE_95, clamped_normal_ci_bounds};
+
 type PredictionMatrix = Vec<Vec<f64>>;
 type QuantilePredictionBands = (PredictionMatrix, PredictionMatrix, PredictionMatrix);
 

--- a/src/validation/uncertainty/quantiles.rs
+++ b/src/validation/uncertainty/quantiles.rs
@@ -60,16 +60,14 @@ pub fn ensemble_uncertainty(
         })
         .collect();
 
-    let z = 1.96 * (1.0 + (1.0 - confidence_level).ln().abs()).sqrt();
+    let z = Z_SCORE_95 * (1.0 + (1.0 - confidence_level).ln().abs()).sqrt();
 
     let prediction_intervals: Vec<Vec<(f64, f64)>> = mean_prediction
         .iter()
         .zip(std_prediction.iter())
         .map(|(m, s)| {
-            m.iter()
-                .zip(s.iter())
-                .map(|(&mi, &si)| ((mi - z * si).clamp(0.0, 1.0), (mi + z * si).clamp(0.0, 1.0)))
-                .collect()
+            let (lower, upper) = clamped_normal_ci_bounds(m, s, z, 0.0, 1.0);
+            lower.into_iter().zip(upper).collect()
         })
         .collect();
 

--- a/src/validation/uno_c_index/comparison.rs
+++ b/src/validation/uno_c_index/comparison.rs
@@ -166,9 +166,7 @@ pub(crate) fn compare_uno_c_indices_core(
 
     let p_value = 2.0 * (1.0 - normal_cdf(z_statistic.abs()));
 
-    let z = 1.96;
-    let ci_lower = difference - z * std_error_diff;
-    let ci_upper = difference + z * std_error_diff;
+    let (ci_lower, ci_upper) = normal_ci_95(difference, std_error_diff);
 
     ConcordanceComparisonResult {
         c_index_1,

--- a/src/validation/uno_c_index/gonen_heller.rs
+++ b/src/validation/uno_c_index/gonen_heller.rs
@@ -133,9 +133,7 @@ pub(crate) fn gonen_heller_core(linear_predictor: &[f64]) -> GonenHellerResult {
     };
 
     let std_error = variance.sqrt();
-    let z = 1.96;
-    let ci_lower = (cpe - z * std_error).clamp(0.0, 1.0);
-    let ci_upper = (cpe + z * std_error).clamp(0.0, 1.0);
+    let (ci_lower, ci_upper) = clamped_normal_ci_95(cpe, std_error, 0.0, 1.0);
 
     GonenHellerResult {
         cpe,
@@ -158,4 +156,3 @@ pub fn gonen_heller_concordance(linear_predictor: Vec<f64>) -> PyResult<GonenHel
 
     Ok(gonen_heller_core(&linear_predictor))
 }
-

--- a/src/validation/uno_c_index/mod.rs
+++ b/src/validation/uno_c_index/mod.rs
@@ -1,4 +1,6 @@
-use crate::constants::{IPCW_SURVIVAL_FLOOR, PARALLEL_THRESHOLD_LARGE};
+use crate::constants::{
+    IPCW_SURVIVAL_FLOOR, PARALLEL_THRESHOLD_LARGE, clamped_normal_ci_95, normal_ci_95,
+};
 use crate::internal::statistical::{compute_censoring_km, km_step_prob_at, normal_cdf};
 use pyo3::prelude::*;
 use rayon::prelude::*;

--- a/src/validation/uno_c_index/uno.rs
+++ b/src/validation/uno_c_index/uno.rs
@@ -172,9 +172,7 @@ pub(crate) fn uno_c_index_core(
     };
 
     let std_error = variance.sqrt();
-    let z = 1.96;
-    let ci_lower = (c_index - z * std_error).clamp(0.0, 1.0);
-    let ci_upper = (c_index + z * std_error).clamp(0.0, 1.0);
+    let (ci_lower, ci_upper) = clamped_normal_ci_95(c_index, std_error, 0.0, 1.0);
 
     UnoCIndexResult {
         c_index,

--- a/src/validation/yates.rs
+++ b/src/validation/yates.rs
@@ -1,3 +1,4 @@
+use crate::constants::{Z_SCORE_90, Z_SCORE_95, Z_SCORE_99, normal_ci, normal_ci_bounds_95};
 use crate::internal::statistical::normal_cdf;
 use pyo3::prelude::*;
 use std::collections::HashMap;
@@ -129,8 +130,9 @@ pub fn yates(
 
         means.push(mean);
         ses.push(se);
-        lowers.push(mean - z * se);
-        uppers.push(mean + z * se);
+        let (lower, upper) = normal_ci(mean, se, z);
+        lowers.push(lower);
+        uppers.push(upper);
         ns.push(group_n);
     }
 
@@ -230,17 +232,7 @@ pub fn yates_contrast(
         ses.push(se);
     }
 
-    let z = 1.96;
-    let lower: Vec<f64> = means
-        .iter()
-        .zip(ses.iter())
-        .map(|(&m, &s)| m - z * s)
-        .collect();
-    let upper: Vec<f64> = means
-        .iter()
-        .zip(ses.iter())
-        .map(|(&m, &s)| m + z * s)
-        .collect();
+    let (lower, upper) = normal_ci_bounds_95(&means, &ses);
 
     Ok(YatesResult {
         levels,
@@ -324,10 +316,10 @@ pub struct YatesPairwiseResult {
 
 fn z_score(conf_level: f64) -> f64 {
     match conf_level {
-        c if (c - 0.90).abs() < 0.001 => 1.645,
-        c if (c - 0.95).abs() < 0.001 => 1.96,
-        c if (c - 0.99).abs() < 0.001 => 2.576,
-        _ => 1.96,
+        c if (c - 0.90).abs() < 0.001 => Z_SCORE_90,
+        c if (c - 0.95).abs() < 0.001 => Z_SCORE_95,
+        c if (c - 0.99).abs() < 0.001 => Z_SCORE_99,
+        _ => Z_SCORE_95,
     }
 }
 

--- a/uv.lock
+++ b/uv.lock
@@ -595,7 +595,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -604,9 +604,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/0e/b5858858d74958632c49b72cb25a3976ff9f632397626715be71c89d3971/pytest-9.1.0.tar.gz", hash = "sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c", size = 1634181, upload-time = "2026-06-13T18:52:45.983Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl", hash = "sha256:8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32", size = 386453, upload-time = "2026-06-13T18:52:44.045Z" },
 ]
 
 [[package]]
@@ -692,27 +692,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.16"
+version = "0.15.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a6/bd/5f7ec371001337d8fa61701c186ff8b613ecac1651848c5950f4c4d5f2e9/ruff-0.15.16.tar.gz", hash = "sha256:d05e78d38c78caf020b03789e25106c93017db5a0cb6e2819885018c61343b78", size = 4714267, upload-time = "2026-06-04T16:33:09.974Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/a9/3abdf488f1bf3d24c699415e454ed554a6350d5d89ce183be1ee0a3361ac/ruff-0.15.17.tar.gz", hash = "sha256:2ec446937fd16c8c4de2674a209cc5af64d9c6f17d21fbf1151054fa0bcf5219", size = 4743346, upload-time = "2026-06-11T17:54:47.663Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/42/53ef1c3953f157956db9bf7861e3bc50b9b887ce93300aa48cdba8336fe6/ruff-0.15.16-py3-none-linux_armv6l.whl", hash = "sha256:6ac3c0b3969cc6cf6b158c4e2f8f682acb58e7d700d8a44b65ecdc72d66ab0b2", size = 10709025, upload-time = "2026-06-04T16:32:51.935Z" },
-    { url = "https://files.pythonhosted.org/packages/93/9a/a79159346f19134a956607754e57d8d128f7a4c00f4ad2f7514d224c172c/ruff-0.15.16-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:197c207ed75ffba54a0dec23db4aa939a27a3053073e085e0042433cbdc58e4a", size = 11063550, upload-time = "2026-06-04T16:32:42.24Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/72/3ce2ac000a5299ec238e01f51397b3b653c93b077d9b1bfe8715bb895f20/ruff-0.15.16-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3a39fec45ab316cc23e7558f23fea4a70403ddb5648ea9a4a3854a16973d0071", size = 10421345, upload-time = "2026-06-04T16:32:37.251Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/c2/cc7fad3ec9169373f5b6a18f1917b91080feec40c3f9658334a1d28e2f03/ruff-0.15.16-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ba93191d79003116b95128c9d306e045200fdbd0bccb782b110f3cd1d4abc5cf", size = 10757217, upload-time = "2026-06-04T16:32:54.722Z" },
-    { url = "https://files.pythonhosted.org/packages/69/d2/3474009eaa0a65b31fa7152a2fad5e2f050c640ceb1e6b02ee6922e94c82/ruff-0.15.16-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c6ee4b90520630120ef032aa5cc10db483852dff950e78b1d717e2993a61ac8d", size = 10507035, upload-time = "2026-06-04T16:33:05.343Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/81/b7ae6ccbd11f0c8dc3d5d67fc4be9b57ff57ca86ba56152021378e1277f2/ruff-0.15.16-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4e4215bc938bc3c8215c1472c1aa437e310fee20cd427335fec9d7e609563628", size = 11255291, upload-time = "2026-06-04T16:32:49.49Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/e1/46e526f1a7cc90857ce6ddf25fbb77eb6568651ac38d71b033af07076dd5/ruff-0.15.16-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7c8d26be963b090f10e29abc8b3e74a2a321f6fa34e02424e30b5af89350ecbb", size = 12124922, upload-time = "2026-06-04T16:33:07.821Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/da/5c791b088b596b24d0deb967fa28ae02ad751a140c0b9ea81c5ab915d6c0/ruff-0.15.16-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f198cf4123602a2280ed46c307bcbafe41758d6fee5b456b6b6058ca1514b3b4", size = 11332186, upload-time = "2026-06-04T16:33:02.971Z" },
-    { url = "https://files.pythonhosted.org/packages/72/11/5da87abe20047c8962361473923ebb2f62b595250126aadfad8c20649c1e/ruff-0.15.16-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb27515fa6240fb586ae82b901a59e67d24acff86f2190b433dc542fe0435aeb", size = 11373541, upload-time = "2026-06-04T16:32:47.007Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/2a/8554754c23a854ae3fd6b507e36ad61ddb121e298c6d5d617dec94ed0f14/ruff-0.15.16-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a267c46ba1593fc26b8eecbea050b39d40c0b6bb7781ee11c90a02cd10032951", size = 11353014, upload-time = "2026-06-04T16:32:34.795Z" },
-    { url = "https://files.pythonhosted.org/packages/62/25/62ea41529ec89f742ea3fed9cb1059c72877ec7cf9b9e99ac9cf3294d1d9/ruff-0.15.16-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:528c68f39a91498a8d50e91ff5985df3d105782bab49cc378e73ac26bff083e8", size = 10737467, upload-time = "2026-06-04T16:32:26.348Z" },
-    { url = "https://files.pythonhosted.org/packages/90/17/334d3ad9de4d40f9dd58fdd09e35ce64553bb501e2f19a839e2fb6be14fc/ruff-0.15.16-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:7ed55c58950df60589a9a7a5d2f8fa5f54ebd287163be805adfe6ee95a9de123", size = 10521910, upload-time = "2026-06-04T16:32:32.54Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/bd/3ac7c6ae77a885c1004b3dda2446ea401768d24f851c14b4ad4b24f6639c/ruff-0.15.16-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d482feaf51512b50f9790ceb417a56a61dd1e9d9bf967662b9ed27c01b34f53a", size = 10979190, upload-time = "2026-06-04T16:32:57.492Z" },
-    { url = "https://files.pythonhosted.org/packages/33/d7/609546e6a413c3f216fbf2a50c928f97c80939154f6a0503114094a86191/ruff-0.15.16-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1e15bc8c94513dae2a40cc9ef07c94fdd4ecc9e29dabebeebe170f952322c9e3", size = 11477014, upload-time = "2026-06-04T16:32:44.687Z" },
-    { url = "https://files.pythonhosted.org/packages/74/0d/f2cd247ad32633a5c36e97141a2c21b11c6279f7957bc2ff360b1e08fddd/ruff-0.15.16-py3-none-win32.whl", hash = "sha256:580378f7bd4aa25f72e74aa54948a9622f142b1e509521dd10902e886681cc1e", size = 10735541, upload-time = "2026-06-04T16:32:30.145Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/9e/02e845ef151b1dee585e55c4739f8e1734ae1d9f1221dff65761c162208b/ruff-0.15.16-py3-none-win_amd64.whl", hash = "sha256:408256017284eddf98fff77b29aa4fb30f586042d535b2d9befc6512f400aaec", size = 11843403, upload-time = "2026-06-04T16:32:39.76Z" },
-    { url = "https://files.pythonhosted.org/packages/15/19/016553f86f207450aebebc2b2b5088d086b901cc8186c02ac4284db3bd88/ruff-0.15.16-py3-none-win_arm64.whl", hash = "sha256:8cd61783afb39638a7133ef0d2dfb1e91277593962f81b5a8423eb0b888a6121", size = 11134555, upload-time = "2026-06-04T16:33:00.136Z" },
+    { url = "https://files.pythonhosted.org/packages/db/4d/e11259f5da07cb6afb2d074c31bf09da9671993f7329d4f15d2fdc458301/ruff-0.15.17-py3-none-linux_armv6l.whl", hash = "sha256:d9feddb927fc68bd295f5eebc587a7e42cfaf9b65f60ca4a2386febff575da8f", size = 10856677, upload-time = "2026-06-11T17:54:49.533Z" },
+    { url = "https://files.pythonhosted.org/packages/29/3e/772d679e1a0dc058e58875bd2c0cb713a0530877b4a76fee3c7966df0d49/ruff-0.15.17-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:25805a226d741c47d274a35ad5c10a7dde175fcddfa511d7cf3da0a21eb3eab7", size = 11223443, upload-time = "2026-06-11T17:55:00.573Z" },
+    { url = "https://files.pythonhosted.org/packages/68/58/bd41f7688b2fd5623012605130ed70e60aa7f2244baa3d5066bdd61530c8/ruff-0.15.17-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f6ad73b14c2d18a3bf8ad7cb6974294d7f613a7898604826058e6ac64918ef4d", size = 10566458, upload-time = "2026-06-11T17:55:07.52Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/5b/733371013fcf1ec339e477ece6ab42bfe10bdd9bba8ee88a9516aa56bfc0/ruff-0.15.17-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ba0c1e4f95bcb3869d0d30cbd5917071ef2e28665abfec970cdab0492c713ed", size = 10914483, upload-time = "2026-06-11T17:55:05.501Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/cc/6f24251cc0252f7239391ccb85833f320efad14ebe5b443943f37ced6332/ruff-0.15.17-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:81647960f10bff57d2e51cadd0c3950fe598400c852863a038720ef5b8cca91e", size = 10647497, upload-time = "2026-06-11T17:54:57.733Z" },
+    { url = "https://files.pythonhosted.org/packages/68/dd/0d10c17ce1a1624d6fc3156309c3f834fdb5dfaad026ec90c85684f3990e/ruff-0.15.17-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0e01a84ddbc8c16c23055ba3924476850f1bbc1917cebbb9376665a63e74260d", size = 11416967, upload-time = "2026-06-11T17:54:51.461Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/91/556bfb156f6144f355e831c23db00b2fc4120f86b3ce81cc5f7fd2df51f3/ruff-0.15.17-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:84fe9f653152f8f294f9f7e03bf3a453d8b4a27f7a59c78c8666167f2b17b96c", size = 12335770, upload-time = "2026-06-11T17:54:45.793Z" },
+    { url = "https://files.pythonhosted.org/packages/88/82/8b5999aa13355e926f06d9f42a32dcca862f623bf0363785ff89d607dffd/ruff-0.15.17-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c0fe88a7676e7a05b73174d4d4a59cb2ac21ff8263583f87a81a6018475a978", size = 11575441, upload-time = "2026-06-11T17:54:32.661Z" },
+    { url = "https://files.pythonhosted.org/packages/11/93/f10377bb04109ca0e8cbc483ff1982c54b6d418210041776f93e8cdc7fa9/ruff-0.15.17-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecfc3c7878fff94633ab0348524e093f9ce3243080416dd7d14f8ba400174719", size = 11557614, upload-time = "2026-06-11T17:54:34.698Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/a6/eeeae7f7d5493df41649ab3db92f086b2d0a30199e4efdf8e3dd7a033f24/ruff-0.15.17-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:b8461180b22420b1bdc289909410930761629fddf2a5aaf60fae1ab26cedc4c4", size = 11544450, upload-time = "2026-06-11T17:54:39.042Z" },
+    { url = "https://files.pythonhosted.org/packages/32/88/5991ce565129a24dd4a00db1254b3b5db2e53018cbe4018ea5a89738e727/ruff-0.15.17-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:6eccbe50a038b503e7140b441aa9c7fc8c1f36edf23ebef9f4165c2f28f568b7", size = 10892524, upload-time = "2026-06-11T17:55:09.432Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/1d/0fdd248313425f55223968af04b0a42125466a8d88d21c1d99c6af0a51e8/ruff-0.15.17-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:382fc0521025f5a8ad447d8bdd523545d0d7646adb718eb1c2dac5065ec27c0f", size = 10659573, upload-time = "2026-06-11T17:54:36.824Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/0e/072e8260deb9461062ce9311ced27a8e541229a6ffd483013dd37661e43e/ruff-0.15.17-py3-none-musllinux_1_2_i686.whl", hash = "sha256:456d41fcd1b2777ad63f09a6e7121d43f7b688bbc76a800c10f7f8fb1f912c3f", size = 11127818, upload-time = "2026-06-11T17:55:03.124Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/b4/55060a34163121498014696b5f656db5b8c6963768f227dbf0d76b311073/ruff-0.15.17-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b1a04bcc94ae6194e9db05d16ad31f298a7194bfbcb08258bbe589cee1d587b8", size = 11655901, upload-time = "2026-06-11T17:54:53.562Z" },
+    { url = "https://files.pythonhosted.org/packages/49/71/9b29d6b87cef468d697f43c6a91e3fae4a80185779d7d5a4ef27d173439f/ruff-0.15.17-py3-none-win32.whl", hash = "sha256:596065960ab1ff593f744220c9fe6580eda00a95003cffa9f4048bb5b1bf0392", size = 10925574, upload-time = "2026-06-11T17:54:55.723Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b2/8fc77f3723228836fa5d12497eb71c808f83782e10d058d2b15cfa14640b/ruff-0.15.17-py3-none-win_amd64.whl", hash = "sha256:6769e5fa1710b179b92e0bfa5a51735b35baea9013dadb06d5f44cbcf9547084", size = 12058788, upload-time = "2026-06-11T17:54:41.042Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/c7/c53e8dbff9c9dc4b7928773421ae294a5d28fcb8dcda1a089579d3a7e510/ruff-0.15.17-py3-none-win_arm64.whl", hash = "sha256:f3be1fbb34bcdfd146240d8fb92a709d4c2c8191348580a3c044ec60fa0b4456", size = 11355275, upload-time = "2026-06-11T17:54:43.635Z" },
 ]
 
 [[package]]
@@ -882,11 +882,11 @@ requires-dist = [
     { name = "pandas", marker = "extra == 'test'", specifier = "==3.0.3" },
     { name = "polars", marker = "extra == 'test'", specifier = "==1.41.2" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = "==4.6.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = "==9.0.3" },
-    { name = "pytest", marker = "extra == 'test'", specifier = "==9.0.3" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = "==9.1.0" },
+    { name = "pytest", marker = "extra == 'test'", specifier = "==9.1.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = "==7.1.0" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = "==7.1.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.16" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.17" },
     { name = "scikit-learn", marker = "extra == 'sklearn'", specifier = ">=1.0.0" },
 ]
 provides-extras = ["dev", "test", "sklearn"]


### PR DESCRIPTION
## Summary
- Expand R-style API support across `survfit`, `coxph`, `survreg`, concordance, residuals, and prediction metadata.
- Add weighted and time-weighted concordance paths plus shared confidence interval and time helper utilities in Rust.
- Update Python type stubs and coverage for the binding contract and R API behavior.

## Validation
- `PYTHONPATH=.:python uv run --no-sync pytest python/tests/test_binding_contract.py python/tests/test_r_api.py -q`
- `PATH="/Users/cameron/.rustup/toolchains/1.94.0-aarch64-apple-darwin/bin:$PATH" cargo test --lib --no-default-features`