### PR TITLE
Avoid default censor-score allocation in two-sided conformal

### DIFF
--- a/src/validation/conformal/tests.rs
+++ b/src/validation/conformal/tests.rs
@@ -340,6 +340,42 @@ fn test_two_sided_conformal_predict() {
 }
 
 #[test]
+fn test_two_sided_conformal_predict_default_censor_scores_match_zeros() {
+    let time = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0];
+    let status = vec![1, 1, 0, 1, 0, 1, 1, 0, 1, 1];
+    let predicted = vec![1.1, 1.9, 2.8, 4.2, 4.8, 6.1, 6.9, 7.8, 9.2, 9.8];
+
+    let calibration = two_sided_conformal_calibrate(time, status, predicted, Some(0.9)).unwrap();
+
+    let predicted_new = vec![3.0, 5.0, 7.0, 9.0];
+    let default_result =
+        two_sided_conformal_predict(&calibration, predicted_new.clone(), None).unwrap();
+    let explicit_zero_result = two_sided_conformal_predict(
+        &calibration,
+        predicted_new.clone(),
+        Some(vec![0.0; predicted_new.len()]),
+    )
+    .unwrap();
+
+    assert_eq!(default_result.lower_bound, explicit_zero_result.lower_bound);
+    assert_eq!(default_result.upper_bound, explicit_zero_result.upper_bound);
+    assert_eq!(
+        default_result.predicted_time,
+        explicit_zero_result.predicted_time
+    );
+    assert_eq!(
+        default_result.is_two_sided,
+        explicit_zero_result.is_two_sided
+    );
+    assert_eq!(default_result.n_two_sided, explicit_zero_result.n_two_sided);
+    assert_eq!(default_result.n_one_sided, explicit_zero_result.n_one_sided);
+    assert_eq!(
+        default_result.coverage_level,
+        explicit_zero_result.coverage_level
+    );
+}
+
+#[test]
 fn test_two_sided_conformal_survival() {
     let time_calib = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0];
     let status_calib = vec![1, 1, 0, 1, 0, 1, 1, 0, 1, 1];

--- a/src/validation/conformal/two_sided.rs
+++ b/src/validation/conformal/two_sided.rs
@@ -183,9 +183,9 @@ pub fn two_sided_conformal_predict(
     let alpha = 1.0 - calibration.coverage_level;
     let alpha_half = alpha / 2.0;
 
-    let censor_scores = censoring_scores_new.unwrap_or_else(|| vec![0.0; n_new]);
+    let censor_scores = censoring_scores_new.as_deref();
 
-    if censor_scores.len() != n_new {
+    if censor_scores.is_some_and(|scores| scores.len() != n_new) {
         return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
             "censoring_scores_new must have the same length as predicted_new",
         ));
@@ -197,7 +197,7 @@ pub fn two_sided_conformal_predict(
 
     for i in 0..n_new {
         let is_uncensored_like = classify_uncensored_like(
-            censor_scores[i],
+            censor_scores.map_or(0.0, |scores| scores[i]),
             calibration.censoring_score_threshold,
             alpha_half,
             calibration.n_censored,


### PR DESCRIPTION
## Summary
- Borrow optional `censoring_scores_new` in two-sided conformal prediction instead of allocating a zero-filled default vector.
- Add a Rust parity test showing the default path matches explicit all-zero censor scores.

## Validation
- `cargo fmt --all -- --check`
- `cargo test two_sided_conformal --lib --no-default-features`
- `cargo test --lib --no-default-features`
- `cargo clippy --all-targets --no-default-features -- -D warnings`
- `cargo clippy --all-targets --features python -- -D warnings`
- `uv run --no-sync --with maturin maturin develop --features extension-module`
- Python API parity check for `two_sided_conformal_predict` default censor scores versus explicit zeros