### PR TITLE
Move dependent censoring curves without cloning

### DIFF
--- a/src/causal/dependent_censoring/bounds.rs
+++ b/src/causal/dependent_censoring/bounds.rs
@@ -115,9 +115,6 @@ pub fn sensitivity_bounds_survival(
             })
             .collect();
 
-        survival_lower.push(surv_lower.clone());
-        survival_upper.push(surv_upper.clone());
-
         let rmst_l = point_estimate - adjustment * tau * 0.5;
         let rmst_u = point_estimate + adjustment * tau * 0.5;
         rmst_lower.push(rmst_l);
@@ -128,6 +125,9 @@ pub fn sensitivity_bounds_survival(
         let hr_u = hr_point * gamma;
         hazard_ratio_lower.push(hr_l);
         hazard_ratio_upper.push(hr_u);
+
+        survival_lower.push(surv_lower);
+        survival_upper.push(surv_upper);
     }
 
     Ok(SensitivityBoundsResult {

--- a/src/causal/dependent_censoring/mnar.rs
+++ b/src/causal/dependent_censoring/mnar.rs
@@ -81,7 +81,6 @@ pub fn mnar_sensitivity_survival(
             .collect();
 
         let adj_surv = estimate_weighted_km(&time, &event, &weights, &eval_times);
-        adjusted_survival.push(adj_surv.clone());
 
         let rmst = compute_rmst(&adj_surv, &eval_times, max_time);
         adjusted_rmst.push(rmst);
@@ -93,6 +92,7 @@ pub fn mnar_sensitivity_survival(
             .map(|(_, t)| *t)
             .unwrap_or(max_time);
         adjusted_median.push(median);
+        adjusted_survival.push(adj_surv);
     }
 
     Ok(MNARSurvivalResult {

--- a/src/causal/dependent_censoring/tests.rs
+++ b/src/causal/dependent_censoring/tests.rs
@@ -31,6 +31,10 @@ mod tests {
             sensitivity_bounds_survival(time, event, treatment, vec![], 10.0, &config).unwrap();
 
         assert_eq!(result.gamma_values.len(), 2);
+        assert_eq!(result.survival_lower.len(), 2);
+        assert_eq!(result.survival_upper.len(), 2);
+        assert!(result.survival_lower.iter().all(|row| row.len() == 50));
+        assert!(result.survival_upper.iter().all(|row| row.len() == 50));
         assert_eq!(result.rmst_lower.len(), 2);
     }
 
@@ -44,6 +48,7 @@ mod tests {
 
         assert_eq!(result.delta_values.len(), 3);
         assert_eq!(result.adjusted_survival.len(), 3);
+        assert!(result.adjusted_survival.iter().all(|row| row.len() == 100));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Move sensitivity-bound survival curves into result storage after scalar summaries are computed
- Move MNAR adjusted survival curves after RMST and median summaries are computed
- Strengthen dependent-censoring tests to check returned curve matrix shapes

## Validation
- `cargo test dependent_censoring --lib --no-default-features`
- `cargo test --lib --no-default-features`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --no-default-features -- -D warnings`
- `cargo clippy --all-targets --features python -- -D warnings`
- `uv run --no-sync --with maturin maturin develop --features extension-module`
- Python dependent-censoring curve shape smoke