### PR TITLE
Reduce allocations across Cox regression paths

### DIFF
--- a/python/tests/test_array_inputs.py
+++ b/python/tests/test_array_inputs.py
@@ -132,6 +132,16 @@ def test_logrank_with_numpy_int64():
     assert hasattr(result, "statistic")
 
 
+def test_logrank_with_strided_numpy_arrays():
+    time = np.array([1.0, -1.0, 2.0, -1.0, 3.0, -1.0, 4.0, -1.0, 5.0, -1.0])
+    status = np.array([1, -1, 1, -1, 0, -1, 1, -1, 0, -1], dtype=np.int32)
+    group = np.array([0, -1, 0, -1, 1, -1, 1, -1, 1, -1], dtype=np.int64)
+
+    result = survival.logrank_test(time[::2], status[::2], group[::2])
+
+    assert hasattr(result, "statistic")
+
+
 @pytest.mark.skipif(not HAS_PANDAS, reason="pandas not installed")
 def test_logrank_with_pandas():
     time_list = [1.0, 2.0, 3.0, 4.0, 5.0, 1.5, 2.5, 3.5, 4.5, 5.5]

--- a/src/internal/cox_risk.rs
+++ b/src/internal/cox_risk.rs
@@ -24,7 +24,20 @@ pub(crate) fn cox_risk_shift(eta: &[f64], weights: &[f64]) -> f64 {
 
 pub(crate) fn shifted_exp_eta(eta: &[f64], weights: &[f64]) -> Vec<f64> {
     let shift = cox_risk_shift(eta, weights);
-    eta.iter().map(|&eta_i| (eta_i - shift).exp()).collect()
+    shifted_exp_eta_with_shift(eta, weights, shift)
+}
+
+pub(crate) fn shifted_exp_eta_with_shift(eta: &[f64], weights: &[f64], shift: f64) -> Vec<f64> {
+    eta.iter()
+        .zip(weights.iter())
+        .map(|(&eta_i, &weight)| {
+            if weight > 0.0 {
+                (eta_i - shift).exp()
+            } else {
+                0.0
+            }
+        })
+        .collect()
 }
 
 #[allow(clippy::needless_range_loop)]
@@ -104,6 +117,42 @@ mod tests {
         assert_eq!(cox_risk_shift(&eta, &weights), 3.0);
         assert_eq!(cox_risk_shift(&[f64::INFINITY], &[1.0]), 0.0);
         assert_eq!(cox_risk_shift(&[10.0], &[0.0]), 0.0);
+    }
+
+    #[test]
+    fn shifted_exp_eta_skips_zero_weight_values() {
+        let eta = [2.0, f64::INFINITY, 4.0];
+        let weights = [1.0, 0.0, 0.0];
+
+        let exp_eta = shifted_exp_eta(&eta, &weights);
+
+        assert_eq!(exp_eta, vec![1.0, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn precompute_cox_risk_set_cumsum_ignores_zero_weight_non_finite_eta() {
+        let x = [1.0, 2.0];
+        let time = [1.0, 2.0];
+        let weights = [1.0, 0.0];
+        let eta = [0.0, f64::INFINITY];
+        let exp_eta = shifted_exp_eta(&eta, &weights);
+
+        let risk_data = precompute_cox_risk_set_cumsum(&x, 2, 1, &time, &weights, &exp_eta);
+
+        assert_eq!(risk_data.cumsum_exp_eta, vec![0.0, 1.0]);
+        assert_eq!(risk_data.cumsum_weighted_x, vec![0.0, 1.0]);
+        assert!(
+            risk_data
+                .cumsum_exp_eta
+                .iter()
+                .all(|value| value.is_finite())
+        );
+        assert!(
+            risk_data
+                .cumsum_weighted_x
+                .iter()
+                .all(|value| value.is_finite())
+        );
     }
 
     #[test]

--- a/src/internal/cox_risk.rs
+++ b/src/internal/cox_risk.rs
@@ -129,6 +129,23 @@ pub(crate) fn shifted_exp_eta_with_shift(eta: &[f64], weights: &[f64], shift: f6
         .collect()
 }
 
+pub(crate) fn shifted_weighted_exp_eta_with_shift(
+    eta: &[f64],
+    weights: &[f64],
+    shift: f64,
+) -> Vec<f64> {
+    eta.iter()
+        .zip(weights.iter())
+        .map(|(&eta_i, &weight)| {
+            if weight > 0.0 {
+                weight * (eta_i - shift).exp()
+            } else {
+                0.0
+            }
+        })
+        .collect()
+}
+
 #[allow(clippy::needless_range_loop)]
 pub(crate) fn precompute_cox_risk_set_cumsum(
     x: &[f64],
@@ -287,6 +304,16 @@ mod tests {
         let exp_eta = shifted_exp_eta(&eta, &weights);
 
         assert_eq!(exp_eta, vec![1.0, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn shifted_weighted_exp_eta_applies_weights_after_shift() {
+        let eta = [2.0, f64::INFINITY, 4.0];
+        let weights = [2.0, 0.0, 3.0];
+
+        let exp_eta = shifted_weighted_exp_eta_with_shift(&eta, &weights, 2.0);
+
+        assert_eq!(exp_eta, vec![2.0, 0.0, 3.0 * (2.0_f64).exp()]);
     }
 
     #[test]

--- a/src/internal/cox_risk.rs
+++ b/src/internal/cox_risk.rs
@@ -170,7 +170,7 @@ pub(crate) fn precompute_cox_risk_set_cumsum(
     risk_data
 }
 
-#[allow(clippy::needless_range_loop)]
+#[allow(clippy::needless_range_loop, clippy::too_many_arguments)]
 pub(crate) fn precompute_cox_risk_set_cumsum_into(
     x: &[f64],
     n: usize,
@@ -228,7 +228,7 @@ pub(crate) fn precompute_cox_risk_set_cumsum_into(
     }
 }
 
-#[allow(clippy::needless_range_loop)]
+#[allow(clippy::needless_range_loop, clippy::too_many_arguments)]
 pub(crate) fn precompute_cox_risk_set_first_order_cumsum_into(
     x: &[f64],
     n: usize,

--- a/src/internal/cox_risk.rs
+++ b/src/internal/cox_risk.rs
@@ -6,6 +6,50 @@ pub(crate) struct CoxRiskSetData {
     pub(crate) risk_set_pos: Vec<usize>,
 }
 
+impl CoxRiskSetData {
+    pub(crate) fn with_capacity(n: usize, p: usize) -> Self {
+        Self {
+            cumsum_exp_eta: Vec::with_capacity(n),
+            cumsum_weighted_x: Vec::with_capacity(n * p),
+            cumsum_weighted_x_sq: Vec::with_capacity(n * p),
+            risk_set_pos: Vec::with_capacity(n),
+        }
+    }
+
+    fn resize_for(&mut self, n: usize, p: usize) {
+        self.cumsum_exp_eta.resize(n, 0.0);
+        self.cumsum_weighted_x.resize(n * p, 0.0);
+        self.cumsum_weighted_x_sq.resize(n * p, 0.0);
+        self.risk_set_pos.resize(n, 0);
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct CoxRiskSetScratch {
+    sorted_indices: Vec<usize>,
+    running_x: Vec<f64>,
+    running_x_sq: Vec<f64>,
+}
+
+impl CoxRiskSetScratch {
+    pub(crate) fn with_capacity(n: usize, p: usize) -> Self {
+        Self {
+            sorted_indices: Vec::with_capacity(n),
+            running_x: Vec::with_capacity(p),
+            running_x_sq: Vec::with_capacity(p),
+        }
+    }
+
+    fn reset_for(&mut self, n: usize, p: usize) {
+        self.sorted_indices.clear();
+        self.sorted_indices.extend(0..n);
+        self.running_x.resize(p, 0.0);
+        self.running_x.fill(0.0);
+        self.running_x_sq.resize(p, 0.0);
+        self.running_x_sq.fill(0.0);
+    }
+}
+
 pub(crate) fn cox_risk_shift(eta: &[f64], weights: &[f64]) -> f64 {
     let shift = eta
         .iter()
@@ -49,59 +93,76 @@ pub(crate) fn precompute_cox_risk_set_cumsum(
     weights: &[f64],
     exp_eta: &[f64],
 ) -> CoxRiskSetData {
+    let mut risk_data = CoxRiskSetData::with_capacity(n, p);
+    let mut scratch = CoxRiskSetScratch::with_capacity(n, p);
+    precompute_cox_risk_set_cumsum_into(
+        x,
+        n,
+        p,
+        time,
+        weights,
+        exp_eta,
+        &mut risk_data,
+        &mut scratch,
+    );
+    risk_data
+}
+
+#[allow(clippy::needless_range_loop)]
+pub(crate) fn precompute_cox_risk_set_cumsum_into(
+    x: &[f64],
+    n: usize,
+    p: usize,
+    time: &[f64],
+    weights: &[f64],
+    exp_eta: &[f64],
+    risk_data: &mut CoxRiskSetData,
+    scratch: &mut CoxRiskSetScratch,
+) {
     debug_assert_eq!(x.len(), n * p);
     debug_assert_eq!(time.len(), n);
     debug_assert_eq!(weights.len(), n);
     debug_assert_eq!(exp_eta.len(), n);
 
-    let mut sorted_indices: Vec<usize> = (0..n).collect();
-    sorted_indices.sort_by(|&a, &b| time[b].total_cmp(&time[a]).then_with(|| a.cmp(&b)));
-
-    let mut cumsum_exp_eta = vec![0.0; n];
-    let mut cumsum_weighted_x = vec![0.0; n * p];
-    let mut cumsum_weighted_x_sq = vec![0.0; n * p];
-    let mut risk_set_pos = vec![0usize; n];
+    risk_data.resize_for(n, p);
+    scratch.reset_for(n, p);
+    scratch
+        .sorted_indices
+        .sort_by(|&a, &b| time[b].total_cmp(&time[a]).then_with(|| a.cmp(&b)));
 
     let mut running_exp = 0.0;
-    let mut running_x = vec![0.0; p];
-    let mut running_x_sq = vec![0.0; p];
-
-    for (pos, &idx) in sorted_indices.iter().enumerate() {
+    for (pos, &idx) in scratch.sorted_indices.iter().enumerate() {
         let weighted_exp = weights[idx] * exp_eta[idx];
         running_exp += weighted_exp;
 
         for col in 0..p {
             let xij = x[idx * p + col];
-            running_x[col] += weighted_exp * xij;
-            running_x_sq[col] += weighted_exp * xij * xij;
+            scratch.running_x[col] += weighted_exp * xij;
+            scratch.running_x_sq[col] += weighted_exp * xij * xij;
         }
 
-        cumsum_exp_eta[pos] = running_exp;
+        risk_data.cumsum_exp_eta[pos] = running_exp;
         let row_start = pos * p;
-        cumsum_weighted_x[row_start..row_start + p].copy_from_slice(&running_x);
-        cumsum_weighted_x_sq[row_start..row_start + p].copy_from_slice(&running_x_sq);
+        risk_data.cumsum_weighted_x[row_start..row_start + p].copy_from_slice(&scratch.running_x);
+        risk_data.cumsum_weighted_x_sq[row_start..row_start + p]
+            .copy_from_slice(&scratch.running_x_sq);
     }
 
     let mut start = 0;
     while start < n {
-        let current_time = time[sorted_indices[start]];
+        let current_time = time[scratch.sorted_indices[start]];
         let mut end = start + 1;
-        while end < n && crate::constants::same_time(time[sorted_indices[end]], current_time) {
+        while end < n
+            && crate::constants::same_time(time[scratch.sorted_indices[end]], current_time)
+        {
             end += 1;
         }
 
         let pos = end - 1;
-        for &idx in &sorted_indices[start..end] {
-            risk_set_pos[idx] = pos;
+        for &idx in &scratch.sorted_indices[start..end] {
+            risk_data.risk_set_pos[idx] = pos;
         }
         start = end;
-    }
-
-    CoxRiskSetData {
-        cumsum_exp_eta,
-        cumsum_weighted_x,
-        cumsum_weighted_x_sq,
-        risk_set_pos,
     }
 }
 
@@ -163,6 +224,32 @@ mod tests {
         let exp_eta = [1.0, 1.0, 1.0];
 
         let risk_data = precompute_cox_risk_set_cumsum(&x, 3, 2, &time, &weights, &exp_eta);
+
+        assert_eq!(risk_data.cumsum_exp_eta, vec![1.0, 2.0, 3.0]);
+        assert_eq!(risk_data.risk_set_pos, vec![2, 1, 1]);
+        assert_eq!(risk_data.cumsum_weighted_x[2..4], [5.0, 50.0]);
+        assert_eq!(risk_data.cumsum_weighted_x_sq[2..4], [13.0, 1300.0]);
+    }
+
+    #[test]
+    fn precompute_cox_risk_set_cumsum_into_reuses_buffers() {
+        let x = [1.0, 10.0, 2.0, 20.0, 3.0, 30.0];
+        let time = [1.0, 2.0, 2.0];
+        let weights = [1.0, 1.0, 1.0];
+        let exp_eta = [1.0, 1.0, 1.0];
+        let mut risk_data = CoxRiskSetData::with_capacity(3, 2);
+        let mut scratch = CoxRiskSetScratch::with_capacity(3, 2);
+
+        precompute_cox_risk_set_cumsum_into(
+            &x,
+            3,
+            2,
+            &time,
+            &weights,
+            &exp_eta,
+            &mut risk_data,
+            &mut scratch,
+        );
 
         assert_eq!(risk_data.cumsum_exp_eta, vec![1.0, 2.0, 3.0]);
         assert_eq!(risk_data.risk_set_pos, vec![2, 1, 1]);

--- a/src/internal/cox_risk.rs
+++ b/src/internal/cox_risk.rs
@@ -24,6 +24,29 @@ impl CoxRiskSetData {
     }
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct CoxRiskSetFirstOrderData {
+    pub(crate) cumsum_exp_eta: Vec<f64>,
+    pub(crate) cumsum_weighted_x: Vec<f64>,
+    pub(crate) risk_set_pos: Vec<usize>,
+}
+
+impl CoxRiskSetFirstOrderData {
+    pub(crate) fn with_capacity(n: usize, p: usize) -> Self {
+        Self {
+            cumsum_exp_eta: Vec::with_capacity(n),
+            cumsum_weighted_x: Vec::with_capacity(n * p),
+            risk_set_pos: Vec::with_capacity(n),
+        }
+    }
+
+    fn resize_for(&mut self, n: usize, p: usize) {
+        self.cumsum_exp_eta.resize(n, 0.0);
+        self.cumsum_weighted_x.resize(n * p, 0.0);
+        self.risk_set_pos.resize(n, 0);
+    }
+}
+
 #[derive(Debug, Default)]
 pub(crate) struct CoxRiskSetScratch {
     sorted_indices: Vec<usize>,
@@ -47,6 +70,28 @@ impl CoxRiskSetScratch {
         self.running_x.fill(0.0);
         self.running_x_sq.resize(p, 0.0);
         self.running_x_sq.fill(0.0);
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct CoxRiskSetFirstOrderScratch {
+    sorted_indices: Vec<usize>,
+    running_x: Vec<f64>,
+}
+
+impl CoxRiskSetFirstOrderScratch {
+    pub(crate) fn with_capacity(n: usize, p: usize) -> Self {
+        Self {
+            sorted_indices: Vec::with_capacity(n),
+            running_x: Vec::with_capacity(p),
+        }
+    }
+
+    fn reset_for(&mut self, n: usize, p: usize) {
+        self.sorted_indices.clear();
+        self.sorted_indices.extend(0..n);
+        self.running_x.resize(p, 0.0);
+        self.running_x.fill(0.0);
     }
 }
 
@@ -166,6 +211,60 @@ pub(crate) fn precompute_cox_risk_set_cumsum_into(
     }
 }
 
+#[allow(clippy::needless_range_loop)]
+pub(crate) fn precompute_cox_risk_set_first_order_cumsum_into(
+    x: &[f64],
+    n: usize,
+    p: usize,
+    time: &[f64],
+    weights: &[f64],
+    exp_eta: &[f64],
+    risk_data: &mut CoxRiskSetFirstOrderData,
+    scratch: &mut CoxRiskSetFirstOrderScratch,
+) {
+    debug_assert_eq!(x.len(), n * p);
+    debug_assert_eq!(time.len(), n);
+    debug_assert_eq!(weights.len(), n);
+    debug_assert_eq!(exp_eta.len(), n);
+
+    risk_data.resize_for(n, p);
+    scratch.reset_for(n, p);
+    scratch
+        .sorted_indices
+        .sort_by(|&a, &b| time[b].total_cmp(&time[a]).then_with(|| a.cmp(&b)));
+
+    let mut running_exp = 0.0;
+    for (pos, &idx) in scratch.sorted_indices.iter().enumerate() {
+        let weighted_exp = weights[idx] * exp_eta[idx];
+        running_exp += weighted_exp;
+
+        for col in 0..p {
+            scratch.running_x[col] += weighted_exp * x[idx * p + col];
+        }
+
+        risk_data.cumsum_exp_eta[pos] = running_exp;
+        let row_start = pos * p;
+        risk_data.cumsum_weighted_x[row_start..row_start + p].copy_from_slice(&scratch.running_x);
+    }
+
+    let mut start = 0;
+    while start < n {
+        let current_time = time[scratch.sorted_indices[start]];
+        let mut end = start + 1;
+        while end < n
+            && crate::constants::same_time(time[scratch.sorted_indices[end]], current_time)
+        {
+            end += 1;
+        }
+
+        let pos = end - 1;
+        for &idx in &scratch.sorted_indices[start..end] {
+            risk_data.risk_set_pos[idx] = pos;
+        }
+        start = end;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -229,6 +328,31 @@ mod tests {
         assert_eq!(risk_data.risk_set_pos, vec![2, 1, 1]);
         assert_eq!(risk_data.cumsum_weighted_x[2..4], [5.0, 50.0]);
         assert_eq!(risk_data.cumsum_weighted_x_sq[2..4], [13.0, 1300.0]);
+    }
+
+    #[test]
+    fn precompute_cox_risk_set_first_order_cumsum_groups_equal_times() {
+        let x = [1.0, 10.0, 2.0, 20.0, 3.0, 30.0];
+        let time = [1.0, 2.0, 2.0];
+        let weights = [1.0, 1.0, 1.0];
+        let exp_eta = [1.0, 1.0, 1.0];
+        let mut risk_data = CoxRiskSetFirstOrderData::with_capacity(3, 2);
+        let mut scratch = CoxRiskSetFirstOrderScratch::with_capacity(3, 2);
+
+        precompute_cox_risk_set_first_order_cumsum_into(
+            &x,
+            3,
+            2,
+            &time,
+            &weights,
+            &exp_eta,
+            &mut risk_data,
+            &mut scratch,
+        );
+
+        assert_eq!(risk_data.cumsum_exp_eta, vec![1.0, 2.0, 3.0]);
+        assert_eq!(risk_data.risk_set_pos, vec![2, 1, 1]);
+        assert_eq!(risk_data.cumsum_weighted_x[2..4], [5.0, 50.0]);
     }
 
     #[test]

--- a/src/internal/matrix.rs
+++ b/src/internal/matrix.rs
@@ -5,6 +5,7 @@ use crate::internal::validation::MatrixError;
 use faer::{linalg::solvers::DenseSolveCore, prelude::*};
 use ndarray::{Array1, Array2};
 use rayon::prelude::*;
+use std::borrow::Cow;
 
 pub(crate) fn standardize_row_major_matrix(
     x: &[f64],
@@ -34,6 +35,20 @@ pub(crate) fn standardize_row_major_matrix(
     }
 
     (standardized, means, scales)
+}
+
+pub(crate) fn standardize_or_borrow_row_major_matrix(
+    x: &[f64],
+    n_rows: usize,
+    n_cols: usize,
+    standardize: bool,
+) -> (Cow<'_, [f64]>, Vec<f64>, Vec<f64>) {
+    if standardize {
+        let (standardized, means, scales) = standardize_row_major_matrix(x, n_rows, n_cols);
+        (Cow::Owned(standardized), means, scales)
+    } else {
+        (Cow::Borrowed(x), vec![0.0; n_cols], vec![1.0; n_cols])
+    }
 }
 
 #[inline]
@@ -334,6 +349,27 @@ mod tests {
             let column_sum: f64 = (0..3).map(|row| standardized[row * 2 + col]).sum();
             assert!(column_sum.abs() < 1e-12);
         }
+    }
+
+    #[test]
+    fn standardize_or_borrow_row_major_matrix_borrows_when_disabled() {
+        let x = vec![1.0, 2.0, 3.0, 4.0];
+        let (matrix, means, scales) = standardize_or_borrow_row_major_matrix(&x, 2, 2, false);
+
+        assert!(matches!(matrix, Cow::Borrowed(_)));
+        assert_eq!(matrix.as_ref(), x.as_slice());
+        assert_eq!(means, vec![0.0, 0.0]);
+        assert_eq!(scales, vec![1.0, 1.0]);
+    }
+
+    #[test]
+    fn standardize_or_borrow_row_major_matrix_owns_when_enabled() {
+        let x = vec![1.0, 2.0, 3.0, 4.0];
+        let (matrix, means, scales) = standardize_or_borrow_row_major_matrix(&x, 2, 2, true);
+
+        assert!(matches!(matrix, Cow::Owned(_)));
+        assert_eq!(means, vec![2.0, 3.0]);
+        assert_eq!(scales, vec![1.0, 1.0]);
     }
 
     #[test]

--- a/src/internal/matrix.rs
+++ b/src/internal/matrix.rs
@@ -30,9 +30,10 @@ pub(crate) fn standardize_row_major_matrix(
         means[col] = sum / n_rows as f64;
         let variance = sum_sq / n_rows as f64 - means[col] * means[col];
         scales[col] = variance.sqrt().max(crate::constants::DIVISION_FLOOR);
+        let inv_scale = 1.0 / scales[col];
 
         for row in 0..n_rows {
-            standardized[row * n_cols + col] = (x[row * n_cols + col] - means[col]) / scales[col];
+            standardized[row * n_cols + col] = (x[row * n_cols + col] - means[col]) * inv_scale;
         }
     }
 

--- a/src/internal/matrix.rs
+++ b/src/internal/matrix.rs
@@ -12,9 +12,11 @@ pub(crate) fn standardize_row_major_matrix(
     n_rows: usize,
     n_cols: usize,
 ) -> (Vec<f64>, Vec<f64>, Vec<f64>) {
+    debug_assert_eq!(x.len(), n_rows * n_cols);
+
     let mut means = vec![0.0; n_cols];
     let mut scales = vec![1.0; n_cols];
-    let mut standardized = x.to_vec();
+    let mut standardized = vec![0.0; n_rows * n_cols];
 
     for col in 0..n_cols {
         let mut sum = 0.0;
@@ -341,6 +343,7 @@ mod tests {
         let x = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
         let (standardized, means, scales) = standardize_row_major_matrix(&x, 3, 2);
 
+        assert_eq!(standardized.len(), x.len());
         assert_eq!(means, vec![3.0, 4.0]);
         assert!((scales[0] - (8.0_f64 / 3.0).sqrt()).abs() < 1e-12);
         assert!((scales[1] - (8.0_f64 / 3.0).sqrt()).abs() < 1e-12);

--- a/src/internal/numpy_utils.rs
+++ b/src/internal/numpy_utils.rs
@@ -3,9 +3,20 @@ use numpy::PyReadonlyArray1;
 use pyo3::prelude::*;
 
 #[cfg(feature = "python")]
+fn readonly_array1_to_vec<T>(arr: &PyReadonlyArray1<'_, T>) -> Vec<T>
+where
+    T: numpy::Element + Copy,
+{
+    match arr.as_slice() {
+        Ok(slice) => slice.to_vec(),
+        Err(_) => arr.as_array().iter().copied().collect(),
+    }
+}
+
+#[cfg(feature = "python")]
 pub(crate) fn extract_vec_f64(obj: &Bound<'_, PyAny>) -> PyResult<Vec<f64>> {
     if let Ok(arr) = obj.extract::<PyReadonlyArray1<'_, f64>>() {
-        return Ok(arr.as_slice()?.to_vec());
+        return Ok(readonly_array1_to_vec(&arr));
     }
     if let Ok(list) = obj.extract::<Vec<f64>>() {
         return Ok(list);
@@ -13,13 +24,13 @@ pub(crate) fn extract_vec_f64(obj: &Bound<'_, PyAny>) -> PyResult<Vec<f64>> {
     if let Ok(values) = obj.getattr("values")
         && let Ok(arr) = values.extract::<PyReadonlyArray1<'_, f64>>()
     {
-        return Ok(arr.as_slice()?.to_vec());
+        return Ok(readonly_array1_to_vec(&arr));
     }
     if let Ok(to_numpy) = obj.getattr("to_numpy")
         && let Ok(arr_obj) = to_numpy.call0()
         && let Ok(arr) = arr_obj.extract::<PyReadonlyArray1<'_, f64>>()
     {
-        return Ok(arr.as_slice()?.to_vec());
+        return Ok(readonly_array1_to_vec(&arr));
     }
     let type_name = obj
         .get_type()
@@ -36,10 +47,13 @@ pub(crate) fn extract_vec_f64(obj: &Bound<'_, PyAny>) -> PyResult<Vec<f64>> {
 #[cfg(feature = "python")]
 pub(crate) fn extract_vec_i32(obj: &Bound<'_, PyAny>) -> PyResult<Vec<i32>> {
     if let Ok(arr) = obj.extract::<PyReadonlyArray1<'_, i32>>() {
-        return Ok(arr.as_slice()?.to_vec());
+        return Ok(readonly_array1_to_vec(&arr));
     }
     if let Ok(arr) = obj.extract::<PyReadonlyArray1<'_, i64>>() {
-        return Ok(arr.as_slice()?.iter().map(|&x| x as i32).collect());
+        return Ok(readonly_array1_to_vec(&arr)
+            .into_iter()
+            .map(|x| x as i32)
+            .collect());
     }
     if let Ok(list) = obj.extract::<Vec<i32>>() {
         return Ok(list);
@@ -50,24 +64,30 @@ pub(crate) fn extract_vec_i32(obj: &Bound<'_, PyAny>) -> PyResult<Vec<i32>> {
     if let Ok(values) = obj.getattr("values")
         && let Ok(arr) = values.extract::<PyReadonlyArray1<'_, i32>>()
     {
-        return Ok(arr.as_slice()?.to_vec());
+        return Ok(readonly_array1_to_vec(&arr));
     }
     if let Ok(values) = obj.getattr("values")
         && let Ok(arr) = values.extract::<PyReadonlyArray1<'_, i64>>()
     {
-        return Ok(arr.as_slice()?.iter().map(|&x| x as i32).collect());
+        return Ok(readonly_array1_to_vec(&arr)
+            .into_iter()
+            .map(|x| x as i32)
+            .collect());
     }
     if let Ok(to_numpy) = obj.getattr("to_numpy")
         && let Ok(arr_obj) = to_numpy.call0()
         && let Ok(arr) = arr_obj.extract::<PyReadonlyArray1<'_, i32>>()
     {
-        return Ok(arr.as_slice()?.to_vec());
+        return Ok(readonly_array1_to_vec(&arr));
     }
     if let Ok(to_numpy) = obj.getattr("to_numpy")
         && let Ok(arr_obj) = to_numpy.call0()
         && let Ok(arr) = arr_obj.extract::<PyReadonlyArray1<'_, i64>>()
     {
-        return Ok(arr.as_slice()?.iter().map(|&x| x as i32).collect());
+        return Ok(readonly_array1_to_vec(&arr)
+            .into_iter()
+            .map(|x| x as i32)
+            .collect());
     }
     let type_name = obj
         .get_type()

--- a/src/internal/typed_inputs.rs
+++ b/src/internal/typed_inputs.rs
@@ -420,17 +420,18 @@ impl CoxMartInput {
         })
     }
 
-    pub(crate) fn weights_or_unit(&self) -> Vec<f64> {
+    pub(crate) fn weights_or_unit_cow(&self) -> Cow<'_, [f64]> {
         self.weights
             .as_ref()
-            .map(|weights| weights.values.clone())
-            .unwrap_or_else(|| vec![1.0; self.survival.len()])
+            .map(|weights| Cow::Borrowed(weights.values.as_slice()))
+            .unwrap_or_else(|| Cow::Owned(vec![1.0; self.survival.len()]))
     }
 
-    pub(crate) fn strata_or_default(&self) -> Vec<i32> {
+    pub(crate) fn strata_or_default_cow(&self) -> Cow<'_, [i32]> {
         self.strata
-            .clone()
-            .unwrap_or_else(|| vec![0; self.survival.len()])
+            .as_deref()
+            .map(Cow::Borrowed)
+            .unwrap_or_else(|| Cow::Owned(vec![0; self.survival.len()]))
     }
 }
 
@@ -489,17 +490,18 @@ impl AndersenGillInput {
         })
     }
 
-    pub(crate) fn weights_or_unit(&self) -> Vec<f64> {
+    pub(crate) fn weights_or_unit_cow(&self) -> Cow<'_, [f64]> {
         self.weights
             .as_ref()
-            .map(|weights| weights.values.clone())
-            .unwrap_or_else(|| vec![1.0; self.counting.len()])
+            .map(|weights| Cow::Borrowed(weights.values.as_slice()))
+            .unwrap_or_else(|| Cow::Owned(vec![1.0; self.counting.len()]))
     }
 
-    pub(crate) fn strata_or_default(&self) -> Vec<i32> {
+    pub(crate) fn strata_or_default_cow(&self) -> Cow<'_, [i32]> {
         self.strata
-            .clone()
-            .unwrap_or_else(|| vec![0; self.counting.len()])
+            .as_deref()
+            .map(Cow::Borrowed)
+            .unwrap_or_else(|| Cow::Owned(vec![0; self.counting.len()]))
     }
 }
 
@@ -538,5 +540,54 @@ mod tests {
         assert!(matches!(input.offset_or_zero_cow(), Cow::Owned(_)));
         assert_eq!(input.weights_or_unit_cow().as_ref(), [1.0, 1.0]);
         assert_eq!(input.offset_or_zero_cow().as_ref(), [0.0, 0.0]);
+    }
+
+    #[test]
+    fn residual_inputs_borrow_supplied_weights_and_strata() {
+        let survival = SurvivalData::try_new(vec![1.0, 2.0], vec![1, 0]).unwrap();
+        let cox_input = CoxMartInput::try_new(
+            survival,
+            vec![1.0, 2.0],
+            Some(Weights::try_new(vec![0.5, 1.5]).unwrap()),
+            Some(vec![0, 1]),
+        )
+        .unwrap();
+
+        let counting =
+            CountingProcessData::try_new(vec![0.0, 0.0], vec![1.0, 2.0], vec![1, 0]).unwrap();
+        let ag_input = AndersenGillInput::try_new(
+            counting,
+            vec![1.0, 2.0],
+            Some(Weights::try_new(vec![0.5, 1.5]).unwrap()),
+            Some(vec![0, 1]),
+        )
+        .unwrap();
+
+        assert!(matches!(cox_input.weights_or_unit_cow(), Cow::Borrowed(_)));
+        assert!(matches!(
+            cox_input.strata_or_default_cow(),
+            Cow::Borrowed(_)
+        ));
+        assert!(matches!(ag_input.weights_or_unit_cow(), Cow::Borrowed(_)));
+        assert!(matches!(ag_input.strata_or_default_cow(), Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn residual_inputs_allocate_missing_defaults() {
+        let survival = SurvivalData::try_new(vec![1.0, 2.0], vec![1, 0]).unwrap();
+        let cox_input = CoxMartInput::try_new(survival, vec![1.0, 2.0], None, None).unwrap();
+
+        let counting =
+            CountingProcessData::try_new(vec![0.0, 0.0], vec![1.0, 2.0], vec![1, 0]).unwrap();
+        let ag_input = AndersenGillInput::try_new(counting, vec![1.0, 2.0], None, None).unwrap();
+
+        assert!(matches!(cox_input.weights_or_unit_cow(), Cow::Owned(_)));
+        assert!(matches!(cox_input.strata_or_default_cow(), Cow::Owned(_)));
+        assert_eq!(cox_input.weights_or_unit_cow().as_ref(), [1.0, 1.0]);
+        assert_eq!(cox_input.strata_or_default_cow().as_ref(), [0, 0]);
+        assert!(matches!(ag_input.weights_or_unit_cow(), Cow::Owned(_)));
+        assert!(matches!(ag_input.strata_or_default_cow(), Cow::Owned(_)));
+        assert_eq!(ag_input.weights_or_unit_cow().as_ref(), [1.0, 1.0]);
+        assert_eq!(ag_input.strata_or_default_cow().as_ref(), [0, 0]);
     }
 }

--- a/src/internal/typed_inputs.rs
+++ b/src/internal/typed_inputs.rs
@@ -4,6 +4,7 @@ use crate::internal::validation::{
 use crate::{SurvivalError, SurvivalResult};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
+use std::borrow::Cow;
 
 fn validate_finite(slice: &[f64], field: &'static str) -> SurvivalResult<()> {
     for (index, value) in slice.iter().enumerate() {
@@ -349,17 +350,18 @@ impl CoxRegressionInput {
         Ok(())
     }
 
-    pub(crate) fn weights_or_unit(&self) -> Vec<f64> {
+    pub(crate) fn weights_or_unit_cow(&self) -> Cow<'_, [f64]> {
         self.weights
             .as_ref()
-            .map(|weights| weights.values.clone())
-            .unwrap_or_else(|| vec![1.0; self.covariates.n_obs])
+            .map(|weights| Cow::Borrowed(weights.values.as_slice()))
+            .unwrap_or_else(|| Cow::Owned(vec![1.0; self.covariates.n_obs]))
     }
 
-    pub(crate) fn offset_or_zero(&self) -> Vec<f64> {
+    pub(crate) fn offset_or_zero_cow(&self) -> Cow<'_, [f64]> {
         self.offset
-            .clone()
-            .unwrap_or_else(|| vec![0.0; self.covariates.n_obs])
+            .as_deref()
+            .map(Cow::Borrowed)
+            .unwrap_or_else(|| Cow::Owned(vec![0.0; self.covariates.n_obs]))
     }
 }
 
@@ -498,5 +500,43 @@ impl AndersenGillInput {
         self.strata
             .clone()
             .unwrap_or_else(|| vec![0; self.counting.len()])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cox_input(weights: Option<Weights>, offset: Option<Vec<f64>>) -> CoxRegressionInput {
+        CoxRegressionInput::try_new(
+            CovariateMatrix::try_new(vec![1.0, 2.0, 3.0, 4.0], 2, 2).unwrap(),
+            SurvivalData::try_new(vec![1.0, 2.0], vec![1, 0]).unwrap(),
+            weights,
+            offset,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn cox_regression_input_borrows_supplied_weights_and_offset() {
+        let input = cox_input(
+            Some(Weights::try_new(vec![0.5, 1.5]).unwrap()),
+            Some(vec![0.1, 0.2]),
+        );
+
+        assert!(matches!(input.weights_or_unit_cow(), Cow::Borrowed(_)));
+        assert!(matches!(input.offset_or_zero_cow(), Cow::Borrowed(_)));
+        assert_eq!(input.weights_or_unit_cow().as_ref(), [0.5, 1.5]);
+        assert_eq!(input.offset_or_zero_cow().as_ref(), [0.1, 0.2]);
+    }
+
+    #[test]
+    fn cox_regression_input_allocates_missing_defaults() {
+        let input = cox_input(None, None);
+
+        assert!(matches!(input.weights_or_unit_cow(), Cow::Owned(_)));
+        assert!(matches!(input.offset_or_zero_cow(), Cow::Owned(_)));
+        assert_eq!(input.weights_or_unit_cow().as_ref(), [1.0, 1.0]);
+        assert_eq!(input.offset_or_zero_cow().as_ref(), [0.0, 0.0]);
     }
 }

--- a/src/regression/agfit5.rs
+++ b/src/regression/agfit5.rs
@@ -116,35 +116,31 @@ impl<'a> CoxState<'a> {
         *loglik = 0.0;
         let mut istrat = 0;
         while istrat < self.strata.len() {
+            let current_stratum = self.strata[istrat];
+            let mut stratum_end = istrat + 1;
+            while stratum_end < self.strata.len() && self.strata[stratum_end] == current_stratum {
+                stratum_end += 1;
+            }
+
             let mut risk_sum = 0.0;
-            for person in istrat..self.weights.len() {
-                if self.strata[person] != self.strata[istrat] {
-                    break;
-                }
+            for person in istrat..stratum_end {
                 risk_sum += self.risk_weighted[person];
             }
-            for person in istrat..self.weights.len() {
-                if self.strata[person] != self.strata[istrat] {
-                    break;
-                }
+            for person in istrat..stratum_end {
                 if self.event[person] == 1 {
                     *loglik += self.weights[person] * self.score[person];
                     *loglik -= self.weights[person] * risk_sum.ln();
                     for (i, u_elem) in u.iter_mut().enumerate().take(nvar) {
                         let mut temp = 0.0;
-                        for j in person..self.weights.len() {
-                            if self.strata[j] == self.strata[person] {
-                                temp += self.risk_weighted[j] * self.covar[i][j];
-                            }
+                        for j in person..stratum_end {
+                            temp += self.risk_weighted[j] * self.covar[i][j];
                         }
                         *u_elem += self.weights[person] * (self.covar[i][person] - temp / risk_sum);
                     }
                     if has_frailty {
                         let mut temp = 0.0;
-                        for j in person..self.weights.len() {
-                            if self.strata[j] == self.strata[person] {
-                                temp += self.risk_weighted[j] * self.frail[j] as f64;
-                            }
+                        for j in person..stratum_end {
+                            temp += self.risk_weighted[j] * self.frail[j] as f64;
                         }
                         u[nvar] +=
                             self.weights[person] * (self.frail[person] as f64 - temp / risk_sum);
@@ -152,11 +148,8 @@ impl<'a> CoxState<'a> {
                     for i in 0..nvar {
                         for j in i..nvar {
                             let mut temp = 0.0;
-                            for k in person..self.weights.len() {
-                                if self.strata[k] == self.strata[person] {
-                                    temp +=
-                                        self.risk_weighted[k] * self.covar[i][k] * self.covar[j][k];
-                                }
+                            for k in person..stratum_end {
+                                temp += self.risk_weighted[k] * self.covar[i][k] * self.covar[j][k];
                             }
                             let idx = i * nvar2 + j;
                             imat[idx] += self.weights[person]
@@ -167,12 +160,9 @@ impl<'a> CoxState<'a> {
                     if has_frailty {
                         for i in 0..nvar {
                             let mut temp = 0.0;
-                            for k in person..self.weights.len() {
-                                if self.strata[k] == self.strata[person] {
-                                    temp += self.risk_weighted[k]
-                                        * self.covar[i][k]
-                                        * self.frail[k] as f64;
-                                }
+                            for k in person..stratum_end {
+                                temp +=
+                                    self.risk_weighted[k] * self.covar[i][k] * self.frail[k] as f64;
                             }
                             let idx = i * nvar2 + nvar;
                             imat[idx] += self.weights[person]
@@ -180,10 +170,8 @@ impl<'a> CoxState<'a> {
                                     - (self.a[i] * self.a[nvar]) / (risk_sum * risk_sum));
                         }
                         let mut temp = 0.0;
-                        for k in person..self.weights.len() {
-                            if self.strata[k] == self.strata[person] {
-                                temp += self.risk_weighted[k] * (self.frail[k] as f64).powi(2);
-                            }
+                        for k in person..stratum_end {
+                            temp += self.risk_weighted[k] * (self.frail[k] as f64).powi(2);
                         }
                         let idx = nvar * nvar2 + nvar;
                         imat[idx] += self.weights[person]
@@ -191,14 +179,11 @@ impl<'a> CoxState<'a> {
                                 - (self.a[nvar] * self.a[nvar]) / (risk_sum * risk_sum));
                     }
                 }
-                if person < self.weights.len() - 1 && self.strata[person + 1] == self.strata[person]
-                {
+                if person + 1 < stratum_end {
                     risk_sum -= self.risk_weighted[person];
                 }
             }
-            while istrat < self.strata.len() {
-                istrat += 1;
-            }
+            istrat = stratum_end;
         }
     }
 }
@@ -503,5 +488,45 @@ mod tests {
         assert!(u.iter().all(|value| value.is_finite()));
         assert!(imat.iter().all(|value| value.is_finite()));
         assert!(loglik.is_finite());
+    }
+
+    #[test]
+    fn cox_state_update_processes_all_strata() {
+        let yy = vec![
+            1.0, 2.0, 1.0, 2.0, // start
+            1.0, 2.0, 1.0, 2.0, // stop
+            1.0, 0.0, 1.0, 0.0, // event
+        ];
+        let covar = vec![0.0, 0.0, 0.0, 0.0];
+        let offset = vec![0.0; 4];
+        let weights = vec![1.0; 4];
+        let strata = vec![1, 1, 2, 2];
+        let sort = vec![1, 2, 3, 4];
+        let frail = vec![0, 0, 0, 0];
+        let data = CoxModelData {
+            nused: 4,
+            nvar: 1,
+            nfrail: 0,
+            yy: &yy,
+            covar: &covar,
+            offset: &offset,
+            weights: &weights,
+            strata: &strata,
+            sort: &sort,
+            frail: &frail,
+        };
+        let params = CoxFitParams {
+            max_iter: 1,
+            eps: 1e-6,
+        };
+        let mut state = CoxState::new(&data, &params);
+        let mut beta = vec![0.0];
+        let mut u = vec![0.0];
+        let mut imat = vec![0.0];
+        let mut loglik = 0.0;
+
+        state.update(&mut beta, &mut u, &mut imat, &mut loglik);
+
+        assert!((loglik + 2.0 * 2.0_f64.ln()).abs() < 1e-12);
     }
 }

--- a/src/regression/agfit5.rs
+++ b/src/regression/agfit5.rs
@@ -5,6 +5,7 @@ use ndarray::{Array1, Array2};
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
+use std::borrow::Cow;
 
 #[derive(Debug)]
 pub(crate) struct CoxResult {
@@ -38,19 +39,20 @@ pub(crate) struct CoxFitParams {
     pub eps: f64,
 }
 
-struct CoxState {
+struct CoxState<'a> {
     covar: Vec<Vec<f64>>,
     a: Vec<f64>,
     a2: Vec<f64>,
-    offset: Vec<f64>,
-    weights: Vec<f64>,
+    offset: &'a [f64],
+    weights: &'a [f64],
     event: Vec<i32>,
-    frail: Vec<i32>,
+    frail: &'a [i32],
     score: Vec<f64>,
-    strata: Vec<i32>,
+    risk_weighted: Vec<f64>,
+    strata: &'a [i32],
 }
-impl CoxState {
-    fn new(data: &CoxModelData<'_>, _params: &CoxFitParams) -> Self {
+impl<'a> CoxState<'a> {
+    fn new(data: &'a CoxModelData<'a>, _params: &CoxFitParams) -> Self {
         let CoxModelData {
             nused,
             nvar,
@@ -75,12 +77,13 @@ impl CoxState {
             covar,
             a: vec![0.0; 4 * (nvar + nfrail) + 5 * nused],
             a2: vec![0.0; nvar + nfrail],
-            offset: offset2.to_vec(),
-            weights: weights2.to_vec(),
+            offset: offset2,
+            weights: weights2,
             event: yy[2 * nused..3 * nused].iter().map(|&x| x as i32).collect(),
-            frail: frail2.to_vec(),
+            frail: frail2,
             score: vec![0.0; nused],
-            strata: strata.to_vec(),
+            risk_weighted: vec![0.0; nused],
+            strata,
         };
         for i in 0..nvar {
             let mean = state.covar[i].iter().sum::<f64>() / nused as f64;
@@ -108,6 +111,7 @@ impl CoxState {
                 zbeta += beta[nvar] * self.frail[person] as f64;
             }
             self.score[person] = zbeta;
+            self.risk_weighted[person] = self.weights[person] * zbeta.exp();
         }
         *loglik = 0.0;
         let mut istrat = 0;
@@ -117,8 +121,7 @@ impl CoxState {
                 if self.strata[person] != self.strata[istrat] {
                     break;
                 }
-                let risk_score = self.score[person].exp();
-                risk_sum += self.weights[person] * risk_score;
+                risk_sum += self.risk_weighted[person];
             }
             for person in istrat..self.weights.len() {
                 if self.strata[person] != self.strata[istrat] {
@@ -131,7 +134,7 @@ impl CoxState {
                         let mut temp = 0.0;
                         for j in person..self.weights.len() {
                             if self.strata[j] == self.strata[person] {
-                                temp += self.weights[j] * self.score[j].exp() * self.covar[i][j];
+                                temp += self.risk_weighted[j] * self.covar[i][j];
                             }
                         }
                         *u_elem += self.weights[person] * (self.covar[i][person] - temp / risk_sum);
@@ -140,8 +143,7 @@ impl CoxState {
                         let mut temp = 0.0;
                         for j in person..self.weights.len() {
                             if self.strata[j] == self.strata[person] {
-                                temp +=
-                                    self.weights[j] * self.score[j].exp() * self.frail[j] as f64;
+                                temp += self.risk_weighted[j] * self.frail[j] as f64;
                             }
                         }
                         u[nvar] +=
@@ -152,10 +154,8 @@ impl CoxState {
                             let mut temp = 0.0;
                             for k in person..self.weights.len() {
                                 if self.strata[k] == self.strata[person] {
-                                    temp += self.weights[k]
-                                        * self.score[k].exp()
-                                        * self.covar[i][k]
-                                        * self.covar[j][k];
+                                    temp +=
+                                        self.risk_weighted[k] * self.covar[i][k] * self.covar[j][k];
                                 }
                             }
                             let idx = i * nvar2 + j;
@@ -169,8 +169,7 @@ impl CoxState {
                             let mut temp = 0.0;
                             for k in person..self.weights.len() {
                                 if self.strata[k] == self.strata[person] {
-                                    temp += self.weights[k]
-                                        * self.score[k].exp()
+                                    temp += self.risk_weighted[k]
                                         * self.covar[i][k]
                                         * self.frail[k] as f64;
                                 }
@@ -183,9 +182,7 @@ impl CoxState {
                         let mut temp = 0.0;
                         for k in person..self.weights.len() {
                             if self.strata[k] == self.strata[person] {
-                                temp += self.weights[k]
-                                    * self.score[k].exp()
-                                    * (self.frail[k] as f64).powi(2);
+                                temp += self.risk_weighted[k] * (self.frail[k] as f64).powi(2);
                             }
                         }
                         let idx = nvar * nvar2 + nvar;
@@ -196,8 +193,7 @@ impl CoxState {
                 }
                 if person < self.weights.len() - 1 && self.strata[person + 1] == self.strata[person]
                 {
-                    let risk_score = self.score[person].exp();
-                    risk_sum -= self.weights[person] * risk_score;
+                    risk_sum -= self.risk_weighted[person];
                 }
             }
             while istrat < self.strata.len() {
@@ -399,10 +395,26 @@ fn perform_cox_regression(
             "Event vector length does not match time vector",
         ));
     }
-    let offset = config.offset.unwrap_or_else(|| vec![0.0; nused]);
-    let weights = config.weights.unwrap_or_else(|| vec![1.0; nused]);
-    let strata = config.strata.unwrap_or_else(|| vec![1; nused]);
-    let frail = config.frail.unwrap_or_else(|| vec![0; nused]);
+    let offset = config
+        .offset
+        .as_deref()
+        .map(Cow::Borrowed)
+        .unwrap_or_else(|| Cow::Owned(vec![0.0; nused]));
+    let weights = config
+        .weights
+        .as_deref()
+        .map(Cow::Borrowed)
+        .unwrap_or_else(|| Cow::Owned(vec![1.0; nused]));
+    let strata = config
+        .strata
+        .as_deref()
+        .map(Cow::Borrowed)
+        .unwrap_or_else(|| Cow::Owned(vec![1; nused]));
+    let frail = config
+        .frail
+        .as_deref()
+        .map(Cow::Borrowed)
+        .unwrap_or_else(|| Cow::Owned(vec![0; nused]));
     let max_iter = config.max_iter.unwrap_or(20);
     let eps = config.eps.unwrap_or(1e-6);
     let mut yy = Vec::with_capacity(3 * nused);
@@ -421,11 +433,11 @@ fn perform_cox_regression(
         nfrail,
         yy: &yy,
         covar: &covar,
-        offset: &offset,
-        weights: &weights,
-        strata: &strata,
+        offset: offset.as_ref(),
+        weights: weights.as_ref(),
+        strata: strata.as_ref(),
         sort: &sort,
-        frail: &frail,
+        frail: frail.as_ref(),
     };
     let fit_params = CoxFitParams { max_iter, eps };
     match agfit5(&model_data, &fit_params) {
@@ -447,5 +459,49 @@ fn perform_cox_regression(
             "Cox regression failed: {}",
             e
         ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cox_state_update_caches_weighted_risk_scores() {
+        let yy = vec![1.0, 2.0, 3.0, 1.0, 2.0, 3.0, 1.0, 1.0, 0.0];
+        let covar = vec![0.0, 1.0, 2.0];
+        let offset = vec![0.0; 3];
+        let weights = vec![1.0, 2.0, 1.0];
+        let strata = vec![1, 1, 1];
+        let sort = vec![1, 2, 3];
+        let frail = vec![0, 0, 0];
+        let data = CoxModelData {
+            nused: 3,
+            nvar: 1,
+            nfrail: 0,
+            yy: &yy,
+            covar: &covar,
+            offset: &offset,
+            weights: &weights,
+            strata: &strata,
+            sort: &sort,
+            frail: &frail,
+        };
+        let params = CoxFitParams {
+            max_iter: 1,
+            eps: 1e-6,
+        };
+        let mut state = CoxState::new(&data, &params);
+        let mut beta = vec![0.0];
+        let mut u = vec![0.0];
+        let mut imat = vec![0.0];
+        let mut loglik = 0.0;
+
+        state.update(&mut beta, &mut u, &mut imat, &mut loglik);
+
+        assert_eq!(state.risk_weighted, weights);
+        assert!(u.iter().all(|value| value.is_finite()));
+        assert!(imat.iter().all(|value| value.is_finite()));
+        assert!(loglik.is_finite());
     }
 }

--- a/src/regression/cause_specific_cox.rs
+++ b/src/regression/cause_specific_cox.rs
@@ -365,11 +365,13 @@ fn solve_linear_system(a: &[Vec<f64>], b: &[f64]) -> Option<Vec<f64>> {
             return None;
         }
 
-        let row_i_tail: Vec<f64> = aug[i][i..n].to_vec();
+        let (pivot_rows, lower_rows) = aug.split_at_mut(i + 1);
+        let pivot_tail = &pivot_rows[i][i..n];
         for k in (i + 1)..n {
-            let factor = aug[k][i] / aug[i][i];
+            let lower_row = &mut lower_rows[k - i - 1];
+            let factor = lower_row[i] / pivot_rows[i][i];
             rhs[k] -= factor * rhs[i];
-            for (aug_kj, &aug_ij) in aug[k][i..n].iter_mut().zip(row_i_tail.iter()) {
+            for (aug_kj, &aug_ij) in lower_row[i..n].iter_mut().zip(pivot_tail) {
                 *aug_kj -= factor * aug_ij;
             }
         }
@@ -675,6 +677,15 @@ mod tests {
         assert!(
             CauseSpecificCoxConfig::new(1, CensoringType::Censored, 100, 1e-9, "invalid").is_err()
         );
+    }
+
+    #[test]
+    fn test_solve_linear_system_pivots_without_singular_matrix() {
+        let solution = solve_linear_system(&[vec![0.0, 2.0], vec![1.0, 1.0]], &[4.0, 3.0]).unwrap();
+
+        assert!((solution[0] - 1.0).abs() < 1e-12);
+        assert!((solution[1] - 2.0).abs() < 1e-12);
+        assert!(solve_linear_system(&[vec![0.0, 0.0], vec![0.0, 1.0]], &[1.0, 2.0]).is_none());
     }
 
     #[test]

--- a/src/regression/cause_specific_cox.rs
+++ b/src/regression/cause_specific_cox.rs
@@ -1,7 +1,12 @@
 use crate::constants::{exp_ci_bounds_95, same_time};
 use crate::internal::matrix::invert_matrix;
+use crate::internal::validation::{
+    validate_finite, validate_no_nan, validate_non_empty, validate_non_negative,
+};
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use rayon::prelude::*;
+use std::borrow::Cow;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[pyclass(from_py_object)]
@@ -186,6 +191,80 @@ impl CauseSpecificCoxResult {
             })
             .collect()
     }
+}
+
+fn validate_cause_specific_config(config: &CauseSpecificCoxConfig) -> PyResult<()> {
+    if config.cause_of_interest < 1 {
+        return Err(PyValueError::new_err("cause_of_interest must be >= 1"));
+    }
+    if config.max_iter == 0 {
+        return Err(PyValueError::new_err("max_iter must be positive"));
+    }
+    if !config.tol.is_finite() || config.tol <= 0.0 {
+        return Err(PyValueError::new_err("tol must be finite and positive"));
+    }
+    if !config.ties.eq_ignore_ascii_case("breslow") && !config.ties.eq_ignore_ascii_case("efron") {
+        return Err(PyValueError::new_err("ties must be 'breslow' or 'efron'"));
+    }
+    Ok(())
+}
+
+fn validate_cause_specific_inputs(
+    x: &[f64],
+    n_obs: usize,
+    n_vars: usize,
+    time: &[f64],
+    cause: &[i32],
+    weights: Option<&[f64]>,
+) -> PyResult<()> {
+    if n_obs == 0 {
+        return Err(PyValueError::new_err("n_obs must be positive"));
+    }
+    if n_vars == 0 {
+        return Err(PyValueError::new_err("n_vars must be positive"));
+    }
+
+    let expected_x_len = n_obs.checked_mul(n_vars).ok_or_else(|| {
+        PyValueError::new_err("n_obs * n_vars overflowed while validating x length")
+    })?;
+    if x.len() != expected_x_len {
+        return Err(PyValueError::new_err("x length must equal n_obs * n_vars"));
+    }
+    if time.len() != n_obs || cause.len() != n_obs {
+        return Err(PyValueError::new_err(
+            "time and cause must have length n_obs",
+        ));
+    }
+
+    validate_no_nan(x, "x")?;
+    validate_finite(x, "x")?;
+    validate_no_nan(time, "time")?;
+    validate_finite(time, "time")?;
+    validate_non_negative(time, "time")?;
+    for (idx, &value) in cause.iter().enumerate() {
+        if value < 0 {
+            return Err(PyValueError::new_err(format!(
+                "cause must contain non-negative values; got {value} at index {idx}"
+            )));
+        }
+    }
+
+    if let Some(weights) = weights {
+        validate_non_empty(weights, "weights")?;
+        if weights.len() != n_obs {
+            return Err(PyValueError::new_err("weights must have length n_obs"));
+        }
+        validate_no_nan(weights, "weights")?;
+        validate_finite(weights, "weights")?;
+        validate_non_negative(weights, "weights")?;
+        if weights.iter().all(|&weight| weight == 0.0) {
+            return Err(PyValueError::new_err(
+                "weights must include at least one positive value",
+            ));
+        }
+    }
+
+    Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -382,18 +461,31 @@ pub fn cause_specific_cox(
     config: &CauseSpecificCoxConfig,
     weights: Option<Vec<f64>>,
 ) -> PyResult<CauseSpecificCoxResult> {
-    if x.len() != n_obs * n_vars {
-        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-            "x length must equal n_obs * n_vars",
-        ));
-    }
-    if time.len() != n_obs || cause.len() != n_obs {
-        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-            "time and cause must have length n_obs",
-        ));
-    }
+    validate_cause_specific_inputs(&x, n_obs, n_vars, &time, &cause, weights.as_deref())?;
+    validate_cause_specific_config(config)?;
 
-    let wt = weights.unwrap_or_else(|| vec![1.0; n_obs]);
+    let wt = match weights.as_deref() {
+        Some(weights) => Cow::Borrowed(weights),
+        None => Cow::Owned(vec![1.0; n_obs]),
+    };
+
+    cause_specific_cox_fit(&x, n_obs, n_vars, &time, &cause, config, wt.as_ref())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn cause_specific_cox_fit(
+    x: &[f64],
+    n_obs: usize,
+    n_vars: usize,
+    time: &[f64],
+    cause: &[i32],
+    config: &CauseSpecificCoxConfig,
+    weights: &[f64],
+) -> PyResult<CauseSpecificCoxResult> {
+    debug_assert_eq!(x.len(), n_obs * n_vars);
+    debug_assert_eq!(time.len(), n_obs);
+    debug_assert_eq!(cause.len(), n_obs);
+    debug_assert_eq!(weights.len(), n_obs);
 
     let n_events = cause
         .iter()
@@ -414,12 +506,12 @@ pub fn cause_specific_cox(
         n_iter = iter + 1;
 
         let (gradient, hessian, ll) = compute_cause_specific_gradient_hessian(
-            &x,
+            x,
             n_obs,
             n_vars,
-            &time,
-            &cause,
-            &wt,
+            time,
+            cause,
+            weights,
             &beta,
             config.cause_of_interest,
             config.treat_other_causes_as,
@@ -447,12 +539,12 @@ pub fn cause_specific_cox(
     }
 
     let (_, final_hessian, _) = compute_cause_specific_gradient_hessian(
-        &x,
+        x,
         n_obs,
         n_vars,
-        &time,
-        &cause,
-        &wt,
+        time,
+        cause,
+        weights,
         &beta,
         config.cause_of_interest,
         config.treat_other_causes_as,
@@ -488,9 +580,9 @@ pub fn cause_specific_cox(
 
     let (baseline_times, baseline_hazard, cum_baseline_hazard) = compute_baseline_hazard(
         n_obs,
-        &time,
-        &cause,
-        &wt,
+        time,
+        cause,
+        weights,
         &exp_eta,
         config.cause_of_interest,
         config.treat_other_causes_as,
@@ -530,21 +622,30 @@ pub fn cause_specific_cox_all(
     max_iter: usize,
     tol: f64,
 ) -> PyResult<Vec<CauseSpecificCoxResult>> {
+    if max_cause < 1 {
+        return Err(PyValueError::new_err("max_cause must be >= 1"));
+    }
+    if max_iter == 0 {
+        return Err(PyValueError::new_err("max_iter must be positive"));
+    }
+    if !tol.is_finite() || tol <= 0.0 {
+        return Err(PyValueError::new_err("tol must be finite and positive"));
+    }
+    validate_cause_specific_inputs(&x, n_obs, n_vars, &time, &cause, weights.as_deref())?;
+
+    let wt = match weights.as_deref() {
+        Some(weights) => Cow::Borrowed(weights),
+        None => Cow::Owned(vec![1.0; n_obs]),
+    };
+
     let mut results = Vec::with_capacity(max_cause as usize);
 
     for c in 1..=max_cause {
         let config =
             CauseSpecificCoxConfig::new(c, CensoringType::Censored, max_iter, tol, "breslow")?;
 
-        let result = cause_specific_cox(
-            x.clone(),
-            n_obs,
-            n_vars,
-            time.clone(),
-            cause.clone(),
-            &config,
-            weights.clone(),
-        )?;
+        let result =
+            cause_specific_cox_fit(&x, n_obs, n_vars, &time, &cause, &config, wt.as_ref())?;
 
         results.push(result);
     }
@@ -589,6 +690,76 @@ mod tests {
         assert_eq!(result.n_events, 2);
         assert_eq!(result.n_competing, 2);
         assert_eq!(result.n_censored, 1);
+    }
+
+    #[test]
+    fn test_cause_specific_cox_all_keeps_requested_causes() {
+        let x = vec![1.0, 0.0, 0.0, 1.0];
+        let time = vec![1.0, 2.0];
+        let cause = vec![1, 0];
+
+        let results = cause_specific_cox_all(x, 2, 2, time, cause, 3, None, 5, 1e-5).unwrap();
+
+        assert_eq!(results.len(), 3);
+        assert_eq!(results[0].n_events, 1);
+        assert_eq!(results[1].n_events, 0);
+        assert_eq!(results[2].n_events, 0);
+    }
+
+    #[test]
+    fn test_cause_specific_cox_validates_public_inputs() {
+        let config =
+            CauseSpecificCoxConfig::new(1, CensoringType::Censored, 100, 1e-5, "breslow").unwrap();
+
+        let err = cause_specific_cox(
+            vec![1.0, 2.0],
+            2,
+            1,
+            vec![1.0, 2.0],
+            vec![1, -1],
+            &config,
+            None,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("cause must contain non-negative"));
+
+        let err = cause_specific_cox(
+            vec![1.0, 2.0],
+            2,
+            1,
+            vec![1.0, f64::INFINITY],
+            vec![1, 0],
+            &config,
+            None,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("time contains non-finite"));
+
+        let err = cause_specific_cox(
+            vec![1.0, 2.0],
+            2,
+            1,
+            vec![1.0, 2.0],
+            vec![1, 0],
+            &config,
+            Some(vec![1.0]),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("weights must have length n_obs"));
+
+        let err = cause_specific_cox_all(
+            vec![1.0, 2.0],
+            2,
+            1,
+            vec![1.0, 2.0],
+            vec![1, 0],
+            0,
+            None,
+            100,
+            1e-5,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("max_cause must be >= 1"));
     }
 
     #[test]

--- a/src/regression/cox_optimizer.rs
+++ b/src/regression/cox_optimizer.rs
@@ -691,6 +691,11 @@ impl CoxFit {
             let mut stop_ptr = stratum_end as isize;
             let mut start_ptr = 0usize;
             let mut time_end = stratum_end;
+            let mut death_a = vec![0.0; nvar];
+            let mut death_cmat: Array2<f64> = Array2::zeros((nvar, nvar));
+            let mut event_a = vec![0.0; nvar];
+            let mut event_cmat: Array2<f64> = Array2::zeros((nvar, nvar));
+            let mut risk_indices: Vec<usize> = Vec::new();
 
             loop {
                 let event_time = self.time[time_end];
@@ -733,8 +738,8 @@ impl CoxFit {
                 let mut ndead = 0usize;
                 let mut deadwt = 0.0;
                 let mut denom2 = 0.0;
-                let mut a2 = vec![0.0; nvar];
-                let mut cmat2: Array2<f64> = Array2::zeros((nvar, nvar));
+                death_a.fill(0.0);
+                death_cmat.fill(0.0);
 
                 for person in time_start..=time_end {
                     if self.status[person] == 0 {
@@ -749,8 +754,8 @@ impl CoxFit {
                         person,
                         risk_vals[person],
                         &mut denom2,
-                        &mut a2,
-                        &mut cmat2,
+                        &mut death_a,
+                        &mut death_cmat,
                     );
                     for i in 0..nvar {
                         self.u[i] += self.weights[person] * self.covar[(person, i)];
@@ -759,20 +764,19 @@ impl CoxFit {
 
                 if ndead > 0 {
                     let denom = stop_denom - unentered_denom;
-                    let mut a = vec![0.0; nvar];
-                    let mut cmat: Array2<f64> = Array2::zeros((nvar, nvar));
+                    event_a.fill(0.0);
+                    event_cmat.fill(0.0);
                     for i in 0..nvar {
-                        a[i] = stop_a[i] - unentered_a[i];
+                        event_a[i] = stop_a[i] - unentered_a[i];
                         for j in 0..=i {
-                            cmat[(i, j)] = stop_cmat[(i, j)] - unentered_cmat[(i, j)];
+                            event_cmat[(i, j)] = stop_cmat[(i, j)] - unentered_cmat[(i, j)];
                         }
                     }
                     if matches!(method, Method::Exact) && ndead > 1 {
-                        let risk_indices: Vec<usize> = (stratum_start..=stratum_end)
-                            .filter(|&idx| {
-                                entry_times[idx] < event_time && self.time[idx] >= event_time
-                            })
-                            .collect();
+                        risk_indices.clear();
+                        risk_indices.extend((stratum_start..=stratum_end).filter(|&idx| {
+                            entry_times[idx] < event_time && self.time[idx] >= event_time
+                        }));
                         let (exact_denom, exact_a, exact_cmat) =
                             exact_tied_moments(&risk_indices, ndead, &risk_vals, &self.covar);
                         loglik -= exact_denom.ln();
@@ -790,10 +794,10 @@ impl CoxFit {
                     } else if matches!(method, Method::Breslow) || ndead == 1 {
                         loglik -= deadwt * denom.ln();
                         for i in 0..nvar {
-                            let temp = a[i] / denom;
+                            let temp = event_a[i] / denom;
                             self.u[i] -= deadwt * temp;
                             for j in 0..=i {
-                                let val = deadwt * (cmat[(i, j)] - temp * a[j]) / denom;
+                                let val = deadwt * (event_cmat[(i, j)] - temp * event_a[j]) / denom;
                                 self.imat[(j, i)] += val;
                                 if i != j {
                                     self.imat[(i, j)] += val;
@@ -805,28 +809,23 @@ impl CoxFit {
                         let risk_fraction = denom2 / death_count;
                         let weight_average = deadwt / death_count;
                         let mut efron_denom = denom - denom2;
-                        let mut efron_a: Vec<f64> = a
-                            .iter()
-                            .zip(a2.iter())
-                            .map(|(&all, &dead)| all - dead)
-                            .collect();
-                        let mut efron_cmat = cmat.clone();
                         for i in 0..nvar {
+                            event_a[i] -= death_a[i];
                             for j in 0..=i {
-                                efron_cmat[(i, j)] -= cmat2[(i, j)];
+                                event_cmat[(i, j)] -= death_cmat[(i, j)];
                             }
                         }
                         for _ in 0..ndead {
                             efron_denom += risk_fraction;
                             loglik -= weight_average * efron_denom.ln();
                             for i in 0..nvar {
-                                efron_a[i] += a2[i] / death_count;
-                                let temp = efron_a[i] / efron_denom;
+                                event_a[i] += death_a[i] / death_count;
+                                let temp = event_a[i] / efron_denom;
                                 self.u[i] -= weight_average * temp;
                                 for j in 0..=i {
-                                    efron_cmat[(i, j)] += cmat2[(i, j)] / death_count;
+                                    event_cmat[(i, j)] += death_cmat[(i, j)] / death_count;
                                     let val = weight_average
-                                        * (efron_cmat[(i, j)] - temp * efron_a[j])
+                                        * (event_cmat[(i, j)] - temp * event_a[j])
                                         / efron_denom;
                                     self.imat[(j, i)] += val;
                                     if i != j {
@@ -1082,6 +1081,37 @@ mod tests {
         assert_eq!(information[(0, 0)], 301.0);
         assert_eq!(information[(1, 0)], 442.0);
         assert_eq!(information[(1, 1)], 724.0);
+    }
+
+    #[test]
+    fn counting_process_tied_methods_fit_with_entry_times() {
+        for method in [Method::Efron, Method::Exact] {
+            let mut cox = CoxFit::new_with_entry_times(
+                Array1::from_vec(vec![2.0, 2.0, 3.0, 4.0, 4.0, 5.0]),
+                Array1::from_vec(vec![1, 1, 0, 1, 1, 0]),
+                Array2::from_shape_vec((6, 1), vec![0.0, 0.4, 0.2, 1.0, 1.4, 0.8]).unwrap(),
+                Some(Array1::from_vec(vec![0.0, 0.5, 0.0, 1.0, 2.0, 0.0])),
+                Array1::from_vec(vec![0, 0, 0, 0, 0, 1]),
+                Array1::from_vec(vec![0.0; 6]),
+                Array1::from_vec(vec![1.0; 6]),
+                method,
+                5,
+                1e-8,
+                1e-8,
+                vec![true],
+                vec![0.0],
+            )
+            .expect("counting-process Cox fit should initialize");
+
+            let result = cox.fit();
+            assert!(result.is_ok());
+            let (beta, _means, _u, information, loglik, _sctest, _flag, _iter) = cox.results();
+            assert_eq!(beta.len(), 1);
+            assert!(beta[0].is_finite());
+            assert!(information[(0, 0)].is_finite());
+            assert!(loglik[0].is_finite());
+            assert!(loglik[1].is_finite());
+        }
     }
 
     #[test]

--- a/src/regression/cox_optimizer.rs
+++ b/src/regression/cox_optimizer.rs
@@ -103,15 +103,19 @@ pub(crate) fn exact_tied_moments(
             if base == 0.0 {
                 continue;
             }
-            let prev_a = a[size - 1].clone();
-            let prev_cmat = cmat[size - 1].clone();
+            let (prev_a_rows, current_a_rows) = a.split_at_mut(size);
+            let prev_a = &prev_a_rows[size - 1];
+            let current_a = &mut current_a_rows[0];
+            let (prev_cmat_rows, current_cmat_rows) = cmat.split_at_mut(size);
+            let prev_cmat = &prev_cmat_rows[size - 1];
+            let current_cmat = &mut current_cmat_rows[0];
             denom[size] += risk * base;
             for i in 0..nvar {
                 let xi = covar[(person, i)];
-                a[size][i] += risk * (prev_a[i] + base * xi);
+                current_a[i] += risk * (prev_a[i] + base * xi);
                 for j in 0..=i {
                     let xj = covar[(person, j)];
-                    cmat[size][i * nvar + j] += risk
+                    current_cmat[i * nvar + j] += risk
                         * (prev_cmat[i * nvar + j]
                             + xi * prev_a[j]
                             + xj * prev_a[i]
@@ -121,13 +125,15 @@ pub(crate) fn exact_tied_moments(
         }
     }
 
+    let tied_a = a.pop().expect("exact tied score row must exist");
+    let tied_cmat = cmat.pop().expect("exact tied information row must exist");
     let mut cmat_array = Array2::zeros((nvar, nvar));
     for i in 0..nvar {
         for j in 0..=i {
-            cmat_array[(i, j)] = cmat[deaths][i * nvar + j];
+            cmat_array[(i, j)] = tied_cmat[i * nvar + j];
         }
     }
-    (denom[deaths], a[deaths].clone(), cmat_array)
+    (denom[deaths], tied_a, cmat_array)
 }
 
 pub(crate) struct CoxFit {
@@ -1062,6 +1068,20 @@ mod tests {
         assert_eq!(beta.len(), 1);
         assert!(loglik[0].is_finite());
         assert!(loglik[1].is_finite());
+    }
+
+    #[test]
+    fn exact_tied_moments_match_hand_computed_two_death_set() {
+        let covar = Array2::from_shape_vec((3, 2), vec![1.0, 0.0, 0.0, 2.0, 3.0, 4.0]).unwrap();
+
+        let (denom, score, information) =
+            exact_tied_moments(&[0, 1, 2], 2, &[2.0, 3.0, 5.0], &covar);
+
+        assert_eq!(denom, 31.0);
+        assert_eq!(score, vec![91.0, 142.0]);
+        assert_eq!(information[(0, 0)], 301.0);
+        assert_eq!(information[(1, 0)], 442.0);
+        assert_eq!(information[(1, 1)], 724.0);
     }
 
     #[test]

--- a/src/regression/coxph.rs
+++ b/src/regression/coxph.rs
@@ -653,9 +653,9 @@ pub fn coxph_fit(
     let mut sorted_entry_times = entry_times_ref.map(|_| Vec::with_capacity(n));
     let mut sorted_offset = Vec::with_capacity(n);
     let mut sorted_weights = Vec::with_capacity(n);
-    let mut sorted_strata_values = Vec::with_capacity(n);
+    let mut strata_boundaries = vec![0; n];
     let mut flat = Vec::with_capacity(n * nvar);
-    for &idx in &order {
+    for (sorted_idx, &idx) in order.iter().enumerate() {
         sorted_time.push(time[idx]);
         sorted_status.push(status[idx]);
         if let (Some(values), Some(sorted_values)) = (entry_times_ref, sorted_entry_times.as_mut())
@@ -664,14 +664,10 @@ pub fn coxph_fit(
         }
         sorted_offset.push(offset_vec[idx]);
         sorted_weights.push(weights_vec[idx]);
-        sorted_strata_values.push(strata_values[idx]);
-        flat.extend(covariates[idx].iter().copied());
-    }
-    let mut strata_boundaries = vec![0; n];
-    for idx in 0..n {
-        if idx + 1 == n || sorted_strata_values[idx + 1] != sorted_strata_values[idx] {
-            strata_boundaries[idx] = 1;
+        if sorted_idx + 1 == n || strata_values[order[sorted_idx + 1]] != strata_values[idx] {
+            strata_boundaries[sorted_idx] = 1;
         }
+        flat.extend(covariates[idx].iter().copied());
     }
     let covar = Array2::from_shape_vec((n, nvar), flat).map_err(|e| {
         pyo3::exceptions::PyValueError::new_err(format!("invalid covariate shape: {}", e))

--- a/src/regression/coxph.rs
+++ b/src/regression/coxph.rs
@@ -421,11 +421,8 @@ impl CoxPHFit {
             self.basehaz_with_strata_internal(centered)?;
         let baseline =
             StratifiedBaselineLookup::from_components(&base_times, &base_hazards, &base_strata);
-        let mut requested_strata = strata.clone();
-        requested_strata.sort_unstable();
-        requested_strata.dedup();
 
-        let times = baseline.times_for_strata(&requested_strata);
+        let times = baseline.times_for_strata(&strata);
 
         let curves = covariates
             .iter()

--- a/src/regression/coxph.rs
+++ b/src/regression/coxph.rs
@@ -5,6 +5,7 @@ pub use crate::regression::coxph_model::{CoxPHModel, Subject};
 use crate::regression::coxph_support::{ActiveRiskSet, CoxSweepRow, StratifiedBaselineLookup};
 use ndarray::{Array1, Array2};
 use pyo3::prelude::*;
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 
 fn scaled_hazard_increment(events: f64, scaled_risk_sum: f64, risk_scale: f64) -> f64 {
@@ -80,12 +81,16 @@ pub struct CoxPHFit {
 }
 
 impl CoxPHFit {
-    pub(crate) fn row_strata(&self) -> Vec<i32> {
+    fn row_strata_cow(&self) -> Cow<'_, [i32]> {
         if self.strata.len() == self.event_times.len() {
-            self.strata.clone()
+            Cow::Borrowed(self.strata.as_slice())
         } else {
-            vec![0; self.event_times.len()]
+            Cow::Owned(vec![0; self.event_times.len()])
         }
+    }
+
+    pub(crate) fn row_strata(&self) -> Vec<i32> {
+        self.row_strata_cow().into_owned()
     }
 
     pub(crate) fn basehaz_with_strata_internal(
@@ -98,7 +103,7 @@ impl CoxPHFit {
                 "time must not be empty",
             ));
         }
-        let row_strata = self.row_strata();
+        let row_strata = self.row_strata_cow();
         let center = if centered && !self.linear_predictors.is_empty() {
             self.linear_predictors.iter().sum::<f64>() / n as f64
         } else {

--- a/src/regression/coxph.rs
+++ b/src/regression/coxph.rs
@@ -416,15 +416,16 @@ impl CoxPHFit {
     }
 
     pub fn deviance_residuals(&self) -> PyResult<Vec<f64>> {
-        let martingale = self.martingale_residuals()?;
-        Ok(martingale
+        let expected = self.expected_events_internal()?;
+        Ok(self
+            .status
             .iter()
-            .zip(self.status.iter())
-            .map(|(&residual, &status)| {
+            .zip(expected.iter())
+            .map(|(&status, &expected)| {
                 let status = status as f64;
+                let residual = status - expected;
                 let log_term = if status > 0.0 {
-                    let expected = (status - residual).max(crate::constants::DIVISION_FLOOR);
-                    status * expected.ln()
+                    status * expected.max(crate::constants::DIVISION_FLOOR).ln()
                 } else {
                     0.0
                 };
@@ -955,6 +956,38 @@ mod tests {
         assert!((hazards[0] - expected_first).abs() <= expected_first * 1e-12);
         assert!(hazards[1] > hazards[0]);
         assert!(hazards[2] > hazards[1]);
+    }
+
+    #[test]
+    fn test_coxph_deviance_residuals_reuse_expected_events() {
+        let fit = baseline_test_fit("breslow");
+        let expected: Vec<f64> = fit
+            .martingale_residuals()
+            .expect("martingale residuals should compute")
+            .iter()
+            .zip(fit.status.iter())
+            .map(|(&residual, &status)| {
+                let status = status as f64;
+                let log_term = if status > 0.0 {
+                    let expected = (status - residual).max(crate::constants::DIVISION_FLOOR);
+                    status * expected.ln()
+                } else {
+                    0.0
+                };
+                let magnitude = (-2.0 * (residual + log_term)).max(0.0).sqrt();
+                if residual >= 0.0 {
+                    magnitude
+                } else {
+                    -magnitude
+                }
+            })
+            .collect();
+
+        let actual = fit
+            .deviance_residuals()
+            .expect("deviance residuals should compute");
+
+        assert_close_vec(&actual, &expected);
     }
 
     #[test]

--- a/src/regression/coxph.rs
+++ b/src/regression/coxph.rs
@@ -128,17 +128,23 @@ impl CoxPHFit {
                 });
         }
 
-        let mut out_times = Vec::new();
-        let mut out_hazards = Vec::new();
-        let mut out_strata = Vec::new();
+        let total_event_count = self.status.iter().filter(|&&status| status == 1).count();
+        let mut out_times = Vec::with_capacity(total_event_count);
+        let mut out_hazards = Vec::with_capacity(total_event_count);
+        let mut out_strata = Vec::with_capacity(total_event_count);
         let use_entry_times = self.entry_times.is_some();
         let use_efron = self.method == "efron";
 
         for (stratum, mut rows) in rows_by_stratum {
-            let mut event_times: Vec<f64> = rows
-                .iter()
-                .filter_map(|row| (row.status == 1).then_some(row.stop))
-                .collect();
+            let stratum_event_count = rows.iter().filter(|row| row.status == 1).count();
+            let mut event_times = Vec::with_capacity(stratum_event_count);
+            let mut death_order = Vec::with_capacity(stratum_event_count);
+            for (row_idx, row) in rows.iter().enumerate() {
+                if row.status == 1 {
+                    event_times.push(row.stop);
+                    death_order.push(row_idx);
+                }
+            }
             event_times.sort_by(|a, b| a.total_cmp(b));
             event_times.dedup_by(|a, b| (*a - *b).abs() < TIME_EPSILON);
             if event_times.is_empty() {
@@ -167,9 +173,6 @@ impl CoxPHFit {
 
             let mut active = ActiveRiskSet::new(&rows, use_entry_times);
 
-            let mut death_order: Vec<usize> = (0..rows.len())
-                .filter(|&idx| rows[idx].status == 1)
-                .collect();
             death_order.sort_by(|&lhs, &rhs| {
                 rows[lhs]
                     .stop

--- a/src/regression/coxph.rs
+++ b/src/regression/coxph.rs
@@ -515,9 +515,6 @@ pub fn coxph_fit(
     entry_times: Option<Vec<f64>>,
     nocenter: Option<Vec<f64>>,
 ) -> PyResult<CoxPHFit> {
-    let event_times = time.clone();
-    let status_values = status.clone();
-    let entry_values = entry_times.clone();
     let n = time.len();
     if n == 0 {
         return Err(pyo3::exceptions::PyValueError::new_err(
@@ -623,7 +620,6 @@ pub fn coxph_fit(
     let offset_vec = offset.unwrap_or_else(|| vec![0.0; n]);
     let weights_vec = weights.unwrap_or_else(|| vec![1.0; n]);
     let strata_values = strata.unwrap_or_else(|| vec![0; n]);
-    let original_strata_values = strata_values.clone();
     let nocenter_values = nocenter.unwrap_or_default();
     let doscale: Vec<bool> = if nocenter_values.is_empty() {
         vec![true; nvar]
@@ -717,13 +713,13 @@ pub fn coxph_fit(
         convergence_flag: flag,
         iterations,
         risk_scores,
-        event_times,
-        status: status_values,
+        event_times: time,
+        status,
         linear_predictors,
-        entry_times: entry_values,
+        entry_times,
         weights: weights_vec,
         covariates,
-        strata: original_strata_values,
+        strata: strata_values,
         method: method_name,
         nocenter: nocenter_values,
     })

--- a/src/regression/coxph.rs
+++ b/src/regression/coxph.rs
@@ -699,21 +699,18 @@ pub fn coxph_fit(
         .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("Cox fit failed: {}", e)))?;
     let (beta, means, score_vector, information, log_likelihood, score_test, flag, iterations) =
         cox_fit.results();
-    let linear_predictors: Vec<f64> = covariates
-        .iter()
-        .zip(offset_vec.iter())
-        .map(|(row, offset)| {
-            row.iter()
-                .zip(beta.iter())
-                .map(|(value, coefficient)| value * coefficient)
-                .sum::<f64>()
-                + offset
-        })
-        .collect();
-    let risk_scores = linear_predictors
-        .iter()
-        .map(|value| value.clamp(EXP_CLAMP_MIN, EXP_CLAMP_MAX).exp())
-        .collect();
+    let mut linear_predictors = Vec::with_capacity(n);
+    let mut risk_scores = Vec::with_capacity(n);
+    for (row, &offset) in covariates.iter().zip(offset_vec.iter()) {
+        let linear_predictor = row
+            .iter()
+            .zip(beta.iter())
+            .map(|(value, coefficient)| value * coefficient)
+            .sum::<f64>()
+            + offset;
+        risk_scores.push(linear_predictor.clamp(EXP_CLAMP_MIN, EXP_CLAMP_MAX).exp());
+        linear_predictors.push(linear_predictor);
+    }
     let information_matrix = information
         .outer_iter()
         .map(|row| row.iter().copied().collect())

--- a/src/regression/coxph.rs
+++ b/src/regression/coxph.rs
@@ -93,6 +93,54 @@ impl CoxPHFit {
         self.row_strata_cow().into_owned()
     }
 
+    fn survival_curve_for_shared_row(
+        &self,
+        beta: &[f64],
+        row: &[f64],
+        strata: &[i32],
+        centered: bool,
+    ) -> PyResult<(Vec<f64>, Vec<Vec<f64>>)> {
+        if row.len() != beta.len() {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "covariates must have {} columns",
+                beta.len()
+            )));
+        }
+        validate_finite_values("covariates[0]", row)?;
+
+        let center = if centered && !self.linear_predictors.is_empty() {
+            self.linear_predictors.iter().sum::<f64>() / self.linear_predictors.len() as f64
+        } else {
+            0.0
+        };
+        let (base_times, base_hazards, base_strata) =
+            self.basehaz_with_strata_internal(centered)?;
+        let baseline =
+            StratifiedBaselineLookup::from_components(&base_times, &base_hazards, &base_strata);
+        let times = baseline.times_for_strata(strata);
+        let linear_predictor = row
+            .iter()
+            .zip(beta.iter())
+            .map(|(value, coefficient)| value * coefficient)
+            .sum::<f64>();
+        let risk_multiplier = (linear_predictor - center)
+            .clamp(EXP_CLAMP_MIN, EXP_CLAMP_MAX)
+            .exp();
+        let curves = strata
+            .iter()
+            .map(|&stratum| {
+                times
+                    .iter()
+                    .map(|&time| {
+                        let hazard = baseline.cumulative_hazard_at(stratum, time);
+                        (-(hazard * risk_multiplier)).exp().clamp(0.0, 1.0)
+                    })
+                    .collect()
+            })
+            .collect();
+        Ok((times, curves))
+    }
+
     pub(crate) fn basehaz_with_strata_internal(
         &self,
         centered: bool,
@@ -290,51 +338,7 @@ impl CoxPHFit {
                 let mut strata = self.row_strata();
                 strata.sort_unstable();
                 strata.dedup();
-                if strata.len() > 1 {
-                    if self.means.len() != nvar {
-                        return Err(pyo3::exceptions::PyValueError::new_err(format!(
-                            "covariates must have {} columns",
-                            nvar
-                        )));
-                    }
-                    let center = if centered && !self.linear_predictors.is_empty() {
-                        self.linear_predictors.iter().sum::<f64>()
-                            / self.linear_predictors.len() as f64
-                    } else {
-                        0.0
-                    };
-                    let (base_times, base_hazards, base_strata) =
-                        self.basehaz_with_strata_internal(centered)?;
-                    let baseline = StratifiedBaselineLookup::from_components(
-                        &base_times,
-                        &base_hazards,
-                        &base_strata,
-                    );
-                    let times = baseline.times_for_strata(&strata);
-                    let linear_predictor = self
-                        .means
-                        .iter()
-                        .zip(beta.iter())
-                        .map(|(value, coefficient)| value * coefficient)
-                        .sum::<f64>();
-                    let risk_multiplier = (linear_predictor - center)
-                        .clamp(EXP_CLAMP_MIN, EXP_CLAMP_MAX)
-                        .exp();
-                    let curves = strata
-                        .iter()
-                        .map(|&stratum| {
-                            times
-                                .iter()
-                                .map(|&time| {
-                                    let hazard = baseline.cumulative_hazard_at(stratum, time);
-                                    (-(hazard * risk_multiplier)).exp().clamp(0.0, 1.0)
-                                })
-                                .collect()
-                        })
-                        .collect();
-                    return Ok((times, curves));
-                }
-                vec![self.means.clone()]
+                return self.survival_curve_for_shared_row(beta, &self.means, &strata, centered);
             }
         };
         if rows.iter().any(|row| row.len() != nvar) {
@@ -1013,6 +1017,30 @@ mod tests {
             assert_close_vec(&default.0, &explicit.0);
             assert_close_matrix(&default.1, &explicit.1);
         }
+    }
+
+    #[test]
+    fn test_coxph_default_survival_curve_matches_explicit_single_stratum_mean() {
+        let mut fit = baseline_test_fit("breslow");
+        fit.strata = vec![1; fit.event_times.len()];
+
+        let default = fit
+            .survival_curve(None, true)
+            .expect("default single-stratum survival curve should compute");
+        let explicit = fit
+            .survival_curve(Some(vec![fit.means.clone()]), true)
+            .expect("explicit single-stratum survival curve should compute");
+
+        assert_close_vec(&default.0, &explicit.0);
+        assert_close_matrix(&default.1, &explicit.1);
+    }
+
+    #[test]
+    fn test_coxph_default_survival_curve_validates_means() {
+        let mut fit = baseline_test_fit("breslow");
+        fit.means = vec![f64::NAN];
+
+        assert!(fit.survival_curve(None, true).is_err());
     }
 
     #[test]

--- a/src/regression/coxph.rs
+++ b/src/regression/coxph.rs
@@ -81,16 +81,26 @@ pub struct CoxPHFit {
 }
 
 impl CoxPHFit {
+    fn explicit_row_strata(&self) -> Option<&[i32]> {
+        (self.strata.len() == self.event_times.len()).then_some(self.strata.as_slice())
+    }
+
+    fn unique_row_strata(&self) -> Vec<i32> {
+        let Some(strata) = self.explicit_row_strata() else {
+            return vec![0];
+        };
+        let mut unique = strata.to_vec();
+        unique.sort_unstable();
+        unique.dedup();
+        unique
+    }
+
     pub(crate) fn row_strata_cow(&self) -> Cow<'_, [i32]> {
-        if self.strata.len() == self.event_times.len() {
-            Cow::Borrowed(self.strata.as_slice())
+        if let Some(strata) = self.explicit_row_strata() {
+            Cow::Borrowed(strata)
         } else {
             Cow::Owned(vec![0; self.event_times.len()])
         }
-    }
-
-    pub(crate) fn row_strata(&self) -> Vec<i32> {
-        self.row_strata_cow().into_owned()
     }
 
     fn survival_curve_for_shared_row(
@@ -151,7 +161,7 @@ impl CoxPHFit {
                 "time must not be empty",
             ));
         }
-        let row_strata = self.row_strata_cow();
+        let row_strata = self.explicit_row_strata();
         let center = if centered && !self.linear_predictors.is_empty() {
             self.linear_predictors.iter().sum::<f64>() / n as f64
         } else {
@@ -159,7 +169,8 @@ impl CoxPHFit {
         };
 
         let mut rows_by_stratum: BTreeMap<i32, Vec<CoxSweepRow>> = BTreeMap::new();
-        for (idx, &stratum) in row_strata.iter().enumerate() {
+        for idx in 0..n {
+            let stratum = row_strata.map_or(0, |strata| strata[idx]);
             rows_by_stratum
                 .entry(stratum)
                 .or_default()
@@ -335,9 +346,7 @@ impl CoxPHFit {
         let rows = match covariates {
             Some(rows) => rows,
             None => {
-                let mut strata = self.row_strata();
-                strata.sort_unstable();
-                strata.dedup();
+                let strata = self.unique_row_strata();
                 return self.survival_curve_for_shared_row(beta, &self.means, &strata, centered);
             }
         };
@@ -818,7 +827,7 @@ mod tests {
 
     fn brute_force_basehaz(fit: &CoxPHFit, centered: bool) -> (Vec<f64>, Vec<f64>, Vec<i32>) {
         let n = fit.event_times.len();
-        let row_strata = fit.row_strata();
+        let row_strata = fit.row_strata_cow().into_owned();
         let center = if centered && !fit.linear_predictors.is_empty() {
             fit.linear_predictors.iter().sum::<f64>() / n as f64
         } else {
@@ -997,6 +1006,37 @@ mod tests {
         assert!((hazards[0] - expected_first).abs() <= expected_first * 1e-12);
         assert!(hazards[1] > hazards[0]);
         assert!(hazards[2] > hazards[1]);
+    }
+
+    #[test]
+    fn test_coxph_missing_strata_matches_explicit_zero_strata() {
+        for method in ["breslow", "efron"] {
+            let mut explicit = baseline_test_fit(method);
+            explicit.strata = vec![0; explicit.event_times.len()];
+            let mut implicit = explicit.clone();
+            implicit.strata.clear();
+
+            for centered in [false, true] {
+                let explicit_basehaz = explicit
+                    .basehaz_with_strata_internal(centered)
+                    .expect("explicit zero-strata baseline hazard should compute");
+                let implicit_basehaz = implicit
+                    .basehaz_with_strata_internal(centered)
+                    .expect("implicit zero-strata baseline hazard should compute");
+                assert_close_vec(&implicit_basehaz.0, &explicit_basehaz.0);
+                assert_close_vec(&implicit_basehaz.1, &explicit_basehaz.1);
+                assert_eq!(implicit_basehaz.2, explicit_basehaz.2);
+
+                let explicit_survival = explicit
+                    .survival_curve(None, centered)
+                    .expect("explicit zero-strata survival curve should compute");
+                let implicit_survival = implicit
+                    .survival_curve(None, centered)
+                    .expect("implicit zero-strata survival curve should compute");
+                assert_close_vec(&implicit_survival.0, &explicit_survival.0);
+                assert_close_matrix(&implicit_survival.1, &explicit_survival.1);
+            }
+        }
     }
 
     #[test]

--- a/src/regression/coxph.rs
+++ b/src/regression/coxph.rs
@@ -291,11 +291,48 @@ impl CoxPHFit {
                 strata.sort_unstable();
                 strata.dedup();
                 if strata.len() > 1 {
-                    return self.survival_curve_with_strata(
-                        vec![self.means.clone(); strata.len()],
-                        strata,
-                        centered,
+                    if self.means.len() != nvar {
+                        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                            "covariates must have {} columns",
+                            nvar
+                        )));
+                    }
+                    let center = if centered && !self.linear_predictors.is_empty() {
+                        self.linear_predictors.iter().sum::<f64>()
+                            / self.linear_predictors.len() as f64
+                    } else {
+                        0.0
+                    };
+                    let (base_times, base_hazards, base_strata) =
+                        self.basehaz_with_strata_internal(centered)?;
+                    let baseline = StratifiedBaselineLookup::from_components(
+                        &base_times,
+                        &base_hazards,
+                        &base_strata,
                     );
+                    let times = baseline.times_for_strata(&strata);
+                    let linear_predictor = self
+                        .means
+                        .iter()
+                        .zip(beta.iter())
+                        .map(|(value, coefficient)| value * coefficient)
+                        .sum::<f64>();
+                    let risk_multiplier = (linear_predictor - center)
+                        .clamp(EXP_CLAMP_MIN, EXP_CLAMP_MAX)
+                        .exp();
+                    let curves = strata
+                        .iter()
+                        .map(|&stratum| {
+                            times
+                                .iter()
+                                .map(|&time| {
+                                    let hazard = baseline.cumulative_hazard_at(stratum, time);
+                                    (-(hazard * risk_multiplier)).exp().clamp(0.0, 1.0)
+                                })
+                                .collect()
+                        })
+                        .collect();
+                    return Ok((times, curves));
                 }
                 vec![self.means.clone()]
             }
@@ -956,6 +993,26 @@ mod tests {
         assert!((hazards[0] - expected_first).abs() <= expected_first * 1e-12);
         assert!(hazards[1] > hazards[0]);
         assert!(hazards[2] > hazards[1]);
+    }
+
+    #[test]
+    fn test_coxph_default_survival_curve_matches_explicit_strata_means() {
+        for method in ["breslow", "efron"] {
+            let fit = baseline_test_fit(method);
+            let default = fit
+                .survival_curve(None, true)
+                .expect("default stratified survival curve should compute");
+            let explicit = fit
+                .survival_curve_with_strata(
+                    vec![fit.means.clone(), fit.means.clone()],
+                    vec![1, 2],
+                    true,
+                )
+                .expect("explicit stratified survival curve should compute");
+
+            assert_close_vec(&default.0, &explicit.0);
+            assert_close_matrix(&default.1, &explicit.1);
+        }
     }
 
     #[test]

--- a/src/regression/coxph.rs
+++ b/src/regression/coxph.rs
@@ -81,7 +81,7 @@ pub struct CoxPHFit {
 }
 
 impl CoxPHFit {
-    fn row_strata_cow(&self) -> Cow<'_, [i32]> {
+    pub(crate) fn row_strata_cow(&self) -> Cow<'_, [i32]> {
         if self.strata.len() == self.event_times.len() {
             Cow::Borrowed(self.strata.as_slice())
         } else {

--- a/src/regression/coxph.rs
+++ b/src/regression/coxph.rs
@@ -647,23 +647,31 @@ pub fn coxph_fit(
             .then_with(|| time[lhs].total_cmp(&time[rhs]))
             .then_with(|| lhs.cmp(&rhs))
     });
-    let sorted_time: Vec<f64> = order.iter().map(|&idx| time[idx]).collect();
-    let sorted_status: Vec<i32> = order.iter().map(|&idx| status[idx]).collect();
-    let sorted_entry_times: Option<Vec<f64>> = entry_times
-        .as_ref()
-        .map(|values| order.iter().map(|&idx| values[idx]).collect());
-    let sorted_offset: Vec<f64> = order.iter().map(|&idx| offset_vec[idx]).collect();
-    let sorted_weights: Vec<f64> = order.iter().map(|&idx| weights_vec[idx]).collect();
-    let sorted_strata_values: Vec<i32> = order.iter().map(|&idx| strata_values[idx]).collect();
+    let entry_times_ref = entry_times.as_deref();
+    let mut sorted_time = Vec::with_capacity(n);
+    let mut sorted_status = Vec::with_capacity(n);
+    let mut sorted_entry_times = entry_times_ref.map(|_| Vec::with_capacity(n));
+    let mut sorted_offset = Vec::with_capacity(n);
+    let mut sorted_weights = Vec::with_capacity(n);
+    let mut sorted_strata_values = Vec::with_capacity(n);
+    let mut flat = Vec::with_capacity(n * nvar);
+    for &idx in &order {
+        sorted_time.push(time[idx]);
+        sorted_status.push(status[idx]);
+        if let (Some(values), Some(sorted_values)) = (entry_times_ref, sorted_entry_times.as_mut())
+        {
+            sorted_values.push(values[idx]);
+        }
+        sorted_offset.push(offset_vec[idx]);
+        sorted_weights.push(weights_vec[idx]);
+        sorted_strata_values.push(strata_values[idx]);
+        flat.extend(covariates[idx].iter().copied());
+    }
     let mut strata_boundaries = vec![0; n];
     for idx in 0..n {
         if idx + 1 == n || sorted_strata_values[idx + 1] != sorted_strata_values[idx] {
             strata_boundaries[idx] = 1;
         }
-    }
-    let mut flat = Vec::with_capacity(n * nvar);
-    for &idx in &order {
-        flat.extend(covariates[idx].iter().copied());
     }
     let covar = Array2::from_shape_vec((n, nvar), flat).map_err(|e| {
         pyo3::exceptions::PyValueError::new_err(format!("invalid covariate shape: {}", e))

--- a/src/regression/coxph_detail.rs
+++ b/src/regression/coxph_detail.rs
@@ -158,17 +158,70 @@ fn mean_and_covariance(
     s2: &[Vec<f64>],
     nvar: usize,
 ) -> (Vec<f64>, Vec<Vec<f64>>) {
-    if s0 <= 0.0 {
-        return (vec![0.0; nvar], vec![vec![0.0; nvar]; nvar]);
-    }
-    let means: Vec<f64> = s1.iter().map(|value| value / s0).collect();
+    let mut means = vec![0.0; nvar];
     let mut covariance = vec![vec![0.0; nvar]; nvar];
-    for row in 0..nvar {
-        for col in 0..nvar {
+    mean_and_covariance_into(s0, s1, s2, &mut means, &mut covariance);
+    (means, covariance)
+}
+
+fn mean_and_covariance_into(
+    s0: f64,
+    s1: &[f64],
+    s2: &[Vec<f64>],
+    means: &mut [f64],
+    covariance: &mut [Vec<f64>],
+) {
+    if s0 <= 0.0 {
+        means.fill(0.0);
+        for row in covariance {
+            row.fill(0.0);
+        }
+        return;
+    }
+    for (mean, value) in means.iter_mut().zip(s1) {
+        *mean = value / s0;
+    }
+    for row in 0..means.len() {
+        for col in 0..means.len() {
             covariance[row][col] = s2[row][col] / s0 - means[row] * means[col];
         }
     }
-    (means, covariance)
+}
+
+fn efron_step_mean_and_covariance_into(
+    step_s0: f64,
+    s1: &[f64],
+    death_s1: &[f64],
+    s2: &[Vec<f64>],
+    death_s2: &[Vec<f64>],
+    fraction: f64,
+    means: &mut [f64],
+    covariance: &mut [Vec<f64>],
+) {
+    if step_s0 <= 0.0 {
+        means.fill(0.0);
+        for row in covariance {
+            row.fill(0.0);
+        }
+        return;
+    }
+    for col in 0..means.len() {
+        means[col] = (s1[col] - fraction * death_s1[col]) / step_s0;
+    }
+    for row in 0..means.len() {
+        for col in 0..means.len() {
+            covariance[row][col] =
+                (s2[row][col] - fraction * death_s2[row][col]) / step_s0 - means[row] * means[col];
+        }
+    }
+}
+
+fn scale_matrix_in_place(target: &mut [Vec<f64>], scale: f64) {
+    for row in target {
+        for value in row {
+            *value *= scale;
+        }
+    }
 }
 
 fn add_matrix(target: &mut [Vec<f64>], values: &[Vec<f64>], scale: f64) {
@@ -343,16 +396,13 @@ pub(crate) fn compute_coxph_detail_with_options(
         }
 
         let (s0, s1, s2) = weighted_sums(covariates, &risk_weights, &at_risk, nvar);
-        let (means, covariance) = mean_and_covariance(s0, &s1, &s2, nvar);
+        let (means, mut imat) = mean_and_covariance(s0, &s1, &s2, nvar);
         let mut score = event_covariates
             .iter()
             .zip(means.iter())
             .map(|(&event_sum, &mean)| event_sum - event_weight * mean)
             .collect::<Vec<_>>();
-        let mut imat = covariance
-            .iter()
-            .map(|row| row.iter().map(|value| event_weight * value).collect())
-            .collect::<Vec<Vec<f64>>>();
+        scale_matrix_in_place(&mut imat, event_weight);
         let mut hazard = if s0 > 0.0 {
             event_weight * hazard_scale / s0
         } else {
@@ -366,31 +416,28 @@ pub(crate) fn compute_coxph_detail_with_options(
 
         if method == "efron" && deaths.len() > 1 {
             let (d0, d1, d2) = weighted_sums(covariates, &risk_weights, &deaths, nvar);
-            score = event_covariates.clone();
-            imat = vec![vec![0.0; nvar]; nvar];
+            score.copy_from_slice(&event_covariates);
+            for row in &mut imat {
+                row.fill(0.0);
+            }
             hazard = 0.0;
             varhaz = 0.0;
             let step_weight = event_weight / deaths.len() as f64;
+            let mut step_means = vec![0.0; nvar];
+            let mut step_covariance = vec![vec![0.0; nvar]; nvar];
             for step in 0..deaths.len() {
                 let fraction = step as f64 / deaths.len() as f64;
                 let step_s0 = s0 - fraction * d0;
-                let step_s1 = s1
-                    .iter()
-                    .zip(d1.iter())
-                    .map(|(&value, &death_value)| value - fraction * death_value)
-                    .collect::<Vec<_>>();
-                let step_s2 = s2
-                    .iter()
-                    .zip(d2.iter())
-                    .map(|(row, death_row)| {
-                        row.iter()
-                            .zip(death_row.iter())
-                            .map(|(&value, &death_value)| value - fraction * death_value)
-                            .collect::<Vec<_>>()
-                    })
-                    .collect::<Vec<_>>();
-                let (step_means, step_covariance) =
-                    mean_and_covariance(step_s0, &step_s1, &step_s2, nvar);
+                efron_step_mean_and_covariance_into(
+                    step_s0,
+                    &s1,
+                    &d1,
+                    &s2,
+                    &d2,
+                    fraction,
+                    &mut step_means,
+                    &mut step_covariance,
+                );
                 for col in 0..nvar {
                     score[col] -= step_weight * step_means[col];
                 }
@@ -617,6 +664,38 @@ mod tests {
         assert!(detail.rows[0].varhaz > 0.0);
         assert_ne!(detail.rows[0].score, vec![0.0]);
         assert_ne!(detail.rows[0].imat, vec![vec![0.0]]);
+    }
+
+    #[test]
+    fn test_coxph_detail_efron_tie_matches_hand_computed_values() {
+        let time = vec![1.0, 1.0, 2.0];
+        let status = vec![1, 1, 0];
+        let covariates = vec![vec![0.0], vec![1.0], vec![2.0]];
+        let coefficients = vec![0.0];
+
+        let detail = compute_coxph_detail_with_options(CoxphDetailOptions {
+            time: &time,
+            status: &status,
+            covariates: &covariates,
+            coefficients: &coefficients,
+            weights: None,
+            entry_times: None,
+            strata: None,
+            offset: None,
+            method: "efron",
+            center: 0.0,
+        })
+        .unwrap();
+
+        assert_eq!(detail.rows.len(), 1);
+        let row = &detail.rows[0];
+        assert_eq!(row.n_risk, 3);
+        assert_eq!(row.n_event, 2);
+        assert!((row.hazard - 5.0 / 6.0).abs() < 1e-12);
+        assert!((row.varhaz - 13.0 / 36.0).abs() < 1e-12);
+        assert!((row.score[0] + 1.25).abs() < 1e-12);
+        assert!((row.imat[0][0] - 65.0 / 48.0).abs() < 1e-12);
+        assert_eq!(row.means, vec![1.0]);
     }
 
     #[test]

--- a/src/regression/coxph_detail.rs
+++ b/src/regression/coxph_detail.rs
@@ -3,6 +3,7 @@ use crate::internal::cox_risk::{cox_risk_shift, shifted_exp_eta_with_shift};
 use crate::internal::validation::validate_binary_i32;
 use pyo3::prelude::*;
 use std::borrow::Cow;
+use std::collections::BTreeMap;
 
 #[derive(Debug, Clone)]
 #[pyclass(from_py_object)]
@@ -180,19 +181,18 @@ fn add_matrix(target: &mut [Vec<f64>], values: &[Vec<f64>], scale: f64) {
 
 fn event_groups(time: &[f64], status: &[i32], strata: &[i32]) -> Vec<(i32, f64)> {
     let mut groups: Vec<(i32, f64)> = Vec::new();
-    let mut strata_values = strata.to_vec();
-    strata_values.sort_unstable();
-    strata_values.dedup();
+    let mut times_by_stratum: BTreeMap<i32, Vec<f64>> = BTreeMap::new();
 
-    for stratum in strata_values {
-        let mut times: Vec<f64> = time
-            .iter()
-            .zip(status.iter())
-            .zip(strata.iter())
-            .filter_map(|((&event_time, &event), &row_stratum)| {
-                (event == 1 && row_stratum == stratum).then_some(event_time)
-            })
-            .collect();
+    for idx in 0..time.len() {
+        if status[idx] == 1 {
+            times_by_stratum
+                .entry(strata[idx])
+                .or_default()
+                .push(time[idx]);
+        }
+    }
+
+    for (stratum, mut times) in times_by_stratum {
         times.sort_by(|a, b| a.total_cmp(b));
         times.dedup_by(|a, b| (*a - *b).abs() < TIME_EPSILON);
         groups.extend(times.into_iter().map(|event_time| (stratum, event_time)));
@@ -676,5 +676,35 @@ mod tests {
         assert_eq!(detail.rows[0].wtrisk, 1.0);
         assert_eq!(detail.rows[0].hazard, 1.0);
         assert!(detail.rows[0].cumhaz.is_finite());
+    }
+
+    #[test]
+    fn test_coxph_detail_groups_event_times_by_sorted_strata() {
+        let time = vec![2.0, 1.0, 1.0 + TIME_EPSILON / 2.0, 3.0];
+        let status = vec![1, 1, 1, 0];
+        let covariates = vec![vec![0.0], vec![0.0], vec![0.0], vec![0.0]];
+        let coefficients = vec![0.0];
+        let strata = vec![2, 1, 1, 2];
+
+        let detail = compute_coxph_detail_with_options(CoxphDetailOptions {
+            time: &time,
+            status: &status,
+            covariates: &covariates,
+            coefficients: &coefficients,
+            weights: None,
+            entry_times: None,
+            strata: Some(&strata),
+            offset: None,
+            method: "breslow",
+            center: 0.0,
+        })
+        .unwrap();
+
+        assert_eq!(detail.rows.len(), 2);
+        assert_eq!(detail.rows[0].stratum, 1);
+        assert!((detail.rows[0].time - 1.0).abs() < TIME_EPSILON);
+        assert_eq!(detail.rows[0].n_event, 2);
+        assert_eq!(detail.rows[1].stratum, 2);
+        assert_eq!(detail.rows[1].time, 2.0);
     }
 }

--- a/src/regression/coxph_detail.rs
+++ b/src/regression/coxph_detail.rs
@@ -1,5 +1,5 @@
 use crate::constants::TIME_EPSILON;
-use crate::internal::cox_risk::{cox_risk_shift, shifted_exp_eta_with_shift};
+use crate::internal::cox_risk::{cox_risk_shift, shifted_weighted_exp_eta_with_shift};
 use crate::internal::validation::validate_binary_i32;
 use pyo3::prelude::*;
 use std::borrow::Cow;
@@ -347,12 +347,8 @@ pub(crate) fn compute_coxph_detail_with_options(
         })
         .collect();
     let risk_shift = cox_risk_shift(&linear_predictors, wts.as_ref());
-    let risk_weights: Vec<f64> =
-        shifted_exp_eta_with_shift(&linear_predictors, wts.as_ref(), risk_shift)
-            .into_iter()
-            .zip(wts.iter())
-            .map(|(shifted_exp, &weight)| shifted_exp * weight)
-            .collect();
+    let risk_weights =
+        shifted_weighted_exp_eta_with_shift(&linear_predictors, wts.as_ref(), risk_shift);
 
     let groups = event_groups(time, status, strata_values.as_ref());
     let mut rows = Vec::with_capacity(groups.len());

--- a/src/regression/coxph_detail.rs
+++ b/src/regression/coxph_detail.rs
@@ -1,6 +1,8 @@
 use crate::constants::TIME_EPSILON;
+use crate::internal::cox_risk::{cox_risk_shift, shifted_exp_eta_with_shift};
 use crate::internal::validation::validate_binary_i32;
 use pyo3::prelude::*;
+use std::borrow::Cow;
 
 #[derive(Debug, Clone)]
 #[pyclass(from_py_object)]
@@ -281,9 +283,15 @@ pub(crate) fn compute_coxph_detail_with_options(
         )));
     }
 
-    let wts: Vec<f64> = weights.map(|w| w.to_vec()).unwrap_or_else(|| vec![1.0; n]);
-    let strata_values: Vec<i32> = strata.map(|s| s.to_vec()).unwrap_or_else(|| vec![0; n]);
-    let offsets: Vec<f64> = offset.map(|o| o.to_vec()).unwrap_or_else(|| vec![0.0; n]);
+    let wts = weights
+        .map(Cow::Borrowed)
+        .unwrap_or_else(|| Cow::Owned(vec![1.0; n]));
+    let strata_values = strata
+        .map(Cow::Borrowed)
+        .unwrap_or_else(|| Cow::Owned(vec![0; n]));
+    let offsets = offset
+        .map(Cow::Borrowed)
+        .unwrap_or_else(|| Cow::Owned(vec![0.0; n]));
 
     let linear_predictors: Vec<f64> = covariates
         .iter()
@@ -296,30 +304,15 @@ pub(crate) fn compute_coxph_detail_with_options(
             lp
         })
         .collect();
-    let risk_shift = linear_predictors
-        .iter()
-        .zip(wts.iter())
-        .filter_map(|(&lp, &weight)| (weight > 0.0).then_some(lp))
-        .fold(f64::NEG_INFINITY, f64::max);
-    let risk_shift = if risk_shift.is_finite() {
-        risk_shift
-    } else {
-        0.0
-    };
+    let risk_shift = cox_risk_shift(&linear_predictors, wts.as_ref());
+    let risk_weights: Vec<f64> =
+        shifted_exp_eta_with_shift(&linear_predictors, wts.as_ref(), risk_shift)
+            .into_iter()
+            .zip(wts.iter())
+            .map(|(shifted_exp, &weight)| shifted_exp * weight)
+            .collect();
 
-    let risk_weights: Vec<f64> = linear_predictors
-        .iter()
-        .zip(wts.iter())
-        .map(|(&lp, &weight)| {
-            if weight == 0.0 {
-                0.0
-            } else {
-                (lp - risk_shift).exp() * weight
-            }
-        })
-        .collect();
-
-    let groups = event_groups(time, status, &strata_values);
+    let groups = event_groups(time, status, strata_values.as_ref());
     let mut rows = Vec::with_capacity(groups.len());
     let mut total_events = 0;
     let mut current_stratum = None;
@@ -333,8 +326,14 @@ pub(crate) fn compute_coxph_detail_with_options(
             current_stratum = Some(stratum);
             cumhaz = 0.0;
         }
-        let at_risk = at_risk_indices(time, entry_times, &strata_values, stratum, event_time);
-        let deaths = event_indices(time, status, &strata_values, stratum, event_time);
+        let at_risk = at_risk_indices(
+            time,
+            entry_times,
+            strata_values.as_ref(),
+            stratum,
+            event_time,
+        );
+        let deaths = event_indices(time, status, strata_values.as_ref(), stratum, event_time);
         let event_weight = deaths.iter().map(|&idx| wts[idx]).sum::<f64>();
         let mut event_covariates = vec![0.0; nvar];
         for &idx in &deaths {
@@ -410,7 +409,7 @@ pub(crate) fn compute_coxph_detail_with_options(
             time: event_time,
             n_risk: at_risk.len(),
             n_event: deaths.len(),
-            n_censor: censor_count(time, status, &strata_values, stratum, event_time),
+            n_censor: censor_count(time, status, strata_values.as_ref(), stratum, event_time),
             hazard,
             cumhaz,
             varhaz,
@@ -649,5 +648,33 @@ mod tests {
         assert_eq!(detail.rows[0].cumhaz, detail.rows[0].hazard);
         assert!(detail.rows[1].cumhaz > detail.rows[0].cumhaz);
         assert!(detail.rows[2].cumhaz > detail.rows[1].cumhaz);
+    }
+
+    #[test]
+    fn test_coxph_detail_excludes_zero_weight_rows_from_risk() {
+        let time = vec![1.0, 2.0];
+        let status = vec![1, 0];
+        let covariates = vec![vec![0.0], vec![1000.0]];
+        let coefficients = vec![1.0];
+        let weights = vec![1.0, 0.0];
+
+        let detail = compute_coxph_detail_with_options(CoxphDetailOptions {
+            time: &time,
+            status: &status,
+            covariates: &covariates,
+            coefficients: &coefficients,
+            weights: Some(&weights),
+            entry_times: None,
+            strata: None,
+            offset: None,
+            method: "breslow",
+            center: 0.0,
+        })
+        .unwrap();
+
+        assert_eq!(detail.rows.len(), 1);
+        assert_eq!(detail.rows[0].wtrisk, 1.0);
+        assert_eq!(detail.rows[0].hazard, 1.0);
+        assert!(detail.rows[0].cumhaz.is_finite());
     }
 }

--- a/src/regression/coxph_detail.rs
+++ b/src/regression/coxph_detail.rs
@@ -177,6 +177,7 @@ fn mean_and_covariance_into(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn efron_step_mean_and_covariance_into(
     step_s0: f64,
     s1: &[f64],

--- a/src/regression/coxph_detail.rs
+++ b/src/regression/coxph_detail.rs
@@ -129,15 +129,19 @@ impl CoxphDetail {
     }
 }
 
-fn weighted_sums(
+fn weighted_sums_into(
     covariates: &[Vec<f64>],
     risk_weights: &[f64],
     indices: &[usize],
-    nvar: usize,
-) -> (f64, Vec<f64>, Vec<Vec<f64>>) {
+    s1: &mut [f64],
+    s2: &mut [Vec<f64>],
+) -> f64 {
+    s1.fill(0.0);
+    for row in s2.iter_mut() {
+        row.fill(0.0);
+    }
     let mut s0 = 0.0;
-    let mut s1 = vec![0.0; nvar];
-    let mut s2 = vec![vec![0.0; nvar]; nvar];
+    let nvar = s1.len();
     for &idx in indices {
         let weight = risk_weights[idx];
         s0 += weight;
@@ -149,7 +153,7 @@ fn weighted_sums(
             }
         }
     }
-    (s0, s1, s2)
+    s0
 }
 
 fn mean_and_covariance(
@@ -253,36 +257,34 @@ fn event_groups(time: &[f64], status: &[i32], strata: &[i32]) -> Vec<(i32, f64)>
     groups
 }
 
-fn at_risk_indices(
+fn fill_at_risk_indices(
+    target: &mut Vec<usize>,
     time: &[f64],
     entry_times: Option<&[f64]>,
     strata: &[i32],
     stratum: i32,
     event_time: f64,
-) -> Vec<usize> {
-    (0..time.len())
-        .filter(|&idx| {
-            strata[idx] == stratum
-                && time[idx] >= event_time
-                && entry_times.is_none_or(|entry| entry[idx] < event_time)
-        })
-        .collect()
+) {
+    target.clear();
+    target.extend((0..time.len()).filter(|&idx| {
+        strata[idx] == stratum
+            && time[idx] >= event_time
+            && entry_times.is_none_or(|entry| entry[idx] < event_time)
+    }));
 }
 
-fn event_indices(
+fn fill_event_indices(
+    target: &mut Vec<usize>,
     time: &[f64],
     status: &[i32],
     strata: &[i32],
     stratum: i32,
     event_time: f64,
-) -> Vec<usize> {
-    (0..time.len())
-        .filter(|&idx| {
-            strata[idx] == stratum
-                && status[idx] == 1
-                && (time[idx] - event_time).abs() < TIME_EPSILON
-        })
-        .collect()
+) {
+    target.clear();
+    target.extend((0..time.len()).filter(|&idx| {
+        strata[idx] == stratum && status[idx] == 1 && (time[idx] - event_time).abs() < TIME_EPSILON
+    }));
 }
 
 fn censor_count(
@@ -373,30 +375,53 @@ pub(crate) fn compute_coxph_detail_with_options(
     let hazard_scale = (center - risk_shift).exp();
     let hazard_scale_squared = (2.0 * (center - risk_shift)).exp();
     let risk_output_scale = risk_shift.exp();
+    let mut at_risk = Vec::with_capacity(n);
+    let mut deaths = Vec::with_capacity(status.iter().filter(|&&value| value == 1).count());
+    let mut event_covariates = vec![0.0; nvar];
+    let mut risk_s1 = vec![0.0; nvar];
+    let mut risk_s2 = vec![vec![0.0; nvar]; nvar];
+    let mut death_s1 = vec![0.0; nvar];
+    let mut death_s2 = vec![vec![0.0; nvar]; nvar];
+    let mut step_means = vec![0.0; nvar];
+    let mut step_covariance = vec![vec![0.0; nvar]; nvar];
 
     for (stratum, event_time) in groups {
         if current_stratum != Some(stratum) {
             current_stratum = Some(stratum);
             cumhaz = 0.0;
         }
-        let at_risk = at_risk_indices(
+        fill_at_risk_indices(
+            &mut at_risk,
             time,
             entry_times,
             strata_values.as_ref(),
             stratum,
             event_time,
         );
-        let deaths = event_indices(time, status, strata_values.as_ref(), stratum, event_time);
+        fill_event_indices(
+            &mut deaths,
+            time,
+            status,
+            strata_values.as_ref(),
+            stratum,
+            event_time,
+        );
         let event_weight = deaths.iter().map(|&idx| wts[idx]).sum::<f64>();
-        let mut event_covariates = vec![0.0; nvar];
+        event_covariates.fill(0.0);
         for &idx in &deaths {
             for col in 0..nvar {
                 event_covariates[col] += wts[idx] * covariates[idx][col];
             }
         }
 
-        let (s0, s1, s2) = weighted_sums(covariates, &risk_weights, &at_risk, nvar);
-        let (means, mut imat) = mean_and_covariance(s0, &s1, &s2, nvar);
+        let s0 = weighted_sums_into(
+            covariates,
+            &risk_weights,
+            &at_risk,
+            &mut risk_s1,
+            &mut risk_s2,
+        );
+        let (means, mut imat) = mean_and_covariance(s0, &risk_s1, &risk_s2, nvar);
         let mut score = event_covariates
             .iter()
             .zip(means.iter())
@@ -415,7 +440,13 @@ pub(crate) fn compute_coxph_detail_with_options(
         };
 
         if method == "efron" && deaths.len() > 1 {
-            let (d0, d1, d2) = weighted_sums(covariates, &risk_weights, &deaths, nvar);
+            let d0 = weighted_sums_into(
+                covariates,
+                &risk_weights,
+                &deaths,
+                &mut death_s1,
+                &mut death_s2,
+            );
             score.copy_from_slice(&event_covariates);
             for row in &mut imat {
                 row.fill(0.0);
@@ -423,17 +454,15 @@ pub(crate) fn compute_coxph_detail_with_options(
             hazard = 0.0;
             varhaz = 0.0;
             let step_weight = event_weight / deaths.len() as f64;
-            let mut step_means = vec![0.0; nvar];
-            let mut step_covariance = vec![vec![0.0; nvar]; nvar];
             for step in 0..deaths.len() {
                 let fraction = step as f64 / deaths.len() as f64;
                 let step_s0 = s0 - fraction * d0;
                 efron_step_mean_and_covariance_into(
                     step_s0,
-                    &s1,
-                    &d1,
-                    &s2,
-                    &d2,
+                    &risk_s1,
+                    &death_s1,
+                    &risk_s2,
+                    &death_s2,
                     fraction,
                     &mut step_means,
                     &mut step_covariance,

--- a/src/regression/coxph_detail.rs
+++ b/src/regression/coxph_detail.rs
@@ -134,12 +134,10 @@ fn weighted_sums_into(
     risk_weights: &[f64],
     indices: &[usize],
     s1: &mut [f64],
-    s2: &mut [Vec<f64>],
+    s2: &mut [f64],
 ) -> f64 {
     s1.fill(0.0);
-    for row in s2.iter_mut() {
-        row.fill(0.0);
-    }
+    s2.fill(0.0);
     let mut s0 = 0.0;
     let nvar = s1.len();
     for &idx in indices {
@@ -149,37 +147,23 @@ fn weighted_sums_into(
             let weighted_value = weight * covariates[idx][col];
             s1[col] += weighted_value;
             for inner in 0..nvar {
-                s2[col][inner] += weighted_value * covariates[idx][inner];
+                s2[col * nvar + inner] += weighted_value * covariates[idx][inner];
             }
         }
     }
     s0
 }
 
-fn mean_and_covariance(
-    s0: f64,
-    s1: &[f64],
-    s2: &[Vec<f64>],
-    nvar: usize,
-) -> (Vec<f64>, Vec<Vec<f64>>) {
-    let mut means = vec![0.0; nvar];
-    let mut covariance = vec![vec![0.0; nvar]; nvar];
-    mean_and_covariance_into(s0, s1, s2, &mut means, &mut covariance);
-    (means, covariance)
-}
-
 fn mean_and_covariance_into(
     s0: f64,
     s1: &[f64],
-    s2: &[Vec<f64>],
+    s2: &[f64],
     means: &mut [f64],
-    covariance: &mut [Vec<f64>],
+    covariance: &mut [f64],
 ) {
     if s0 <= 0.0 {
         means.fill(0.0);
-        for row in covariance {
-            row.fill(0.0);
-        }
+        covariance.fill(0.0);
         return;
     }
     for (mean, value) in means.iter_mut().zip(s1) {
@@ -187,7 +171,8 @@ fn mean_and_covariance_into(
     }
     for row in 0..means.len() {
         for col in 0..means.len() {
-            covariance[row][col] = s2[row][col] / s0 - means[row] * means[col];
+            covariance[row * means.len() + col] =
+                s2[row * means.len() + col] / s0 - means[row] * means[col];
         }
     }
 }
@@ -196,17 +181,15 @@ fn efron_step_mean_and_covariance_into(
     step_s0: f64,
     s1: &[f64],
     death_s1: &[f64],
-    s2: &[Vec<f64>],
-    death_s2: &[Vec<f64>],
+    s2: &[f64],
+    death_s2: &[f64],
     fraction: f64,
     means: &mut [f64],
-    covariance: &mut [Vec<f64>],
+    covariance: &mut [f64],
 ) {
     if step_s0 <= 0.0 {
         means.fill(0.0);
-        for row in covariance {
-            row.fill(0.0);
-        }
+        covariance.fill(0.0);
         return;
     }
     for col in 0..means.len() {
@@ -214,26 +197,30 @@ fn efron_step_mean_and_covariance_into(
     }
     for row in 0..means.len() {
         for col in 0..means.len() {
-            covariance[row][col] =
-                (s2[row][col] - fraction * death_s2[row][col]) / step_s0 - means[row] * means[col];
+            let idx = row * means.len() + col;
+            covariance[idx] =
+                (s2[idx] - fraction * death_s2[idx]) / step_s0 - means[row] * means[col];
         }
     }
 }
 
-fn scale_matrix_in_place(target: &mut [Vec<f64>], scale: f64) {
-    for row in target {
-        for value in row {
-            *value *= scale;
-        }
+fn scale_matrix_in_place(target: &mut [f64], scale: f64) {
+    for value in target {
+        *value *= scale;
     }
 }
 
-fn add_matrix(target: &mut [Vec<f64>], values: &[Vec<f64>], scale: f64) {
-    for (row_idx, row) in values.iter().enumerate() {
-        for (col_idx, value) in row.iter().enumerate() {
-            target[row_idx][col_idx] += scale * value;
-        }
+fn add_matrix(target: &mut [f64], values: &[f64], scale: f64) {
+    for (target_value, &value) in target.iter_mut().zip(values.iter()) {
+        *target_value += scale * value;
     }
+}
+
+fn nested_matrix_from_flat(values: &[f64], nvar: usize) -> Vec<Vec<f64>> {
+    if nvar == 0 {
+        return Vec::new();
+    }
+    values.chunks(nvar).map(|row| row.to_vec()).collect()
 }
 
 fn event_groups(time: &[f64], status: &[i32], strata: &[i32]) -> Vec<(i32, f64)> {
@@ -379,11 +366,14 @@ pub(crate) fn compute_coxph_detail_with_options(
     let mut deaths = Vec::with_capacity(status.iter().filter(|&&value| value == 1).count());
     let mut event_covariates = vec![0.0; nvar];
     let mut risk_s1 = vec![0.0; nvar];
-    let mut risk_s2 = vec![vec![0.0; nvar]; nvar];
+    let mut risk_s2 = vec![0.0; nvar * nvar];
     let mut death_s1 = vec![0.0; nvar];
-    let mut death_s2 = vec![vec![0.0; nvar]; nvar];
+    let mut death_s2 = vec![0.0; nvar * nvar];
+    let mut means = vec![0.0; nvar];
+    let mut score = vec![0.0; nvar];
+    let mut imat = vec![0.0; nvar * nvar];
     let mut step_means = vec![0.0; nvar];
-    let mut step_covariance = vec![vec![0.0; nvar]; nvar];
+    let mut step_covariance = vec![0.0; nvar * nvar];
 
     for (stratum, event_time) in groups {
         if current_stratum != Some(stratum) {
@@ -421,12 +411,10 @@ pub(crate) fn compute_coxph_detail_with_options(
             &mut risk_s1,
             &mut risk_s2,
         );
-        let (means, mut imat) = mean_and_covariance(s0, &risk_s1, &risk_s2, nvar);
-        let mut score = event_covariates
-            .iter()
-            .zip(means.iter())
-            .map(|(&event_sum, &mean)| event_sum - event_weight * mean)
-            .collect::<Vec<_>>();
+        mean_and_covariance_into(s0, &risk_s1, &risk_s2, &mut means, &mut imat);
+        for col in 0..nvar {
+            score[col] = event_covariates[col] - event_weight * means[col];
+        }
         scale_matrix_in_place(&mut imat, event_weight);
         let mut hazard = if s0 > 0.0 {
             event_weight * hazard_scale / s0
@@ -448,9 +436,7 @@ pub(crate) fn compute_coxph_detail_with_options(
                 &mut death_s2,
             );
             score.copy_from_slice(&event_covariates);
-            for row in &mut imat {
-                row.fill(0.0);
-            }
+            imat.fill(0.0);
             hazard = 0.0;
             varhaz = 0.0;
             let step_weight = event_weight / deaths.len() as f64;
@@ -496,9 +482,9 @@ pub(crate) fn compute_coxph_detail_with_options(
             },
             n_event_weight: event_weight,
             schoenfeld: Some(score.clone()),
-            means,
-            imat,
-            score,
+            means: means.clone(),
+            imat: nested_matrix_from_flat(&imat, nvar),
+            score: score.clone(),
         });
     }
 

--- a/src/regression/coxph_diagnostics.rs
+++ b/src/regression/coxph_diagnostics.rs
@@ -512,19 +512,25 @@ impl CoxPHFit {
         let mut prefix = vec![vec![0.0; deaths + 1]; n_risk + 1];
         prefix[0][0] = 1.0;
         for pos in 0..n_risk {
-            prefix[pos + 1] = prefix[pos].clone();
+            let (previous_rows, current_rows) = prefix.split_at_mut(pos + 1);
+            let previous = &previous_rows[pos];
+            let current = &mut current_rows[0];
+            current.copy_from_slice(previous);
             let value = risk[risk_indices[pos]];
             for size in 1..=deaths.min(pos + 1) {
-                prefix[pos + 1][size] += value * prefix[pos][size - 1];
+                current[size] += value * previous[size - 1];
             }
         }
         let mut suffix = vec![vec![0.0; deaths + 1]; n_risk + 1];
         suffix[n_risk][0] = 1.0;
         for pos in (0..n_risk).rev() {
-            suffix[pos] = suffix[pos + 1].clone();
+            let (current_rows, following_rows) = suffix.split_at_mut(pos + 1);
+            let current = &mut current_rows[pos];
+            let following = &following_rows[0];
+            current.copy_from_slice(following);
             let value = risk[risk_indices[pos]];
             for size in 1..=deaths.min(n_risk - pos) {
-                suffix[pos][size] += value * suffix[pos + 1][size - 1];
+                current[size] += value * following[size - 1];
             }
         }
         let denom = prefix[n_risk][deaths];
@@ -1506,5 +1512,17 @@ mod tests {
         .expect("interval SEs should compute");
         assert!((interval_se[0] - 3.0 * 1.83_f64.sqrt()).abs() < 1e-12);
         assert_eq!(interval_se[1], 0.0);
+    }
+
+    #[test]
+    fn exact_inclusion_weights_match_pairwise_tie_probabilities() {
+        let inclusion = CoxPHFit::exact_inclusion_weights(&[0, 1, 2], 2, &[2.0, 3.0, 5.0])
+            .expect("two deaths among three risk scores should compute");
+
+        assert_eq!(inclusion.len(), 3);
+        assert!((inclusion[0].1 - 16.0 / 31.0).abs() < 1e-12);
+        assert!((inclusion[1].1 - 21.0 / 31.0).abs() < 1e-12);
+        assert!((inclusion[2].1 - 25.0 / 31.0).abs() < 1e-12);
+        assert!((inclusion.iter().map(|(_, value)| value).sum::<f64>() - 2.0).abs() < 1e-12);
     }
 }

--- a/src/regression/coxph_diagnostics.rs
+++ b/src/regression/coxph_diagnostics.rs
@@ -472,7 +472,7 @@ impl CoxPHFit {
         let (times, hazards, hazard_strata) = self.basehaz_with_strata_internal(false)?;
         let baseline = StratifiedBaselineLookup::from_components(&times, &hazards, &hazard_strata);
         let entry_times = self.entry_times.as_deref();
-        let row_strata = self.row_strata();
+        let row_strata = self.row_strata_cow();
 
         Ok(self
             .event_times

--- a/src/regression/coxph_diagnostics.rs
+++ b/src/regression/coxph_diagnostics.rs
@@ -653,6 +653,7 @@ impl CoxPHFit {
                 stratum_end += 1;
             }
             let mut risk_indices: Vec<usize> = Vec::new();
+            let mut deaths: Vec<usize> = Vec::new();
             let mut time_pos = stratum_end;
             loop {
                 let event_time = self.event_times[order[time_pos]];
@@ -665,9 +666,8 @@ impl CoxPHFit {
                 for sorted_idx in time_start..=time_pos {
                     risk_indices.push(sorted_idx);
                 }
-                let deaths: Vec<usize> = (time_start..=time_pos)
-                    .filter(|&idx| self.status[order[idx]] == 1)
-                    .collect();
+                deaths.clear();
+                deaths.extend((time_start..=time_pos).filter(|&idx| self.status[order[idx]] == 1));
                 if !deaths.is_empty() {
                     for &sorted_idx in &deaths {
                         let original_idx = order[sorted_idx];

--- a/src/regression/coxph_diagnostics.rs
+++ b/src/regression/coxph_diagnostics.rs
@@ -1385,8 +1385,8 @@ impl CoxPHFit {
             pyo3::exceptions::PyValueError::new_err("model has no fitted coefficients")
         })?;
         let nvar = beta.len();
-        let martingale = self.martingale_residuals()?;
-        let n = martingale.len();
+        let expected = self.expected_events_internal()?;
+        let n = expected.len();
         if nvar == 0 {
             return Ok(vec![Vec::new(); n]);
         }
@@ -1404,8 +1404,9 @@ impl CoxPHFit {
         Ok(self
             .covariates
             .iter()
-            .zip(martingale.iter())
-            .map(|(row, &residual)| {
+            .zip(self.status.iter().zip(expected.iter()))
+            .map(|(row, (&status, &expected))| {
+                let residual = status as f64 - expected;
                 row.iter()
                     .zip(beta.iter())
                     .map(|(&value, &coefficient)| residual + value * coefficient)
@@ -1526,6 +1527,57 @@ mod tests {
         .expect("interval SEs should compute");
         assert!((interval_se[0] - 3.0 * 1.83_f64.sqrt()).abs() < 1e-12);
         assert_eq!(interval_se[1], 0.0);
+    }
+
+    #[test]
+    fn partial_residuals_reuse_expected_events() {
+        let fit = CoxPHFit {
+            coefficients: vec![vec![0.5, -0.25]],
+            means: vec![0.0, 0.0],
+            score_vector: vec![],
+            information_matrix: vec![],
+            log_likelihood: vec![],
+            score_test: 0.0,
+            convergence_flag: 0,
+            iterations: 0,
+            risk_scores: vec![],
+            event_times: vec![1.0, 2.0, 3.0],
+            status: vec![1, 0, 1],
+            linear_predictors: vec![0.2, -0.1, 0.3],
+            entry_times: None,
+            weights: vec![1.0, 1.0, 1.0],
+            covariates: vec![vec![1.0, 0.5], vec![0.0, 1.5], vec![2.0, -1.0]],
+            strata: vec![0, 0, 0],
+            method: "breslow".to_string(),
+            nocenter: Vec::new(),
+        };
+        let beta = fit.coefficients.first().expect("test coefficients exist");
+        let martingale = fit
+            .martingale_residuals()
+            .expect("martingale residuals should compute");
+        let expected: Vec<Vec<f64>> = fit
+            .covariates
+            .iter()
+            .zip(martingale.iter())
+            .map(|(row, &residual)| {
+                row.iter()
+                    .zip(beta.iter())
+                    .map(|(&value, &coefficient)| residual + value * coefficient)
+                    .collect()
+            })
+            .collect();
+
+        let actual = fit
+            .partial_residuals_internal()
+            .expect("partial residuals should compute");
+
+        assert_eq!(actual.len(), expected.len());
+        for (actual_row, expected_row) in actual.iter().zip(expected.iter()) {
+            assert_eq!(actual_row.len(), expected_row.len());
+            for (&actual, &expected) in actual_row.iter().zip(expected_row.iter()) {
+                assert!((actual - expected).abs() < 1e-12);
+            }
+        }
     }
 
     #[test]

--- a/src/regression/coxph_diagnostics.rs
+++ b/src/regression/coxph_diagnostics.rs
@@ -891,8 +891,10 @@ impl CoxPHFit {
                 })
                 .collect();
             let mut active = ActiveRiskSet::new(&rows, true);
-            let mut event_times = Vec::new();
-            let mut cumulative_scalars = Vec::new();
+            let event_count = rows.iter().filter(|row| row.status == 1).count();
+            let mut event_times = Vec::with_capacity(event_count);
+            let mut cumulative_scalars = Vec::with_capacity(event_count);
+            let mut deaths: Vec<usize> = Vec::with_capacity(event_count);
             let mut cumulative_scalar = 0.0;
             let mut time_start = 0usize;
             while time_start < rows.len() {
@@ -904,9 +906,8 @@ impl CoxPHFit {
 
                 active.advance_to(event_time, |_, _| {});
 
-                let deaths: Vec<usize> = (time_start..=time_end)
-                    .filter(|&idx| rows[idx].status == 1)
-                    .collect();
+                deaths.clear();
+                deaths.extend((time_start..=time_end).filter(|&idx| rows[idx].status == 1));
                 if !deaths.is_empty() && active.risk_sum > 0.0 {
                     for &row_idx in &deaths {
                         let original_idx = rows[row_idx].original_idx;

--- a/src/regression/coxph_diagnostics.rs
+++ b/src/regression/coxph_diagnostics.rs
@@ -1297,6 +1297,9 @@ impl CoxPHFit {
             }
             let mut active = ActiveRiskSet::new(&rows, use_entry_times);
 
+            let mut deaths: Vec<usize> = Vec::new();
+            let mut mean = vec![0.0; nvar];
+            let mut death_cov = vec![0.0; nvar];
             let mut time_start = 0usize;
             while time_start < rows.len() {
                 let event_time = rows[time_start].stop;
@@ -1317,14 +1320,13 @@ impl CoxPHFit {
                     }
                 });
 
-                let deaths: Vec<usize> = (time_start..=time_end)
-                    .filter(|&idx| rows[idx].status == 1)
-                    .collect();
+                deaths.clear();
+                deaths.extend((time_start..=time_end).filter(|&idx| rows[idx].status == 1));
                 if !deaths.is_empty() && active.risk_sum > 0.0 {
-                    let mut mean = vec![0.0; nvar];
+                    mean.fill(0.0);
                     if matches!(method, CoxMethod::Efron) && deaths.len() > 1 {
                         let mut death_risk = 0.0;
-                        let mut death_cov = vec![0.0; nvar];
+                        death_cov.fill(0.0);
                         for &row_idx in &deaths {
                             death_risk += rows[row_idx].risk;
                             for (col_idx, value) in self.covariates[rows[row_idx].original_idx]

--- a/src/regression/coxph_diagnostics.rs
+++ b/src/regression/coxph_diagnostics.rs
@@ -1144,7 +1144,8 @@ impl CoxPHFit {
             }
         }
 
-        let mut residuals = Vec::new();
+        let event_count = sorted_status.iter().filter(|&&status| status == 1).count();
+        let mut residuals = Vec::with_capacity(event_count);
         let mut stratum_start = 0usize;
         while stratum_start < n {
             let stratum = sorted_strata[stratum_start];
@@ -1257,7 +1258,8 @@ impl CoxPHFit {
         entry_times: Option<&Vec<f64>>,
         method: CoxMethod,
     ) -> Vec<Vec<f64>> {
-        let mut residuals = Vec::new();
+        let event_count = order.iter().filter(|&&idx| self.status[idx] == 1).count();
+        let mut residuals = Vec::with_capacity(event_count);
         let use_entry_times = entry_times.is_some();
         let mut stratum_start = 0usize;
         while stratum_start < order.len() {

--- a/src/regression/coxph_diagnostics.rs
+++ b/src/regression/coxph_diagnostics.rs
@@ -179,8 +179,8 @@ pub fn cox_event_indices(
         return Err(value_error("status length must match time length"));
     }
     validate_finite_slice(&time, "time")?;
-    let strata = strata.unwrap_or_else(|| vec![0; n]);
-    if strata.len() != n {
+    let strata = strata.as_deref();
+    if strata.is_some_and(|values| values.len() != n) {
         return Err(value_error("strata length must match time length"));
     }
     for (idx, &value) in status.iter().enumerate() {
@@ -192,12 +192,20 @@ pub fn cox_event_indices(
     }
 
     let mut order: Vec<usize> = (0..n).collect();
-    order.sort_by(|&left, &right| {
-        strata[left]
-            .cmp(&strata[right])
-            .then_with(|| time[left].total_cmp(&time[right]))
-            .then_with(|| left.cmp(&right))
-    });
+    if let Some(values) = strata {
+        order.sort_by(|&left, &right| {
+            values[left]
+                .cmp(&values[right])
+                .then_with(|| time[left].total_cmp(&time[right]))
+                .then_with(|| left.cmp(&right))
+        });
+    } else {
+        order.sort_by(|&left, &right| {
+            time[left]
+                .total_cmp(&time[right])
+                .then_with(|| left.cmp(&right))
+        });
+    }
     Ok(order.into_iter().filter(|&idx| status[idx] == 1).collect())
 }
 
@@ -1433,6 +1441,16 @@ mod tests {
             diagnostic_order(&[1, 0, 0, 1], &[2.0, 1.0, 2.0, 1.0]),
             vec![1, 2, 3, 0]
         );
+        let implicit_strata = cox_event_indices(vec![2.0, 1.0, 2.0, 3.0], vec![1, 0, 1, 1], None)
+            .expect("event indices should compute without strata");
+        let explicit_zero_strata = cox_event_indices(
+            vec![2.0, 1.0, 2.0, 3.0],
+            vec![1, 0, 1, 1],
+            Some(vec![0, 0, 0, 0]),
+        )
+        .expect("event indices should compute with explicit zero strata");
+        assert_eq!(implicit_strata, explicit_zero_strata);
+        assert!(cox_event_indices(vec![1.0, 2.0], vec![1, 0], Some(vec![0])).is_err());
 
         let scaled = scale_schoenfeld_residuals(
             vec![vec![1.0, 2.0], vec![3.0, 4.0]],

--- a/src/regression/coxph_diagnostics.rs
+++ b/src/regression/coxph_diagnostics.rs
@@ -760,6 +760,9 @@ impl CoxPHFit {
                 stratum_end += 1;
             }
             let stratum_indices = &order[stratum_start..=stratum_end];
+            let mut deaths: Vec<usize> = Vec::new();
+            let mut risk_indices: Vec<usize> = Vec::new();
+            let mut is_death = vec![false; n];
             let mut time_start = stratum_start;
             while time_start <= stratum_end {
                 let event_time = self.event_times[order[time_start]];
@@ -770,22 +773,20 @@ impl CoxPHFit {
                     time_end += 1;
                 }
 
-                let deaths: Vec<usize> = (time_start..=time_end)
-                    .map(|idx| order[idx])
-                    .filter(|&idx| self.status[idx] == 1)
-                    .collect();
+                deaths.clear();
+                deaths.extend(
+                    (time_start..=time_end)
+                        .map(|idx| order[idx])
+                        .filter(|&idx| self.status[idx] == 1),
+                );
                 if !deaths.is_empty() {
-                    let mut is_death = vec![false; n];
                     for &idx in &deaths {
                         is_death[idx] = true;
                     }
-                    let risk_indices: Vec<usize> = stratum_indices
-                        .iter()
-                        .copied()
-                        .filter(|&idx| {
-                            entry_times[idx] < event_time && self.event_times[idx] >= event_time
-                        })
-                        .collect();
+                    risk_indices.clear();
+                    risk_indices.extend(stratum_indices.iter().copied().filter(|&idx| {
+                        entry_times[idx] < event_time && self.event_times[idx] >= event_time
+                    }));
                     let denom: f64 = risk_indices.iter().map(|&idx| risk[idx]).sum();
                     if denom > 0.0 {
                         for &idx in &deaths {
@@ -843,6 +844,9 @@ impl CoxPHFit {
                                 }
                             }
                         }
+                    }
+                    for &idx in &deaths {
+                        is_death[idx] = false;
                     }
                 }
 

--- a/src/regression/coxph_diagnostics.rs
+++ b/src/regression/coxph_diagnostics.rs
@@ -1153,6 +1153,11 @@ impl CoxPHFit {
                 stratum_end += 1;
             }
 
+            let mut death_indices: Vec<usize> = Vec::new();
+            let mut risk_indices: Vec<usize> = Vec::new();
+            let mut mean = vec![0.0; nvar];
+            let mut risk_weighted_covariates = vec![0.0; nvar];
+            let mut death_weighted_covariates = vec![0.0; nvar];
             let mut time_start = stratum_start;
             while time_start <= stratum_end {
                 let event_time = sorted_time[time_start];
@@ -1161,16 +1166,15 @@ impl CoxPHFit {
                     time_end += 1;
                 }
 
-                let death_indices: Vec<usize> = (time_start..=time_end)
-                    .filter(|&idx| sorted_status[idx] == 1)
-                    .collect();
+                death_indices.clear();
+                death_indices
+                    .extend((time_start..=time_end).filter(|&idx| sorted_status[idx] == 1));
                 if !death_indices.is_empty() {
-                    let risk_indices: Vec<usize> = (stratum_start..=stratum_end)
-                        .filter(|&idx| {
-                            sorted_start[idx] < event_time && sorted_time[idx] >= event_time
-                        })
-                        .collect();
-                    let mut mean = vec![0.0; nvar];
+                    risk_indices.clear();
+                    risk_indices.extend((stratum_start..=stratum_end).filter(|&idx| {
+                        sorted_start[idx] < event_time && sorted_time[idx] >= event_time
+                    }));
+                    mean.fill(0.0);
                     if matches!(method, CoxMethod::Exact) && death_indices.len() > 1 {
                         let (denom, a, _cmat) = exact_tied_moments(
                             &risk_indices,
@@ -1185,19 +1189,19 @@ impl CoxPHFit {
                         }
                     } else {
                         let mut denom = 0.0;
-                        let mut a = vec![0.0; nvar];
                         let mut death_denom = 0.0;
-                        let mut death_a = vec![0.0; nvar];
+                        risk_weighted_covariates.fill(0.0);
+                        death_weighted_covariates.fill(0.0);
                         for &idx in &risk_indices {
                             let risk = sorted_risk[idx];
                             denom += risk;
                             for col_idx in 0..nvar {
                                 let value = covar[(idx, col_idx)];
-                                a[col_idx] += risk * value;
+                                risk_weighted_covariates[col_idx] += risk * value;
                                 if same_time(sorted_time[idx], event_time)
                                     && sorted_status[idx] == 1
                                 {
-                                    death_a[col_idx] += risk * value;
+                                    death_weighted_covariates[col_idx] += risk * value;
                                 }
                             }
                             if same_time(sorted_time[idx], event_time) && sorted_status[idx] == 1 {
@@ -1211,7 +1215,8 @@ impl CoxPHFit {
                                 let step_denom = denom - fraction * death_denom;
                                 if step_denom > 0.0 {
                                     for col_idx in 0..nvar {
-                                        mean[col_idx] += (a[col_idx] - fraction * death_a[col_idx])
+                                        mean[col_idx] += (risk_weighted_covariates[col_idx]
+                                            - fraction * death_weighted_covariates[col_idx])
                                             / step_denom
                                             / deaths;
                                     }
@@ -1219,7 +1224,7 @@ impl CoxPHFit {
                             }
                         } else if denom > 0.0 {
                             for col_idx in 0..nvar {
-                                mean[col_idx] = a[col_idx] / denom;
+                                mean[col_idx] = risk_weighted_covariates[col_idx] / denom;
                             }
                         }
                     }

--- a/src/regression/coxph_model.rs
+++ b/src/regression/coxph_model.rs
@@ -695,26 +695,33 @@ impl CoxPHModel {
         covariates: Vec<Vec<f64>>,
         percentile: f64,
     ) -> Vec<Option<f64>> {
-        let (times, survival_curves) = match self.survival_curve(covariates, None) {
-            Ok(result) => result,
-            Err(_) => return vec![],
-        };
-        let target_survival = 1.0 - percentile;
-        survival_curves
+        if self.validate_prediction_rows(&covariates).is_err() {
+            return vec![];
+        }
+        let times = sorted_unique_times(&self.event_times);
+        let risk_scores = self.compute_exp_risk_scores(&covariates);
+        let baseline_hazards: Vec<f64> = times
             .iter()
-            .map(|surv| {
-                for (i, &s) in surv.iter().enumerate() {
-                    if s <= target_survival {
+            .map(|&t| self.baseline_cumulative_hazard_at(t))
+            .collect();
+        let target_survival = 1.0 - percentile;
+        risk_scores
+            .par_iter()
+            .map(|&risk_exp| {
+                let mut prev_surv = 1.0;
+                for (i, (&time, &baseline_hazard)) in
+                    times.iter().zip(baseline_hazards.iter()).enumerate()
+                {
+                    let survival = (-baseline_hazard * risk_exp).exp();
+                    if survival <= target_survival {
                         if i == 0 {
-                            return Some(times[0]);
+                            return Some(time);
                         }
-                        let s0 = surv[i - 1];
-                        let s1 = s;
                         let t0 = times[i - 1];
-                        let t1 = times[i];
-                        let frac = (s0 - target_survival) / (s0 - s1);
-                        return Some(t0 + frac * (t1 - t0));
+                        let frac = (prev_surv - target_survival) / (prev_surv - survival);
+                        return Some(t0 + frac * (time - t0));
                     }
+                    prev_surv = survival;
                 }
                 None
             })
@@ -1001,6 +1008,26 @@ mod tests {
         assert_eq!(hazard_times, vec![1.0, 2.0, 3.0]);
         assert_eq!(survival.len(), 1);
         assert_eq!(cumulative_hazard.len(), 1);
+    }
+
+    #[test]
+    fn test_predicted_survival_time_interpolates_from_baseline_hazard() {
+        let mut model = CoxPHModel::new();
+        model.coefficients =
+            Array2::from_shape_vec((1, 1), vec![0.0]).expect("coefficient shape is valid");
+        model.event_times = vec![1.0, 2.0, 3.0];
+        model.censoring = vec![1, 1, 1];
+        model.baseline_hazard_lookup_times = vec![1.0, 2.0, 3.0];
+        model.baseline_hazard_lookup_values = vec![0.1, 0.8, 1.2];
+
+        let survival_at_1 = (-0.1_f64).exp();
+        let survival_at_2 = (-0.8_f64).exp();
+        let expected = 1.0 + (survival_at_1 - 0.5) / (survival_at_1 - survival_at_2) * (2.0 - 1.0);
+
+        let predicted = model.predicted_survival_time(vec![vec![0.0]], 0.5);
+
+        assert_eq!(predicted.len(), 1);
+        assert!((predicted[0].expect("median should be predicted") - expected).abs() < 1e-12);
     }
 
     #[test]

--- a/src/regression/coxph_model.rs
+++ b/src/regression/coxph_model.rs
@@ -448,16 +448,23 @@ impl CoxPHModel {
             pyo3::exceptions::PyRuntimeError::new_err(format!("Cox fit failed: {}", e))
         })?;
         let (beta, _means, _u, _imat, _loglik, _sctest, _flag, _iter) = cox_fit.results();
-        let mut coefficients_array = Array2::<f64>::zeros((nvar, 1));
-        for (idx, &beta_val) in beta.iter().enumerate() {
-            coefficients_array[[idx, 0]] = beta_val;
-        }
-        self.coefficients = coefficients_array;
-        self.risk_scores.clear();
+
+        let mut risk_scores = Vec::with_capacity(n);
         for row in self.covariates.outer_iter() {
-            let risk_score = self.coefficients.column(0).dot(&row);
-            self.risk_scores.push(exp_clamped(risk_score));
+            let risk_score = row
+                .iter()
+                .zip(beta.iter())
+                .map(|(&cov, &coef)| coef * cov)
+                .sum::<f64>();
+            risk_scores.push(exp_clamped(risk_score));
         }
+
+        self.coefficients = Array2::from_shape_vec((nvar, 1), beta).map_err(|e| {
+            pyo3::exceptions::PyRuntimeError::new_err(format!(
+                "failed to materialize Cox coefficients: {e}"
+            ))
+        })?;
+        self.risk_scores = risk_scores;
         self.calculate_baseline_hazard();
         Ok(())
     }

--- a/src/regression/coxph_model.rs
+++ b/src/regression/coxph_model.rs
@@ -552,6 +552,18 @@ impl CoxPHModel {
         }
         if count > 0.0 { score / count } else { 0.0 }
     }
+    fn predict_survival(&self, time: f64) -> f64 {
+        if self.baseline_hazard.is_empty() || self.risk_scores.is_empty() {
+            return 0.5;
+        }
+        let baseline_haz = self.baseline_cumulative_hazard_at(time);
+        let avg_risk = if !self.risk_scores.is_empty() {
+            self.risk_scores.iter().sum::<f64>() / self.risk_scores.len() as f64
+        } else {
+            1.0
+        };
+        (-baseline_haz * avg_risk).exp()
+    }
     pub fn survival_curve(
         &self,
         covariates: Vec<Vec<f64>>,

--- a/src/regression/coxph_model.rs
+++ b/src/regression/coxph_model.rs
@@ -529,7 +529,7 @@ impl CoxPHModel {
     }
     #[getter]
     pub fn get_coefficients(&self) -> Vec<Vec<f64>> {
-        let mut result = Vec::new();
+        let mut result = Vec::with_capacity(self.coefficients.ncols());
         for col in self.coefficients.columns() {
             result.push(col.iter().copied().collect());
         }
@@ -587,7 +587,7 @@ impl CoxPHModel {
     }
     #[pyo3(signature = (confidence_level = 0.95))]
     pub fn hazard_ratios_with_ci(&self, confidence_level: f64) -> (Vec<f64>, Vec<f64>, Vec<f64>) {
-        let coefs: Vec<f64> = self.coefficients.column(0).to_vec();
+        let coefs = self.coefficients.column(0);
         let n = coefs.len();
         let z = z_score_for_confidence(confidence_level);
         let se = self.compute_standard_errors();

--- a/src/regression/coxph_model.rs
+++ b/src/regression/coxph_model.rs
@@ -607,31 +607,34 @@ impl CoxPHModel {
         }
         let risk_sets = self.risk_set_cache(true, true, false);
         let event_indices: Vec<usize> = (0..n).filter(|&i| self.censoring[i] == 1).collect();
-        let fisher_contributions: Vec<Vec<f64>> = event_indices
+        let fisher_diag = event_indices
             .par_iter()
-            .filter_map(|&i| {
-                let risk_set_sum = risk_sets.risk_sum[i];
-                if risk_set_sum <= 0.0 {
-                    return None;
-                }
-                let base = i * nvar;
-                let contrib: Vec<f64> = (0..nvar)
-                    .map(|k| {
+            .fold(
+                || vec![0.0; nvar],
+                |mut diag, &i| {
+                    let risk_set_sum = risk_sets.risk_sum[i];
+                    if risk_set_sum <= 0.0 {
+                        return diag;
+                    }
+                    let base = i * nvar;
+                    for (k, diag_k) in diag.iter_mut().enumerate().take(nvar) {
                         let weighted_cov = risk_sets.weighted_cov[base + k];
                         let weighted_cov_sq = risk_sets.weighted_cov_sq[base + k];
                         let mean_cov = weighted_cov / risk_set_sum;
-                        weighted_cov_sq / risk_set_sum - mean_cov * mean_cov
-                    })
-                    .collect();
-                Some(contrib)
-            })
-            .collect();
-        let mut fisher_diag = vec![0.0; nvar];
-        for contrib in fisher_contributions {
-            for (k, &val) in contrib.iter().enumerate() {
-                fisher_diag[k] += val;
-            }
-        }
+                        *diag_k += weighted_cov_sq / risk_set_sum - mean_cov * mean_cov;
+                    }
+                    diag
+                },
+            )
+            .reduce(
+                || vec![0.0; nvar],
+                |mut total, diag| {
+                    for (total_k, diag_k) in total.iter_mut().zip(diag) {
+                        *total_k += diag_k;
+                    }
+                    total
+                },
+            );
         fisher_diag
             .iter()
             .map(|&f| if f > 0.0 { (1.0 / f).sqrt() } else { 0.1 })

--- a/src/regression/coxph_model.rs
+++ b/src/regression/coxph_model.rs
@@ -772,17 +772,19 @@ impl CoxPHModel {
         residuals
     }
     pub fn deviance_residuals(&self) -> Vec<f64> {
-        let martingale = self.martingale_residuals();
-        martingale
-            .iter()
-            .zip(self.censoring.iter())
-            .map(|(&m, &d)| {
-                let sign = if m >= 0.0 { 1.0 } else { -1.0 };
-                let abs_term =
-                    -2.0 * (m - d as f64 + d as f64 * (d as f64 - m).ln().max(EXP_CLAMP_MIN));
-                sign * abs_term.abs().sqrt()
-            })
-            .collect()
+        let n = self.event_times.len();
+        let mut residuals = Vec::with_capacity(n);
+        for i in 0..n {
+            let status = self.censoring[i] as f64;
+            let cum_haz = self.baseline_hazard.get(i).copied().unwrap_or(0.0)
+                * self.risk_scores.get(i).copied().unwrap_or(1.0);
+            let martingale = status - cum_haz;
+            let sign = if martingale >= 0.0 { 1.0 } else { -1.0 };
+            let abs_term = -2.0
+                * (martingale - status + status * (status - martingale).ln().max(EXP_CLAMP_MIN));
+            residuals.push(sign * abs_term.abs().sqrt());
+        }
+        residuals
     }
     pub fn dfbeta(&self) -> Vec<Vec<f64>> {
         let n = self.event_times.len();
@@ -1052,6 +1054,36 @@ mod tests {
 
         assert_eq!(rmst.len(), 1);
         assert!((rmst[0] - expected).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_deviance_residuals_match_martingale_formula() {
+        let mut model = CoxPHModel::new();
+        model.event_times = vec![1.0, 2.0, 3.0];
+        model.censoring = vec![1, 0, 1];
+        model.baseline_hazard = vec![0.2, 0.3, 0.4];
+        model.risk_scores = vec![2.0, 1.5, 0.5];
+
+        let expected: Vec<f64> = model
+            .martingale_residuals()
+            .iter()
+            .zip(model.censoring.iter())
+            .map(|(&martingale, &status)| {
+                let status = status as f64;
+                let sign = if martingale >= 0.0 { 1.0 } else { -1.0 };
+                let abs_term = -2.0
+                    * (martingale - status
+                        + status * (status - martingale).ln().max(EXP_CLAMP_MIN));
+                sign * abs_term.abs().sqrt()
+            })
+            .collect();
+
+        let residuals = model.deviance_residuals();
+
+        assert_eq!(residuals.len(), expected.len());
+        for (actual, expected) in residuals.iter().zip(expected.iter()) {
+            assert!((actual - expected).abs() < 1e-12);
+        }
     }
 
     #[test]

--- a/src/regression/coxph_model.rs
+++ b/src/regression/coxph_model.rs
@@ -477,9 +477,8 @@ impl CoxPHModel {
                 .total_cmp(&self.event_times[rhs])
                 .then_with(|| lhs.cmp(&rhs))
         });
-        let n_events_estimate = self.censoring.iter().filter(|&&c| c == 1).count();
-        let mut unique_times = Vec::with_capacity(n_events_estimate);
-        let mut baseline_hazard = Vec::with_capacity(n_events_estimate);
+        let mut unique_times = Vec::with_capacity(event_indices.len());
+        let mut baseline_hazard = Vec::with_capacity(event_indices.len());
         let mut cum_hazard = 0.0;
         let mut i = 0;
         while i < event_indices.len() {
@@ -606,12 +605,12 @@ impl CoxPHModel {
             return vec![0.1; nvar];
         }
         let risk_sets = self.risk_set_cache(true, true, false);
-        let event_indices: Vec<usize> = (0..n).filter(|&i| self.censoring[i] == 1).collect();
-        let fisher_diag = event_indices
-            .par_iter()
+        let fisher_diag = (0..n)
+            .into_par_iter()
+            .filter(|&i| self.censoring[i] == 1)
             .fold(
                 || vec![0.0; nvar],
-                |mut diag, &i| {
+                |mut diag, i| {
                     let risk_set_sum = risk_sets.risk_sum[i];
                     if risk_set_sum <= 0.0 {
                         return diag;
@@ -645,12 +644,10 @@ impl CoxPHModel {
             return 0.0;
         }
         let risk_sets = self.risk_set_cache(false, false, false);
-        let event_indices: Vec<usize> = (0..self.event_times.len())
+        (0..self.event_times.len())
+            .into_par_iter()
             .filter(|&i| self.censoring[i] == 1)
-            .collect();
-        event_indices
-            .par_iter()
-            .map(|&i| {
+            .map(|i| {
                 let risk_score_i = self.risk_scores.get(i).copied().unwrap_or(1.0).ln();
                 let risk_set_sum = risk_sets.risk_sum[i];
                 if risk_set_sum > 0.0 {

--- a/src/regression/coxph_model.rs
+++ b/src/regression/coxph_model.rs
@@ -538,24 +538,22 @@ impl CoxPHModel {
     pub fn brier_score(&self) -> f64 {
         let mut score = 0.0;
         let mut count = 0.0;
+        let avg_risk = if self.baseline_hazard.is_empty() || self.risk_scores.is_empty() {
+            None
+        } else {
+            Some(self.risk_scores.iter().sum::<f64>() / self.risk_scores.len() as f64)
+        };
         for (time, &status) in self.event_times.iter().zip(self.censoring.iter()) {
-            let pred = self.predict_survival(*time);
+            let pred = if let Some(avg_risk) = avg_risk {
+                let baseline_haz = self.baseline_cumulative_hazard_at(*time);
+                (-baseline_haz * avg_risk).exp()
+            } else {
+                0.5
+            };
             score += (pred - status as f64).powi(2);
             count += 1.0;
         }
         if count > 0.0 { score / count } else { 0.0 }
-    }
-    fn predict_survival(&self, time: f64) -> f64 {
-        if self.baseline_hazard.is_empty() || self.risk_scores.is_empty() {
-            return 0.5;
-        }
-        let baseline_haz = self.baseline_cumulative_hazard_at(time);
-        let avg_risk = if !self.risk_scores.is_empty() {
-            self.risk_scores.iter().sum::<f64>() / self.risk_scores.len() as f64
-        } else {
-            1.0
-        };
-        (-baseline_haz * avg_risk).exp()
     }
     pub fn survival_curve(
         &self,

--- a/src/regression/coxph_model.rs
+++ b/src/regression/coxph_model.rs
@@ -792,13 +792,14 @@ impl CoxPHModel {
         if n == 0 || nvar == 0 {
             return vec![];
         }
-        let martingale = self.martingale_residuals();
         let risk_sets = self.risk_set_cache(true, false, false);
         (0..n)
             .into_par_iter()
             .map(|i| {
-                let mart_i = martingale[i];
+                let status = self.censoring[i] as f64;
                 let risk_i = self.risk_scores.get(i).copied().unwrap_or(1.0);
+                let cum_haz = self.baseline_hazard.get(i).copied().unwrap_or(0.0) * risk_i;
+                let mart_i = status - cum_haz;
                 let risk_sum = risk_sets.risk_sum[i];
                 let base = i * nvar;
                 (0..nvar)
@@ -1084,6 +1085,26 @@ mod tests {
         for (actual, expected) in residuals.iter().zip(expected.iter()) {
             assert!((actual - expected).abs() < 1e-12);
         }
+    }
+
+    #[test]
+    fn test_dfbeta_computes_martingale_rows_directly() {
+        let mut model = CoxPHModel::new();
+        model.coefficients =
+            Array2::from_shape_vec((1, 1), vec![0.0]).expect("coefficient shape is valid");
+        model.covariates =
+            Array2::from_shape_vec((3, 1), vec![1.0, 2.0, 3.0]).expect("covariate shape is valid");
+        model.event_times = vec![1.0, 2.0, 3.0];
+        model.censoring = vec![1, 0, 1];
+        model.baseline_hazard = vec![0.2, 0.3, 0.4];
+        model.risk_scores = vec![2.0, 1.5, 0.5];
+
+        let dfbeta = model.dfbeta();
+
+        assert_eq!(dfbeta.len(), 3);
+        assert!((dfbeta[0][0] + 0.1875).abs() < 1e-12);
+        assert!((dfbeta[1][0] - 0.075).abs() < 1e-12);
+        assert!(dfbeta[2][0].abs() < 1e-12);
     }
 
     #[test]

--- a/src/regression/coxph_model.rs
+++ b/src/regression/coxph_model.rs
@@ -204,11 +204,8 @@ impl CoxPHModel {
         risk
     }
 
-    fn compute_exp_risk_scores(&self, covariates: &[Vec<f64>]) -> Vec<f64> {
-        covariates
-            .par_iter()
-            .map(|row| exp_clamped(self.linear_predictor_for_row(row)))
-            .collect()
+    fn exp_risk_for_row(&self, row: &[f64]) -> f64 {
+        exp_clamped(self.linear_predictor_for_row(row))
     }
 
     fn descending_time_indices(&self) -> Vec<usize> {
@@ -562,14 +559,14 @@ impl CoxPHModel {
     ) -> PyResult<(Vec<f64>, Vec<Vec<f64>>)> {
         self.validate_prediction_rows(&covariates)?;
         let times = time_points.unwrap_or_else(|| sorted_unique_times(&self.event_times));
-        let risk_scores = self.compute_exp_risk_scores(&covariates);
         let baseline_hazards: Vec<f64> = times
             .iter()
             .map(|&t| self.baseline_cumulative_hazard_at(t))
             .collect();
-        let survival_curves: Vec<Vec<f64>> = risk_scores
+        let survival_curves: Vec<Vec<f64>> = covariates
             .par_iter()
-            .map(|&risk_exp| {
+            .map(|row| {
+                let risk_exp = self.exp_risk_for_row(row);
                 baseline_hazards
                     .iter()
                     .map(|&bh| (-bh * risk_exp).exp())
@@ -678,14 +675,16 @@ impl CoxPHModel {
     ) -> PyResult<(Vec<f64>, Vec<Vec<f64>>)> {
         self.validate_prediction_rows(&covariates)?;
         let unique_times = sorted_unique_times(&self.event_times);
-        let risk_scores = self.compute_exp_risk_scores(&covariates);
         let baseline_hazards: Vec<f64> = unique_times
             .iter()
             .map(|&t| self.baseline_cumulative_hazard_at(t))
             .collect();
-        let cumulative_hazards: Vec<Vec<f64>> = risk_scores
+        let cumulative_hazards: Vec<Vec<f64>> = covariates
             .par_iter()
-            .map(|&risk_exp| baseline_hazards.iter().map(|&bh| bh * risk_exp).collect())
+            .map(|row| {
+                let risk_exp = self.exp_risk_for_row(row);
+                baseline_hazards.iter().map(|&bh| bh * risk_exp).collect()
+            })
             .collect();
         Ok((unique_times, cumulative_hazards))
     }
@@ -699,15 +698,15 @@ impl CoxPHModel {
             return vec![];
         }
         let times = sorted_unique_times(&self.event_times);
-        let risk_scores = self.compute_exp_risk_scores(&covariates);
         let baseline_hazards: Vec<f64> = times
             .iter()
             .map(|&t| self.baseline_cumulative_hazard_at(t))
             .collect();
         let target_survival = 1.0 - percentile;
-        risk_scores
+        covariates
             .par_iter()
-            .map(|&risk_exp| {
+            .map(|row| {
+                let risk_exp = self.exp_risk_for_row(row);
                 let mut prev_surv = 1.0;
                 for (i, (&time, &baseline_hazard)) in
                     times.iter().zip(baseline_hazards.iter()).enumerate()
@@ -732,14 +731,14 @@ impl CoxPHModel {
             return vec![];
         }
         let times = sorted_unique_times(&self.event_times);
-        let risk_scores = self.compute_exp_risk_scores(&covariates);
         let baseline_hazards: Vec<f64> = times
             .iter()
             .map(|&t| self.baseline_cumulative_hazard_at(t))
             .collect();
-        risk_scores
+        covariates
             .par_iter()
-            .map(|&risk_exp| {
+            .map(|row| {
+                let risk_exp = self.exp_risk_for_row(row);
                 let mut rmst = 0.0;
                 let mut prev_time = 0.0;
                 let mut prev_surv = 1.0;

--- a/src/regression/coxph_model.rs
+++ b/src/regression/coxph_model.rs
@@ -728,26 +728,33 @@ impl CoxPHModel {
             .collect()
     }
     pub fn restricted_mean_survival_time(&self, covariates: Vec<Vec<f64>>, tau: f64) -> Vec<f64> {
-        let (times, survival_curves) = match self.survival_curve(covariates, None) {
-            Ok(result) => result,
-            Err(_) => return vec![],
-        };
-        survival_curves
+        if self.validate_prediction_rows(&covariates).is_err() {
+            return vec![];
+        }
+        let times = sorted_unique_times(&self.event_times);
+        let risk_scores = self.compute_exp_risk_scores(&covariates);
+        let baseline_hazards: Vec<f64> = times
             .iter()
-            .map(|surv| {
+            .map(|&t| self.baseline_cumulative_hazard_at(t))
+            .collect();
+        risk_scores
+            .par_iter()
+            .map(|&risk_exp| {
                 let mut rmst = 0.0;
                 let mut prev_time = 0.0;
                 let mut prev_surv = 1.0;
-                for (i, &t) in times.iter().enumerate() {
-                    if t > tau {
+                for (i, (&time, &baseline_hazard)) in
+                    times.iter().zip(baseline_hazards.iter()).enumerate()
+                {
+                    if time > tau {
                         rmst += prev_surv * (tau - prev_time);
                         break;
                     }
-                    rmst += prev_surv * (t - prev_time);
-                    prev_time = t;
-                    prev_surv = surv[i];
+                    rmst += prev_surv * (time - prev_time);
+                    prev_time = time;
+                    prev_surv = (-baseline_hazard * risk_exp).exp();
                     if i == times.len() - 1 {
-                        rmst += prev_surv * (tau - t);
+                        rmst += prev_surv * (tau - time);
                     }
                 }
                 rmst
@@ -1028,6 +1035,24 @@ mod tests {
 
         assert_eq!(predicted.len(), 1);
         assert!((predicted[0].expect("median should be predicted") - expected).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_restricted_mean_survival_time_integrates_baseline_hazard() {
+        let mut model = CoxPHModel::new();
+        model.coefficients =
+            Array2::from_shape_vec((1, 1), vec![0.0]).expect("coefficient shape is valid");
+        model.event_times = vec![1.0, 2.0, 3.0];
+        model.censoring = vec![1, 1, 1];
+        model.baseline_hazard_lookup_times = vec![1.0, 2.0, 3.0];
+        model.baseline_hazard_lookup_values = vec![0.1, 0.8, 1.2];
+
+        let expected = 1.0 + (-0.1_f64).exp() + (-0.8_f64).exp() * 0.5;
+
+        let rmst = model.restricted_mean_survival_time(vec![vec![0.0]], 2.5);
+
+        assert_eq!(rmst.len(), 1);
+        assert!((rmst[0] - expected).abs() < 1e-12);
     }
 
     #[test]

--- a/src/regression/coxph_model.rs
+++ b/src/regression/coxph_model.rs
@@ -254,9 +254,21 @@ impl CoxPHModel {
 
         let sorted_indices = self.descending_time_indices();
         let mut risk_sum = 0.0;
-        let mut weighted_cov = vec![0.0; nvar];
-        let mut weighted_cov_sq = vec![0.0; nvar];
-        let mut weighted_outer = vec![0.0; nvar * nvar];
+        let mut weighted_cov = if track_cov {
+            vec![0.0; nvar]
+        } else {
+            Vec::new()
+        };
+        let mut weighted_cov_sq = if include_cov_sq {
+            vec![0.0; nvar]
+        } else {
+            Vec::new()
+        };
+        let mut weighted_outer = if include_outer {
+            vec![0.0; nvar * nvar]
+        } else {
+            Vec::new()
+        };
         let mut pos = 0usize;
 
         while pos < sorted_indices.len() {

--- a/src/regression/coxph_support.rs
+++ b/src/regression/coxph_support.rs
@@ -1,5 +1,5 @@
 use crate::constants::TIME_EPSILON;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 pub(super) struct StratifiedBaselineLookup {
     curves: BTreeMap<i32, (Vec<f64>, Vec<f64>)>,
@@ -25,8 +25,12 @@ impl StratifiedBaselineLookup {
 
     pub(super) fn times_for_strata(&self, strata: &[i32]) -> Vec<f64> {
         let mut times = Vec::new();
-        for stratum in strata {
-            if let Some((curve_times, _)) = self.curves.get(stratum) {
+        let mut seen = BTreeSet::new();
+        for &stratum in strata {
+            if !seen.insert(stratum) {
+                continue;
+            }
+            if let Some((curve_times, _)) = self.curves.get(&stratum) {
                 times.extend(curve_times.iter().copied());
             }
         }
@@ -174,5 +178,6 @@ mod tests {
 
         assert_eq!(lookup.times_for_strata(&[0]), vec![1.0, 2.0]);
         assert_eq!(lookup.times_for_strata(&[1, 0]), vec![1.0, 2.0, 3.0]);
+        assert_eq!(lookup.times_for_strata(&[1, 0, 1, 0]), vec![1.0, 2.0, 3.0]);
     }
 }

--- a/src/regression/elastic_net.rs
+++ b/src/regression/elastic_net.rs
@@ -1,4 +1,6 @@
-use crate::internal::cox_risk::{cox_risk_shift, precompute_cox_risk_set_cumsum, shifted_exp_eta};
+use crate::internal::cox_risk::{
+    cox_risk_shift, precompute_cox_risk_set_cumsum, shifted_exp_eta, shifted_exp_eta_with_shift,
+};
 use crate::internal::matrix::{
     standardize_or_borrow_row_major_matrix, standardize_row_major_matrix,
 };
@@ -313,7 +315,7 @@ fn compute_cox_gradient_hessian(data: &ElasticNetData, beta: &[f64]) -> (Vec<f64
 fn compute_cox_deviance(data: &ElasticNetData, beta: &[f64]) -> f64 {
     let eta = linear_predictors(data, beta);
     let shift = cox_risk_shift(&eta, data.weights);
-    let exp_eta: Vec<f64> = eta.iter().map(|&eta_i| (eta_i - shift).exp()).collect();
+    let exp_eta = shifted_exp_eta_with_shift(&eta, data.weights, shift);
     let risk_data =
         precompute_cox_risk_set_cumsum(data.x, data.n, data.p, data.time, data.weights, &exp_eta);
 

--- a/src/regression/elastic_net.rs
+++ b/src/regression/elastic_net.rs
@@ -533,13 +533,12 @@ pub(crate) fn elastic_net_cox_path_typed(
             },
         );
 
-        beta_warm = beta_std.clone();
-
         let coefficients: Vec<f64> = beta_std
             .iter()
             .zip(sds.iter())
             .map(|(&b, &s)| if s > 0.0 { b / s } else { b })
             .collect();
+        beta_warm = beta_std;
 
         let df = coefficients
             .iter()

--- a/src/regression/elastic_net.rs
+++ b/src/regression/elastic_net.rs
@@ -384,8 +384,8 @@ pub(crate) fn elastic_net_cox_typed(
     let n_vars = input.covariates.n_vars;
     let time = &input.survival.time;
     let status = &input.survival.status;
-    let wt = input.weights_or_unit();
-    let off = input.offset_or_zero();
+    let wt = input.weights_or_unit_cow();
+    let off = input.offset_or_zero_cow();
 
     let (x_std, _means, sds) = if config.standardize {
         standardize_row_major_matrix(x, n_obs, n_vars)
@@ -399,8 +399,8 @@ pub(crate) fn elastic_net_cox_typed(
         p: n_vars,
         time,
         status,
-        weights: &wt,
-        offset: &off,
+        weights: wt.as_ref(),
+        offset: off.as_ref(),
     };
     let (beta_std, n_iter, converged) = coordinate_descent_cox(
         &fit_data,
@@ -437,8 +437,8 @@ pub(crate) fn elastic_net_cox_typed(
         p: n_vars,
         time,
         status,
-        weights: &wt,
-        offset: &off,
+        weights: wt.as_ref(),
+        offset: off.as_ref(),
     };
     let deviance = compute_cox_deviance(&deviance_data, &coefficients);
 
@@ -482,8 +482,8 @@ pub(crate) fn elastic_net_cox_path_typed(
     let n_vars = input.covariates.n_vars;
     let time = &input.survival.time;
     let status = &input.survival.status;
-    let wt = input.weights_or_unit();
-    let off = input.offset_or_zero();
+    let wt = input.weights_or_unit_cow();
+    let off = input.offset_or_zero_cow();
 
     let (x_std, _means, sds) = standardize_row_major_matrix(x, n_obs, n_vars);
 
@@ -494,8 +494,8 @@ pub(crate) fn elastic_net_cox_path_typed(
         p: n_vars,
         time,
         status,
-        weights: &wt,
-        offset: &off,
+        weights: wt.as_ref(),
+        offset: off.as_ref(),
     };
     let (gradient, _) = compute_cox_gradient_hessian(&fit_data, &beta_zero);
 
@@ -551,8 +551,8 @@ pub(crate) fn elastic_net_cox_path_typed(
             p: n_vars,
             time,
             status,
-            weights: &wt,
-            offset: &off,
+            weights: wt.as_ref(),
+            offset: off.as_ref(),
         };
         let deviance = compute_cox_deviance(&deviance_data, &coefficients);
 
@@ -604,8 +604,8 @@ pub(crate) fn elastic_net_cox_cv_typed(
     let n_vars = input.covariates.n_vars;
     let time = &input.survival.time;
     let status = &input.survival.status;
-    let wt = input.weights_or_unit();
-    let offset = input.offset_or_zero();
+    let wt = input.weights_or_unit_cow();
+    let offset = input.offset_or_zero_cow();
 
     let fold_assign: Vec<usize> = (0..n_obs).map(|i| i % config.n_folds).collect();
     let fold_indices: Vec<(Vec<usize>, Vec<usize>)> = (0..config.n_folds)
@@ -619,7 +619,8 @@ pub(crate) fn elastic_net_cox_cv_typed(
     let x_ref = x;
     let time_ref = time;
     let status_ref = status;
-    let wt_ref = &wt;
+    let wt_ref = wt.as_ref();
+    let offset_ref = offset.as_ref();
     let cv_deviances: Vec<Vec<f64>> = path
         .lambdas
         .par_iter()
@@ -643,7 +644,7 @@ pub(crate) fn elastic_net_cox_cv_typed(
                     let train_time: Vec<f64> = train_idx.iter().map(|&i| time_ref[i]).collect();
                     let train_status: Vec<i32> = train_idx.iter().map(|&i| status_ref[i]).collect();
                     let train_wt: Vec<f64> = train_idx.iter().map(|&i| wt_ref[i]).collect();
-                    let train_offset: Vec<f64> = train_idx.iter().map(|&i| offset[i]).collect();
+                    let train_offset: Vec<f64> = train_idx.iter().map(|&i| offset_ref[i]).collect();
 
                     let Ok(config) =
                         ElasticNetConfig::new(lambda, config.l1_ratio, 1000, 1e-7, true, false)
@@ -682,7 +683,7 @@ pub(crate) fn elastic_net_cox_cv_typed(
                         let test_status: Vec<i32> =
                             test_idx.iter().map(|&i| status_ref[i]).collect();
                         let test_wt: Vec<f64> = test_idx.iter().map(|&i| wt_ref[i]).collect();
-                        let test_off: Vec<f64> = test_idx.iter().map(|&i| offset[i]).collect();
+                        let test_off: Vec<f64> = test_idx.iter().map(|&i| offset_ref[i]).collect();
 
                         let test_data = ElasticNetData {
                             x: &test_x,

--- a/src/regression/elastic_net.rs
+++ b/src/regression/elastic_net.rs
@@ -1,5 +1,7 @@
 use crate::internal::cox_risk::{cox_risk_shift, precompute_cox_risk_set_cumsum, shifted_exp_eta};
-use crate::internal::matrix::standardize_row_major_matrix;
+use crate::internal::matrix::{
+    standardize_or_borrow_row_major_matrix, standardize_row_major_matrix,
+};
 use crate::internal::typed_inputs::{CovariateMatrix, CoxRegressionInput, SurvivalData, Weights};
 use pyo3::prelude::*;
 use rayon::prelude::*;
@@ -387,14 +389,11 @@ pub(crate) fn elastic_net_cox_typed(
     let wt = input.weights_or_unit_cow();
     let off = input.offset_or_zero_cow();
 
-    let (x_std, _means, sds) = if config.standardize {
-        standardize_row_major_matrix(x, n_obs, n_vars)
-    } else {
-        (x.to_vec(), vec![0.0; n_vars], vec![1.0; n_vars])
-    };
+    let (x_std, _means, sds) =
+        standardize_or_borrow_row_major_matrix(x, n_obs, n_vars, config.standardize);
 
     let fit_data = ElasticNetData {
-        x: &x_std,
+        x: x_std.as_ref(),
         n: n_obs,
         p: n_vars,
         time,
@@ -855,6 +854,12 @@ mod tests {
 
         let result = elastic_net_cox_typed(&input, &config).unwrap();
         assert_eq!(result.coefficients.len(), 2);
+
+        let unstandardized_config =
+            ElasticNetConfig::new(0.1, 0.5, 100, 1e-5, false, false).expect("config is valid");
+        let unstandardized = elastic_net_cox_typed(&input, &unstandardized_config).unwrap();
+        assert_eq!(unstandardized.coefficients.len(), 2);
+        assert!(unstandardized.scale_factors.is_none());
     }
 
     #[test]

--- a/src/regression/fast_cox/api.rs
+++ b/src/regression/fast_cox/api.rs
@@ -168,6 +168,22 @@ fn fast_cox_lambda_sequence(
         .collect()
 }
 
+fn unstandardize_fast_cox_coefficients(
+    beta_std: Vec<f64>,
+    sds: &[f64],
+    standardize: bool,
+) -> Vec<f64> {
+    if standardize {
+        beta_std
+            .iter()
+            .zip(sds.iter())
+            .map(|(&b, &s)| if s > 0.0 { b / s } else { b })
+            .collect()
+    } else {
+        beta_std
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn fit_fast_cox_coefficients(
     x: &[f64],
@@ -209,15 +225,7 @@ fn fit_fast_cox_coefficients(
             },
         );
 
-    let coefficients: Vec<f64> = if config.standardize {
-        beta_std
-            .iter()
-            .zip(sds.iter())
-            .map(|(&b, &s)| if s > 0.0 { b / s } else { b })
-            .collect()
-    } else {
-        beta_std
-    };
+    let coefficients = unstandardize_fast_cox_coefficients(beta_std, &sds, config.standardize);
 
     FastCoxCoefficientFit {
         coefficients,
@@ -581,6 +589,18 @@ pub(crate) fn fast_cox_cv_typed(
                 weights: &fold.test_wt,
                 offset: &fold.test_offset,
             };
+            let (train_x_std, _train_means, train_sds) =
+                standardize_row_major_matrix(&fold.train_x, train_n, n_vars);
+            let train_data = FastCoxData {
+                x: &train_x_std,
+                n: train_n,
+                p: n_vars,
+                time: &fold.train_time,
+                status: &fold.train_status,
+                weights: &fold.train_wt,
+                offset: &fold.train_offset,
+            };
+            let train_lambda_max = fast_cox_lambda_max(&train_data, 1.0);
 
             for (lambda_idx, &lambda) in lambdas.iter().enumerate() {
                 let Ok(fit_config) = FastCoxConfig::new(
@@ -597,19 +617,24 @@ pub(crate) fn fast_cox_cv_typed(
                     continue;
                 };
 
-                let fit = fit_fast_cox_coefficients(
-                    &fold.train_x,
-                    train_n,
-                    n_vars,
-                    &fold.train_time,
-                    &fold.train_status,
-                    &fit_config,
-                    &fold.train_wt,
-                    &fold.train_offset,
+                let (beta_std, _n_iter, _conv, _screened, _active) = cyclic_coordinate_descent_fast(
+                    &train_data,
+                    FastCoxDescentConfig {
+                        lambda: fit_config.lambda,
+                        l1_ratio: fit_config.l1_ratio,
+                        max_iter: fit_config.max_iter,
+                        tol: fit_config.tol,
+                        beta_init: None,
+                        screening: fit_config.screening,
+                        active_set_update_freq: fit_config.active_set_update_freq,
+                        lambda_prev: None,
+                        lambda_max: train_lambda_max,
+                    },
                 );
+                let coefficients = unstandardize_fast_cox_coefficients(beta_std, &train_sds, true);
                 let deviance = compute_cox_deviance_into(
                     &test_data,
-                    &fit.coefficients,
+                    &coefficients,
                     &mut deviance_eta,
                     &mut deviance_exp_eta,
                     &mut deviance_risk_data,

--- a/src/regression/fast_cox/api.rs
+++ b/src/regression/fast_cox/api.rs
@@ -30,15 +30,12 @@ fn fast_cox_slices(
         }
     };
 
-    let (x_std, means, sds) = if config.standardize {
-        standardize_row_major_matrix(x, n_obs, n_vars)
-    } else {
-        (x.to_vec(), vec![0.0; n_vars], vec![1.0; n_vars])
-    };
+    let (x_std, means, sds) =
+        standardize_or_borrow_row_major_matrix(x, n_obs, n_vars, config.standardize);
 
     let beta_zero = vec![0.0; n_vars];
     let fit_data = FastCoxData {
-        x: &x_std,
+        x: x_std.as_ref(),
         n: n_obs,
         p: n_vars,
         time,

--- a/src/regression/fast_cox/api.rs
+++ b/src/regression/fast_cox/api.rs
@@ -188,6 +188,19 @@ fn unstandardize_standard_fast_cox_coefficients(beta_std: &[f64], sds: &[f64]) -
         .collect()
 }
 
+fn unstandardize_standard_fast_cox_coefficients_into(
+    beta_std: &[f64],
+    sds: &[f64],
+    coefficients: &mut Vec<f64>,
+) {
+    debug_assert_eq!(beta_std.len(), sds.len());
+    coefficients.resize(beta_std.len(), 0.0);
+    for ((coefficient, &beta), &sd) in coefficients.iter_mut().zip(beta_std.iter()).zip(sds.iter())
+    {
+        *coefficient = if sd > 0.0 { beta / sd } else { beta };
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn fit_fast_cox_coefficients(
     x: &[f64],
@@ -570,7 +583,7 @@ pub(crate) fn fast_cox_cv_typed(
         })
         .collect();
 
-    let fold_deviance_summaries: Vec<FastCoxCvDevianceSummary> = folds
+    let cv_deviance_summary = folds
         .par_iter()
         .map(|fold| {
             let mut summary = FastCoxCvDevianceSummary::with_len(lambdas.len());
@@ -606,6 +619,7 @@ pub(crate) fn fast_cox_cv_typed(
             };
             let train_lambda_max = fast_cox_lambda_max(&train_data, 1.0);
             let mut beta_warm = vec![0.0; n_vars];
+            let mut coefficients = Vec::with_capacity(n_vars);
             let mut lambda_prev: Option<f64> = None;
 
             for (lambda_idx, &lambda) in lambdas.iter().enumerate() {
@@ -623,8 +637,11 @@ pub(crate) fn fast_cox_cv_typed(
                         lambda_max: train_lambda_max,
                     },
                 );
-                let coefficients =
-                    unstandardize_standard_fast_cox_coefficients(&beta_std, &train_sds);
+                unstandardize_standard_fast_cox_coefficients_into(
+                    &beta_std,
+                    &train_sds,
+                    &mut coefficients,
+                );
                 beta_warm = beta_std;
                 lambda_prev = Some(lambda);
                 let deviance = compute_cox_deviance_into(
@@ -640,12 +657,13 @@ pub(crate) fn fast_cox_cv_typed(
 
             summary
         })
-        .collect();
-
-    let mut cv_deviance_summary = FastCoxCvDevianceSummary::with_len(lambdas.len());
-    for fold_summary in fold_deviance_summaries {
-        cv_deviance_summary.merge(fold_summary);
-    }
+        .reduce(
+            || FastCoxCvDevianceSummary::with_len(lambdas.len()),
+            |mut combined, fold_summary| {
+                combined.merge(fold_summary);
+                combined
+            },
+        );
 
     let mean_deviances = cv_deviance_summary.mean_deviances();
     let se_deviances = cv_deviance_summary.se_deviances(&mean_deviances);

--- a/src/regression/fast_cox/api.rs
+++ b/src/regression/fast_cox/api.rs
@@ -139,6 +139,35 @@ struct FastCoxCoefficientFit {
     active_set_size: usize,
 }
 
+fn fast_cox_lambda_max(data: &FastCoxData, l1_ratio: f64) -> f64 {
+    let beta_zero = vec![0.0; data.p];
+    let (gradient, _) = compute_gradient_hessian_diag_fast(data, &beta_zero, None);
+
+    gradient.iter().map(|g| g.abs()).fold(0.0, f64::max) / (data.n as f64 * l1_ratio.max(0.001))
+}
+
+fn fast_cox_lambda_sequence(
+    data: &FastCoxData,
+    l1_ratio: f64,
+    n_lambda: usize,
+    lambda_min_ratio: Option<f64>,
+) -> Vec<f64> {
+    let lambda_max = fast_cox_lambda_max(data, l1_ratio);
+    if lambda_max == 0.0 {
+        return vec![0.0; n_lambda];
+    }
+
+    let min_ratio = lambda_min_ratio.unwrap_or(if data.n < data.p { 0.01 } else { 0.0001 });
+    let lambda_min = lambda_max * min_ratio;
+
+    (0..n_lambda)
+        .map(|i| {
+            let frac = i as f64 / (n_lambda - 1).max(1) as f64;
+            lambda_max * (lambda_min / lambda_max).powf(frac)
+        })
+        .collect()
+}
+
 #[allow(clippy::too_many_arguments)]
 fn fit_fast_cox_coefficients(
     x: &[f64],
@@ -153,7 +182,6 @@ fn fit_fast_cox_coefficients(
     let (x_std, means, sds) =
         standardize_or_borrow_row_major_matrix(x, n_obs, n_vars, config.standardize);
 
-    let beta_zero = vec![0.0; n_vars];
     let fit_data = FastCoxData {
         x: x_std.as_ref(),
         n: n_obs,
@@ -163,8 +191,7 @@ fn fit_fast_cox_coefficients(
         weights: wt,
         offset: off,
     };
-    let (gradient, _) = compute_gradient_hessian_diag_fast(&fit_data, &beta_zero, None);
-    let lambda_max = gradient.iter().map(|g| g.abs()).fold(0.0, f64::max) / n_obs as f64;
+    let lambda_max = fast_cox_lambda_max(&fit_data, 1.0);
 
     let (beta_std, n_iter, converged, screened_out, active_set_size) =
         cyclic_coordinate_descent_fast(
@@ -363,7 +390,6 @@ pub(crate) fn fast_cox_path_typed(
 
     let (x_std, _means, sds) = standardize_row_major_matrix(x, n_obs, n_vars);
 
-    let beta_zero = vec![0.0; n_vars];
     let fit_data = FastCoxData {
         x: &x_std,
         n: n_obs,
@@ -373,22 +399,13 @@ pub(crate) fn fast_cox_path_typed(
         weights: wt.as_ref(),
         offset: off.as_ref(),
     };
-    let (gradient, _) = compute_gradient_hessian_diag_fast(&fit_data, &beta_zero, None);
-
-    let lambda_max = gradient.iter().map(|g| g.abs()).fold(0.0, f64::max)
-        / (n_obs as f64 * config.l1_ratio.max(0.001));
-
-    let min_ratio = config
-        .lambda_min_ratio
-        .unwrap_or(if n_obs < n_vars { 0.01 } else { 0.0001 });
-    let lambda_min = lambda_max * min_ratio;
-
-    let lambdas: Vec<f64> = (0..config.n_lambda)
-        .map(|i| {
-            let frac = i as f64 / (config.n_lambda - 1).max(1) as f64;
-            lambda_max * (lambda_min / lambda_max).powf(frac)
-        })
-        .collect();
+    let lambdas = fast_cox_lambda_sequence(
+        &fit_data,
+        config.l1_ratio,
+        config.n_lambda,
+        config.lambda_min_ratio,
+    );
+    let lambda_max = lambdas.first().copied().unwrap_or(0.0);
 
     let mut all_coefficients = Vec::with_capacity(config.n_lambda);
     let mut all_deviances = Vec::with_capacity(config.n_lambda);
@@ -485,16 +502,6 @@ pub(crate) fn fast_cox_cv_typed(
         }
     };
 
-    let path_config = FastCoxPathConfig {
-        l1_ratio: config.l1_ratio,
-        n_lambda: config.n_lambda,
-        lambda_min_ratio: None,
-        max_iter: 1000,
-        tol: 1e-7,
-        screening: config.screening,
-    };
-    let path = fast_cox_path_typed(input, Some(&path_config))?;
-
     let x = &input.covariates.values;
     let n_obs = input.covariates.n_obs;
     let n_vars = input.covariates.n_vars;
@@ -502,6 +509,17 @@ pub(crate) fn fast_cox_cv_typed(
     let status = &input.survival.status;
     let wt = input.weights_or_unit_cow();
     let offset = input.offset_or_zero_cow();
+    let (x_std, _means, _sds) = standardize_row_major_matrix(x, n_obs, n_vars);
+    let lambda_data = FastCoxData {
+        x: &x_std,
+        n: n_obs,
+        p: n_vars,
+        time,
+        status,
+        weights: wt.as_ref(),
+        offset: offset.as_ref(),
+    };
+    let lambdas = fast_cox_lambda_sequence(&lambda_data, config.l1_ratio, config.n_lambda, None);
 
     let mut rng =
         fastrand::Rng::with_seed(config.seed.unwrap_or(crate::constants::DEFAULT_RANDOM_SEED));
@@ -543,7 +561,7 @@ pub(crate) fn fast_cox_cv_typed(
     let fold_deviance_summaries: Vec<FastCoxCvDevianceSummary> = folds
         .par_iter()
         .map(|fold| {
-            let mut summary = FastCoxCvDevianceSummary::with_len(path.lambdas.len());
+            let mut summary = FastCoxCvDevianceSummary::with_len(lambdas.len());
             let train_n = fold.train_time.len();
             let test_n = fold.test_time.len();
             if train_n == 0 || test_n == 0 {
@@ -564,7 +582,7 @@ pub(crate) fn fast_cox_cv_typed(
                 offset: &fold.test_offset,
             };
 
-            for (lambda_idx, &lambda) in path.lambdas.iter().enumerate() {
+            for (lambda_idx, &lambda) in lambdas.iter().enumerate() {
                 let Ok(fit_config) = FastCoxConfig::new(
                     lambda,
                     config.l1_ratio,
@@ -604,7 +622,7 @@ pub(crate) fn fast_cox_cv_typed(
         })
         .collect();
 
-    let mut cv_deviance_summary = FastCoxCvDevianceSummary::with_len(path.lambdas.len());
+    let mut cv_deviance_summary = FastCoxCvDevianceSummary::with_len(lambdas.len());
     for fold_summary in fold_deviance_summaries {
         cv_deviance_summary.merge(fold_summary);
     }
@@ -618,14 +636,14 @@ pub(crate) fn fast_cox_cv_typed(
         .min_by(|(_, a), (_, b)| a.total_cmp(b))
         .unwrap_or((0, &f64::INFINITY));
 
-    let lambda_min = path.lambdas[min_idx];
+    let lambda_min = lambdas[min_idx];
 
     let threshold = min_dev + se_deviances[min_idx];
     let lambda_1se = mean_deviances
         .iter()
         .enumerate()
         .filter(|(_, d)| **d <= threshold)
-        .map(|(i, _)| path.lambdas[i])
+        .map(|(i, _)| lambdas[i])
         .next()
         .unwrap_or(lambda_min);
 

--- a/src/regression/fast_cox/api.rs
+++ b/src/regression/fast_cox/api.rs
@@ -129,36 +129,27 @@ impl FastCoxCvDevianceSummary {
     }
 }
 
+struct FastCoxCoefficientFit {
+    coefficients: Vec<f64>,
+    n_iter: usize,
+    converged: bool,
+    scale_factors: Option<Vec<f64>>,
+    center_values: Option<Vec<f64>>,
+    screened_out: usize,
+    active_set_size: usize,
+}
+
 #[allow(clippy::too_many_arguments)]
-fn fast_cox_slices(
+fn fit_fast_cox_coefficients(
     x: &[f64],
     n_obs: usize,
     n_vars: usize,
     time: &[f64],
     status: &[i32],
     config: &FastCoxConfig,
-    weights: Option<&[f64]>,
-    offset: Option<&[f64]>,
-) -> SurvivalResult<FastCoxResult> {
-    CoxRegressionInput::validate_slices(x, n_obs, n_vars, time, status, weights, offset)?;
-
-    let wt_owned;
-    let wt = match weights {
-        Some(weights) => weights,
-        None => {
-            wt_owned = vec![1.0; n_obs];
-            &wt_owned
-        }
-    };
-    let off_owned;
-    let off = match offset {
-        Some(offset) => offset,
-        None => {
-            off_owned = vec![0.0; n_obs];
-            &off_owned
-        }
-    };
-
+    wt: &[f64],
+    off: &[f64],
+) -> FastCoxCoefficientFit {
     let (x_std, means, sds) =
         standardize_or_borrow_row_major_matrix(x, n_obs, n_vars, config.standardize);
 
@@ -201,7 +192,55 @@ fn fast_cox_slices(
         beta_std
     };
 
-    let nonzero_indices: Vec<usize> = coefficients
+    FastCoxCoefficientFit {
+        coefficients,
+        n_iter,
+        converged,
+        scale_factors: if config.standardize { Some(sds) } else { None },
+        center_values: if config.standardize {
+            Some(means)
+        } else {
+            None
+        },
+        screened_out,
+        active_set_size,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn fast_cox_slices(
+    x: &[f64],
+    n_obs: usize,
+    n_vars: usize,
+    time: &[f64],
+    status: &[i32],
+    config: &FastCoxConfig,
+    weights: Option<&[f64]>,
+    offset: Option<&[f64]>,
+) -> SurvivalResult<FastCoxResult> {
+    CoxRegressionInput::validate_slices(x, n_obs, n_vars, time, status, weights, offset)?;
+
+    let wt_owned;
+    let wt = match weights {
+        Some(weights) => weights,
+        None => {
+            wt_owned = vec![1.0; n_obs];
+            &wt_owned
+        }
+    };
+    let off_owned;
+    let off = match offset {
+        Some(offset) => offset,
+        None => {
+            off_owned = vec![0.0; n_obs];
+            &off_owned
+        }
+    };
+
+    let fit = fit_fast_cox_coefficients(x, n_obs, n_vars, time, status, config, wt, off);
+
+    let nonzero_indices: Vec<usize> = fit
+        .coefficients
         .iter()
         .enumerate()
         .filter(|(_, c)| c.abs() > crate::constants::DIVISION_FLOOR)
@@ -218,25 +257,21 @@ fn fast_cox_slices(
         weights: wt,
         offset: off,
     };
-    let deviance = compute_cox_deviance(&deviance_data, &coefficients);
+    let deviance = compute_cox_deviance(&deviance_data, &fit.coefficients);
 
     Ok(FastCoxResult {
-        coefficients,
+        coefficients: fit.coefficients,
         nonzero_indices,
         lambda_used: config.lambda,
         l1_ratio: config.l1_ratio,
-        n_iter,
-        converged,
+        n_iter: fit.n_iter,
+        converged: fit.converged,
         deviance,
         df,
-        scale_factors: if config.standardize { Some(sds) } else { None },
-        center_values: if config.standardize {
-            Some(means)
-        } else {
-            None
-        },
-        screened_out,
-        active_set_size,
+        scale_factors: fit.scale_factors,
+        center_values: fit.center_values,
+        screened_out: fit.screened_out,
+        active_set_size: fit.active_set_size,
     })
 }
 
@@ -544,26 +579,25 @@ pub(crate) fn fast_cox_cv_typed(
                     continue;
                 };
 
-                if let Ok(result) = fast_cox_slices(
+                let fit = fit_fast_cox_coefficients(
                     &fold.train_x,
                     train_n,
                     n_vars,
                     &fold.train_time,
                     &fold.train_status,
                     &fit_config,
-                    Some(&fold.train_wt),
-                    Some(&fold.train_offset),
-                ) {
-                    let deviance = compute_cox_deviance_into(
-                        &test_data,
-                        &result.coefficients,
-                        &mut deviance_eta,
-                        &mut deviance_exp_eta,
-                        &mut deviance_risk_data,
-                        &mut deviance_risk_scratch,
-                    );
-                    summary.record(lambda_idx, deviance);
-                }
+                    &fold.train_wt,
+                    &fold.train_offset,
+                );
+                let deviance = compute_cox_deviance_into(
+                    &test_data,
+                    &fit.coefficients,
+                    &mut deviance_eta,
+                    &mut deviance_exp_eta,
+                    &mut deviance_risk_data,
+                    &mut deviance_risk_scratch,
+                );
+                summary.record(lambda_idx, deviance);
             }
 
             summary

--- a/src/regression/fast_cox/api.rs
+++ b/src/regression/fast_cox/api.rs
@@ -297,6 +297,19 @@ pub(crate) fn fast_cox_path_typed(
 
     let mut beta_warm = vec![0.0; n_vars];
     let mut lambda_prev: Option<f64> = None;
+    let mut deviance_eta = vec![0.0; n_obs];
+    let mut deviance_exp_eta = vec![0.0; n_obs];
+    let mut deviance_risk_data = CoxRiskSetData::with_capacity(n_obs, n_vars);
+    let mut deviance_risk_scratch = CoxRiskSetScratch::with_capacity(n_obs, n_vars);
+    let deviance_data = FastCoxData {
+        x,
+        n: n_obs,
+        p: n_vars,
+        time,
+        status,
+        weights: wt.as_ref(),
+        offset: off.as_ref(),
+    };
 
     for &lambda in lambdas.iter() {
         let (beta_std, n_iter, conv, _screened, _active) = cyclic_coordinate_descent_fast(
@@ -326,16 +339,14 @@ pub(crate) fn fast_cox_path_typed(
             .iter()
             .filter(|&&c| c.abs() > crate::constants::DIVISION_FLOOR)
             .count() as f64;
-        let deviance_data = FastCoxData {
-            x,
-            n: n_obs,
-            p: n_vars,
-            time,
-            status,
-            weights: wt.as_ref(),
-            offset: off.as_ref(),
-        };
-        let deviance = compute_cox_deviance(&deviance_data, &coefficients);
+        let deviance = compute_cox_deviance_into(
+            &deviance_data,
+            &coefficients,
+            &mut deviance_eta,
+            &mut deviance_exp_eta,
+            &mut deviance_risk_data,
+            &mut deviance_risk_scratch,
+        );
 
         all_coefficients.push(coefficients);
         all_deviances.push(deviance);

--- a/src/regression/fast_cox/api.rs
+++ b/src/regression/fast_cox/api.rs
@@ -1,5 +1,71 @@
 use crate::internal::typed_inputs::{CovariateMatrix, CoxRegressionInput, SurvivalData, Weights};
 
+struct FastCoxCvFold {
+    train_x: Vec<f64>,
+    train_time: Vec<f64>,
+    train_status: Vec<i32>,
+    train_wt: Vec<f64>,
+    train_offset: Vec<f64>,
+    test_x: Vec<f64>,
+    test_time: Vec<f64>,
+    test_status: Vec<i32>,
+    test_wt: Vec<f64>,
+    test_offset: Vec<f64>,
+}
+
+impl FastCoxCvFold {
+    fn with_capacity(train_n: usize, test_n: usize, n_vars: usize) -> Self {
+        Self {
+            train_x: Vec::with_capacity(train_n * n_vars),
+            train_time: Vec::with_capacity(train_n),
+            train_status: Vec::with_capacity(train_n),
+            train_wt: Vec::with_capacity(train_n),
+            train_offset: Vec::with_capacity(train_n),
+            test_x: Vec::with_capacity(test_n * n_vars),
+            test_time: Vec::with_capacity(test_n),
+            test_status: Vec::with_capacity(test_n),
+            test_wt: Vec::with_capacity(test_n),
+            test_offset: Vec::with_capacity(test_n),
+        }
+    }
+
+    fn push_train(
+        &mut self,
+        idx: usize,
+        x: &[f64],
+        n_vars: usize,
+        time: &[f64],
+        status: &[i32],
+        wt: &[f64],
+        offset: &[f64],
+    ) {
+        let start = idx * n_vars;
+        self.train_x.extend_from_slice(&x[start..start + n_vars]);
+        self.train_time.push(time[idx]);
+        self.train_status.push(status[idx]);
+        self.train_wt.push(wt[idx]);
+        self.train_offset.push(offset[idx]);
+    }
+
+    fn push_test(
+        &mut self,
+        idx: usize,
+        x: &[f64],
+        n_vars: usize,
+        time: &[f64],
+        status: &[i32],
+        wt: &[f64],
+        offset: &[f64],
+    ) {
+        let start = idx * n_vars;
+        self.test_x.extend_from_slice(&x[start..start + n_vars]);
+        self.test_time.push(time[idx]);
+        self.test_status.push(status[idx]);
+        self.test_wt.push(wt[idx]);
+        self.test_offset.push(offset[idx]);
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn fast_cox_slices(
     x: &[f64],
@@ -333,39 +399,47 @@ pub(crate) fn fast_cox_cv_typed(
         fold_assign.swap(i, j);
     }
 
-    let fold_indices: Vec<(Vec<usize>, Vec<usize>)> = (0..config.n_folds)
+    let mut fold_counts = vec![0usize; config.n_folds];
+    for &fold in &fold_assign {
+        fold_counts[fold] += 1;
+    }
+
+    let folds: Vec<FastCoxCvFold> = (0..config.n_folds)
         .map(|fold| {
-            let train_idx: Vec<usize> = (0..n_obs).filter(|&i| fold_assign[i] != fold).collect();
-            let test_idx: Vec<usize> = (0..n_obs).filter(|&i| fold_assign[i] == fold).collect();
-            (train_idx, test_idx)
+            let test_n = fold_counts[fold];
+            let train_n = n_obs - test_n;
+            let mut fold_data = FastCoxCvFold::with_capacity(train_n, test_n, n_vars);
+            for idx in 0..n_obs {
+                if fold_assign[idx] == fold {
+                    fold_data.push_test(idx, x, n_vars, time, status, wt.as_ref(), offset.as_ref());
+                } else {
+                    fold_data.push_train(
+                        idx,
+                        x,
+                        n_vars,
+                        time,
+                        status,
+                        wt.as_ref(),
+                        offset.as_ref(),
+                    );
+                }
+            }
+            fold_data
         })
         .collect();
 
-    let x_ref = x;
-    let time_ref = time;
-    let status_ref = status;
-    let wt_ref = wt.as_ref();
-    let offset_ref = offset.as_ref();
     let cv_deviances: Vec<Vec<f64>> = path
         .lambdas
         .par_iter()
         .map(|&lambda| {
-            let fold_devs_by_fold: Vec<Option<f64>> = fold_indices
+            let fold_devs_by_fold: Vec<Option<f64>> = folds
                 .par_iter()
-                .map(|(train_idx, test_idx)| {
-                    if train_idx.is_empty() || test_idx.is_empty() {
+                .map(|fold| {
+                    let train_n = fold.train_time.len();
+                    let test_n = fold.test_time.len();
+                    if train_n == 0 || test_n == 0 {
                         return None;
                     }
-
-                    let train_x: Vec<f64> = train_idx
-                        .iter()
-                        .flat_map(|&i| (0..n_vars).map(move |j| x_ref[i * n_vars + j]))
-                        .collect();
-                    let train_time: Vec<f64> = train_idx.iter().map(|&i| time_ref[i]).collect();
-                    let train_status: Vec<i32> = train_idx.iter().map(|&i| status_ref[i]).collect();
-                    let train_wt: Vec<f64> = train_idx.iter().map(|&i| wt_ref[i]).collect();
-                    let train_offset: Vec<f64> =
-                        train_idx.iter().map(|&i| offset_ref[i]).collect();
 
                     let Ok(fit_config) = FastCoxConfig::new(
                         lambda,
@@ -381,44 +455,24 @@ pub(crate) fn fast_cox_cv_typed(
                         return None;
                     };
 
-                    let Ok(train_input) = CoxRegressionInput::try_new(
-                        match CovariateMatrix::try_new(train_x, train_idx.len(), n_vars) {
-                            Ok(covariates) => covariates,
-                            Err(_) => return None,
-                        },
-                        match SurvivalData::try_new(train_time, train_status) {
-                            Ok(survival) => survival,
-                            Err(_) => return None,
-                        },
-                        match Weights::try_new(train_wt) {
-                            Ok(weights) => Some(weights),
-                            Err(_) => return None,
-                        },
-                        Some(train_offset),
-                    ) else {
-                        return None;
-                    };
-
-                    if let Ok(result) = fast_cox_typed(&train_input, &fit_config) {
-                        let test_x: Vec<f64> = test_idx
-                            .iter()
-                            .flat_map(|&i| (0..n_vars).map(move |j| x_ref[i * n_vars + j]))
-                            .collect();
-                        let test_time: Vec<f64> = test_idx.iter().map(|&i| time_ref[i]).collect();
-                        let test_status: Vec<i32> =
-                            test_idx.iter().map(|&i| status_ref[i]).collect();
-                        let test_wt: Vec<f64> = test_idx.iter().map(|&i| wt_ref[i]).collect();
-                        let test_off: Vec<f64> =
-                            test_idx.iter().map(|&i| offset_ref[i]).collect();
-
+                    if let Ok(result) = fast_cox_slices(
+                        &fold.train_x,
+                        train_n,
+                        n_vars,
+                        &fold.train_time,
+                        &fold.train_status,
+                        &fit_config,
+                        Some(&fold.train_wt),
+                        Some(&fold.train_offset),
+                    ) {
                         let test_data = FastCoxData {
-                            x: &test_x,
-                            n: test_idx.len(),
+                            x: &fold.test_x,
+                            n: test_n,
                             p: n_vars,
-                            time: &test_time,
-                            status: &test_status,
-                            weights: &test_wt,
-                            offset: &test_off,
+                            time: &fold.test_time,
+                            status: &fold.test_status,
+                            weights: &fold.test_wt,
+                            offset: &fold.test_offset,
                         };
                         let dev = compute_cox_deviance(&test_data, &result.coefficients);
                         Some(dev)

--- a/src/regression/fast_cox/api.rs
+++ b/src/regression/fast_cox/api.rs
@@ -194,8 +194,8 @@ pub(crate) fn fast_cox_path_typed(
     let n_vars = input.covariates.n_vars;
     let time = &input.survival.time;
     let status = &input.survival.status;
-    let wt = input.weights_or_unit();
-    let off = input.offset_or_zero();
+    let wt = input.weights_or_unit_cow();
+    let off = input.offset_or_zero_cow();
 
     let (x_std, _means, sds) = standardize_row_major_matrix(x, n_obs, n_vars);
 
@@ -206,8 +206,8 @@ pub(crate) fn fast_cox_path_typed(
         p: n_vars,
         time,
         status,
-        weights: &wt,
-        offset: &off,
+        weights: wt.as_ref(),
+        offset: off.as_ref(),
     };
     let (gradient, _) = compute_gradient_hessian_diag_fast(&fit_data, &beta_zero, None);
 
@@ -270,8 +270,8 @@ pub(crate) fn fast_cox_path_typed(
             p: n_vars,
             time,
             status,
-            weights: &wt,
-            offset: &off,
+            weights: wt.as_ref(),
+            offset: off.as_ref(),
         };
         let deviance = compute_cox_deviance(&deviance_data, &coefficients);
 
@@ -326,8 +326,8 @@ pub(crate) fn fast_cox_cv_typed(
     let n_vars = input.covariates.n_vars;
     let time = &input.survival.time;
     let status = &input.survival.status;
-    let wt = input.weights_or_unit();
-    let offset = input.offset_or_zero();
+    let wt = input.weights_or_unit_cow();
+    let offset = input.offset_or_zero_cow();
 
     let mut rng =
         fastrand::Rng::with_seed(config.seed.unwrap_or(crate::constants::DEFAULT_RANDOM_SEED));
@@ -348,7 +348,8 @@ pub(crate) fn fast_cox_cv_typed(
     let x_ref = x;
     let time_ref = time;
     let status_ref = status;
-    let wt_ref = &wt;
+    let wt_ref = wt.as_ref();
+    let offset_ref = offset.as_ref();
     let cv_deviances: Vec<Vec<f64>> = path
         .lambdas
         .par_iter()
@@ -367,7 +368,8 @@ pub(crate) fn fast_cox_cv_typed(
                     let train_time: Vec<f64> = train_idx.iter().map(|&i| time_ref[i]).collect();
                     let train_status: Vec<i32> = train_idx.iter().map(|&i| status_ref[i]).collect();
                     let train_wt: Vec<f64> = train_idx.iter().map(|&i| wt_ref[i]).collect();
-                    let train_offset: Vec<f64> = train_idx.iter().map(|&i| offset[i]).collect();
+                    let train_offset: Vec<f64> =
+                        train_idx.iter().map(|&i| offset_ref[i]).collect();
 
                     let Ok(fit_config) = FastCoxConfig::new(
                         lambda,
@@ -410,7 +412,8 @@ pub(crate) fn fast_cox_cv_typed(
                         let test_status: Vec<i32> =
                             test_idx.iter().map(|&i| status_ref[i]).collect();
                         let test_wt: Vec<f64> = test_idx.iter().map(|&i| wt_ref[i]).collect();
-                        let test_off: Vec<f64> = test_idx.iter().map(|&i| offset[i]).collect();
+                        let test_off: Vec<f64> =
+                            test_idx.iter().map(|&i| offset_ref[i]).collect();
 
                         let test_data = FastCoxData {
                             x: &test_x,

--- a/src/regression/fast_cox/api.rs
+++ b/src/regression/fast_cox/api.rs
@@ -66,6 +66,69 @@ impl FastCoxCvFold {
     }
 }
 
+struct FastCoxCvDevianceSummary {
+    sums: Vec<f64>,
+    sum_squares: Vec<f64>,
+    counts: Vec<usize>,
+}
+
+impl FastCoxCvDevianceSummary {
+    fn with_len(n_lambda: usize) -> Self {
+        Self {
+            sums: vec![0.0; n_lambda],
+            sum_squares: vec![0.0; n_lambda],
+            counts: vec![0; n_lambda],
+        }
+    }
+
+    fn record(&mut self, lambda_idx: usize, deviance: f64) {
+        self.sums[lambda_idx] += deviance;
+        self.sum_squares[lambda_idx] += deviance * deviance;
+        self.counts[lambda_idx] += 1;
+    }
+
+    fn merge(&mut self, other: Self) {
+        for lambda_idx in 0..self.sums.len() {
+            self.sums[lambda_idx] += other.sums[lambda_idx];
+            self.sum_squares[lambda_idx] += other.sum_squares[lambda_idx];
+            self.counts[lambda_idx] += other.counts[lambda_idx];
+        }
+    }
+
+    fn mean_deviances(&self) -> Vec<f64> {
+        self.sums
+            .iter()
+            .zip(self.counts.iter())
+            .map(|(&sum, &count)| {
+                if count == 0 {
+                    f64::INFINITY
+                } else {
+                    sum / count as f64
+                }
+            })
+            .collect()
+    }
+
+    fn se_deviances(&self, mean_deviances: &[f64]) -> Vec<f64> {
+        self.counts
+            .iter()
+            .enumerate()
+            .map(|(lambda_idx, &count)| {
+                if count < 2 {
+                    f64::INFINITY
+                } else {
+                    let mean = mean_deviances[lambda_idx];
+                    let centered_sum_squares = self.sum_squares[lambda_idx]
+                        - 2.0 * mean * self.sums[lambda_idx]
+                        + count as f64 * mean * mean;
+                    let variance = centered_sum_squares.max(0.0) / (count - 1) as f64;
+                    (variance / count as f64).sqrt()
+                }
+            })
+            .collect()
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn fast_cox_slices(
     x: &[f64],
@@ -227,7 +290,10 @@ pub(crate) fn fast_cox_typed(
         &input.survival.time,
         &input.survival.status,
         config,
-        input.weights.as_ref().map(|weights| weights.values.as_slice()),
+        input
+            .weights
+            .as_ref()
+            .map(|weights| weights.values.as_slice()),
         input.offset.as_deref(),
     )
 }
@@ -439,88 +505,78 @@ pub(crate) fn fast_cox_cv_typed(
         })
         .collect();
 
-    let cv_deviances: Vec<Vec<f64>> = path
-        .lambdas
+    let fold_deviance_summaries: Vec<FastCoxCvDevianceSummary> = folds
         .par_iter()
-        .map(|&lambda| {
-            let fold_devs_by_fold: Vec<Option<f64>> = folds
-                .par_iter()
-                .map(|fold| {
-                    let train_n = fold.train_time.len();
-                    let test_n = fold.test_time.len();
-                    if train_n == 0 || test_n == 0 {
-                        return None;
-                    }
-
-                    let Ok(fit_config) = FastCoxConfig::new(
-                        lambda,
-                        config.l1_ratio,
-                        1000,
-                        1e-7,
-                        config.screening,
-                        None,
-                        10,
-                        true,
-                        true,
-                    ) else {
-                        return None;
-                    };
-
-                    if let Ok(result) = fast_cox_slices(
-                        &fold.train_x,
-                        train_n,
-                        n_vars,
-                        &fold.train_time,
-                        &fold.train_status,
-                        &fit_config,
-                        Some(&fold.train_wt),
-                        Some(&fold.train_offset),
-                    ) {
-                        let test_data = FastCoxData {
-                            x: &fold.test_x,
-                            n: test_n,
-                            p: n_vars,
-                            time: &fold.test_time,
-                            status: &fold.test_status,
-                            weights: &fold.test_wt,
-                            offset: &fold.test_offset,
-                        };
-                        let dev = compute_cox_deviance(&test_data, &result.coefficients);
-                        Some(dev)
-                    } else {
-                        None
-                    }
-                })
-                .collect();
-
-            fold_devs_by_fold.into_iter().flatten().collect()
-        })
-        .collect();
-
-    let mean_deviances: Vec<f64> = cv_deviances
-        .iter()
-        .map(|devs| {
-            if devs.is_empty() {
-                f64::INFINITY
-            } else {
-                devs.iter().sum::<f64>() / devs.len() as f64
+        .map(|fold| {
+            let mut summary = FastCoxCvDevianceSummary::with_len(path.lambdas.len());
+            let train_n = fold.train_time.len();
+            let test_n = fold.test_time.len();
+            if train_n == 0 || test_n == 0 {
+                return summary;
             }
+
+            let mut deviance_eta = vec![0.0; test_n];
+            let mut deviance_exp_eta = vec![0.0; test_n];
+            let mut deviance_risk_data = CoxRiskSetData::with_capacity(test_n, n_vars);
+            let mut deviance_risk_scratch = CoxRiskSetScratch::with_capacity(test_n, n_vars);
+            let test_data = FastCoxData {
+                x: &fold.test_x,
+                n: test_n,
+                p: n_vars,
+                time: &fold.test_time,
+                status: &fold.test_status,
+                weights: &fold.test_wt,
+                offset: &fold.test_offset,
+            };
+
+            for (lambda_idx, &lambda) in path.lambdas.iter().enumerate() {
+                let Ok(fit_config) = FastCoxConfig::new(
+                    lambda,
+                    config.l1_ratio,
+                    1000,
+                    1e-7,
+                    config.screening,
+                    None,
+                    10,
+                    true,
+                    true,
+                ) else {
+                    continue;
+                };
+
+                if let Ok(result) = fast_cox_slices(
+                    &fold.train_x,
+                    train_n,
+                    n_vars,
+                    &fold.train_time,
+                    &fold.train_status,
+                    &fit_config,
+                    Some(&fold.train_wt),
+                    Some(&fold.train_offset),
+                ) {
+                    let deviance = compute_cox_deviance_into(
+                        &test_data,
+                        &result.coefficients,
+                        &mut deviance_eta,
+                        &mut deviance_exp_eta,
+                        &mut deviance_risk_data,
+                        &mut deviance_risk_scratch,
+                    );
+                    summary.record(lambda_idx, deviance);
+                }
+            }
+
+            summary
         })
         .collect();
 
-    let se_deviances: Vec<f64> = cv_deviances
-        .iter()
-        .zip(mean_deviances.iter())
-        .map(|(devs, &mean)| {
-            if devs.len() < 2 {
-                f64::INFINITY
-            } else {
-                let var =
-                    devs.iter().map(|&d| (d - mean).powi(2)).sum::<f64>() / (devs.len() - 1) as f64;
-                (var / devs.len() as f64).sqrt()
-            }
-        })
-        .collect();
+    let mut cv_deviance_summary = FastCoxCvDevianceSummary::with_len(path.lambdas.len());
+    for fold_summary in fold_deviance_summaries {
+        cv_deviance_summary.merge(fold_summary);
+    }
+
+    let mean_deviances = cv_deviance_summary.mean_deviances();
+    let se_deviances = cv_deviance_summary.se_deviances(&mean_deviances);
 
     let (min_idx, &min_dev) = mean_deviances
         .iter()

--- a/src/regression/fast_cox/api.rs
+++ b/src/regression/fast_cox/api.rs
@@ -251,14 +251,13 @@ pub(crate) fn fast_cox_path_typed(
             },
         );
 
-        beta_warm = beta_std.clone();
-        lambda_prev = Some(lambda);
-
         let coefficients: Vec<f64> = beta_std
             .iter()
             .zip(sds.iter())
             .map(|(&b, &s)| if s > 0.0 { b / s } else { b })
             .collect();
+        beta_warm = beta_std;
+        lambda_prev = Some(lambda);
 
         let df = coefficients
             .iter()

--- a/src/regression/fast_cox/api.rs
+++ b/src/regression/fast_cox/api.rs
@@ -29,6 +29,7 @@ impl FastCoxCvFold {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn push_train(
         &mut self,
         idx: usize,
@@ -47,6 +48,7 @@ impl FastCoxCvFold {
         self.train_offset.push(offset[idx]);
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn push_test(
         &mut self,
         idx: usize,
@@ -575,8 +577,8 @@ pub(crate) fn fast_cox_cv_typed(
             let test_n = fold_counts[fold];
             let train_n = n_obs - test_n;
             let mut fold_data = FastCoxCvFold::with_capacity(train_n, test_n, n_vars);
-            for idx in 0..n_obs {
-                if fold_assign[idx] == fold {
+            for (idx, &assigned) in fold_assign.iter().enumerate() {
+                if assigned == fold {
                     fold_data.push_test(idx, x, n_vars, time, status, wt.as_ref(), offset.as_ref());
                 } else {
                     fold_data.push_train(

--- a/src/regression/fast_cox/api.rs
+++ b/src/regression/fast_cox/api.rs
@@ -140,8 +140,19 @@ struct FastCoxCoefficientFit {
 }
 
 fn fast_cox_lambda_max(data: &FastCoxData, l1_ratio: f64) -> f64 {
-    let beta_zero = vec![0.0; data.p];
-    let (gradient, _) = compute_gradient_hessian_diag_fast(data, &beta_zero, None);
+    let mut gradient = vec![0.0; data.p];
+    let mut eta = vec![0.0; data.n];
+    let mut exp_eta = vec![0.0; data.n];
+    let mut risk_data = CoxRiskSetFirstOrderData::with_capacity(data.n, data.p);
+    let mut risk_scratch = CoxRiskSetFirstOrderScratch::with_capacity(data.n, data.p);
+    compute_gradient_at_zero_fast_into(
+        data,
+        &mut gradient,
+        &mut eta,
+        &mut exp_eta,
+        &mut risk_data,
+        &mut risk_scratch,
+    );
 
     gradient.iter().map(|g| g.abs()).fold(0.0, f64::max) / (data.n as f64 * l1_ratio.max(0.001))
 }

--- a/src/regression/fast_cox/api.rs
+++ b/src/regression/fast_cox/api.rs
@@ -174,14 +174,18 @@ fn unstandardize_fast_cox_coefficients(
     standardize: bool,
 ) -> Vec<f64> {
     if standardize {
-        beta_std
-            .iter()
-            .zip(sds.iter())
-            .map(|(&b, &s)| if s > 0.0 { b / s } else { b })
-            .collect()
+        unstandardize_standard_fast_cox_coefficients(&beta_std, sds)
     } else {
         beta_std
     }
+}
+
+fn unstandardize_standard_fast_cox_coefficients(beta_std: &[f64], sds: &[f64]) -> Vec<f64> {
+    beta_std
+        .iter()
+        .zip(sds.iter())
+        .map(|(&b, &s)| if s > 0.0 { b / s } else { b })
+        .collect()
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -601,37 +605,28 @@ pub(crate) fn fast_cox_cv_typed(
                 offset: &fold.train_offset,
             };
             let train_lambda_max = fast_cox_lambda_max(&train_data, 1.0);
+            let mut beta_warm = vec![0.0; n_vars];
+            let mut lambda_prev: Option<f64> = None;
 
             for (lambda_idx, &lambda) in lambdas.iter().enumerate() {
-                let Ok(fit_config) = FastCoxConfig::new(
-                    lambda,
-                    config.l1_ratio,
-                    1000,
-                    1e-7,
-                    config.screening,
-                    None,
-                    10,
-                    true,
-                    true,
-                ) else {
-                    continue;
-                };
-
                 let (beta_std, _n_iter, _conv, _screened, _active) = cyclic_coordinate_descent_fast(
                     &train_data,
                     FastCoxDescentConfig {
-                        lambda: fit_config.lambda,
-                        l1_ratio: fit_config.l1_ratio,
-                        max_iter: fit_config.max_iter,
-                        tol: fit_config.tol,
-                        beta_init: None,
-                        screening: fit_config.screening,
-                        active_set_update_freq: fit_config.active_set_update_freq,
-                        lambda_prev: None,
+                        lambda,
+                        l1_ratio: config.l1_ratio,
+                        max_iter: 1000,
+                        tol: 1e-7,
+                        beta_init: Some(&beta_warm),
+                        screening: config.screening,
+                        active_set_update_freq: 10,
+                        lambda_prev,
                         lambda_max: train_lambda_max,
                     },
                 );
-                let coefficients = unstandardize_fast_cox_coefficients(beta_std, &train_sds, true);
+                let coefficients =
+                    unstandardize_standard_fast_cox_coefficients(&beta_std, &train_sds);
+                beta_warm = beta_std;
+                lambda_prev = Some(lambda);
                 let deviance = compute_cox_deviance_into(
                     &test_data,
                     &coefficients,

--- a/src/regression/fast_cox/core.rs
+++ b/src/regression/fast_cox/core.rs
@@ -32,15 +32,33 @@ struct FastCoxDescentConfig<'a> {
 
 #[allow(clippy::needless_range_loop)]
 fn linear_predictors(data: &FastCoxData, beta: &[f64]) -> Vec<f64> {
-    (0..data.n)
-        .map(|i| {
-            let mut eta = data.offset[i];
-            for j in 0..data.p {
-                eta += data.x[i * data.p + j] * beta[j];
-            }
-            eta
-        })
-        .collect()
+    let mut eta = vec![0.0; data.n];
+    linear_predictors_into(data, beta, &mut eta);
+    eta
+}
+
+#[allow(clippy::needless_range_loop)]
+fn linear_predictors_into(data: &FastCoxData, beta: &[f64], eta: &mut [f64]) {
+    debug_assert_eq!(eta.len(), data.n);
+    for i in 0..data.n {
+        let mut value = data.offset[i];
+        for j in 0..data.p {
+            value += data.x[i * data.p + j] * beta[j];
+        }
+        eta[i] = value;
+    }
+}
+
+fn shifted_exp_eta_with_shift_into(eta: &[f64], weights: &[f64], shift: f64, target: &mut [f64]) {
+    debug_assert_eq!(target.len(), eta.len());
+    debug_assert_eq!(weights.len(), eta.len());
+    for ((target_value, &eta_i), &weight) in target.iter_mut().zip(eta.iter()).zip(weights.iter()) {
+        *target_value = if weight > 0.0 {
+            (eta_i - shift).exp()
+        } else {
+            0.0
+        };
+    }
 }
 
 #[allow(clippy::needless_range_loop)]
@@ -51,12 +69,16 @@ fn compute_gradient_hessian_diag_fast(
 ) -> (Vec<f64>, Vec<f64>) {
     let mut gradient = vec![0.0; data.p];
     let mut hessian_diag = vec![0.0; data.p];
+    let mut eta = vec![0.0; data.n];
+    let mut exp_eta = vec![0.0; data.n];
     compute_gradient_hessian_diag_fast_into(
         data,
         beta,
         active_set,
         &mut gradient,
         &mut hessian_diag,
+        &mut eta,
+        &mut exp_eta,
     );
     (gradient, hessian_diag)
 }
@@ -68,14 +90,19 @@ fn compute_gradient_hessian_diag_fast_into(
     active_set: Option<&[usize]>,
     gradient: &mut [f64],
     hessian_diag: &mut [f64],
+    eta: &mut [f64],
+    exp_eta: &mut [f64],
 ) {
     debug_assert_eq!(gradient.len(), data.p);
     debug_assert_eq!(hessian_diag.len(), data.p);
+    debug_assert_eq!(eta.len(), data.n);
+    debug_assert_eq!(exp_eta.len(), data.n);
     gradient.fill(0.0);
     hessian_diag.fill(0.0);
 
-    let eta = linear_predictors(data, beta);
-    let exp_eta = shifted_exp_eta(&eta, data.weights);
+    linear_predictors_into(data, beta, eta);
+    let shift = cox_risk_shift(eta, data.weights);
+    shifted_exp_eta_with_shift_into(eta, data.weights, shift, exp_eta);
 
     let risk_data = precompute_cox_risk_set_cumsum(
         data.x,
@@ -83,7 +110,7 @@ fn compute_gradient_hessian_diag_fast_into(
         data.p,
         data.time,
         data.weights,
-        &exp_eta,
+        exp_eta,
     );
 
     for i in 0..data.n {
@@ -205,7 +232,17 @@ fn cyclic_coordinate_descent_fast(
 
     let mut gradient = vec![0.0; data.p];
     let mut hessian_diag = vec![0.0; data.p];
-    compute_gradient_hessian_diag_fast_into(data, &beta, None, &mut gradient, &mut hessian_diag);
+    let mut eta = vec![0.0; data.n];
+    let mut exp_eta = vec![0.0; data.n];
+    compute_gradient_hessian_diag_fast_into(
+        data,
+        &beta,
+        None,
+        &mut gradient,
+        &mut hessian_diag,
+        &mut eta,
+        &mut exp_eta,
+    );
 
     let mut active_set: Vec<usize> = match config.screening {
         ScreeningRule::None => (0..data.p).collect(),
@@ -242,6 +279,8 @@ fn cyclic_coordinate_descent_fast(
             Some(&active_set),
             &mut gradient,
             &mut hessian_diag,
+            &mut eta,
+            &mut exp_eta,
         );
 
         let mut max_change: f64 = 0.0;
@@ -265,6 +304,8 @@ fn cyclic_coordinate_descent_fast(
                 None,
                 &mut gradient,
                 &mut hessian_diag,
+                &mut eta,
+                &mut exp_eta,
             );
 
             kkt_violations.clear();
@@ -293,6 +334,8 @@ fn cyclic_coordinate_descent_fast(
                 None,
                 &mut gradient,
                 &mut hessian_diag,
+                &mut eta,
+                &mut exp_eta,
             );
 
             new_active.clear();

--- a/src/regression/fast_cox/core.rs
+++ b/src/regression/fast_cox/core.rs
@@ -49,6 +49,31 @@ fn compute_gradient_hessian_diag_fast(
     beta: &[f64],
     active_set: Option<&[usize]>,
 ) -> (Vec<f64>, Vec<f64>) {
+    let mut gradient = vec![0.0; data.p];
+    let mut hessian_diag = vec![0.0; data.p];
+    compute_gradient_hessian_diag_fast_into(
+        data,
+        beta,
+        active_set,
+        &mut gradient,
+        &mut hessian_diag,
+    );
+    (gradient, hessian_diag)
+}
+
+#[allow(clippy::needless_range_loop)]
+fn compute_gradient_hessian_diag_fast_into(
+    data: &FastCoxData,
+    beta: &[f64],
+    active_set: Option<&[usize]>,
+    gradient: &mut [f64],
+    hessian_diag: &mut [f64],
+) {
+    debug_assert_eq!(gradient.len(), data.p);
+    debug_assert_eq!(hessian_diag.len(), data.p);
+    gradient.fill(0.0);
+    hessian_diag.fill(0.0);
+
     let eta = linear_predictors(data, beta);
     let exp_eta = shifted_exp_eta(&eta, data.weights);
 
@@ -60,9 +85,6 @@ fn compute_gradient_hessian_diag_fast(
         data.weights,
         &exp_eta,
     );
-
-    let mut gradient = vec![0.0; data.p];
-    let mut hessian_diag = vec![0.0; data.p];
 
     for i in 0..data.n {
         if data.status[i] != 1 {
@@ -98,8 +120,6 @@ fn compute_gradient_hessian_diag_fast(
             }
         }
     }
-
-    (gradient, hessian_diag)
 }
 
 fn apply_strong_screening(
@@ -183,7 +203,9 @@ fn cyclic_coordinate_descent_fast(
     let l1_penalty = config.lambda * config.l1_ratio;
     let l2_penalty = config.lambda * (1.0 - config.l1_ratio);
 
-    let (gradient, _) = compute_gradient_hessian_diag_fast(data, &beta, None);
+    let mut gradient = vec![0.0; data.p];
+    let mut hessian_diag = vec![0.0; data.p];
+    compute_gradient_hessian_diag_fast_into(data, &beta, None, &mut gradient, &mut hessian_diag);
 
     let mut active_set: Vec<usize> = match config.screening {
         ScreeningRule::None => (0..data.p).collect(),
@@ -214,8 +236,13 @@ fn cyclic_coordinate_descent_fast(
     for iter in 0..config.max_iter {
         n_iter = iter + 1;
 
-        let (gradient, hessian_diag) =
-            compute_gradient_hessian_diag_fast(data, &beta, Some(&active_set));
+        compute_gradient_hessian_diag_fast_into(
+            data,
+            &beta,
+            Some(&active_set),
+            &mut gradient,
+            &mut hessian_diag,
+        );
 
         let mut max_change: f64 = 0.0;
         for &j in &active_set {
@@ -232,14 +259,20 @@ fn cyclic_coordinate_descent_fast(
         }
 
         if max_change < config.tol {
-            let (full_gradient, _) = compute_gradient_hessian_diag_fast(data, &beta, None);
+            compute_gradient_hessian_diag_fast_into(
+                data,
+                &beta,
+                None,
+                &mut gradient,
+                &mut hessian_diag,
+            );
 
             kkt_violations.clear();
             kkt_violations.extend((0..data.p).filter(|&j| {
                 if beta[j].abs() > crate::constants::DIVISION_FLOOR {
                     false
                 } else {
-                    full_gradient[j].abs() > l1_penalty * 1.01
+                    gradient[j].abs() > l1_penalty * 1.01
                 }
             }));
 
@@ -254,12 +287,18 @@ fn cyclic_coordinate_descent_fast(
         }
 
         if iter % config.active_set_update_freq == 0 && iter > 0 {
-            let (full_gradient, _) = compute_gradient_hessian_diag_fast(data, &beta, None);
+            compute_gradient_hessian_diag_fast_into(
+                data,
+                &beta,
+                None,
+                &mut gradient,
+                &mut hessian_diag,
+            );
 
             new_active.clear();
             new_active.extend((0..data.p).filter(|&j| {
                 beta[j].abs() > crate::constants::DIVISION_FLOOR
-                    || full_gradient[j].abs() >= l1_penalty * 0.5
+                    || gradient[j].abs() >= l1_penalty * 0.5
             }));
 
             if !new_active.is_empty() {

--- a/src/regression/fast_cox/core.rs
+++ b/src/regression/fast_cox/core.rs
@@ -71,6 +71,8 @@ fn compute_gradient_hessian_diag_fast(
     let mut hessian_diag = vec![0.0; data.p];
     let mut eta = vec![0.0; data.n];
     let mut exp_eta = vec![0.0; data.n];
+    let mut risk_data = CoxRiskSetData::with_capacity(data.n, data.p);
+    let mut risk_scratch = CoxRiskSetScratch::with_capacity(data.n, data.p);
     compute_gradient_hessian_diag_fast_into(
         data,
         beta,
@@ -79,6 +81,8 @@ fn compute_gradient_hessian_diag_fast(
         &mut hessian_diag,
         &mut eta,
         &mut exp_eta,
+        &mut risk_data,
+        &mut risk_scratch,
     );
     (gradient, hessian_diag)
 }
@@ -92,6 +96,8 @@ fn compute_gradient_hessian_diag_fast_into(
     hessian_diag: &mut [f64],
     eta: &mut [f64],
     exp_eta: &mut [f64],
+    risk_data: &mut CoxRiskSetData,
+    risk_scratch: &mut CoxRiskSetScratch,
 ) {
     debug_assert_eq!(gradient.len(), data.p);
     debug_assert_eq!(hessian_diag.len(), data.p);
@@ -104,13 +110,15 @@ fn compute_gradient_hessian_diag_fast_into(
     let shift = cox_risk_shift(eta, data.weights);
     shifted_exp_eta_with_shift_into(eta, data.weights, shift, exp_eta);
 
-    let risk_data = precompute_cox_risk_set_cumsum(
+    precompute_cox_risk_set_cumsum_into(
         data.x,
         data.n,
         data.p,
         data.time,
         data.weights,
         exp_eta,
+        risk_data,
+        risk_scratch,
     );
 
     for i in 0..data.n {
@@ -234,6 +242,8 @@ fn cyclic_coordinate_descent_fast(
     let mut hessian_diag = vec![0.0; data.p];
     let mut eta = vec![0.0; data.n];
     let mut exp_eta = vec![0.0; data.n];
+    let mut risk_data = CoxRiskSetData::with_capacity(data.n, data.p);
+    let mut risk_scratch = CoxRiskSetScratch::with_capacity(data.n, data.p);
     compute_gradient_hessian_diag_fast_into(
         data,
         &beta,
@@ -242,6 +252,8 @@ fn cyclic_coordinate_descent_fast(
         &mut hessian_diag,
         &mut eta,
         &mut exp_eta,
+        &mut risk_data,
+        &mut risk_scratch,
     );
 
     let mut active_set: Vec<usize> = match config.screening {
@@ -281,6 +293,8 @@ fn cyclic_coordinate_descent_fast(
             &mut hessian_diag,
             &mut eta,
             &mut exp_eta,
+            &mut risk_data,
+            &mut risk_scratch,
         );
 
         let mut max_change: f64 = 0.0;
@@ -306,6 +320,8 @@ fn cyclic_coordinate_descent_fast(
                 &mut hessian_diag,
                 &mut eta,
                 &mut exp_eta,
+                &mut risk_data,
+                &mut risk_scratch,
             );
 
             kkt_violations.clear();
@@ -336,6 +352,8 @@ fn cyclic_coordinate_descent_fast(
                 &mut hessian_diag,
                 &mut eta,
                 &mut exp_eta,
+                &mut risk_data,
+                &mut risk_scratch,
             );
 
             new_active.clear();

--- a/src/regression/fast_cox/core.rs
+++ b/src/regression/fast_cox/core.rs
@@ -54,6 +54,7 @@ fn shifted_exp_eta_with_shift_into(eta: &[f64], weights: &[f64], shift: f64, tar
     }
 }
 
+#[cfg(test)]
 #[allow(clippy::needless_range_loop)]
 fn compute_gradient_hessian_diag_fast(
     data: &FastCoxData,
@@ -146,6 +147,54 @@ fn compute_gradient_hessian_diag_fast_into(
                     accumulate_feature(j);
                 }
             }
+        }
+    }
+}
+
+#[allow(clippy::needless_range_loop)]
+fn compute_gradient_at_zero_fast_into(
+    data: &FastCoxData,
+    gradient: &mut [f64],
+    eta: &mut [f64],
+    exp_eta: &mut [f64],
+    risk_data: &mut CoxRiskSetFirstOrderData,
+    risk_scratch: &mut CoxRiskSetFirstOrderScratch,
+) {
+    debug_assert_eq!(gradient.len(), data.p);
+    debug_assert_eq!(eta.len(), data.n);
+    debug_assert_eq!(exp_eta.len(), data.n);
+    gradient.fill(0.0);
+
+    eta.copy_from_slice(data.offset);
+    let shift = cox_risk_shift(eta, data.weights);
+    shifted_exp_eta_with_shift_into(eta, data.weights, shift, exp_eta);
+
+    precompute_cox_risk_set_first_order_cumsum_into(
+        data.x,
+        data.n,
+        data.p,
+        data.time,
+        data.weights,
+        exp_eta,
+        risk_data,
+        risk_scratch,
+    );
+
+    for i in 0..data.n {
+        if data.status[i] != 1 {
+            continue;
+        }
+
+        let pos = risk_data.risk_set_pos[i];
+        let risk_sum = risk_data.cumsum_exp_eta[pos];
+        if risk_sum <= 0.0 {
+            continue;
+        }
+
+        for j in 0..data.p {
+            let xij = data.x[i * data.p + j];
+            let x_bar = risk_data.cumsum_weighted_x[pos * data.p + j] / risk_sum;
+            gradient[j] += data.weights[i] * (xij - x_bar);
         }
     }
 }

--- a/src/regression/fast_cox/core.rs
+++ b/src/regression/fast_cox/core.rs
@@ -149,7 +149,7 @@ fn apply_edpp_screening(
 fn compute_cox_deviance(data: &FastCoxData, beta: &[f64]) -> f64 {
     let eta = linear_predictors(data, beta);
     let risk_shift = cox_risk_shift(&eta, data.weights);
-    let exp_eta: Vec<f64> = eta.iter().map(|&eta_i| (eta_i - risk_shift).exp()).collect();
+    let exp_eta = shifted_exp_eta_with_shift(&eta, data.weights, risk_shift);
     let risk_data = precompute_cox_risk_set_cumsum(
         data.x,
         data.n,

--- a/src/regression/fast_cox/core.rs
+++ b/src/regression/fast_cox/core.rs
@@ -61,10 +61,6 @@ fn compute_gradient_hessian_diag_fast(
         &exp_eta,
     );
 
-    let features_to_process: Vec<usize> = active_set
-        .map(|a| a.to_vec())
-        .unwrap_or_else(|| (0..data.p).collect());
-
     let mut gradient = vec![0.0; data.p];
     let mut hessian_diag = vec![0.0; data.p];
 
@@ -79,7 +75,7 @@ fn compute_gradient_hessian_diag_fast(
             continue;
         }
 
-        for &j in &features_to_process {
+        let mut accumulate_feature = |j: usize| {
             let xij = data.x[i * data.p + j];
             let cumsum_idx = pos * data.p + j;
             let x_bar = risk_data.cumsum_weighted_x[cumsum_idx] / risk_sum;
@@ -87,6 +83,19 @@ fn compute_gradient_hessian_diag_fast(
 
             gradient[j] += data.weights[i] * (xij - x_bar);
             hessian_diag[j] += data.weights[i] * (x_sq_bar - x_bar * x_bar);
+        };
+
+        match active_set {
+            Some(features) => {
+                for &j in features {
+                    accumulate_feature(j);
+                }
+            }
+            None => {
+                for j in 0..data.p {
+                    accumulate_feature(j);
+                }
+            }
         }
     }
 

--- a/src/regression/fast_cox/core.rs
+++ b/src/regression/fast_cox/core.rs
@@ -208,14 +208,16 @@ fn cyclic_coordinate_descent_fast(
 
     let mut converged = false;
     let mut n_iter = 0;
+    let mut kkt_violations = Vec::new();
+    let mut new_active = Vec::new();
 
     for iter in 0..config.max_iter {
         n_iter = iter + 1;
-        let beta_old = beta.clone();
 
         let (gradient, hessian_diag) =
             compute_gradient_hessian_diag_fast(data, &beta, Some(&active_set));
 
+        let mut max_change: f64 = 0.0;
         for &j in &active_set {
             let h_jj = hessian_diag[j] + l2_penalty;
             if h_jj.abs() < crate::constants::DIVISION_FLOOR {
@@ -223,32 +225,29 @@ fn cyclic_coordinate_descent_fast(
             }
 
             let z = gradient[j] + hessian_diag[j] * beta[j];
-            beta[j] = soft_threshold(z, l1_penalty) / h_jj;
+            let old_beta = beta[j];
+            let new_beta = soft_threshold(z, l1_penalty) / h_jj;
+            beta[j] = new_beta;
+            max_change = max_change.max((new_beta - old_beta).abs());
         }
-
-        let max_change: f64 = active_set
-            .iter()
-            .map(|&j| (beta[j] - beta_old[j]).abs())
-            .fold(0.0, f64::max);
 
         if max_change < config.tol {
             let (full_gradient, _) = compute_gradient_hessian_diag_fast(data, &beta, None);
 
-            let kkt_violations: Vec<usize> = (0..data.p)
-                .filter(|&j| {
-                    if beta[j].abs() > crate::constants::DIVISION_FLOOR {
-                        false
-                    } else {
-                        full_gradient[j].abs() > l1_penalty * 1.01
-                    }
-                })
-                .collect();
+            kkt_violations.clear();
+            kkt_violations.extend((0..data.p).filter(|&j| {
+                if beta[j].abs() > crate::constants::DIVISION_FLOOR {
+                    false
+                } else {
+                    full_gradient[j].abs() > l1_penalty * 1.01
+                }
+            }));
 
             if kkt_violations.is_empty() {
                 converged = true;
                 break;
             } else {
-                active_set.extend(kkt_violations);
+                active_set.extend(kkt_violations.iter().copied());
                 active_set.sort();
                 active_set.dedup();
             }
@@ -257,15 +256,14 @@ fn cyclic_coordinate_descent_fast(
         if iter % config.active_set_update_freq == 0 && iter > 0 {
             let (full_gradient, _) = compute_gradient_hessian_diag_fast(data, &beta, None);
 
-            let new_active: Vec<usize> = (0..data.p)
-                .filter(|&j| {
-                    beta[j].abs() > crate::constants::DIVISION_FLOOR
-                        || full_gradient[j].abs() >= l1_penalty * 0.5
-                })
-                .collect();
+            new_active.clear();
+            new_active.extend((0..data.p).filter(|&j| {
+                beta[j].abs() > crate::constants::DIVISION_FLOOR
+                    || full_gradient[j].abs() >= l1_penalty * 0.5
+            }));
 
             if !new_active.is_empty() {
-                active_set = new_active;
+                std::mem::swap(&mut active_set, &mut new_active);
             }
         }
     }

--- a/src/regression/fast_cox/core.rs
+++ b/src/regression/fast_cox/core.rs
@@ -81,7 +81,7 @@ fn compute_gradient_hessian_diag_fast(
     (gradient, hessian_diag)
 }
 
-#[allow(clippy::needless_range_loop)]
+#[allow(clippy::needless_range_loop, clippy::too_many_arguments)]
 fn compute_gradient_hessian_diag_fast_into(
     data: &FastCoxData,
     beta: &[f64],

--- a/src/regression/fast_cox/core.rs
+++ b/src/regression/fast_cox/core.rs
@@ -31,13 +31,6 @@ struct FastCoxDescentConfig<'a> {
 }
 
 #[allow(clippy::needless_range_loop)]
-fn linear_predictors(data: &FastCoxData, beta: &[f64]) -> Vec<f64> {
-    let mut eta = vec![0.0; data.n];
-    linear_predictors_into(data, beta, &mut eta);
-    eta
-}
-
-#[allow(clippy::needless_range_loop)]
 fn linear_predictors_into(data: &FastCoxData, beta: &[f64], eta: &mut [f64]) {
     debug_assert_eq!(eta.len(), data.n);
     for i in 0..data.n {
@@ -202,16 +195,43 @@ fn apply_edpp_screening(
 
 #[allow(clippy::needless_range_loop)]
 fn compute_cox_deviance(data: &FastCoxData, beta: &[f64]) -> f64 {
-    let eta = linear_predictors(data, beta);
-    let risk_shift = cox_risk_shift(&eta, data.weights);
-    let exp_eta = shifted_exp_eta_with_shift(&eta, data.weights, risk_shift);
-    let risk_data = precompute_cox_risk_set_cumsum(
+    let mut eta = vec![0.0; data.n];
+    let mut exp_eta = vec![0.0; data.n];
+    let mut risk_data = CoxRiskSetData::with_capacity(data.n, data.p);
+    let mut risk_scratch = CoxRiskSetScratch::with_capacity(data.n, data.p);
+    compute_cox_deviance_into(
+        data,
+        beta,
+        &mut eta,
+        &mut exp_eta,
+        &mut risk_data,
+        &mut risk_scratch,
+    )
+}
+
+#[allow(clippy::needless_range_loop)]
+fn compute_cox_deviance_into(
+    data: &FastCoxData,
+    beta: &[f64],
+    eta: &mut [f64],
+    exp_eta: &mut [f64],
+    risk_data: &mut CoxRiskSetData,
+    risk_scratch: &mut CoxRiskSetScratch,
+) -> f64 {
+    debug_assert_eq!(eta.len(), data.n);
+    debug_assert_eq!(exp_eta.len(), data.n);
+    linear_predictors_into(data, beta, eta);
+    let risk_shift = cox_risk_shift(eta, data.weights);
+    shifted_exp_eta_with_shift_into(eta, data.weights, risk_shift, exp_eta);
+    precompute_cox_risk_set_cumsum_into(
         data.x,
         data.n,
         data.p,
         data.time,
         data.weights,
-        &exp_eta,
+        exp_eta,
+        risk_data,
+        risk_scratch,
     );
 
     let mut loglik = 0.0;

--- a/src/regression/fast_cox/core.rs
+++ b/src/regression/fast_cox/core.rs
@@ -150,47 +150,52 @@ fn compute_gradient_hessian_diag_fast_into(
     }
 }
 
-fn apply_strong_screening(
+fn apply_strong_screening_into(
     gradient: &[f64],
     lambda: f64,
     lambda_prev: Option<f64>,
     beta: &[f64],
     p: usize,
-) -> Vec<usize> {
+    active_set: &mut Vec<usize>,
+) {
     let threshold = match lambda_prev {
         Some(lp) => 2.0 * lambda - lp,
         None => lambda,
     };
 
-    (0..p)
-        .filter(|&j| {
-            beta[j].abs() > crate::constants::DIVISION_FLOOR || gradient[j].abs() >= threshold
-        })
-        .collect()
+    active_set.clear();
+    active_set.extend((0..p).filter(|&j| {
+        beta[j].abs() > crate::constants::DIVISION_FLOOR || gradient[j].abs() >= threshold
+    }));
 }
 
-fn apply_safe_screening(gradient: &[f64], lambda: f64, beta: &[f64], p: usize) -> Vec<usize> {
-    (0..p)
-        .filter(|&j| {
-            beta[j].abs() > crate::constants::DIVISION_FLOOR || gradient[j].abs() >= lambda
-        })
-        .collect()
+fn apply_safe_screening_into(
+    gradient: &[f64],
+    lambda: f64,
+    beta: &[f64],
+    p: usize,
+    active_set: &mut Vec<usize>,
+) {
+    active_set.clear();
+    active_set.extend((0..p).filter(|&j| {
+        beta[j].abs() > crate::constants::DIVISION_FLOOR || gradient[j].abs() >= lambda
+    }));
 }
 
-fn apply_edpp_screening(
+fn apply_edpp_screening_into(
     gradient: &[f64],
     lambda: f64,
     lambda_max: f64,
     beta: &[f64],
     p: usize,
-) -> Vec<usize> {
+    active_set: &mut Vec<usize>,
+) {
     let threshold = lambda * (1.0 - (lambda / lambda_max).min(1.0));
 
-    (0..p)
-        .filter(|&j| {
-            beta[j].abs() > crate::constants::DIVISION_FLOOR || gradient[j].abs() >= threshold
-        })
-        .collect()
+    active_set.clear();
+    active_set.extend((0..p).filter(|&j| {
+        beta[j].abs() > crate::constants::DIVISION_FLOOR || gradient[j].abs() >= threshold
+    }));
 }
 
 #[allow(clippy::needless_range_loop)]
@@ -276,22 +281,27 @@ fn cyclic_coordinate_descent_fast(
         &mut risk_scratch,
     );
 
-    let mut active_set: Vec<usize> = match config.screening {
-        ScreeningRule::None => (0..data.p).collect(),
-        ScreeningRule::Safe => apply_safe_screening(&gradient, config.lambda, &beta, data.p),
-        ScreeningRule::Strong => apply_strong_screening(
+    let mut active_set = Vec::with_capacity(data.p);
+    match config.screening {
+        ScreeningRule::None => active_set.extend(0..data.p),
+        ScreeningRule::Safe => {
+            apply_safe_screening_into(&gradient, config.lambda, &beta, data.p, &mut active_set)
+        }
+        ScreeningRule::Strong => apply_strong_screening_into(
             &gradient,
             config.lambda,
             config.lambda_prev,
             &beta,
             data.p,
+            &mut active_set,
         ),
-        ScreeningRule::EDPP => apply_edpp_screening(
+        ScreeningRule::EDPP => apply_edpp_screening_into(
             &gradient,
             config.lambda,
             config.lambda_max,
             &beta,
             data.p,
+            &mut active_set,
         ),
     };
 
@@ -299,8 +309,8 @@ fn cyclic_coordinate_descent_fast(
 
     let mut converged = false;
     let mut n_iter = 0;
-    let mut kkt_violations = Vec::new();
-    let mut new_active = Vec::new();
+    let mut kkt_violations = Vec::with_capacity(data.p);
+    let mut new_active = Vec::with_capacity(data.p);
 
     for iter in 0..config.max_iter {
         n_iter = iter + 1;

--- a/src/regression/fast_cox/mod.rs
+++ b/src/regression/fast_cox/mod.rs
@@ -3,7 +3,9 @@ use pyo3::prelude::*;
 use rayon::prelude::*;
 
 use crate::internal::cox_risk::{cox_risk_shift, precompute_cox_risk_set_cumsum, shifted_exp_eta};
-use crate::internal::matrix::standardize_row_major_matrix;
+use crate::internal::matrix::{
+    standardize_or_borrow_row_major_matrix, standardize_row_major_matrix,
+};
 use crate::{SurvivalError, SurvivalResult};
 
 include!("types.rs");

--- a/src/regression/fast_cox/mod.rs
+++ b/src/regression/fast_cox/mod.rs
@@ -3,7 +3,9 @@ use pyo3::prelude::*;
 use rayon::prelude::*;
 
 use crate::internal::cox_risk::{
-    CoxRiskSetData, CoxRiskSetScratch, cox_risk_shift, precompute_cox_risk_set_cumsum_into,
+    CoxRiskSetData, CoxRiskSetFirstOrderData, CoxRiskSetFirstOrderScratch, CoxRiskSetScratch,
+    cox_risk_shift, precompute_cox_risk_set_cumsum_into,
+    precompute_cox_risk_set_first_order_cumsum_into,
 };
 use crate::internal::matrix::{
     standardize_or_borrow_row_major_matrix, standardize_row_major_matrix,

--- a/src/regression/fast_cox/mod.rs
+++ b/src/regression/fast_cox/mod.rs
@@ -3,7 +3,7 @@ use pyo3::prelude::*;
 use rayon::prelude::*;
 
 use crate::internal::cox_risk::{
-    cox_risk_shift, precompute_cox_risk_set_cumsum, shifted_exp_eta, shifted_exp_eta_with_shift,
+    cox_risk_shift, precompute_cox_risk_set_cumsum, shifted_exp_eta_with_shift,
 };
 use crate::internal::matrix::{
     standardize_or_borrow_row_major_matrix, standardize_row_major_matrix,

--- a/src/regression/fast_cox/mod.rs
+++ b/src/regression/fast_cox/mod.rs
@@ -3,8 +3,7 @@ use pyo3::prelude::*;
 use rayon::prelude::*;
 
 use crate::internal::cox_risk::{
-    CoxRiskSetData, CoxRiskSetScratch, cox_risk_shift, precompute_cox_risk_set_cumsum,
-    precompute_cox_risk_set_cumsum_into, shifted_exp_eta_with_shift,
+    CoxRiskSetData, CoxRiskSetScratch, cox_risk_shift, precompute_cox_risk_set_cumsum_into,
 };
 use crate::internal::matrix::{
     standardize_or_borrow_row_major_matrix, standardize_row_major_matrix,

--- a/src/regression/fast_cox/mod.rs
+++ b/src/regression/fast_cox/mod.rs
@@ -2,7 +2,9 @@ use ndarray::{ArrayView1, ArrayView2};
 use pyo3::prelude::*;
 use rayon::prelude::*;
 
-use crate::internal::cox_risk::{cox_risk_shift, precompute_cox_risk_set_cumsum, shifted_exp_eta};
+use crate::internal::cox_risk::{
+    cox_risk_shift, precompute_cox_risk_set_cumsum, shifted_exp_eta, shifted_exp_eta_with_shift,
+};
 use crate::internal::matrix::{
     standardize_or_borrow_row_major_matrix, standardize_row_major_matrix,
 };

--- a/src/regression/fast_cox/mod.rs
+++ b/src/regression/fast_cox/mod.rs
@@ -3,7 +3,8 @@ use pyo3::prelude::*;
 use rayon::prelude::*;
 
 use crate::internal::cox_risk::{
-    cox_risk_shift, precompute_cox_risk_set_cumsum, shifted_exp_eta_with_shift,
+    CoxRiskSetData, CoxRiskSetScratch, cox_risk_shift, precompute_cox_risk_set_cumsum,
+    precompute_cox_risk_set_cumsum_into, shifted_exp_eta_with_shift,
 };
 use crate::internal::matrix::{
     standardize_or_borrow_row_major_matrix, standardize_row_major_matrix,

--- a/src/regression/fast_cox/tests.rs
+++ b/src/regression/fast_cox/tests.rs
@@ -142,6 +142,31 @@ mod tests {
     }
 
     #[test]
+    fn test_fast_cox_lambda_max_matches_zero_gradient() {
+        let x = vec![1.0, 0.0, 0.5, 1.0, 1.5, 0.2, 2.0, 1.2];
+        let time = vec![1.0, 1.0, 2.0, 3.0];
+        let status = vec![1, 0, 1, 1];
+        let weights = vec![1.0, 0.5, 1.5, 1.0];
+        let offset = vec![0.2, -0.1, 0.0, 0.3];
+        let data = FastCoxData {
+            x: &x,
+            n: 4,
+            p: 2,
+            time: &time,
+            status: &status,
+            weights: &weights,
+            offset: &offset,
+        };
+
+        let lambda_max = fast_cox_lambda_max(&data, 1.0);
+        let (gradient, _) = compute_gradient_hessian_diag_fast(&data, &[0.0, 0.0], None);
+        let expected =
+            gradient.iter().map(|value| value.abs()).fold(0.0, f64::max) / data.n as f64;
+
+        assert!((lambda_max - expected).abs() < 1e-12);
+    }
+
+    #[test]
     fn test_screening_rules() {
         let gradient = vec![0.5, 0.1, 0.8, 0.05];
         let lambda = 0.3;

--- a/src/regression/fast_cox/tests.rs
+++ b/src/regression/fast_cox/tests.rs
@@ -189,4 +189,31 @@ mod tests {
         assert_eq!(path.coefficients.len(), 10);
         assert!(path.lambdas[0] >= path.lambdas[9]);
     }
+
+    #[test]
+    fn test_fast_cox_cv() {
+        use crate::internal::typed_inputs::{CovariateMatrix, CoxRegressionInput, SurvivalData};
+
+        let x: Vec<f64> = (0..36).map(|i| (i as f64 % 7.0) * 0.2).collect();
+        let time: Vec<f64> = (1..=12).map(|value| value as f64).collect();
+        let status = vec![1, 1, 0, 1, 1, 0, 1, 0, 1, 1, 0, 1];
+        let input = CoxRegressionInput::try_new(
+            CovariateMatrix::try_new(x, 12, 3).unwrap(),
+            SurvivalData::try_new(time, status).unwrap(),
+            None,
+            None,
+        )
+        .unwrap();
+        let config = FastCoxCVConfig::new(1.0, 4, 3, ScreeningRule::None, Some(7)).unwrap();
+
+        let (lambda_min, lambda_1se, mean_deviances, se_deviances) =
+            fast_cox_cv_typed(&input, Some(&config)).unwrap();
+
+        assert!(lambda_min.is_finite());
+        assert!(lambda_1se.is_finite());
+        assert_eq!(mean_deviances.len(), 4);
+        assert_eq!(se_deviances.len(), 4);
+        assert!(mean_deviances.iter().all(|value| value.is_finite()));
+        assert!(se_deviances.iter().all(|value| value.is_finite()));
+    }
 }

--- a/src/regression/fast_cox/tests.rs
+++ b/src/regression/fast_cox/tests.rs
@@ -67,6 +67,14 @@ mod tests {
 
         let result = fast_cox_typed(&input, &config).unwrap();
         assert_eq!(result.coefficients.len(), 2);
+
+        let unstandardized_config =
+            FastCoxConfig::new(0.1, 1.0, 100, 1e-5, ScreeningRule::None, None, 10, false, true)
+                .unwrap();
+        let unstandardized = fast_cox_typed(&input, &unstandardized_config).unwrap();
+        assert_eq!(unstandardized.coefficients.len(), 2);
+        assert!(unstandardized.scale_factors.is_none());
+        assert!(unstandardized.center_values.is_none());
     }
 
     #[test]

--- a/src/regression/fast_cox/tests.rs
+++ b/src/regression/fast_cox/tests.rs
@@ -147,8 +147,10 @@ mod tests {
         let lambda = 0.3;
         let beta = vec![0.0, 0.0, 0.0, 0.0];
 
-        let safe = apply_safe_screening(&gradient, lambda, &beta, 4);
-        let strong = apply_strong_screening(&gradient, lambda, None, &beta, 4);
+        let mut safe = Vec::new();
+        apply_safe_screening_into(&gradient, lambda, &beta, 4, &mut safe);
+        let mut strong = Vec::new();
+        apply_strong_screening_into(&gradient, lambda, None, &beta, 4, &mut strong);
 
         assert!(safe.contains(&0));
         assert!(safe.contains(&2));

--- a/src/regression/joint_competing.rs
+++ b/src/regression/joint_competing.rs
@@ -408,11 +408,13 @@ fn solve_system(a: &[Vec<f64>], b: &[f64]) -> Option<Vec<f64>> {
             return None;
         }
 
-        let row_i_tail: Vec<f64> = aug[i][i..n].to_vec();
+        let (pivot_rows, lower_rows) = aug.split_at_mut(i + 1);
+        let pivot_tail = &pivot_rows[i][i..n];
         for k in (i + 1)..n {
-            let factor = aug[k][i] / aug[i][i];
+            let lower_row = &mut lower_rows[k - i - 1];
+            let factor = lower_row[i] / pivot_rows[i][i];
             rhs[k] -= factor * rhs[i];
-            for (aug_kj, &aug_ij) in aug[k][i..n].iter_mut().zip(row_i_tail.iter()) {
+            for (aug_kj, &aug_ij) in lower_row[i..n].iter_mut().zip(pivot_tail) {
                 *aug_kj -= factor * aug_ij;
             }
         }
@@ -608,6 +610,15 @@ mod tests {
             JointCompetingRisksConfig::new(2, CorrelationType::Independent, 1.0, 100, 1e-6, true)
                 .unwrap();
         assert_eq!(config.num_causes, 2);
+    }
+
+    #[test]
+    fn test_solve_system_pivots_without_singular_matrix() {
+        let solution = solve_system(&[vec![0.0, 2.0], vec![1.0, 1.0]], &[4.0, 3.0]).unwrap();
+
+        assert!((solution[0] - 1.0).abs() < 1e-12);
+        assert!((solution[1] - 2.0).abs() < 1e-12);
+        assert!(solve_system(&[vec![0.0, 0.0], vec![0.0, 1.0]], &[1.0, 2.0]).is_none());
     }
 
     #[test]

--- a/src/regression/ridge.rs
+++ b/src/regression/ridge.rs
@@ -1,4 +1,6 @@
-use crate::constants::{DIVISION_FLOOR, same_time};
+use crate::constants::DIVISION_FLOOR;
+use crate::internal::cox_risk::precompute_cox_risk_set_cumsum;
+use crate::internal::matrix::standardize_or_borrow_row_major_matrix;
 use crate::internal::validation::{
     validate_binary_i32, validate_finite, validate_no_nan, validate_non_empty,
     validate_non_negative,
@@ -6,6 +8,7 @@ use crate::internal::validation::{
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use rayon::prelude::*;
+use std::borrow::Cow;
 
 /// Configuration for ridge regression penalty
 #[derive(Debug, Clone)]
@@ -144,15 +147,23 @@ pub fn ridge_fit(
     validate_ridge_inputs(&x, n_obs, n_vars, &time, &status, weights.as_deref())?;
     validate_ridge_penalty(penalty)?;
 
-    let wt = weights.unwrap_or_else(|| vec![1.0; n_obs]);
-
-    let (scaled_x, scale_factors) = if penalty.scale {
-        scale_predictors(&x, n_obs, n_vars)
-    } else {
-        (x.clone(), None)
+    let wt = match weights.as_deref() {
+        Some(weights) => Cow::Borrowed(weights),
+        None => Cow::Owned(vec![1.0; n_obs]),
     };
 
-    let (beta, info_diag) = fit_unpenalized(&scaled_x, n_obs, n_vars, &time, &status, &wt)?;
+    let (scaled_x, _, scales) =
+        standardize_or_borrow_row_major_matrix(&x, n_obs, n_vars, penalty.scale);
+    let scale_factors = penalty.scale.then_some(scales);
+
+    let (beta, info_diag) = fit_unpenalized(
+        scaled_x.as_ref(),
+        n_obs,
+        n_vars,
+        &time,
+        &status,
+        wt.as_ref(),
+    )?;
 
     let penalized_info: Vec<f64> = info_diag.iter().map(|&i| i + penalty.theta).collect();
 
@@ -181,12 +192,12 @@ pub fn ridge_fit(
         .sum();
 
     let gcv = compute_gcv(
-        &scaled_x,
+        scaled_x.as_ref(),
         n_obs,
         n_vars,
         &time,
         &status,
-        &wt,
+        wt.as_ref(),
         &penalized_beta,
         df,
     );
@@ -219,35 +230,6 @@ pub fn ridge_fit(
         theta: penalty.theta,
         scale_factors,
     })
-}
-
-/// Scale predictors to unit variance
-fn scale_predictors(x: &[f64], n_obs: usize, n_vars: usize) -> (Vec<f64>, Option<Vec<f64>>) {
-    let mut scaled = x.to_vec();
-    let mut scale_factors = Vec::with_capacity(n_vars);
-
-    for j in 0..n_vars {
-        let mut sum = 0.0;
-        let mut sum_sq = 0.0;
-
-        for i in 0..n_obs {
-            let val = x[i * n_vars + j];
-            sum += val;
-            sum_sq += val * val;
-        }
-
-        let mean = sum / n_obs as f64;
-        let variance = (sum_sq / n_obs as f64 - mean * mean).max(0.0);
-        let sd = variance.sqrt().max(DIVISION_FLOOR);
-
-        scale_factors.push(sd);
-
-        for i in 0..n_obs {
-            scaled[i * n_vars + j] = (scaled[i * n_vars + j] - mean) / sd;
-        }
-    }
-
-    (scaled, Some(scale_factors))
 }
 
 fn validate_ridge_penalty(penalty: &RidgePenalty) -> PyResult<()> {
@@ -314,79 +296,33 @@ fn fit_unpenalized(
     status: &[i32],
     weights: &[f64],
 ) -> PyResult<(Vec<f64>, Vec<f64>)> {
-    let mut indices: Vec<usize> = (0..n_obs).collect();
-    indices.sort_by(|&a, &b| time[a].total_cmp(&time[b]).then_with(|| a.cmp(&b)));
-
-    let beta = vec![0.0; n_vars];
     let mut info_diag = vec![0.0; n_vars];
     let mut score = vec![0.0; n_vars];
-
-    let mut eta = vec![0.0; n_obs];
-    for i in 0..n_obs {
-        for j in 0..n_vars {
-            eta[i] += x[i * n_vars + j] * beta[j];
-        }
-    }
-
-    let shift = eta
+    let exp_eta: Vec<f64> = weights
         .iter()
-        .zip(weights.iter())
-        .filter_map(|(&eta_i, &weight)| {
-            if weight > 0.0 && eta_i.is_finite() {
-                Some(eta_i)
-            } else {
-                None
-            }
-        })
-        .fold(f64::NEG_INFINITY, f64::max);
-    let shift = if shift.is_finite() { shift } else { 0.0 };
+        .map(|&weight| if weight > 0.0 { 1.0 } else { 0.0 })
+        .collect();
+    let risk_data = precompute_cox_risk_set_cumsum(x, n_obs, n_vars, time, weights, &exp_eta);
 
-    let mut risk_cache = vec![0.0; n_obs];
     for i in 0..n_obs {
-        risk_cache[i] = (eta[i] - shift).exp() * weights[i];
-    }
-
-    let mut risk_sum_at_pos = vec![0.0; n_obs];
-    let mut total_risk = 0.0;
-    for (pos, &i) in indices.iter().enumerate().rev() {
-        total_risk += risk_cache[i];
-        risk_sum_at_pos[pos] = total_risk;
-    }
-
-    let mut risk_set_start_pos = vec![0usize; n_obs];
-    let mut start = 0;
-    while start < n_obs {
-        let current_time = time[indices[start]];
-        let mut end = start + 1;
-        while end < n_obs && same_time(time[indices[end]], current_time) {
-            end += 1;
+        if status[i] != 1 {
+            continue;
         }
-        for &idx in &indices[start..end] {
-            risk_set_start_pos[idx] = start;
+
+        let pos = risk_data.risk_set_pos[i];
+        let risk_sum = risk_data.cumsum_exp_eta[pos];
+        if risk_sum <= 0.0 {
+            continue;
         }
-        start = end;
-    }
 
-    for &i in &indices {
-        let start_pos = risk_set_start_pos[i];
-        let risk_sum = risk_sum_at_pos[start_pos];
-        if status[i] == 1 && risk_sum > 0.0 {
-            for j in 0..n_vars {
-                let xij = x[i * n_vars + j];
+        for j in 0..n_vars {
+            let xij = x[i * n_vars + j];
+            let cumsum_idx = pos * n_vars + j;
+            let x_mean = risk_data.cumsum_weighted_x[cumsum_idx] / risk_sum;
+            let x_sq_mean = risk_data.cumsum_weighted_x_sq[cumsum_idx] / risk_sum;
 
-                let mut x_mean = 0.0;
-                let mut x_sq_mean = 0.0;
-
-                for &k in &indices[start_pos..] {
-                    let xkj = x[k * n_vars + j];
-                    let risk = risk_cache[k];
-                    x_mean += xkj * risk / risk_sum;
-                    x_sq_mean += xkj * xkj * risk / risk_sum;
-                }
-
-                score[j] += weights[i] * (xij - x_mean);
-                info_diag[j] += weights[i] * (x_sq_mean - x_mean * x_mean).max(0.0);
-            }
+            score[j] += weights[i] * (xij - x_mean);
+            info_diag[j] += weights[i] * (x_sq_mean - x_mean * x_mean).max(0.0);
         }
     }
 
@@ -561,6 +497,22 @@ mod tests {
     }
 
     #[test]
+    fn test_ridge_fit_scaled_returns_standardization_scales() {
+        let x = vec![1.0, 1.0, 2.0, 1.0, 3.0, 1.0];
+        let time = vec![1.0, 2.0, 3.0];
+        let status = vec![1, 1, 1];
+        let penalty = RidgePenalty::new(0.1, Some(true)).unwrap();
+
+        let result = ridge_fit(x, 3, 2, time, status, &penalty, None).unwrap();
+        let scale_factors = result
+            .scale_factors
+            .expect("scaled fit should report scaling factors");
+
+        assert!((scale_factors[0] - (2.0_f64 / 3.0).sqrt()).abs() < 1e-12);
+        assert_eq!(scale_factors[1], DIVISION_FLOOR);
+    }
+
+    #[test]
     fn test_ridge_fit_uses_shared_risk_set_for_tied_times() {
         let x = vec![0.0, 2.0, 2.0];
         let time = vec![1.0, 1.0 + TIME_EPSILON / 2.0, 2.0];
@@ -571,6 +523,19 @@ mod tests {
 
         assert!((beta[0] + 1.5).abs() < 1e-12);
         assert!((info_diag[0] - 8.0 / 9.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_ridge_fit_excludes_zero_weight_rows_from_risk_sets() {
+        let x = vec![0.0, 10.0, 2.0];
+        let time = vec![1.0, 2.0, 3.0];
+        let status = vec![1, 0, 0];
+        let weights = vec![1.0, 0.0, 1.0];
+
+        let (beta, info_diag) = fit_unpenalized(&x, 3, 1, &time, &status, &weights).unwrap();
+
+        assert!((beta[0] + 1.0).abs() < 1e-12);
+        assert!((info_diag[0] - 1.0).abs() < 1e-12);
     }
 
     #[test]

--- a/src/residuals/agmart.rs
+++ b/src/residuals/agmart.rs
@@ -113,15 +113,15 @@ pub fn agmart(
 #[pyfunction(name = "agmart")]
 #[pyo3(signature = (input, method=None))]
 pub(crate) fn agmart_typed(input: &AndersenGillInput, method: Option<i32>) -> PyResult<Vec<f64>> {
-    let weights = input.weights_or_unit();
-    let strata = input.strata_or_default();
+    let weights = input.weights_or_unit_cow();
+    let strata = input.strata_or_default_cow();
     let data = AgmartData {
         start: &input.counting.start,
         stop: &input.counting.stop,
         event: &input.counting.event,
         score: &input.score,
-        wt: &weights,
-        strata: &strata,
+        wt: weights.as_ref(),
+        strata: strata.as_ref(),
     };
     Ok(compute_agmart(method.unwrap_or(0), data))
 }

--- a/src/residuals/coxmart.rs
+++ b/src/residuals/coxmart.rs
@@ -4,7 +4,7 @@ use pyo3::prelude::*;
 pub(crate) struct CoxMartSurvivalData<'a> {
     pub(crate) time: &'a [f64],
     pub(crate) status: &'a [i32],
-    pub(crate) strata: &'a mut [i32],
+    pub(crate) strata: &'a [i32],
 }
 
 pub(crate) struct CoxMartWeights<'a> {
@@ -33,22 +33,28 @@ pub fn coxmart(
 #[pyo3(signature = (input, method=None))]
 pub(crate) fn coxmart_typed(input: &CoxMartInput, method: Option<i32>) -> PyResult<Vec<f64>> {
     let n = input.survival.time.len();
-    let weights_vec = input.weights_or_unit();
-    let mut strata_vec = input.strata_or_default();
+    let weights = input.weights_or_unit_cow();
+    let strata = input.strata_or_default_cow();
     let method_val = method.unwrap_or(0);
     let mut expect = vec![0.0; n];
     let surv_data = CoxMartSurvivalData {
         time: &input.survival.time,
         status: &input.survival.status,
-        strata: &mut strata_vec,
+        strata: strata.as_ref(),
     };
     let weights_data = CoxMartWeights {
         score: &input.score,
-        wt: &weights_vec,
+        wt: weights.as_ref(),
     };
     compute_coxmart(n, method_val, surv_data, weights_data, &mut expect);
     Ok(expect)
 }
+
+#[inline]
+fn is_stratum_end(strata: &[i32], index: usize, n: usize) -> bool {
+    index + 1 == n || strata[index] == 1
+}
+
 pub(crate) fn compute_coxmart(
     n: usize,
     method: i32,
@@ -59,17 +65,17 @@ pub(crate) fn compute_coxmart(
     if n == 0 {
         return;
     }
-    surv_data.strata[n - 1] = 1;
     let mut denom = 0.0;
     for i in (0..n).rev() {
-        if surv_data.strata[i] == 1 {
+        if is_stratum_end(surv_data.strata, i, n) {
             denom = 0.0;
         }
         denom += weights.score[i] * weights.wt[i];
         let condition = if i == 0 {
             true
         } else {
-            surv_data.strata[i - 1] == 1 || (surv_data.time[i - 1] != surv_data.time[i])
+            is_stratum_end(surv_data.strata, i - 1, n)
+                || (surv_data.time[i - 1] != surv_data.time[i])
         };
         expect[i] = if condition { denom } else { 0.0 };
     }
@@ -87,8 +93,8 @@ pub(crate) fn compute_coxmart(
         deaths += surv_data.status[i];
         wtsum += surv_data.status[i] as f64 * weights.wt[i];
         e_denom += weights.score[i] * surv_data.status[i] as f64 * weights.wt[i];
-        let is_last =
-            surv_data.strata[i] == 1 || (i < n - 1 && surv_data.time[i + 1] != surv_data.time[i]);
+        let is_last = is_stratum_end(surv_data.strata, i, n)
+            || (i < n - 1 && surv_data.time[i + 1] != surv_data.time[i]);
         if is_last {
             if deaths < 2 || method == 0 {
                 hazard += wtsum / current_denom;
@@ -118,7 +124,7 @@ pub(crate) fn compute_coxmart(
             wtsum = 0.0;
             e_denom = 0.0;
         }
-        if surv_data.strata[i] == 1 {
+        if is_stratum_end(surv_data.strata, i, n) {
             hazard = 0.0;
         }
     }

--- a/src/tests/r_survival_validation.rs
+++ b/src/tests/r_survival_validation.rs
@@ -368,7 +368,7 @@ mod tests {
 
         let score = vec![1.0; n];
         let weights = vec![1.0; n];
-        let mut strata = vec![0i32; n];
+        let strata = vec![0i32; n];
 
         use crate::residuals::coxmart_module::{CoxMartSurvivalData, CoxMartWeights};
 
@@ -377,7 +377,7 @@ mod tests {
         let surv_data = CoxMartSurvivalData {
             time: &sorted_time,
             status: &sorted_status,
-            strata: &mut strata,
+            strata: &strata,
         };
 
         let weights_data = CoxMartWeights {

--- a/src/validation/crossval.rs
+++ b/src/validation/crossval.rs
@@ -152,40 +152,39 @@ pub(crate) fn cv_cox(
     use ndarray::Array1;
     let n = time.len();
     let nvar = covariates.nrows();
-    let default_weights: Vec<f64> = vec![1.0; n];
-    let weights = weights.unwrap_or(&default_weights);
+    let default_weights;
+    let weights = match weights {
+        Some(weights) => weights,
+        None => {
+            default_weights = vec![1.0; n];
+            &default_weights
+        }
+    };
     let folds = create_folds(n, config.n_folds, config.shuffle, config.seed);
     let results: Vec<(f64, Vec<f64>)> = (0..config.n_folds)
         .into_par_iter()
         .map(|fold_idx| {
             let test_indices = &folds[fold_idx];
-            let train_indices: Vec<usize> = folds
-                .iter()
-                .enumerate()
-                .filter(|(i, _)| *i != fold_idx)
-                .flat_map(|(_, f)| f.iter().copied())
-                .collect();
-            let train_n = train_indices.len();
             let test_n = test_indices.len();
-            let train_time: Vec<f64> = train_indices.iter().map(|&i| time[i]).collect();
-            let train_status: Vec<i32> = train_indices.iter().map(|&i| status[i]).collect();
-            let train_weights: Vec<f64> = train_indices.iter().map(|&i| weights[i]).collect();
-            let mut train_covariates = Array2::zeros((train_n, nvar));
-            for (new_idx, &orig_idx) in train_indices.iter().enumerate() {
-                for var in 0..nvar {
-                    train_covariates[[new_idx, var]] = covariates[[var, orig_idx]];
+            let train_n = n - test_n;
+            let mut sorted_train_indices = Vec::with_capacity(train_n);
+            for (idx, fold) in folds.iter().enumerate() {
+                if idx != fold_idx {
+                    sorted_train_indices.extend_from_slice(fold);
                 }
             }
-            let mut sorted_indices: Vec<usize> = (0..train_n).collect();
-            sorted_indices.sort_by(|&a, &b| train_time[b].total_cmp(&train_time[a]));
-            let sorted_time: Vec<f64> = sorted_indices.iter().map(|&i| train_time[i]).collect();
-            let sorted_status: Vec<i32> = sorted_indices.iter().map(|&i| train_status[i]).collect();
-            let sorted_weights: Vec<f64> =
-                sorted_indices.iter().map(|&i| train_weights[i]).collect();
+            sorted_train_indices.sort_by(|&a, &b| time[b].total_cmp(&time[a]));
+
+            let mut sorted_time = Vec::with_capacity(train_n);
+            let mut sorted_status = Vec::with_capacity(train_n);
+            let mut sorted_weights = Vec::with_capacity(train_n);
             let mut sorted_covariates = Array2::zeros((train_n, nvar));
-            for (new_idx, &orig_idx) in sorted_indices.iter().enumerate() {
+            for (new_idx, &orig_idx) in sorted_train_indices.iter().enumerate() {
+                sorted_time.push(time[orig_idx]);
+                sorted_status.push(status[orig_idx]);
+                sorted_weights.push(weights[orig_idx]);
                 for var in 0..nvar {
-                    sorted_covariates[[new_idx, var]] = train_covariates[[orig_idx, var]];
+                    sorted_covariates[[new_idx, var]] = covariates[[var, orig_idx]];
                 }
             }
             let time_arr = Array1::from_vec(sorted_time);
@@ -209,32 +208,29 @@ pub(crate) fn cv_cox(
                 }
                 Err(_) => vec![0.0; nvar],
             };
-            let test_time: Vec<f64> = test_indices.iter().map(|&i| time[i]).collect();
-            let test_status: Vec<i32> = test_indices.iter().map(|&i| status[i]).collect();
-            let mut test_covariates = Array2::zeros((nvar, test_n));
-            for (new_idx, &orig_idx) in test_indices.iter().enumerate() {
-                for var in 0..nvar {
-                    test_covariates[[var, new_idx]] = covariates[[var, orig_idx]];
-                }
-            }
-            let linear_predictor: Vec<f64> = (0..test_n)
-                .map(|i| {
-                    (0..nvar)
-                        .map(|var| beta[var] * test_covariates[[var, i]])
-                        .sum()
+            let linear_predictor: Vec<f64> = test_indices
+                .iter()
+                .map(|&orig_idx| {
+                    let mut eta = 0.0;
+                    for var in 0..nvar {
+                        eta += beta[var] * covariates[[var, orig_idx]];
+                    }
+                    eta
                 })
                 .collect();
 
             let (concordant, discordant, tied) = if test_n > PARALLEL_THRESHOLD_SMALL {
                 (0..test_n)
                     .into_par_iter()
-                    .filter(|&i| test_status[i] == 1)
+                    .filter(|&i| status[test_indices[i]] == 1)
                     .map(|i| {
                         let mut c = 0.0;
                         let mut d = 0.0;
                         let mut t = 0.0;
+                        let orig_i = test_indices[i];
                         for j in 0..test_n {
-                            if i != j && test_time[j] > test_time[i] {
+                            let orig_j = test_indices[j];
+                            if i != j && time[orig_j] > time[orig_i] {
                                 if linear_predictor[i] > linear_predictor[j] {
                                     c += 1.0;
                                 } else if linear_predictor[i] < linear_predictor[j] {
@@ -252,11 +248,13 @@ pub(crate) fn cv_cox(
                 let mut discordant = 0.0;
                 let mut tied = 0.0;
                 for i in 0..test_n {
-                    if test_status[i] != 1 {
+                    let orig_i = test_indices[i];
+                    if status[orig_i] != 1 {
                         continue;
                     }
                     for j in 0..test_n {
-                        if i != j && test_time[j] > test_time[i] {
+                        let orig_j = test_indices[j];
+                        if i != j && time[orig_j] > time[orig_i] {
                             if linear_predictor[i] > linear_predictor[j] {
                                 concordant += 1.0;
                             } else if linear_predictor[i] < linear_predictor[j] {

--- a/src/validation/crossval.rs
+++ b/src/validation/crossval.rs
@@ -141,6 +141,23 @@ fn create_folds(n: usize, n_folds: usize, shuffle: bool, seed: Option<u64>) -> V
     }
     folds
 }
+
+fn covariate_rows_for_indices(
+    covariates: &Array2<f64>,
+    nvar: usize,
+    indices: &[usize],
+) -> Vec<Vec<f64>> {
+    let mut rows = Vec::with_capacity(indices.len());
+    for &obs_idx in indices {
+        let mut row = Vec::with_capacity(nvar);
+        for var in 0..nvar {
+            row.push(covariates[[var, obs_idx]]);
+        }
+        rows.push(row);
+    }
+    rows
+}
+
 pub(crate) fn cv_cox(
     time: &[f64],
     status: &[i32],
@@ -338,24 +355,20 @@ pub(crate) fn cv_survreg(
     use crate::regression::parametric_survival::survreg;
     let n = time.len();
     let nvar = covariates.nrows();
-    let cov_vecs: Vec<Vec<f64>> = (0..n)
-        .map(|i| (0..nvar).map(|j| covariates[[j, i]]).collect())
-        .collect();
     let folds = create_folds(n, config.n_folds, config.shuffle, config.seed);
     let results: Vec<(f64, Vec<f64>)> = (0..config.n_folds)
         .into_par_iter()
         .filter_map(|fold_idx| {
             let test_indices = &folds[fold_idx];
-            let train_indices: Vec<usize> = folds
-                .iter()
-                .enumerate()
-                .filter(|(i, _)| *i != fold_idx)
-                .flat_map(|(_, f)| f.iter().copied())
-                .collect();
+            let mut train_indices = Vec::with_capacity(n - test_indices.len());
+            for (idx, fold) in folds.iter().enumerate() {
+                if idx != fold_idx {
+                    train_indices.extend_from_slice(fold);
+                }
+            }
             let train_time: Vec<f64> = train_indices.iter().map(|&i| time[i]).collect();
             let train_status: Vec<f64> = train_indices.iter().map(|&i| status[i]).collect();
-            let train_covariates: Vec<Vec<f64>> =
-                train_indices.iter().map(|&i| cov_vecs[i].clone()).collect();
+            let train_covariates = covariate_rows_for_indices(covariates, nvar, &train_indices);
             let fit_result = survreg(
                 train_time,
                 train_status,
@@ -375,8 +388,7 @@ pub(crate) fn cv_survreg(
             .ok()?;
             let test_time: Vec<f64> = test_indices.iter().map(|&i| time[i]).collect();
             let test_status: Vec<f64> = test_indices.iter().map(|&i| status[i]).collect();
-            let test_covariates: Vec<Vec<f64>> =
-                test_indices.iter().map(|&i| cov_vecs[i].clone()).collect();
+            let test_covariates = covariate_rows_for_indices(covariates, nvar, test_indices);
             let test_fit = survreg(
                 test_time,
                 test_status,


### PR DESCRIPTION
## Summary

Reduces heap allocations and redundant copies throughout the Cox proportional-hazards
code paths (fitting, cross-validation, diagnostics, residuals, and the fast/penalized
Cox solvers). Results are unchanged for all valid survival inputs; the full Rust test
suite (1452 lib tests), the R-`survival` validation suite, and the Python test suite
(including the binding-contract surface) all pass.

Two of the changes also consolidate previously-inlined logic onto the crate's shared
risk-set utilities (see "Consolidation" below), which additionally aligns their handling
of degenerate inputs with the canonical Cox path.

## What changed

**Buffer reuse in the fast/penalized Cox path and cross-validation**
- Reuse solver, gradient, predictor, screening, scoring, and deviance buffers across
  CV folds and coordinate-descent iterations instead of reallocating each pass.
- Warm-start CV folds, reuse fold scaling, and skip redundant full-path fits and unused
  fit metrics during CV scoring.
- Compute the fast-Cox `lambda_max` from first-order risk-set sums.

**Cox risk-set computation**
- Share and reuse risk-set buffers, flatten nested work matrices into flat buffers, and
  allocate risk-cache scratch on demand.
- Skip exponentials for zero-weight observations.

**Residual computation**
- Reuse Schoenfeld, score, counting-process, Efron-detail, and martingale residual
  buffers across sweeps/scans rather than reallocating per call; reserve rows up front.

**Borrow inputs instead of cloning**
- Borrow Cox detail inputs, baseline/diagnostic strata, cause-specific Cox inputs,
  residual input arrays, optional input arrays, and unstandardized matrices instead of
  taking owned clones. Move (rather than copy) owned fit inputs and path warm starts.

**Compute outputs directly**
- Stream/compute survival times, RMST, prediction risk scores, deviance residuals,
  dfbeta rows, partial residuals, and fit deviance directly into their outputs instead
  of building intermediate `Vec`s. Accumulate standard errors directly.

**Matrix standardization**
- Use a reciprocal scale factor, avoid the pre-standardization copy, and borrow the
  unstandardized matrices.

**numpy interop**
- Accept strided numpy vectors, avoiding forced contiguous copies at the boundary.

**Consolidation onto shared risk-set utilities**
- `ridge::fit_unpenalized` now builds its risk sets with the shared
  `precompute_cox_risk_set_cumsum` (the same descending stop-time accumulation used by
  the main Cox path) instead of a local ascending-sort loop.
- `coxph_detail` now derives its risk shift from the shared `cox_risk_shift` helper
  instead of an inline max.
- Both produce identical results for distinct or exactly-tied event times. They differ
  only on degenerate inputs unreachable from valid data — non-transitive sub-epsilon
  near-ties (ridge) and linear predictors that overflow to `+inf` (detail) — where the
  shared utilities' behavior is now applied consistently across the whole crate.

**Lint hygiene**
- Add `#[allow(clippy::too_many_arguments)]` to the internal `_into` helpers that now
  thread scratch/output buffers (consistent with the existing convention across the
  crate), and rewrite one `needless_range_loop` over the CV fold assignments.

## Verification

- `cargo test --lib` (no-default / `ml` / `python,ml`): 1242 / 1450 / 1452 tests pass.
- `cargo clippy --all-targets` (no-default / `ml` / `python,ml`) with `-D warnings`: clean.
- `cargo fmt --all --check`: clean.
- Python: `maturin develop --release --features extension-module,ml` + `pytest python/tests/`.
