### PR TITLE
Avoid calibration bin index copies

### DIFF
--- a/src/validation/calibration.rs
+++ b/src/validation/calibration.rs
@@ -304,7 +304,7 @@ pub(crate) fn calibration_curve(
         if end <= start {
             continue;
         }
-        let group_indices: Vec<usize> = indices[start..end].to_vec();
+        let group_indices = &indices[start..end];
         let n_in_group = group_indices.len();
         let sum_pred: f64 = group_indices.iter().map(|&i| predicted_risk[i]).sum();
         let sum_obs: f64 = group_indices

--- a/src/validation/d_calibration/one_calibration.rs
+++ b/src/validation/d_calibration/one_calibration.rs
@@ -101,7 +101,7 @@ pub(crate) fn one_calibration_core(
             continue;
         }
 
-        let group_indices: Vec<usize> = indices[start..end].to_vec();
+        let group_indices = &indices[start..end];
         let n_in_group = group_indices.len();
 
         let sum_pred: f64 = group_indices

--- a/src/validation/d_calibration/plot.rs
+++ b/src/validation/d_calibration/plot.rs
@@ -98,7 +98,7 @@ pub(crate) fn calibration_plot_data_core(
             continue;
         }
 
-        let group_indices: Vec<usize> = indices[start..end].to_vec();
+        let group_indices = &indices[start..end];
         let n_in_group = group_indices.len();
 
         let sum_pred: f64 = group_indices


### PR DESCRIPTION
## Summary

- Use borrowed index slices for grouped calibration bins instead of copying each bin into a temporary `Vec<usize>`.
- Apply the same allocation cleanup to standard calibration, one-time calibration, and calibration plot data generation.

## Impact

This keeps the existing bin ordering and calculations unchanged while avoiding per-group heap allocations in calibration paths.

## Validation

- `PATH="/Users/cameron/.rustup/toolchains/1.94.0-aarch64-apple-darwin/bin:$PATH" cargo fmt --all -- --check`
- `PATH="/Users/cameron/.rustup/toolchains/1.94.0-aarch64-apple-darwin/bin:$PATH" cargo test validation::calibration --lib --no-default-features`
- `PATH="/Users/cameron/.rustup/toolchains/1.94.0-aarch64-apple-darwin/bin:$PATH" cargo test validation::d_calibration_module --lib --no-default-features`
- `PATH="/Users/cameron/.rustup/toolchains/1.94.0-aarch64-apple-darwin/bin:$PATH" cargo clippy --all-targets --no-default-features -- -D warnings`
- `PATH="/Users/cameron/.rustup/toolchains/1.94.0-aarch64-apple-darwin/bin:$PATH" cargo test --lib --no-default-features`
- `PATH="/Users/cameron/.rustup/toolchains/1.94.0-aarch64-apple-darwin/bin:$PATH" cargo clippy --all-targets --features ml -- -D warnings`