### PR TITLE
Remove lightweight dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,15 +1166,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1893,15 +1884,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "safe_arch"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f7caad094bd561859bcd467734a720c3c1f5d1f338995351fefe2190c45efed"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2059,9 +2041,7 @@ dependencies = [
  "divan",
  "faer",
  "fastrand",
- "itertools",
  "ndarray",
- "num_cpus",
  "numpy",
  "pulp",
  "pyo3",
@@ -2070,7 +2050,6 @@ dependencies = [
  "serde",
  "serde_json",
  "survival-pyo3-macros-shim",
- "wide",
 ]
 
 [[package]]
@@ -2407,16 +2386,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "wide"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfdfe6a32973f2d1b268b8895845a8a96cac2f0191e72c27cc929036060dbf89"
-dependencies = [
- "bytemuck",
- "safe_arch",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,14 +23,11 @@ crate-type = ["cdylib", "rlib"]
 pyo3 = { version = "0.29.0", optional = true }
 numpy = { version = "0.29.0", optional = true }
 ndarray = { version = "0.17.2", features = ["rayon"] }
-itertools = "0.15.0"
 rayon = "1.12.0"
 faer = "0.24.0"
 fastrand = "2.4.1"
 pulp = "0.22.2"
-wide = "1.4.0"
 burn = { version = "0.21.0", default-features = false, features = ["autodiff", "ndarray"], optional = true }
-num_cpus = "1.17.0"
 survival-pyo3-macros-shim = { path = "survival-pyo3-macros-shim" }
 
 [features]

--- a/src/data_prep/rttright.rs
+++ b/src/data_prep/rttright.rs
@@ -262,8 +262,7 @@ pub fn rttright_stratified(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::common::initialize_python;
-    use itertools::Itertools;
+    use crate::tests::common::{index_permutations, initialize_python};
 
     fn assert_close_slice(actual: &[f64], expected: &[f64]) {
         assert_eq!(actual.len(), expected.len());
@@ -459,7 +458,7 @@ mod tests {
         )
         .unwrap();
 
-        for permutation in (0..base_time.len()).permutations(base_time.len()) {
+        for permutation in index_permutations(base_time.len()) {
             let time: Vec<f64> = permutation.iter().map(|&i| base_time[i]).collect();
             let status: Vec<i32> = permutation.iter().map(|&i| base_status[i]).collect();
             let weights: Vec<f64> = permutation.iter().map(|&i| base_weights[i]).collect();

--- a/src/data_prep/surv2data.rs
+++ b/src/data_prep/surv2data.rs
@@ -203,8 +203,7 @@ pub fn surv2data(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::common::initialize_python;
-    use itertools::Itertools;
+    use crate::tests::common::{index_permutations, initialize_python};
 
     #[test]
     fn test_surv2data_basic() {
@@ -258,7 +257,7 @@ mod tests {
             (2, 3.0, 8.0, 0),
         ];
 
-        for permutation in (0..base_id.len()).permutations(base_id.len()) {
+        for permutation in index_permutations(base_id.len()) {
             let id: Vec<i32> = permutation.iter().map(|&i| base_id[i]).collect();
             let time: Vec<f64> = permutation.iter().map(|&i| base_time[i]).collect();
             let event_time: Vec<f64> = permutation.iter().map(|&i| base_event_time[i]).collect();

--- a/src/data_prep/survcondense.rs
+++ b/src/data_prep/survcondense.rs
@@ -158,8 +158,7 @@ pub fn survcondense(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::common::initialize_python;
-    use itertools::Itertools;
+    use crate::tests::common::{index_permutations, initialize_python};
 
     #[test]
     fn test_survcondense_basic() {
@@ -225,7 +224,7 @@ mod tests {
         let base_status = [0, 0, 1, 0, 0];
         let expected = vec![(1, 0.0, 6.0, 1), (2, 0.0, 5.0, 0)];
 
-        for permutation in (0..base_id.len()).permutations(base_id.len()) {
+        for permutation in index_permutations(base_id.len()) {
             let id: Vec<i32> = permutation.iter().map(|&i| base_id[i]).collect();
             let time1: Vec<f64> = permutation.iter().map(|&i| base_time1[i]).collect();
             let time2: Vec<f64> = permutation.iter().map(|&i| base_time2[i]).collect();

--- a/src/ml/gpu_acceleration.rs
+++ b/src/ml/gpu_acceleration.rs
@@ -3,6 +3,12 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 static GPU_AVAILABLE: AtomicBool = AtomicBool::new(false);
 
+fn available_cpu_count() -> usize {
+    std::thread::available_parallelism()
+        .map(|count| count.get())
+        .unwrap_or(1)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[pyclass(eq, eq_int, from_py_object)]
 pub enum ComputeBackend {
@@ -58,7 +64,7 @@ impl GPUConfig {
         use_mixed_precision: bool,
     ) -> Self {
         let n_threads = if n_threads == 0 {
-            num_cpus::get()
+            available_cpu_count()
         } else {
             n_threads
         };
@@ -295,13 +301,14 @@ fn parallel_gradient_hessian(
 #[pyfunction]
 pub fn get_available_devices() -> PyResult<Vec<DeviceInfo>> {
     let mut devices = Vec::new();
+    let cpu_count = available_cpu_count();
 
     devices.push(DeviceInfo {
-        name: format!("CPU ({} cores)", num_cpus::get()),
+        name: format!("CPU ({cpu_count} cores)"),
         backend: ComputeBackend::CPU,
         memory_total_mb: 0,
         memory_available_mb: 0,
-        compute_units: num_cpus::get(),
+        compute_units: cpu_count,
         is_available: true,
     });
 

--- a/src/regression/agexact.rs
+++ b/src/regression/agexact.rs
@@ -1,5 +1,4 @@
 use crate::constants::{CONVERGENCE_FLAG, PARALLEL_THRESHOLD_LARGE};
-use itertools::Itertools;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use rayon::prelude::*;
@@ -547,12 +546,64 @@ fn agexact_impl(
     }
 }
 #[inline]
-fn iter_combinations(
+fn iter_combinations(start: usize, end: usize, k: usize) -> IndexCombinations {
+    IndexCombinations::new(start, end, k)
+}
+
+struct IndexCombinations {
     start: usize,
-    end: usize,
+    len: usize,
     k: usize,
-) -> itertools::Combinations<std::ops::Range<usize>> {
-    (start..end).combinations(k)
+    current: Vec<usize>,
+    first: bool,
+    done: bool,
+}
+
+impl IndexCombinations {
+    fn new(start: usize, end: usize, k: usize) -> Self {
+        let len = end.saturating_sub(start);
+        let done = k > len;
+        Self {
+            start,
+            len,
+            k,
+            current: (0..k).map(|i| start + i).collect(),
+            first: !done,
+            done,
+        }
+    }
+}
+
+impl Iterator for IndexCombinations {
+    type Item = Vec<usize>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
+        if self.first {
+            self.first = false;
+            return Some(self.current.clone());
+        }
+        if self.k == 0 {
+            self.done = true;
+            return None;
+        }
+
+        for i in (0..self.k).rev() {
+            let max_at_i = self.start + self.len - self.k + i;
+            if self.current[i] < max_at_i {
+                self.current[i] += 1;
+                for j in (i + 1)..self.k {
+                    self.current[j] = self.current[j - 1] + 1;
+                }
+                return Some(self.current.clone());
+            }
+        }
+
+        self.done = true;
+        None
+    }
 }
 #[inline]
 fn cholesky2(matrix: &mut [f64], n: usize, tol: f64) -> i32 {
@@ -692,5 +743,26 @@ mod tests {
             err.to_string()
                 .contains("start, stop, event, offset, and strata must all have length nused")
         );
+    }
+
+    #[test]
+    fn iter_combinations_yields_lexicographic_combinations() {
+        let combinations: Vec<Vec<usize>> = iter_combinations(0, 4, 2).collect();
+        assert_eq!(
+            combinations,
+            vec![
+                vec![0, 1],
+                vec![0, 2],
+                vec![0, 3],
+                vec![1, 2],
+                vec![1, 3],
+                vec![2, 3],
+            ]
+        );
+
+        let empty_combination: Vec<Vec<usize>> = iter_combinations(2, 5, 0).collect();
+        assert_eq!(empty_combination, vec![Vec::<usize>::new()]);
+
+        assert!(iter_combinations(0, 2, 3).next().is_none());
     }
 }

--- a/src/simd_ops.rs
+++ b/src/simd_ops.rs
@@ -1,28 +1,33 @@
-use wide::f64x4;
+use pulp::{Arch, Simd, WithSimd};
 
 pub fn dot_product_simd(a: &[f64], b: &[f64]) -> f64 {
     let n = a.len().min(b.len());
-    let chunks = n / 4;
-    let remainder = n % 4;
 
-    let mut sum = f64x4::ZERO;
+    struct DotProduct<'a>(&'a [f64], &'a [f64]);
 
-    for i in 0..chunks {
-        let idx = i * 4;
-        let va = f64x4::new([a[idx], a[idx + 1], a[idx + 2], a[idx + 3]]);
-        let vb = f64x4::new([b[idx], b[idx + 1], b[idx + 2], b[idx + 3]]);
-        sum += va * vb;
+    impl WithSimd for DotProduct<'_> {
+        type Output = f64;
+
+        #[inline(always)]
+        fn with_simd<S: Simd>(self, simd: S) -> Self::Output {
+            let (a_head, a_tail) = S::as_simd_f64s(self.0);
+            let (b_head, b_tail) = S::as_simd_f64s(self.1);
+
+            let mut acc = simd.splat_f64s(0.0);
+            for (&a_chunk, &b_chunk) in a_head.iter().zip(b_head.iter()) {
+                acc = simd.mul_add_f64s(a_chunk, b_chunk, acc);
+            }
+
+            simd.reduce_sum_f64s(acc)
+                + a_tail
+                    .iter()
+                    .zip(b_tail.iter())
+                    .map(|(&a_val, &b_val)| a_val * b_val)
+                    .sum::<f64>()
+        }
     }
 
-    let arr = sum.to_array();
-    let mut result = arr[0] + arr[1] + arr[2] + arr[3];
-
-    let base = chunks * 4;
-    for i in 0..remainder {
-        result += a[base + i] * b[base + i];
-    }
-
-    result
+    Arch::new().dispatch(DotProduct(&a[..n], &b[..n]))
 }
 
 pub fn weighted_sum_simd(values: &[f64], weights: &[f64]) -> f64 {
@@ -30,61 +35,11 @@ pub fn weighted_sum_simd(values: &[f64], weights: &[f64]) -> f64 {
 }
 
 pub fn sum_simd(values: &[f64]) -> f64 {
-    let n = values.len();
-    let chunks = n / 4;
-    let remainder = n % 4;
-
-    let mut sum = f64x4::ZERO;
-
-    for i in 0..chunks {
-        let idx = i * 4;
-        let v = f64x4::new([
-            values[idx],
-            values[idx + 1],
-            values[idx + 2],
-            values[idx + 3],
-        ]);
-        sum += v;
-    }
-
-    let arr = sum.to_array();
-    let mut result = arr[0] + arr[1] + arr[2] + arr[3];
-
-    let base = chunks * 4;
-    for i in 0..remainder {
-        result += values[base + i];
-    }
-
-    result
+    crate::internal::simd::sum_f64(values)
 }
 
 pub fn sum_of_squares_simd(values: &[f64]) -> f64 {
-    let n = values.len();
-    let chunks = n / 4;
-    let remainder = n % 4;
-
-    let mut sum = f64x4::ZERO;
-
-    for i in 0..chunks {
-        let idx = i * 4;
-        let v = f64x4::new([
-            values[idx],
-            values[idx + 1],
-            values[idx + 2],
-            values[idx + 3],
-        ]);
-        sum += v * v;
-    }
-
-    let arr = sum.to_array();
-    let mut result = arr[0] + arr[1] + arr[2] + arr[3];
-
-    let base = chunks * 4;
-    for i in 0..remainder {
-        result += values[base + i] * values[base + i];
-    }
-
-    result
+    dot_product_simd(values, values)
 }
 
 pub fn mean_simd(values: &[f64]) -> f64 {
@@ -95,90 +50,24 @@ pub fn mean_simd(values: &[f64]) -> f64 {
 }
 
 pub fn subtract_scalar_simd(values: &[f64], scalar: f64) -> Vec<f64> {
-    let n = values.len();
-    let chunks = n / 4;
-    let remainder = n % 4;
-
-    let mut result = Vec::with_capacity(n);
-    let scalar_vec = f64x4::splat(scalar);
-
-    for i in 0..chunks {
-        let idx = i * 4;
-        let v = f64x4::new([
-            values[idx],
-            values[idx + 1],
-            values[idx + 2],
-            values[idx + 3],
-        ]);
-        let diff = v - scalar_vec;
-        let arr = diff.to_array();
-        result.extend_from_slice(&arr);
-    }
-
-    let base = chunks * 4;
-    for i in 0..remainder {
-        result.push(values[base + i] - scalar);
-    }
-
-    result
+    values.iter().map(|&value| value - scalar).collect()
 }
 
 pub fn multiply_elementwise_simd(a: &[f64], b: &[f64]) -> Vec<f64> {
     let n = a.len().min(b.len());
-    let chunks = n / 4;
-    let remainder = n % 4;
-
-    let mut result = Vec::with_capacity(n);
-
-    for i in 0..chunks {
-        let idx = i * 4;
-        let va = f64x4::new([a[idx], a[idx + 1], a[idx + 2], a[idx + 3]]);
-        let vb = f64x4::new([b[idx], b[idx + 1], b[idx + 2], b[idx + 3]]);
-        let prod = va * vb;
-        let arr = prod.to_array();
-        result.extend_from_slice(&arr);
-    }
-
-    let base = chunks * 4;
-    for i in 0..remainder {
-        result.push(a[base + i] * b[base + i]);
-    }
-
-    result
+    a[..n]
+        .iter()
+        .zip(b[..n].iter())
+        .map(|(&a_val, &b_val)| a_val * b_val)
+        .collect()
 }
 
 pub fn exp_approx_simd(values: &[f64]) -> Vec<f64> {
-    let n = values.len();
-    let chunks = n / 4;
-    let remainder = n % 4;
-
-    let mut result = Vec::with_capacity(n);
-
-    for i in 0..chunks {
-        let idx = i * 4;
-        result.push(values[idx].exp());
-        result.push(values[idx + 1].exp());
-        result.push(values[idx + 2].exp());
-        result.push(values[idx + 3].exp());
-    }
-
-    let base = chunks * 4;
-    for i in 0..remainder {
-        result.push(values[base + i].exp());
-    }
-
-    result
+    values.iter().map(|&value| value.exp()).collect()
 }
 
 pub fn logistic_simd(values: &[f64]) -> Vec<f64> {
-    let n = values.len();
-    let mut result = Vec::with_capacity(n);
-
-    for &x in values {
-        result.push(1.0 / (1.0 + (-x).exp()));
-    }
-
-    result
+    values.iter().map(|&x| 1.0 / (1.0 + (-x).exp())).collect()
 }
 
 pub fn variance_simd(values: &[f64]) -> f64 {
@@ -221,69 +110,12 @@ pub fn count_concordant_pairs_simd(
     skip_idx: usize,
 ) -> PairwiseCounts {
     let n = risk_scores.len().min(times.len());
-    let chunks = n / 4;
-    let remainder = n % 4;
-
-    let risk_i_vec = f64x4::splat(risk_i);
-    let time_i_vec = f64x4::splat(time_i);
-
     let mut concordant = 0usize;
     let mut discordant = 0usize;
     let mut tied = 0usize;
     let mut valid_pairs = 0usize;
 
-    for chunk in 0..chunks {
-        let idx = chunk * 4;
-
-        if idx <= skip_idx && skip_idx < idx + 4 {
-            for j in idx..idx + 4 {
-                if j == skip_idx || times[j] <= time_i {
-                    continue;
-                }
-                valid_pairs += 1;
-                if risk_i > risk_scores[j] {
-                    concordant += 1;
-                } else if risk_i < risk_scores[j] {
-                    discordant += 1;
-                } else {
-                    tied += 1;
-                }
-            }
-            continue;
-        }
-
-        let times_j = f64x4::new([times[idx], times[idx + 1], times[idx + 2], times[idx + 3]]);
-        let risks_j = f64x4::new([
-            risk_scores[idx],
-            risk_scores[idx + 1],
-            risk_scores[idx + 2],
-            risk_scores[idx + 3],
-        ]);
-
-        let valid_mask = times_j.simd_gt(time_i_vec);
-        let concordant_mask = risk_i_vec.simd_gt(risks_j);
-        let discordant_mask = risk_i_vec.simd_lt(risks_j);
-
-        let valid_arr = valid_mask.to_array();
-        let conc_arr = concordant_mask.to_array();
-        let disc_arr = discordant_mask.to_array();
-
-        for k in 0..4 {
-            if valid_arr[k].to_bits() != 0 {
-                valid_pairs += 1;
-                if conc_arr[k].to_bits() != 0 {
-                    concordant += 1;
-                } else if disc_arr[k].to_bits() != 0 {
-                    discordant += 1;
-                } else {
-                    tied += 1;
-                }
-            }
-        }
-    }
-
-    let base = chunks * 4;
-    for j in base..base + remainder {
+    for j in 0..n {
         if j == skip_idx || times[j] <= time_i {
             continue;
         }

--- a/src/tests/common.rs
+++ b/src/tests/common.rs
@@ -32,6 +32,31 @@ pub(crate) fn rel_approx_eq(a: f64, b: f64, rel_tol: f64) -> bool {
     (a - b).abs() / max_abs < rel_tol
 }
 
+pub(crate) fn index_permutations(n: usize) -> Vec<Vec<usize>> {
+    let mut current: Vec<usize> = (0..n).collect();
+    let mut permutations = Vec::new();
+    loop {
+        permutations.push(current.clone());
+        if !next_permutation(&mut current) {
+            break;
+        }
+    }
+    permutations
+}
+
+fn next_permutation(values: &mut [usize]) -> bool {
+    let Some(i) = values.windows(2).rposition(|window| window[0] < window[1]) else {
+        return false;
+    };
+    let j = values
+        .iter()
+        .rposition(|&value| value > values[i])
+        .expect("successor exists after pivot");
+    values.swap(i, j);
+    values[i + 1..].reverse();
+    true
+}
+
 pub(crate) fn aml_maintained() -> (Vec<f64>, Vec<i32>) {
     (
         vec![


### PR DESCRIPTION
## Summary
- Remove direct `itertools`, `wide`, and `num_cpus` dependencies.
- Replace exact-combination generation and test permutation helpers with local implementations.
- Consolidate public numeric helper reductions onto the existing `pulp` path or standard iterators.

## Validation
- `cargo check`
- `cargo check --features ml`
- `cargo check --benches`
- `cargo test simd_ops::tests`
- `cargo test is_invariant_to_input_order`
- `cargo test iter_combinations_yields_lexicographic_combinations`
- `cargo test validate_agexact`