### PR TITLE
Share Cox risk set utilities

### DIFF
--- a/src/internal/cox_risk.rs
+++ b/src/internal/cox_risk.rs
@@ -1,0 +1,122 @@
+#[derive(Debug, Clone)]
+pub(crate) struct CoxRiskSetData {
+    pub(crate) cumsum_exp_eta: Vec<f64>,
+    pub(crate) cumsum_weighted_x: Vec<Vec<f64>>,
+    pub(crate) cumsum_weighted_x_sq: Vec<Vec<f64>>,
+    pub(crate) risk_set_pos: Vec<usize>,
+}
+
+pub(crate) fn cox_risk_shift(eta: &[f64], weights: &[f64]) -> f64 {
+    let shift = eta
+        .iter()
+        .zip(weights.iter())
+        .filter_map(|(&eta_i, &weight)| {
+            if weight > 0.0 && eta_i.is_finite() {
+                Some(eta_i)
+            } else {
+                None
+            }
+        })
+        .fold(f64::NEG_INFINITY, f64::max);
+
+    if shift.is_finite() { shift } else { 0.0 }
+}
+
+pub(crate) fn shifted_exp_eta(eta: &[f64], weights: &[f64]) -> Vec<f64> {
+    let shift = cox_risk_shift(eta, weights);
+    eta.iter().map(|&eta_i| (eta_i - shift).exp()).collect()
+}
+
+#[allow(clippy::needless_range_loop)]
+pub(crate) fn precompute_cox_risk_set_cumsum(
+    x: &[f64],
+    n: usize,
+    p: usize,
+    time: &[f64],
+    weights: &[f64],
+    exp_eta: &[f64],
+) -> CoxRiskSetData {
+    debug_assert_eq!(x.len(), n * p);
+    debug_assert_eq!(time.len(), n);
+    debug_assert_eq!(weights.len(), n);
+    debug_assert_eq!(exp_eta.len(), n);
+
+    let mut sorted_indices: Vec<usize> = (0..n).collect();
+    sorted_indices.sort_by(|&a, &b| time[b].total_cmp(&time[a]).then_with(|| a.cmp(&b)));
+
+    let mut cumsum_exp_eta = vec![0.0; n];
+    let mut cumsum_weighted_x = vec![vec![0.0; p]; n];
+    let mut cumsum_weighted_x_sq = vec![vec![0.0; p]; n];
+    let mut risk_set_pos = vec![0usize; n];
+
+    let mut running_exp = 0.0;
+    let mut running_x = vec![0.0; p];
+    let mut running_x_sq = vec![0.0; p];
+
+    for (pos, &idx) in sorted_indices.iter().enumerate() {
+        let weighted_exp = weights[idx] * exp_eta[idx];
+        running_exp += weighted_exp;
+
+        for col in 0..p {
+            let xij = x[idx * p + col];
+            running_x[col] += weighted_exp * xij;
+            running_x_sq[col] += weighted_exp * xij * xij;
+        }
+
+        cumsum_exp_eta[pos] = running_exp;
+        cumsum_weighted_x[pos] = running_x.clone();
+        cumsum_weighted_x_sq[pos] = running_x_sq.clone();
+    }
+
+    let mut start = 0;
+    while start < n {
+        let current_time = time[sorted_indices[start]];
+        let mut end = start + 1;
+        while end < n && crate::constants::same_time(time[sorted_indices[end]], current_time) {
+            end += 1;
+        }
+
+        let pos = end - 1;
+        for &idx in &sorted_indices[start..end] {
+            risk_set_pos[idx] = pos;
+        }
+        start = end;
+    }
+
+    CoxRiskSetData {
+        cumsum_exp_eta,
+        cumsum_weighted_x,
+        cumsum_weighted_x_sq,
+        risk_set_pos,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cox_risk_shift_ignores_zero_weight_and_non_finite_values() {
+        let eta = [1.0, 5.0, f64::INFINITY, 3.0];
+        let weights = [1.0, 0.0, 1.0, 2.0];
+
+        assert_eq!(cox_risk_shift(&eta, &weights), 3.0);
+        assert_eq!(cox_risk_shift(&[f64::INFINITY], &[1.0]), 0.0);
+        assert_eq!(cox_risk_shift(&[10.0], &[0.0]), 0.0);
+    }
+
+    #[test]
+    fn precompute_cox_risk_set_cumsum_groups_equal_times() {
+        let x = [1.0, 10.0, 2.0, 20.0, 3.0, 30.0];
+        let time = [1.0, 2.0, 2.0];
+        let weights = [1.0, 1.0, 1.0];
+        let exp_eta = [1.0, 1.0, 1.0];
+
+        let risk_data = precompute_cox_risk_set_cumsum(&x, 3, 2, &time, &weights, &exp_eta);
+
+        assert_eq!(risk_data.cumsum_exp_eta, vec![1.0, 2.0, 3.0]);
+        assert_eq!(risk_data.risk_set_pos, vec![2, 1, 1]);
+        assert_eq!(risk_data.cumsum_weighted_x[1], vec![5.0, 50.0]);
+        assert_eq!(risk_data.cumsum_weighted_x_sq[1], vec![13.0, 1300.0]);
+    }
+}

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod cox_risk;
 pub(crate) mod fenwick;
 pub(crate) mod logrank;
 pub(crate) mod matrix;

--- a/src/regression/elastic_net.rs
+++ b/src/regression/elastic_net.rs
@@ -1,3 +1,4 @@
+use crate::internal::cox_risk::{cox_risk_shift, precompute_cox_risk_set_cumsum, shifted_exp_eta};
 use crate::internal::matrix::standardize_row_major_matrix;
 use crate::internal::typed_inputs::{CovariateMatrix, CoxRegressionInput, SurvivalData, Weights};
 use pyo3::prelude::*;
@@ -251,13 +252,6 @@ struct ElasticNetData<'a> {
     offset: &'a [f64],
 }
 
