### PR TITLE
Validate concordance order vectors

### DIFF
--- a/python/tests/test_concordance_additional.py
+++ b/python/tests/test_concordance_additional.py
@@ -220,6 +220,16 @@ def test_low_level_concordance_wrappers_validate_index_inputs():
             False,
         )
 
+    with pytest.raises(RuntimeError, match="sort_stop must be a permutation"):
+        survival.perform_concordance3_calculation(
+            extended_time_data,
+            [0, 1, 2, 3],
+            extended_weights,
+            time_weights,
+            [0, 1, 1, 3],
+            False,
+        )
+
     with pytest.raises(RuntimeError, match="predictor_values contains negative value"):
         survival.perform_concordance_calculation(
             extended_time_data,
@@ -227,6 +237,15 @@ def test_low_level_concordance_wrappers_validate_index_inputs():
             extended_weights,
             time_weights,
             [0, 1, 2, 3],
+        )
+
+    with pytest.raises(RuntimeError, match="sort_stop must be a permutation"):
+        survival.perform_concordance_calculation(
+            extended_time_data,
+            [0, 1, 2, 3],
+            extended_weights,
+            time_weights,
+            [0, 1, 1, 3],
         )
 
     with pytest.raises(RuntimeError, match="sort_start length"):
@@ -247,4 +266,14 @@ def test_low_level_concordance_wrappers_validate_index_inputs():
             time_weights,
             [0, 1, 2, 3],
             [0, 1, 2, 4],
+        )
+
+    with pytest.raises(RuntimeError, match="sort_start must be a permutation"):
+        survival.perform_concordance_calculation(
+            extended_time_data,
+            [0, 1, 2, 3],
+            extended_weights,
+            time_weights,
+            [0, 1, 2, 3],
+            [0, 1, 1, 3],
         )

--- a/src/concordance/common.rs
+++ b/src/concordance/common.rs
@@ -1,4 +1,4 @@
-use crate::internal::validation::{validate_length, ValidationError};
+use crate::internal::validation::{ValidationError, validate_length};
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
@@ -304,15 +304,19 @@ mod tests {
 
         let i32_out_of_bounds = validate_i32_order_indices(&[0, 2], 2, "sort_stop")
             .expect_err("order index outside observations should fail");
-        assert!(i32_out_of_bounds
-            .to_string()
-            .contains("outside observation count"));
+        assert!(
+            i32_out_of_bounds
+                .to_string()
+                .contains("outside observation count")
+        );
 
         let usize_out_of_bounds = validate_usize_order_indices(&[0, 2], 2, "sort_stop")
             .expect_err("order index outside observations should fail");
-        assert!(usize_out_of_bounds
-            .to_string()
-            .contains("outside observation count"));
+        assert!(
+            usize_out_of_bounds
+                .to_string()
+                .contains("outside observation count")
+        );
 
         let i32_duplicate = validate_i32_permutation_indices(&[0, 0], 2, "sort_stop")
             .expect_err("duplicate order index should fail");
@@ -320,8 +324,10 @@ mod tests {
 
         let usize_duplicate = validate_usize_permutation_indices(&[0, 0], 2, "sort_stop")
             .expect_err("duplicate order index should fail");
-        assert!(usize_duplicate
-            .to_string()
-            .contains("must be a permutation"));
+        assert!(
+            usize_duplicate
+                .to_string()
+                .contains("must be a permutation")
+        );
     }
 }

--- a/src/concordance/common.rs
+++ b/src/concordance/common.rs
@@ -1,4 +1,4 @@
-use crate::internal::validation::{ValidationError, validate_length};
+use crate::internal::validation::{validate_length, ValidationError};
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
@@ -78,6 +78,25 @@ pub(crate) fn validate_i32_order_indices(values: &[i32], n: usize, field: &str) 
     Ok(())
 }
 
