### PR TITLE
Share order permutation validation

### DIFF
--- a/src/concordance/common.rs
+++ b/src/concordance/common.rs
@@ -1,4 +1,7 @@
-use crate::internal::validation::{ValidationError, validate_length};
+use crate::internal::validation::{
+    PermutationIndexError, ValidationError, validate_length, validate_zero_based_i32_permutation,
+    validate_zero_based_usize_permutation,
+};
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
@@ -64,50 +67,29 @@ pub(crate) fn validate_i32_tree_indices(values: &[i32], ntree: i32, field: &str)
     Ok(())
 }
 
-pub(crate) fn validate_i32_order_indices(values: &[i32], n: usize, field: &str) -> PyResult<()> {
-    validate_non_negative_i32_indices(values, field)?;
-    if let Some((index, value)) = values
-        .iter()
-        .enumerate()
-        .find(|(_, value)| **value as usize >= n)
-    {
-        return Err(PyRuntimeError::new_err(format!(
-            "{field} value {value} at index {index} is outside observation count {n}"
-        )));
-    }
-    Ok(())
-}
-
 pub(crate) fn validate_i32_permutation_indices(
     values: &[i32],
     n: usize,
     field: &str,
 ) -> PyResult<()> {
-    validate_i32_order_indices(values, n, field)?;
-    let mut seen = vec![false; n];
-    for (index, &value) in values.iter().enumerate() {
-        let value = value as usize;
-        if seen[value] {
-            return Err(PyRuntimeError::new_err(format!(
-                "{field} must be a permutation; duplicate index {value} at position {index}"
-            )));
+    match validate_zero_based_i32_permutation(values, n) {
+        Ok(()) => Ok(()),
+        Err(PermutationIndexError::Negative { position, value }) => {
+            Err(PyRuntimeError::new_err(format!(
+                "{field} contains negative value {value} at index {position}"
+            )))
         }
-        seen[value] = true;
+        Err(PermutationIndexError::OutOfBounds { position, value }) => {
+            Err(PyRuntimeError::new_err(format!(
+                "{field} value {value} at index {position} is outside observation count {n}"
+            )))
+        }
+        Err(PermutationIndexError::Duplicate { position, value }) => {
+            Err(PyRuntimeError::new_err(format!(
+                "{field} must be a permutation; duplicate index {value} at position {position}"
+            )))
+        }
     }
-    Ok(())
-}
-
-pub(crate) fn validate_usize_order_indices(
-    values: &[usize],
-    n: usize,
-    field: &str,
-) -> PyResult<()> {
-    if let Some((index, value)) = values.iter().enumerate().find(|(_, value)| **value >= n) {
-        return Err(PyRuntimeError::new_err(format!(
-            "{field} value {value} at index {index} is outside observation count {n}"
-        )));
-    }
-    Ok(())
 }
 
 pub(crate) fn validate_usize_permutation_indices(
@@ -115,17 +97,22 @@ pub(crate) fn validate_usize_permutation_indices(
     n: usize,
     field: &str,
 ) -> PyResult<()> {
-    validate_usize_order_indices(values, n, field)?;
-    let mut seen = vec![false; n];
-    for (index, &value) in values.iter().enumerate() {
-        if seen[value] {
-            return Err(PyRuntimeError::new_err(format!(
-                "{field} must be a permutation; duplicate index {value} at position {index}"
-            )));
+    match validate_zero_based_usize_permutation(values, n) {
+        Ok(()) => Ok(()),
+        Err(PermutationIndexError::OutOfBounds { position, value }) => {
+            Err(PyRuntimeError::new_err(format!(
+                "{field} value {value} at index {position} is outside observation count {n}"
+            )))
         }
-        seen[value] = true;
+        Err(PermutationIndexError::Duplicate { position, value }) => {
+            Err(PyRuntimeError::new_err(format!(
+                "{field} must be a permutation; duplicate index {value} at position {position}"
+            )))
+        }
+        Err(PermutationIndexError::Negative { .. }) => {
+            unreachable!("usize indices are never negative")
+        }
     }
-    Ok(())
 }
 
 pub(crate) fn build_concordance_result(
@@ -293,16 +280,14 @@ mod tests {
 
     #[test]
     fn validate_order_indices_rejects_invalid_values() {
-        assert!(validate_i32_order_indices(&[0, 1], 2, "sort_stop").is_ok());
-        assert!(validate_usize_order_indices(&[0, 1], 2, "sort_stop").is_ok());
         assert!(validate_i32_permutation_indices(&[1, 0], 2, "sort_stop").is_ok());
         assert!(validate_usize_permutation_indices(&[1, 0], 2, "sort_stop").is_ok());
 
-        let negative = validate_i32_order_indices(&[0, -1], 2, "sort_stop")
+        let negative = validate_i32_permutation_indices(&[0, -1], 2, "sort_stop")
             .expect_err("negative order index should fail");
         assert!(negative.to_string().contains("negative value"));
 
-        let i32_out_of_bounds = validate_i32_order_indices(&[0, 2], 2, "sort_stop")
+        let i32_out_of_bounds = validate_i32_permutation_indices(&[0, 2], 2, "sort_stop")
             .expect_err("order index outside observations should fail");
         assert!(
             i32_out_of_bounds
@@ -310,7 +295,7 @@ mod tests {
                 .contains("outside observation count")
         );
 
-        let usize_out_of_bounds = validate_usize_order_indices(&[0, 2], 2, "sort_stop")
+        let usize_out_of_bounds = validate_usize_permutation_indices(&[0, 2], 2, "sort_stop")
             .expect_err("order index outside observations should fail");
         assert!(
             usize_out_of_bounds

--- a/src/concordance/common.rs
+++ b/src/concordance/common.rs
@@ -74,11 +74,9 @@ pub(crate) fn validate_i32_permutation_indices(
 ) -> PyResult<()> {
     match validate_zero_based_i32_permutation(values, n) {
         Ok(()) => Ok(()),
-        Err(PermutationIndexError::Negative { position, value }) => {
-            Err(PyRuntimeError::new_err(format!(
-                "{field} contains negative value {value} at index {position}"
-            )))
-        }
+        Err(PermutationIndexError::Negative { position, value }) => Err(PyRuntimeError::new_err(
+            format!("{field} contains negative value {value} at index {position}"),
+        )),
         Err(PermutationIndexError::OutOfBounds { position, value }) => {
             Err(PyRuntimeError::new_err(format!(
                 "{field} value {value} at index {position} is outside observation count {n}"

--- a/src/core/coxcount1.rs
+++ b/src/core/coxcount1.rs
@@ -1,6 +1,8 @@
 use pyo3::prelude::*;
 
-use crate::internal::validation::validate_binary_f64;
+use crate::internal::validation::{
+    PermutationIndexError, validate_binary_f64, validate_zero_based_usize_permutation,
+};
 
 fn value_error(message: impl Into<String>) -> PyErr {
     pyo3::exceptions::PyValueError::new_err(message.into())
@@ -43,21 +45,18 @@ fn validate_strata_markers(values: &[i32], n: usize) -> PyResult<()> {
 }
 
 fn validate_sort_indices(values: &[usize], n: usize, name: &str) -> PyResult<()> {
-    let mut seen = vec![false; n];
-    for (idx, &value) in values.iter().enumerate() {
-        if value >= n {
-            return Err(value_error(format!(
-                "{name} index out of bounds at position {idx}: {value} >= {n}"
-            )));
+    match validate_zero_based_usize_permutation(values, n) {
+        Ok(()) => Ok(()),
+        Err(PermutationIndexError::OutOfBounds { position, value }) => Err(value_error(format!(
+            "{name} index out of bounds at position {position}: {value} >= {n}"
+        ))),
+        Err(PermutationIndexError::Duplicate { position, value }) => Err(value_error(format!(
+            "{name} must be a permutation of 0..{n}; duplicate index {value} at position {position}"
+        ))),
+        Err(PermutationIndexError::Negative { .. }) => {
+            unreachable!("usize indices are never negative")
         }
-        if seen[value] {
-            return Err(value_error(format!(
-                "{name} must be a permutation of 0..{n}; duplicate index {value} at position {idx}"
-            )));
-        }
-        seen[value] = true;
     }
-    Ok(())
 }
 
 fn validate_coxcount1_inputs(time: &[f64], status: &[f64], strata: &[i32]) -> PyResult<()> {

--- a/src/data_prep/collapse.rs
+++ b/src/data_prep/collapse.rs
@@ -2,6 +2,8 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
+use crate::internal::validation::{PermutationIndexError, validate_zero_based_i32_permutation};
+
 fn length_error(field: &str, actual: usize, expected: usize) -> PyErr {
     PyValueError::new_err(format!(
         "{field} length mismatch: got {actual}, expected {expected}"
@@ -20,28 +22,27 @@ fn validate_finite(values: &[f64], field: &str) -> PyResult<()> {
 }
 
 fn validate_order(order: &[i32], n: usize) -> PyResult<()> {
-    let mut seen = vec![false; n];
-    for (position, &raw_index) in order.iter().enumerate() {
-        if raw_index < 0 {
-            return Err(PyValueError::new_err(format!(
-                "order values must be non-negative, got {raw_index} at position {position}"
-            )));
-        }
-
-        let index = raw_index as usize;
-        if index >= n {
-            return Err(PyValueError::new_err(format!(
-                "order values must be less than {n}, got {raw_index} at position {position}"
-            )));
-        }
-        if seen[index] {
-            return Err(PyValueError::new_err(format!(
-                "order must be a permutation; duplicate index {raw_index} at position {position}"
-            )));
-        }
-        seen[index] = true;
+    match validate_zero_based_i32_permutation(order, n) {
+        Ok(()) => Ok(()),
+        Err(PermutationIndexError::Negative {
+            position,
+            value: raw_index,
+        }) => Err(PyValueError::new_err(format!(
+            "order values must be non-negative, got {raw_index} at position {position}"
+        ))),
+        Err(PermutationIndexError::OutOfBounds {
+            position,
+            value: raw_index,
+        }) => Err(PyValueError::new_err(format!(
+            "order values must be less than {n}, got {raw_index} at position {position}"
+        ))),
+        Err(PermutationIndexError::Duplicate {
+            position,
+            value: raw_index,
+        }) => Err(PyValueError::new_err(format!(
+            "order must be a permutation; duplicate index {raw_index} at position {position}"
+        ))),
     }
-    Ok(())
 }
 
 struct CollapseSlices<'a> {

--- a/src/internal/validation.rs
+++ b/src/internal/validation.rs
@@ -207,18 +207,9 @@ pub(crate) fn validate_binary_f64(
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum PermutationIndexError {
-    Negative {
-        position: usize,
-        value: i32,
-    },
-    OutOfBounds {
-        position: usize,
-        value: String,
-    },
-    Duplicate {
-        position: usize,
-        value: usize,
-    },
+    Negative { position: usize, value: i32 },
+    OutOfBounds { position: usize, value: String },
+    Duplicate { position: usize, value: usize },
 }
 
 fn mark_permutation_index(

--- a/src/internal/validation.rs
+++ b/src/internal/validation.rs
@@ -205,6 +205,90 @@ pub(crate) fn validate_binary_f64(
     Ok(())
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PermutationIndexError {
+    Negative {
+        position: usize,
+        value: i32,
+    },
+    OutOfBounds {
+        position: usize,
+        value: String,
+    },
+    Duplicate {
+        position: usize,
+        value: usize,
+    },
+}
+
+fn mark_permutation_index(
+    seen: &mut [bool],
+    position: usize,
+    zero_based_value: usize,
+    display_value: usize,
+) -> Result<(), PermutationIndexError> {
+    if zero_based_value >= seen.len() {
+        return Err(PermutationIndexError::OutOfBounds {
+            position,
+            value: display_value.to_string(),
+        });
+    }
+    if seen[zero_based_value] {
+        return Err(PermutationIndexError::Duplicate {
+            position,
+            value: display_value,
+        });
+    }
+    seen[zero_based_value] = true;
+    Ok(())
+}
+
+pub(crate) fn validate_zero_based_usize_permutation(
+    values: &[usize],
+    n: usize,
+) -> Result<(), PermutationIndexError> {
+    let mut seen = vec![false; n];
+    for (position, &value) in values.iter().enumerate() {
+        mark_permutation_index(&mut seen, position, value, value)?;
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_zero_based_i32_permutation(
+    values: &[i32],
+    n: usize,
+) -> Result<(), PermutationIndexError> {
+    let mut seen = vec![false; n];
+    for (position, &value) in values.iter().enumerate() {
+        if value < 0 {
+            return Err(PermutationIndexError::Negative { position, value });
+        }
+        let value = value as usize;
+        mark_permutation_index(&mut seen, position, value, value)?;
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_one_based_i32_permutation(
+    values: &[i32],
+    n: usize,
+) -> Result<Vec<usize>, PermutationIndexError> {
+    let mut seen = vec![false; n];
+    let mut normalized = Vec::with_capacity(values.len());
+    for (position, &raw_value) in values.iter().enumerate() {
+        if raw_value < 1 {
+            return Err(PermutationIndexError::OutOfBounds {
+                position,
+                value: raw_value.to_string(),
+            });
+        }
+        let zero_based_value = raw_value as usize - 1;
+        mark_permutation_index(&mut seen, position, zero_based_value, raw_value as usize)?;
+        normalized.push(zero_based_value);
+    }
+    Ok(normalized)
+}
+
 pub(crate) fn validate_non_overlapping_intervals_i32(
     id: &[i32],
     start: &[f64],
@@ -279,4 +363,87 @@ pub(crate) fn validate_confidence_level(confidence_level: f64) -> Result<(), PyE
 
 pub(crate) fn clamp_probability(value: f64) -> f64 {
     value.clamp(0.0, 1.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_based_usize_permutation_rejects_invalid_indices() {
+        assert!(validate_zero_based_usize_permutation(&[2, 0, 1], 3).is_ok());
+
+        let out_of_bounds = validate_zero_based_usize_permutation(&[0, 3, 1], 3)
+            .expect_err("out-of-bounds index should fail");
+        assert_eq!(
+            out_of_bounds,
+            PermutationIndexError::OutOfBounds {
+                position: 1,
+                value: "3".to_string(),
+            }
+        );
+
+        let duplicate = validate_zero_based_usize_permutation(&[0, 0, 1], 3)
+            .expect_err("duplicate index should fail");
+        assert_eq!(
+            duplicate,
+            PermutationIndexError::Duplicate {
+                position: 1,
+                value: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn zero_based_i32_permutation_rejects_invalid_indices() {
+        assert!(validate_zero_based_i32_permutation(&[2, 0, 1], 3).is_ok());
+
+        let negative = validate_zero_based_i32_permutation(&[0, -1, 1], 3)
+            .expect_err("negative index should fail");
+        assert_eq!(
+            negative,
+            PermutationIndexError::Negative {
+                position: 1,
+                value: -1,
+            }
+        );
+
+        let out_of_bounds = validate_zero_based_i32_permutation(&[0, 3, 1], 3)
+            .expect_err("out-of-bounds index should fail");
+        assert_eq!(
+            out_of_bounds,
+            PermutationIndexError::OutOfBounds {
+                position: 1,
+                value: "3".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn one_based_i32_permutation_normalizes_valid_indices() {
+        assert_eq!(
+            validate_one_based_i32_permutation(&[3, 1, 2], 3).unwrap(),
+            vec![2, 0, 1]
+        );
+
+        let zero = validate_one_based_i32_permutation(&[1, 0, 3], 3)
+            .expect_err("zero one-based index should fail");
+        assert_eq!(
+            zero,
+            PermutationIndexError::OutOfBounds {
+                position: 1,
+                value: "0".to_string(),
+            }
+        );
+
+        let duplicate = validate_one_based_i32_permutation(&[1, 1, 3], 3)
+            .expect_err("duplicate one-based index should fail");
+        assert_eq!(
+            duplicate,
+            PermutationIndexError::Duplicate {
+                position: 1,
+                value: 1,
+            }
+        );
+    }
 }

--- a/src/scoring/agscore3.rs
+++ b/src/scoring/agscore3.rs
@@ -1,6 +1,7 @@
 use super::common::{
     apply_deltas_add, apply_deltas_set, build_score_result, validate_scoring_inputs,
 };
+use crate::internal::validation::{PermutationIndexError, validate_one_based_i32_permutation};
 use ndarray::{Array2, ArrayView2};
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
@@ -9,25 +10,18 @@ fn validate_one_based_sort1(sort1: &[i32], n: usize) -> Result<Vec<usize>, Strin
     if sort1.len() != n {
         return Err("Sort1 length does not match observations".to_string());
     }
-    let mut seen = vec![false; n];
-    let mut normalized = Vec::with_capacity(n);
-    for (idx, &value) in sort1.iter().enumerate() {
-        if value < 1 || value as usize > n {
-            return Err(format!(
-                "Sort1 value {value} at position {idx} is outside 1..={n}"
-            ));
-        }
-        let value = value as usize - 1;
-        if seen[value] {
-            return Err(format!(
-                "Sort1 must be a permutation of 1..={n}; duplicate index {} at position {idx}",
-                value + 1
-            ));
-        }
-        seen[value] = true;
-        normalized.push(value);
+    match validate_one_based_i32_permutation(sort1, n) {
+        Ok(normalized) => Ok(normalized),
+        Err(PermutationIndexError::Negative { position, value }) => Err(format!(
+            "Sort1 value {value} at position {position} is outside 1..={n}"
+        )),
+        Err(PermutationIndexError::OutOfBounds { position, value }) => Err(format!(
+            "Sort1 value {value} at position {position} is outside 1..={n}"
+        )),
+        Err(PermutationIndexError::Duplicate { position, value }) => Err(format!(
+            "Sort1 must be a permutation of 1..={n}; duplicate index {value} at position {position}"
+        )),
     }
-    Ok(normalized)
 }
 
 #[inline]

--- a/src/surv_analysis/norisk.rs
+++ b/src/surv_analysis/norisk.rs
@@ -1,6 +1,8 @@
 use pyo3::prelude::*;
 
-use crate::internal::validation::validate_binary_i32;
+use crate::internal::validation::{
+    PermutationIndexError, validate_binary_i32, validate_zero_based_i32_permutation,
+};
 
 fn value_error(message: impl Into<String>) -> PyErr {
     pyo3::exceptions::PyValueError::new_err(message.into())
@@ -27,22 +29,18 @@ fn validate_finite(values: &[f64], name: &str) -> PyResult<()> {
 }
 
 fn validate_sort_indices(values: &[i32], n: usize, name: &str) -> PyResult<()> {
-    let mut seen = vec![false; n];
-    for (idx, &value) in values.iter().enumerate() {
-        if value < 0 || value as usize >= n {
-            return Err(value_error(format!(
-                "{name} index out of bounds at position {idx}: {value}"
-            )));
-        }
-        let value = value as usize;
-        if seen[value] {
-            return Err(value_error(format!(
-                "{name} must be a permutation of 0..{n}; duplicate index {value} at position {idx}"
-            )));
-        }
-        seen[value] = true;
+    match validate_zero_based_i32_permutation(values, n) {
+        Ok(()) => Ok(()),
+        Err(PermutationIndexError::Negative { position, value }) => Err(value_error(format!(
+            "{name} index out of bounds at position {position}: {value}"
+        ))),
+        Err(PermutationIndexError::OutOfBounds { position, value }) => Err(value_error(format!(
+            "{name} index out of bounds at position {position}: {value}"
+        ))),
+        Err(PermutationIndexError::Duplicate { position, value }) => Err(value_error(format!(
+            "{name} must be a permutation of 0..{n}; duplicate index {value} at position {position}"
+        ))),
     }
-    Ok(())
 }
 
 fn validate_strata_boundaries(values: &[i32], n: usize) -> PyResult<()> {


### PR DESCRIPTION
## Summary
- add shared Rust helpers for zero-based and one-based permutation index validation
- reuse the helpers in concordance, coxcount, norisk, collapse, and agscore paths
- preserve existing public error messages while removing duplicated validation loops

## Validation
- `cargo test`
- `uv run --with maturin maturin develop --release --features extension-module,ml`
- `.venv/bin/python -m pytest python/tests/test_core.py python/tests/test_specialized.py python/tests/test_concordance_additional.py python/tests/test_utilities.py -q`
- `git diff --check`