-struct RiskSetData {
-    cumsum_exp_eta: Vec<f64>,
-    cumsum_weighted_x: Vec<Vec<f64>>,
-    cumsum_weighted_x_sq: Vec<Vec<f64>>,
-    risk_set_pos: Vec<usize>,
-}
-
 struct ElasticNetDescentConfig<'a> {
     lambda: f64,
     l1_ratio: f64,
@@ -279,86 +273,6 @@ fn linear_predictors(data: &ElasticNetData, beta: &[f64]) -> Vec<f64> {
         .collect()
 }
 
-fn risk_shift(eta: &[f64], weights: &[f64]) -> f64 {
-    let shift = eta
-        .iter()
-        .zip(weights.iter())
-        .filter_map(|(&eta_i, &weight)| {
-            if weight > 0.0 && eta_i.is_finite() {
-                Some(eta_i)
-            } else {
-                None
-            }
-        })
-        .fold(f64::NEG_INFINITY, f64::max);
-
-    if shift.is_finite() { shift } else { 0.0 }
-}
-
-fn shifted_exp_eta(eta: &[f64], weights: &[f64]) -> Vec<f64> {
-    let shift = risk_shift(eta, weights);
-    eta.iter().map(|&eta_i| (eta_i - shift).exp()).collect()
-}
-
-#[allow(clippy::needless_range_loop)]
-fn precompute_risk_set_cumsum(
-    x: &[f64],
-    n: usize,
-    p: usize,
-    time: &[f64],
-    weights: &[f64],
-    exp_eta: &[f64],
-) -> RiskSetData {
-    let mut indices: Vec<usize> = (0..n).collect();
-    indices.sort_by(|&a, &b| time[b].total_cmp(&time[a]).then_with(|| a.cmp(&b)));
-
-    let mut cumsum_exp_eta = vec![0.0; n];
-    let mut cumsum_weighted_x = vec![vec![0.0; p]; n];
-    let mut cumsum_weighted_x_sq = vec![vec![0.0; p]; n];
-    let mut risk_set_pos = vec![0usize; n];
-
-    let mut running_exp = 0.0;
-    let mut running_x = vec![0.0; p];
-    let mut running_x_sq = vec![0.0; p];
-
-    for (pos, &idx) in indices.iter().enumerate() {
-        let w = weights[idx] * exp_eta[idx];
-        running_exp += w;
-
-        for j in 0..p {
-            let xij = x[idx * p + j];
-            running_x[j] += w * xij;
-            running_x_sq[j] += w * xij * xij;
-        }
-
-        cumsum_exp_eta[pos] = running_exp;
-        cumsum_weighted_x[pos] = running_x.clone();
-        cumsum_weighted_x_sq[pos] = running_x_sq.clone();
-    }
-
-    let mut start = 0;
-    while start < n {
-        let current_time = time[indices[start]];
-        let mut end = start + 1;
-        while end < n && crate::constants::same_time(time[indices[end]], current_time) {
-            end += 1;
-        }
-
-        let pos = end - 1;
-        for &idx in &indices[start..end] {
-            risk_set_pos[idx] = pos;
-        }
-        start = end;
-    }
-
-    RiskSetData {
-        cumsum_exp_eta,
-        cumsum_weighted_x,
-        cumsum_weighted_x_sq,
-        risk_set_pos,
-    }
-}
-
 #[allow(clippy::needless_range_loop)]
 fn compute_cox_gradient_hessian(data: &ElasticNetData, beta: &[f64]) -> (Vec<f64>, Vec<f64>) {
     let mut gradient = vec![0.0; data.p];
@@ -366,7 +280,7 @@ fn compute_cox_gradient_hessian(data: &ElasticNetData, beta: &[f64]) -> (Vec<f64
     let eta = linear_predictors(data, beta);
     let exp_eta = shifted_exp_eta(&eta, data.weights);
     let risk_data =
-        precompute_risk_set_cumsum(data.x, data.n, data.p, data.time, data.weights, &exp_eta);
+        precompute_cox_risk_set_cumsum(data.x, data.n, data.p, data.time, data.weights, &exp_eta);
 
     for i in 0..data.n {
         if data.status[i] != 1 {
@@ -395,10 +309,10 @@ fn compute_cox_gradient_hessian(data: &ElasticNetData, beta: &[f64]) -> (Vec<f64
 #[allow(clippy::needless_range_loop)]
 fn compute_cox_deviance(data: &ElasticNetData, beta: &[f64]) -> f64 {
     let eta = linear_predictors(data, beta);
-    let shift = risk_shift(&eta, data.weights);
+    let shift = cox_risk_shift(&eta, data.weights);
     let exp_eta: Vec<f64> = eta.iter().map(|&eta_i| (eta_i - shift).exp()).collect();
     let risk_data =
-        precompute_risk_set_cumsum(data.x, data.n, data.p, data.time, data.weights, &exp_eta);
+        precompute_cox_risk_set_cumsum(data.x, data.n, data.p, data.time, data.weights, &exp_eta);
 
     let mut loglik = 0.0;
 

--- a/src/regression/fast_cox/core.rs
+++ b/src/regression/fast_cox/core.rs
@@ -8,13 +8,6 @@ fn soft_threshold(x: f64, lambda: f64) -> f64 {
     }
 }
 
-struct RiskSetData {
-    cumsum_exp_eta: Vec<f64>,
-    cumsum_weighted_x: Vec<Vec<f64>>,
-    cumsum_weighted_x_sq: Vec<Vec<f64>>,
-    risk_set_pos: Vec<usize>,
-}
-
 struct FastCoxData<'a> {
     x: &'a [f64],
     n: usize,
@@ -37,64 +30,6 @@ struct FastCoxDescentConfig<'a> {
     lambda_max: f64,
 }
 
-fn precompute_risk_set_cumsum(
-    x: &[f64],
-    n: usize,
-    p: usize,
-    time: &[f64],
-    weights: &[f64],
-    exp_eta: &[f64],
-) -> RiskSetData {
-    let mut sorted_indices: Vec<usize> = (0..n).collect();
-    sorted_indices.sort_by(|&a, &b| time[b].total_cmp(&time[a]).then_with(|| a.cmp(&b)));
-
-    let mut cumsum_exp_eta = vec![0.0; n];
-    let mut cumsum_weighted_x = vec![vec![0.0; p]; n];
-    let mut cumsum_weighted_x_sq = vec![vec![0.0; p]; n];
-    let mut risk_set_pos = vec![0usize; n];
-
-    let mut running_exp = 0.0;
-    let mut running_wx = vec![0.0; p];
-    let mut running_wxsq = vec![0.0; p];
-
-    for (pos, &idx) in sorted_indices.iter().enumerate() {
-        let w = weights[idx] * exp_eta[idx];
-        running_exp += w;
-
-        for j in 0..p {
-            let xij = x[idx * p + j];
-            running_wx[j] += w * xij;
-            running_wxsq[j] += w * xij * xij;
-        }
-
-        cumsum_exp_eta[pos] = running_exp;
-        cumsum_weighted_x[pos] = running_wx.clone();
-        cumsum_weighted_x_sq[pos] = running_wxsq.clone();
-    }
-
-    let mut start = 0;
-    while start < n {
-        let current_time = time[sorted_indices[start]];
-        let mut end = start + 1;
-        while end < n && crate::constants::same_time(time[sorted_indices[end]], current_time) {
-            end += 1;
-        }
-
-        let pos = end - 1;
-        for &idx in &sorted_indices[start..end] {
-            risk_set_pos[idx] = pos;
-        }
-        start = end;
-    }
-
-    RiskSetData {
-        cumsum_exp_eta,
-        cumsum_weighted_x,
-        cumsum_weighted_x_sq,
-        risk_set_pos,
-    }
-}
-
 #[allow(clippy::needless_range_loop)]
 fn linear_predictors(data: &FastCoxData, beta: &[f64]) -> Vec<f64> {
     (0..data.n)
@@ -108,29 +43,6 @@ fn linear_predictors(data: &FastCoxData, beta: &[f64]) -> Vec<f64> {
         .collect()
 }
 
-fn shifted_exp_eta(eta: &[f64], weights: &[f64]) -> Vec<f64> {
-    let risk_shift = eta
-        .iter()
-        .zip(weights.iter())
-        .filter_map(|(&eta_i, &weight)| {
-            if weight > 0.0 && eta_i.is_finite() {
-                Some(eta_i)
-            } else {
-                None
-            }
-        })
-        .fold(f64::NEG_INFINITY, f64::max);
-    let risk_shift = if risk_shift.is_finite() {
-        risk_shift
-    } else {
-        0.0
-    };
-
-    eta.iter()
-        .map(|&eta_i| (eta_i - risk_shift).exp())
-        .collect()
-}
-
 #[allow(clippy::needless_range_loop)]
 fn compute_gradient_hessian_diag_fast(
     data: &FastCoxData,
@@ -140,7 +52,7 @@ fn compute_gradient_hessian_diag_fast(
     let eta = linear_predictors(data, beta);
     let exp_eta = shifted_exp_eta(&eta, data.weights);
 
-    let risk_data = precompute_risk_set_cumsum(
+    let risk_data = precompute_cox_risk_set_cumsum(
         data.x,
         data.n,
         data.p,
@@ -226,24 +138,9 @@ fn apply_edpp_screening(
 #[allow(clippy::needless_range_loop)]
 fn compute_cox_deviance(data: &FastCoxData, beta: &[f64]) -> f64 {
     let eta = linear_predictors(data, beta);
-    let risk_shift = eta
-        .iter()
-        .zip(data.weights.iter())
-        .filter_map(|(&eta_i, &weight)| {
-            if weight > 0.0 && eta_i.is_finite() {
-                Some(eta_i)
-            } else {
-                None
-            }
-        })
-        .fold(f64::NEG_INFINITY, f64::max);
-    let risk_shift = if risk_shift.is_finite() {
-        risk_shift
-    } else {
-        0.0
-    };
+    let risk_shift = cox_risk_shift(&eta, data.weights);
     let exp_eta: Vec<f64> = eta.iter().map(|&eta_i| (eta_i - risk_shift).exp()).collect();
-    let risk_data = precompute_risk_set_cumsum(
+    let risk_data = precompute_cox_risk_set_cumsum(
         data.x,
         data.n,
         data.p,

--- a/src/regression/fast_cox/mod.rs
+++ b/src/regression/fast_cox/mod.rs
@@ -2,6 +2,7 @@ use ndarray::{ArrayView1, ArrayView2};
 use pyo3::prelude::*;
 use rayon::prelude::*;
 
+use crate::internal::cox_risk::{cox_risk_shift, precompute_cox_risk_set_cumsum, shifted_exp_eta};
 use crate::internal::matrix::standardize_row_major_matrix;
 use crate::{SurvivalError, SurvivalResult};
 


### PR DESCRIPTION
## Summary
- add an internal Cox risk-set helper for risk shifting, shifted exponentials, and cumulative risk sums
- reuse the helper from fast Cox and elastic-net Cox paths
- remove duplicate private risk-set implementations while keeping model-specific gradient and deviance logic unchanged

## Validation
- cargo test cox_risk
- cargo test fast_cox
- cargo test elastic_net
- cargo fmt --check
- git diff --check