+pub(crate) fn validate_i32_permutation_indices(
+    values: &[i32],
+    n: usize,
+    field: &str,
+) -> PyResult<()> {
+    validate_i32_order_indices(values, n, field)?;
+    let mut seen = vec![false; n];
+    for (index, &value) in values.iter().enumerate() {
+        let value = value as usize;
+        if seen[value] {
+            return Err(PyRuntimeError::new_err(format!(
+                "{field} must be a permutation; duplicate index {value} at position {index}"
+            )));
+        }
+        seen[value] = true;
+    }
+    Ok(())
+}
+
 pub(crate) fn validate_usize_order_indices(
     values: &[usize],
     n: usize,
@@ -87,6 +106,24 @@ pub(crate) fn validate_usize_order_indices(
         return Err(PyRuntimeError::new_err(format!(
             "{field} value {value} at index {index} is outside observation count {n}"
         )));
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_usize_permutation_indices(
+    values: &[usize],
+    n: usize,
+    field: &str,
+) -> PyResult<()> {
+    validate_usize_order_indices(values, n, field)?;
+    let mut seen = vec![false; n];
+    for (index, &value) in values.iter().enumerate() {
+        if seen[value] {
+            return Err(PyRuntimeError::new_err(format!(
+                "{field} must be a permutation; duplicate index {value} at position {index}"
+            )));
+        }
+        seen[value] = true;
     }
     Ok(())
 }
@@ -258,6 +295,8 @@ mod tests {
     fn validate_order_indices_rejects_invalid_values() {
         assert!(validate_i32_order_indices(&[0, 1], 2, "sort_stop").is_ok());
         assert!(validate_usize_order_indices(&[0, 1], 2, "sort_stop").is_ok());
+        assert!(validate_i32_permutation_indices(&[1, 0], 2, "sort_stop").is_ok());
+        assert!(validate_usize_permutation_indices(&[1, 0], 2, "sort_stop").is_ok());
 
         let negative = validate_i32_order_indices(&[0, -1], 2, "sort_stop")
             .expect_err("negative order index should fail");
@@ -265,18 +304,24 @@ mod tests {
 
         let i32_out_of_bounds = validate_i32_order_indices(&[0, 2], 2, "sort_stop")
             .expect_err("order index outside observations should fail");
-        assert!(
-            i32_out_of_bounds
-                .to_string()
-                .contains("outside observation count")
-        );
+        assert!(i32_out_of_bounds
+            .to_string()
+            .contains("outside observation count"));
 
         let usize_out_of_bounds = validate_usize_order_indices(&[0, 2], 2, "sort_stop")
             .expect_err("order index outside observations should fail");
-        assert!(
-            usize_out_of_bounds
-                .to_string()
-                .contains("outside observation count")
-        );
+        assert!(usize_out_of_bounds
+            .to_string()
+            .contains("outside observation count"));
+
+        let i32_duplicate = validate_i32_permutation_indices(&[0, 0], 2, "sort_stop")
+            .expect_err("duplicate order index should fail");
+        assert!(i32_duplicate.to_string().contains("must be a permutation"));
+
+        let usize_duplicate = validate_usize_permutation_indices(&[0, 0], 2, "sort_stop")
+            .expect_err("duplicate order index should fail");
+        assert!(usize_duplicate
+            .to_string()
+            .contains("must be a permutation"));
     }
 }

--- a/src/concordance/concordance3.rs
+++ b/src/concordance/concordance3.rs
@@ -2,7 +2,7 @@
 
 use super::common::{
     add_to_binary_tree, build_concordance_result, validate_extended_concordance_inputs,
-    validate_i32_order_indices, validate_non_negative_i32_indices, walkup_binary_tree,
+    validate_i32_permutation_indices, validate_non_negative_i32_indices, walkup_binary_tree,
 };
 use crate::constants::{CONCORDANCE_COUNT_SIZE_EXTENDED, PARALLEL_THRESHOLD_LARGE};
 use pyo3::prelude::*;
@@ -206,7 +206,7 @@ pub fn perform_concordance3_calculation(
         sort_stop.len(),
     )?;
     validate_non_negative_i32_indices(&indices, "indices")?;
-    validate_i32_order_indices(&sort_stop, n, "sort_stop")?;
+    validate_i32_permutation_indices(&sort_stop, n, "sort_stop")?;
     let (count, imat, resid_opt) = concordance3(
         &time_data,
         &indices,

--- a/src/concordance/concordance5.rs
+++ b/src/concordance/concordance5.rs
@@ -2,11 +2,11 @@
 
 use super::common::{
     build_concordance_result, validate_extended_concordance_inputs,
-    validate_non_negative_i32_indices, validate_usize_order_indices,
+    validate_non_negative_i32_indices, validate_usize_permutation_indices,
 };
 use crate::constants::{CONCORDANCE_COUNT_SIZE_EXTENDED, PARALLEL_THRESHOLD_SMALL};
 use crate::internal::fenwick::FenwickTree;
-use crate::internal::validation::{ValidationError, validate_length};
+use crate::internal::validation::{validate_length, ValidationError};
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 use rayon::prelude::*;
@@ -249,11 +249,11 @@ pub fn perform_concordance_calculation(
         sort_stop.len(),
     )?;
     validate_non_negative_i32_indices(&predictor_values, "predictor_values")?;
-    validate_usize_order_indices(&sort_stop, n, "sort_stop")?;
+    validate_usize_permutation_indices(&sort_stop, n, "sort_stop")?;
     if let Some(values) = sort_start.as_deref() {
         validate_length(n, values.len(), "sort_start")
             .map_err(|error: ValidationError| PyRuntimeError::new_err(error.to_string()))?;
-        validate_usize_order_indices(values, n, "sort_start")?;
+        validate_usize_permutation_indices(values, n, "sort_start")?;
     }
     let doresid = do_residuals.unwrap_or(false);
     let (count, imat, resid) = concordance5(

--- a/src/concordance/concordance5.rs
+++ b/src/concordance/concordance5.rs
@@ -6,7 +6,7 @@ use super::common::{
 };
 use crate::constants::{CONCORDANCE_COUNT_SIZE_EXTENDED, PARALLEL_THRESHOLD_SMALL};
 use crate::internal::fenwick::FenwickTree;
-use crate::internal::validation::{validate_length, ValidationError};
+use crate::internal::validation::{ValidationError, validate_length};
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 use rayon::prelude::*;


### PR DESCRIPTION
## Summary
- add shared permutation validation for concordance order vectors
- reject duplicate `sort_stop` and `sort_start` inputs in the low-level concordance wrappers
- cover duplicate order-vector failures in Rust and Python tests

## Validation
- `rustfmt --check src/concordance/common.rs src/concordance/concordance3.rs src/concordance/concordance5.rs`
- `cargo test concordance::`
- `.venv/bin/python -m pytest python/tests/test_concordance_additional.py -q`
- `.venv/bin/ruff check python/tests/test_concordance_additional.py`
- `.venv/bin/ruff format python/tests/test_concordance_additional.py --check`
- `git diff --check`
