### PR TITLE
Share row-major matrix standardization

### DIFF
--- a/src/internal/matrix.rs
+++ b/src/internal/matrix.rs
@@ -6,6 +6,36 @@ use faer::{linalg::solvers::DenseSolveCore, prelude::*};
 use ndarray::{Array1, Array2};
 use rayon::prelude::*;
 
+pub(crate) fn standardize_row_major_matrix(
+    x: &[f64],
+    n_rows: usize,
+    n_cols: usize,
+) -> (Vec<f64>, Vec<f64>, Vec<f64>) {
+    let mut means = vec![0.0; n_cols];
+    let mut scales = vec![1.0; n_cols];
+    let mut standardized = x.to_vec();
+
+    for col in 0..n_cols {
+        let mut sum = 0.0;
+        let mut sum_sq = 0.0;
+        for row in 0..n_rows {
+            let value = x[row * n_cols + col];
+            sum += value;
+            sum_sq += value * value;
+        }
+
+        means[col] = sum / n_rows as f64;
+        let variance = sum_sq / n_rows as f64 - means[col] * means[col];
+        scales[col] = variance.sqrt().max(crate::constants::DIVISION_FLOOR);
+
+        for row in 0..n_rows {
+            standardized[row * n_cols + col] = (x[row * n_cols + col] - means[col]) / scales[col];
+        }
+    }
+
+    (standardized, means, scales)
+}
+
 #[inline]
 fn ndarray_to_faer(arr: &Array2<f64>) -> Mat<f64> {
     let (rows, cols) = arr.dim();
@@ -289,6 +319,21 @@ mod tests {
         let result = regularized_lu_solve(&matrix, &vector).unwrap();
         assert!((result[0] - 1.0).abs() < 1e-10);
         assert!((result[1] - 2.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn standardize_row_major_matrix_centers_and_scales_columns() {
+        let x = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+        let (standardized, means, scales) = standardize_row_major_matrix(&x, 3, 2);
+
+        assert_eq!(means, vec![3.0, 4.0]);
+        assert!((scales[0] - (8.0_f64 / 3.0).sqrt()).abs() < 1e-12);
+        assert!((scales[1] - (8.0_f64 / 3.0).sqrt()).abs() < 1e-12);
+
+        for col in 0..2 {
+            let column_sum: f64 = (0..3).map(|row| standardized[row * 2 + col]).sum();
+            assert!(column_sum.abs() < 1e-12);
+        }
     }
 
     #[test]

--- a/src/regression/elastic_net.rs
+++ b/src/regression/elastic_net.rs
@@ -1,3 +1,4 @@
+use crate::internal::matrix::standardize_row_major_matrix;
 use crate::internal::typed_inputs::{CovariateMatrix, CoxRegressionInput, SurvivalData, Weights};
 use pyo3::prelude::*;
 use rayon::prelude::*;
@@ -240,31 +241,6 @@ fn soft_threshold(x: f64, lambda: f64) -> f64 {
     }
 }
 
-fn standardize_matrix(x: &[f64], n: usize, p: usize) -> (Vec<f64>, Vec<f64>, Vec<f64>) {
-    let mut means = vec![0.0; p];
-    let mut sds = vec![1.0; p];
-    let mut x_std = x.to_vec();
-
-    for j in 0..p {
-        let mut sum = 0.0;
-        let mut sum_sq = 0.0;
-        for i in 0..n {
-            let val = x[i * p + j];
-            sum += val;
-            sum_sq += val * val;
-        }
-        means[j] = sum / n as f64;
-        let var = sum_sq / n as f64 - means[j] * means[j];
-        sds[j] = var.sqrt().max(crate::constants::DIVISION_FLOOR);
-
-        for i in 0..n {
-            x_std[i * p + j] = (x[i * p + j] - means[j]) / sds[j];
-        }
-    }
-
-    (x_std, means, sds)
-}
-
 struct ElasticNetData<'a> {
     x: &'a [f64],
     n: usize,
@@ -497,7 +473,7 @@ pub(crate) fn elastic_net_cox_typed(
     let off = input.offset_or_zero();
 
     let (x_std, _means, sds) = if config.standardize {
-        standardize_matrix(x, n_obs, n_vars)
+        standardize_row_major_matrix(x, n_obs, n_vars)
     } else {
         (x.to_vec(), vec![0.0; n_vars], vec![1.0; n_vars])
     };
@@ -594,7 +570,7 @@ pub(crate) fn elastic_net_cox_path_typed(
     let wt = input.weights_or_unit();
     let off = input.offset_or_zero();
 
-    let (x_std, _means, sds) = standardize_matrix(x, n_obs, n_vars);
+    let (x_std, _means, sds) = standardize_row_major_matrix(x, n_obs, n_vars);
 
     let beta_zero = vec![0.0; n_vars];
     let fit_data = ElasticNetData {

--- a/src/regression/fast_cox/api.rs
+++ b/src/regression/fast_cox/api.rs
@@ -31,7 +31,7 @@ fn fast_cox_slices(
     };
 
     let (x_std, means, sds) = if config.standardize {
-        standardize_matrix(x, n_obs, n_vars)
+        standardize_row_major_matrix(x, n_obs, n_vars)
     } else {
         (x.to_vec(), vec![0.0; n_vars], vec![1.0; n_vars])
     };
@@ -197,7 +197,7 @@ pub(crate) fn fast_cox_path_typed(
     let wt = input.weights_or_unit();
     let off = input.offset_or_zero();
 
-    let (x_std, _means, sds) = standardize_matrix(x, n_obs, n_vars);
+    let (x_std, _means, sds) = standardize_row_major_matrix(x, n_obs, n_vars);
 
     let beta_zero = vec![0.0; n_vars];
     let fit_data = FastCoxData {

--- a/src/regression/fast_cox/core.rs
+++ b/src/regression/fast_cox/core.rs
@@ -8,31 +8,6 @@ fn soft_threshold(x: f64, lambda: f64) -> f64 {
     }
 }
 
-fn standardize_matrix(x: &[f64], n: usize, p: usize) -> (Vec<f64>, Vec<f64>, Vec<f64>) {
-    let mut means = vec![0.0; p];
-    let mut sds = vec![1.0; p];
-    let mut x_std = x.to_vec();
-
-    for j in 0..p {
-        let mut sum = 0.0;
-        let mut sum_sq = 0.0;
-        for i in 0..n {
-            let val = x[i * p + j];
-            sum += val;
-            sum_sq += val * val;
-        }
-        means[j] = sum / n as f64;
-        let var = sum_sq / n as f64 - means[j] * means[j];
-        sds[j] = var.sqrt().max(crate::constants::DIVISION_FLOOR);
-
-        for i in 0..n {
-            x_std[i * p + j] = (x[i * p + j] - means[j]) / sds[j];
-        }
-    }
-
-    (x_std, means, sds)
-}
-
 struct RiskSetData {
     cumsum_exp_eta: Vec<f64>,
     cumsum_weighted_x: Vec<Vec<f64>>,

--- a/src/regression/fast_cox/mod.rs
+++ b/src/regression/fast_cox/mod.rs
@@ -2,6 +2,7 @@ use ndarray::{ArrayView1, ArrayView2};
 use pyo3::prelude::*;
 use rayon::prelude::*;
 
+use crate::internal::matrix::standardize_row_major_matrix;
 use crate::{SurvivalError, SurvivalResult};
 
 include!("types.rs");


### PR DESCRIPTION
## Summary
- add a shared row-major column standardization helper in the internal matrix module
- reuse it from fast Cox and elastic-net Cox paths
- remove duplicate private standardization routines

## Validation
- cargo test standardize_row_major_matrix
- cargo test fast_cox
- cargo test elastic_net
- cargo fmt --check
- git diff --check