### PR TITLE
Add strict Rust CI workflow

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -1,0 +1,45 @@
+name: Rust CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -D warnings
+
+jobs:
+  rust:
+    name: Rust checks (${{ matrix.manifest }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        manifest:
+          - Cargo.toml
+          - fuzz/Cargo.toml
+          - survival-pyo3-macros-shim/Cargo.toml
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install stable --profile minimal --component clippy rustfmt
+          rustup default stable
+
+      - name: Check formatting
+        run: cargo fmt --all --manifest-path "${{ matrix.manifest }}" -- --check
+
+      - name: Build with warnings denied
+        run: cargo build --manifest-path "${{ matrix.manifest }}" --all-targets --all-features
+
+      - name: Run clippy with warnings denied
+        run: cargo clippy --manifest-path "${{ matrix.manifest }}" --all-targets --all-features -- -D warnings

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -35,11 +35,22 @@ jobs:
           rustup toolchain install stable --profile minimal --component clippy --component rustfmt
           rustup default stable
 
+      - name: Prepare Cargo manifest path
+        run: |
+          manifest="${{ matrix.manifest }}"
+          dir="$(dirname "$manifest")"
+          base="$(basename "$manifest")"
+          if [ "$base" != "Cargo.toml" ]; then
+            ln -sf "$base" "$dir/Cargo.toml"
+            manifest="$dir/Cargo.toml"
+          fi
+          echo "CARGO_MANIFEST_PATH=$manifest" >> "$GITHUB_ENV"
+
       - name: Check formatting
-        run: cargo fmt --all --manifest-path "${{ matrix.manifest }}" -- --check
+        run: cargo fmt --all --manifest-path "$CARGO_MANIFEST_PATH" -- --check
 
       - name: Build with warnings denied
-        run: cargo build --manifest-path "${{ matrix.manifest }}" --all-targets --all-features
+        run: cargo build --manifest-path "$CARGO_MANIFEST_PATH" --all-targets --all-features
 
       - name: Run clippy with warnings denied
-        run: cargo clippy --manifest-path "${{ matrix.manifest }}" --all-targets --all-features -- -D warnings
+        run: cargo clippy --manifest-path "$CARGO_MANIFEST_PATH" --all-targets --all-features -- -D warnings

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install Rust toolchain
         run: |
-          rustup toolchain install stable --profile minimal --component clippy rustfmt
+          rustup toolchain install stable --profile minimal --component clippy --component rustfmt
           rustup default stable
 
       - name: Check formatting


### PR DESCRIPTION
Adds a Rust CI workflow that runs on push, pull request, and manual dispatch.

Checks added:
- `cargo fmt --all -- --check`
- `cargo build` with `RUSTFLAGS=-D warnings`
- `cargo clippy -- -D warnings`

Manifest matrix:
- `Cargo.toml`
- `fuzz/Cargo.toml`
- `survival-pyo3-macros-shim/Cargo.toml`
