### PR TITLE
Use rank-aware Cox information factorization

### DIFF
--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -9218,6 +9218,95 @@ def test_low_level_coxph_tie_methods_match_hand_likelihood_at_initial_beta():
         assert fit.log_likelihood == pytest.approx([expected, expected])
 
 
+@pytest.mark.parametrize(
+    ("method", "expected_beta", "expected_variance", "expected_loglik", "expected_iterations"),
+    [
+        (
+            "breslow",
+            [0.17569299458865062, -0.8920800877103963],
+            [
+                [1.7665625849926303, 0.7884637138499169],
+                [0.7884637138499169, 2.3311009321070157],
+            ],
+            [-8.070906088787817, -7.818812517162524],
+            3,
+        ),
+        (
+            "efron",
+            [0.10305623522446912, -1.021973929290916],
+            [
+                [1.8044465510612007, 0.9722159657351814],
+                [0.9722159657351814, 2.6559563822056127],
+            ],
+            [-7.7142311448490855, -7.430873243936032],
+            4,
+        ),
+        (
+            "exact",
+            [0.18990918067302853, -1.1018604705682347],
+            [
+                [2.1702188669318634, 1.0117674000364538],
+                [1.0117674000364538, 2.9114455509256167],
+            ],
+            [-6.327936783729195, -6.021664785573822],
+            3,
+        ),
+    ],
+)
+def test_low_level_coxph_rank_aware_information_matches_reference(
+    method,
+    expected_beta,
+    expected_variance,
+    expected_loglik,
+    expected_iterations,
+):
+    time = [1.0, 1.0, 2.0, 3.0, 3.0, 4.0, 5.0, 5.0]
+    status = [1, 1, 0, 1, 1, 0, 1, 0]
+    x1 = [0.2, 0.8, 0.4, 1.1, 0.7, 0.3, 1.3, 0.5]
+    x2 = [1.0, 0.2, 0.7, 1.3, 0.4, 1.1, 0.5, 0.9]
+    fit = survival.regression.coxph_fit(
+        time,
+        status,
+        [[left, right] for left, right in zip(x1, x2, strict=True)],
+        method=method,
+        max_iter=50,
+        eps=1e-9,
+        toler=1e-9,
+    )
+
+    assert fit.coefficients[0] == pytest.approx(expected_beta, rel=0, abs=1e-12)
+    for actual, expected in zip(fit.information_matrix, expected_variance, strict=True):
+        assert actual == pytest.approx(expected, rel=0, abs=1e-12)
+    assert fit.log_likelihood == pytest.approx(expected_loglik, rel=0, abs=1e-12)
+    assert fit.convergence_flag == 2
+    assert fit.iterations == expected_iterations
+
+
+def test_low_level_coxph_reduces_rank_for_dependent_columns():
+    time = [1.0, 1.0, 2.0, 3.0, 3.0, 4.0, 5.0, 5.0]
+    status = [1, 1, 0, 1, 1, 0, 1, 0]
+    x1 = [0.2, 0.8, 0.4, 1.1, 0.7, 0.3, 1.3, 0.5]
+    fit = survival.regression.coxph_fit(
+        time,
+        status,
+        [[value, 2.0 * value] for value in x1],
+        method="efron",
+        max_iter=50,
+        eps=1e-9,
+        toler=1e-9,
+    )
+
+    assert fit.coefficients[0][0] == pytest.approx(0.43940480983777153, rel=0, abs=1e-12)
+    assert fit.coefficients[0][1] == 0.0
+    assert fit.information_matrix[0][0] == pytest.approx(1.3555601527463446, rel=0, abs=1e-12)
+    assert fit.information_matrix[0][1] == 0.0
+    assert fit.information_matrix[1] == [0.0, 0.0]
+    assert fit.log_likelihood[1] == pytest.approx(-7.643272995750461, rel=0, abs=1e-12)
+    assert fit.convergence_flag == 1
+    assert fit.iterations == 3
+    assert all(math.isfinite(value) for value in fit.predict([[0.25, 0.5], [1.0, 2.0]]))
+
+
 def test_low_level_coxph_accepts_zero_column_null_model():
     data = _toy_data()
     fit = survival.regression.coxph_fit(

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,6 +1,5 @@
 pub const CHOLESKY_TOL: f64 = 1e-10;
 pub const RIDGE_REGULARIZATION: f64 = 1e-6;
-pub const SYMMETRY_TOL: f64 = 1e-10;
 pub const NEAR_ZERO_MATRIX: f64 = 1e-10;
 pub const TIME_EPSILON: f64 = 1e-9;
 pub const PYEARS_TIME_EPSILON: f64 = 1e-8;

--- a/src/internal/matrix.rs
+++ b/src/internal/matrix.rs
@@ -304,27 +304,6 @@ pub(crate) fn invert_matrix(mat: &[Vec<f64>]) -> Option<Vec<Vec<f64>>> {
     Some(aug.into_iter().map(|row| row[n..].to_vec()).collect())
 }
 
-pub(crate) fn cholesky_check(matrix: &Array2<f64>) -> bool {
-    let n = matrix.nrows();
-    if n == 0 {
-        return true;
-    }
-
-    for i in 0..n {
-        if matrix[[i, i]] <= 0.0 {
-            return false;
-        }
-        for j in 0..i {
-            if (matrix[[i, j]] - matrix[[j, i]]).abs() > crate::constants::SYMMETRY_TOL {
-                return false;
-            }
-        }
-    }
-
-    let b = Array1::from_elem(n, 1.0);
-    lu_solve(matrix, &b).is_some()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/regression/cox_optimizer.rs
+++ b/src/regression/cox_optimizer.rs
@@ -1,11 +1,9 @@
 use crate::constants::{
     CHOLESKY_TOL, CONVERGENCE_EPSILON, CONVERGENCE_FLAG, COX_MAX_ITER, DEFAULT_MAX_ITER,
-    PARALLEL_THRESHOLD_MEDIUM, RIDGE_REGULARIZATION,
+    PARALLEL_THRESHOLD_MEDIUM,
 };
-use crate::internal::matrix::{cholesky_check, lu_solve, matrix_inverse};
 use ndarray::{Array1, Array2};
 use rayon::prelude::*;
-use std::fmt;
 
 #[derive(Debug, Clone)]
 pub(crate) struct CoxFitConfig {
@@ -29,22 +27,7 @@ impl Default for CoxFitConfig {
     }
 }
 
-#[derive(Debug)]
-pub(crate) enum CoxError {
-    CholeskyDecomposition,
-    MatrixInversion,
-}
-
-impl fmt::Display for CoxError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            CoxError::CholeskyDecomposition => write!(f, "Cholesky decomposition failed"),
-            CoxError::MatrixInversion => write!(f, "Matrix inversion failed"),
-        }
-    }
-}
-
-impl std::error::Error for CoxError {}
+pub(crate) type CoxError = std::convert::Infallible;
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum Method {
     Breslow,
@@ -870,11 +853,11 @@ impl CoxFit {
             return Ok(());
         }
         a.copy_from_slice(&self.u);
-        self.flag = Self::cholesky(&mut self.imat, self.toler)?;
-        Self::chsolve(&self.imat, &mut a)?;
+        self.flag = Self::cholesky(&mut self.imat, self.toler);
+        Self::chsolve(&self.imat, &mut a);
         self.sctest = a.iter().zip(&self.u).map(|(ai, ui)| ai * ui).sum();
         if self.max_iter == 0 || !self.loglik[0].is_finite() {
-            Self::chinv(&mut self.imat)?;
+            Self::chinv(&mut self.imat);
             self.rescale_params();
             return Ok(());
         }
@@ -892,6 +875,7 @@ impl CoxFit {
                     f64::NAN
                 }
             };
+            self.flag = Self::cholesky(&mut self.imat, self.toler);
             _notfinite = !newlk.is_finite();
             if !_notfinite {
                 for i in 0..nvar {
@@ -907,10 +891,10 @@ impl CoxFit {
                     }
                 }
             }
-            if !_notfinite && ((self.loglik[1] - newlk).abs() / newlk.abs() <= self.eps) {
+            if !_notfinite && (1.0 - self.loglik[1] / newlk).abs() <= self.eps {
                 self.loglik[1] = newlk;
                 self.beta.copy_from_slice(&newbeta);
-                Self::chinv(&mut self.imat)?;
+                Self::chinv(&mut self.imat);
                 self.rescale_params();
                 if halving > 0 {
                     self.flag = -2;
@@ -929,7 +913,7 @@ impl CoxFit {
                 self.loglik[1] = newlk;
                 self.beta.copy_from_slice(&newbeta);
                 a.copy_from_slice(&self.u);
-                Self::chsolve(&self.imat, &mut a)?;
+                Self::chsolve(&self.imat, &mut a);
                 for (newbeta_elem, (beta_elem, a_elem)) in newbeta
                     .iter_mut()
                     .zip(self.beta.iter().zip(a.iter()))
@@ -941,7 +925,8 @@ impl CoxFit {
         }
         let beta_final = self.beta.clone();
         self.loglik[1] = self.iterate(&beta_final)?;
-        Self::chinv(&mut self.imat)?;
+        self.flag = Self::cholesky(&mut self.imat, self.toler);
+        Self::chinv(&mut self.imat);
         self.rescale_params();
         self.flag = CONVERGENCE_FLAG;
         Ok(())
@@ -960,39 +945,101 @@ impl CoxFit {
             }
         }
     }
-    fn cholesky(mat: &mut Array2<f64>, toler: f64) -> Result<i32, CoxError> {
+    fn cholesky(mat: &mut Array2<f64>, toler: f64) -> i32 {
+        let n = mat.nrows();
+        let mut eps = 0.0_f64;
+        for i in 0..n {
+            if mat[(i, i)] > eps {
+                eps = mat[(i, i)];
+            }
+            for j in (i + 1)..n {
+                mat[(j, i)] = mat[(i, j)];
+            }
+        }
+        eps = if eps == 0.0 { toler } else { eps * toler };
+
+        let mut rank = 0_i32;
+        let mut nonnegative = 1_i32;
+        for i in 0..n {
+            let pivot = mat[(i, i)];
+            if !pivot.is_finite() || pivot < eps {
+                mat[(i, i)] = 0.0;
+                if pivot < -8.0 * eps {
+                    nonnegative = -1;
+                }
+                continue;
+            }
+
+            rank += 1;
+            for j in (i + 1)..n {
+                let temp = mat[(j, i)] / pivot;
+                mat[(j, i)] = temp;
+                mat[(j, j)] -= temp * temp * pivot;
+                for k in (j + 1)..n {
+                    mat[(k, j)] -= temp * mat[(k, i)];
+                }
+            }
+        }
+        rank * nonnegative
+    }
+    fn chsolve(chol: &Array2<f64>, a: &mut [f64]) {
+        for i in 0..a.len() {
+            let mut temp = a[i];
+            for j in 0..i {
+                temp -= a[j] * chol[(i, j)];
+            }
+            a[i] = temp;
+        }
+        for i in (0..a.len()).rev() {
+            if chol[(i, i)] == 0.0 {
+                a[i] = 0.0;
+            } else {
+                let mut temp = a[i] / chol[(i, i)];
+                for j in (i + 1)..a.len() {
+                    temp -= a[j] * chol[(j, i)];
+                }
+                a[i] = temp;
+            }
+        }
+    }
+    fn chinv(mat: &mut Array2<f64>) {
         let n = mat.nrows();
         for i in 0..n {
-            for j in (i + 1)..n {
+            if mat[(i, i)] > 0.0 {
+                mat[(i, i)] = 1.0 / mat[(i, i)];
+                for j in (i + 1)..n {
+                    mat[(j, i)] = -mat[(j, i)];
+                    for k in 0..i {
+                        mat[(j, k)] += mat[(j, i)] * mat[(i, k)];
+                    }
+                }
+            }
+        }
+
+        for i in 0..n {
+            if mat[(i, i)] == 0.0 {
+                for j in 0..i {
+                    mat[(j, i)] = 0.0;
+                }
+                for j in i..n {
+                    mat[(i, j)] = 0.0;
+                }
+            } else {
+                for j in (i + 1)..n {
+                    let temp = mat[(j, i)] * mat[(j, j)];
+                    mat[(i, j)] = temp;
+                    for k in i..j {
+                        mat[(i, k)] += temp * mat[(j, k)];
+                    }
+                }
+            }
+        }
+
+        for i in 0..n {
+            for j in 0..i {
                 mat[(i, j)] = mat[(j, i)];
             }
         }
-        if cholesky_check(mat) {
-            Ok(n as i32)
-        } else {
-            for i in 0..n {
-                if mat[(i, i)] < toler {
-                    return Ok(i as i32);
-                }
-            }
-            Err(CoxError::CholeskyDecomposition)
-        }
-    }
-    fn chsolve(chol: &Array2<f64>, a: &mut [f64]) -> Result<(), CoxError> {
-        let b = Array1::from_iter(a.iter().copied());
-        let result = lu_solve(chol, &b).ok_or(CoxError::CholeskyDecomposition)?;
-        a.copy_from_slice(result.as_slice().unwrap_or(&[]));
-        Ok(())
-    }
-    fn chinv(mat: &mut Array2<f64>) -> Result<(), CoxError> {
-        let mut mat_reg = mat.clone();
-        mat_reg
-            .diag_mut()
-            .iter_mut()
-            .for_each(|d| *d += RIDGE_REGULARIZATION);
-        let inv = matrix_inverse(&mat_reg).ok_or(CoxError::MatrixInversion)?;
-        *mat = inv;
-        Ok(())
     }
     pub(crate) fn results(self) -> CoxFitResults {
         (
@@ -1103,6 +1150,47 @@ mod tests {
     }
 
     #[test]
+    fn nonconverged_fit_refactors_information_at_the_last_accepted_beta() {
+        let time = Array1::from_vec((1..=8).map(f64::from).collect());
+        let status = Array1::from_vec(vec![1, 0, 1, 1, 0, 1, 0, 1]);
+        let covar = Array2::from_shape_vec(
+            (8, 2),
+            vec![
+                0.0, 0.2, 1.0, 0.7, 0.4, 1.2, 1.5, 0.1, 0.8, 1.0, 1.1, 0.3, 1.8, 0.9, 2.0, 0.5,
+            ],
+        )
+        .unwrap();
+        let mut fit = CoxFitBuilder::new(time.clone(), status.clone(), covar.clone())
+            .max_iter(1)
+            .eps(1e-12)
+            .build()
+            .expect("limited-iteration fixture should initialize");
+
+        fit.fit().expect("limited-iteration fixture should fit");
+        let (beta, _means, score, variance, loglik, _sctest, flag, _iter) = fit.results();
+        assert_eq!(flag, CONVERGENCE_FLAG);
+
+        let mut evaluation = CoxFitBuilder::new(time, status, covar)
+            .max_iter(0)
+            .initial_beta(beta)
+            .build()
+            .expect("accepted coefficient evaluation should initialize");
+        evaluation
+            .fit()
+            .expect("accepted coefficient evaluation should succeed");
+        let (_beta, _means, evaluated_score, evaluated_variance, evaluated_loglik, ..) =
+            evaluation.results();
+
+        assert!((evaluated_loglik[0] - loglik[1]).abs() < 1e-12);
+        for i in 0..2 {
+            assert!((evaluated_score[i] - score[i]).abs() < 1e-12);
+            for j in 0..2 {
+                assert!((evaluated_variance[(i, j)] - variance[(i, j)]).abs() < 1e-12);
+            }
+        }
+    }
+
+    #[test]
     fn exact_tied_moments_match_hand_computed_two_death_set() {
         let covar = Array2::from_shape_vec((3, 2), vec![1.0, 0.0, 0.0, 2.0, 3.0, 4.0]).unwrap();
 
@@ -1148,12 +1236,131 @@ mod tests {
     }
 
     #[test]
-    fn test_cox_error_display() {
-        let chol_err = CoxError::CholeskyDecomposition;
-        let inv_err = CoxError::MatrixInversion;
+    fn information_factorization_inverts_spd_matrix() {
+        let mut information = Array2::from_shape_vec((2, 2), vec![4.0, 2.0, 0.0, 3.0]).unwrap();
 
-        assert_eq!(format!("{}", chol_err), "Cholesky decomposition failed");
-        assert_eq!(format!("{}", inv_err), "Matrix inversion failed");
+        let rank = CoxFit::cholesky(&mut information, 1e-9);
+        CoxFit::chinv(&mut information);
+
+        assert_eq!(rank, 2);
+        let expected = [[0.375, -0.25], [-0.25, 0.5]];
+        for i in 0..2 {
+            for j in 0..2 {
+                assert!((information[(i, j)] - expected[i][j]).abs() < 1e-12);
+            }
+        }
+    }
+
+    #[test]
+    fn singular_information_solve_and_inverse_zero_the_alias() {
+        let mut information = Array2::from_shape_vec((2, 2), vec![2.0, 2.0, 0.0, 2.0]).unwrap();
+        let rank = CoxFit::cholesky(&mut information, 1e-9);
+        let mut score = vec![2.0, 2.0];
+
+        CoxFit::chsolve(&information, &mut score);
+        CoxFit::chinv(&mut information);
+
+        assert_eq!(rank, 1);
+        assert_eq!(score, vec![1.0, 0.0]);
+        assert_eq!(information[(0, 0)], 0.5);
+        assert_eq!(information[(0, 1)], 0.0);
+        assert_eq!(information[(1, 0)], 0.0);
+        assert_eq!(information[(1, 1)], 0.0);
+    }
+
+    #[test]
+    fn singular_information_preserves_active_pivots_after_an_alias() {
+        let mut information =
+            Array2::from_shape_vec((3, 3), vec![2.0, 2.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 3.0])
+                .unwrap();
+        let rank = CoxFit::cholesky(&mut information, 1e-9);
+        let mut score = vec![2.0, 2.0, 6.0];
+
+        CoxFit::chsolve(&information, &mut score);
+        CoxFit::chinv(&mut information);
+
+        assert_eq!(rank, 2);
+        assert_eq!(score, vec![1.0, 0.0, 2.0]);
+        assert_eq!(information[(0, 0)], 0.5);
+        assert_eq!(information[(1, 1)], 0.0);
+        assert_eq!(information[(2, 2)], 1.0 / 3.0);
+        for i in 0..3 {
+            assert_eq!(information[(i, 1)], 0.0);
+            assert_eq!(information[(1, i)], 0.0);
+        }
+    }
+
+    #[test]
+    fn information_factorization_reports_indefinite_rank() {
+        let mut information = Array2::from_shape_vec((2, 2), vec![1.0, 2.0, 0.0, 1.0]).unwrap();
+
+        let rank = CoxFit::cholesky(&mut information, 1e-9);
+
+        assert_eq!(rank, -1);
+        assert_eq!(information[(1, 1)], 0.0);
+    }
+
+    #[test]
+    fn information_factorization_uses_a_strict_relative_pivot_tolerance() {
+        let tolerance = 1e-9;
+        let threshold = 2.0 * tolerance;
+        let mut at_threshold =
+            Array2::from_shape_vec((2, 2), vec![2.0, 0.0, 0.0, threshold]).unwrap();
+        let mut below_threshold =
+            Array2::from_shape_vec((2, 2), vec![2.0, 0.0, 0.0, threshold / 2.0]).unwrap();
+
+        assert_eq!(CoxFit::cholesky(&mut at_threshold, tolerance), 2);
+        assert_eq!(CoxFit::cholesky(&mut below_threshold, tolerance), 1);
+    }
+
+    #[test]
+    fn collinear_tied_efron_fit_reports_rank_and_zero_alias_variance() {
+        let time = Array1::from_vec(vec![1.0, 2.0, 2.0, 3.0, 4.0, 4.0, 5.0, 6.0, 7.0, 8.0]);
+        let status = Array1::from_vec(vec![1, 1, 1, 0, 1, 1, 0, 1, 0, 1]);
+        let x1 = [0.0, 0.4, 0.8, 0.2, 1.0, 1.4, 0.6, 1.2, 1.6, 1.8];
+        let x2 = [0.2, 0.16, 0.62, -0.07, 0.95, 0.61, 0.49, 0.68, 1.24, 0.97];
+        let mut covariates = Vec::with_capacity(30);
+        for (&first, &second) in x1.iter().zip(&x2) {
+            covariates.extend_from_slice(&[first, second, first + second]);
+        }
+        let covar = Array2::from_shape_vec((10, 3), covariates).unwrap();
+        let mut strata = Array1::zeros(10);
+        strata[9] = 1;
+        let mut fit = CoxFit::new(
+            time,
+            status,
+            covar,
+            strata,
+            Array1::zeros(10),
+            Array1::ones(10),
+            Method::Efron,
+            50,
+            1e-9,
+            1e-12,
+            vec![true; 3],
+            vec![0.0; 3],
+        )
+        .expect("collinear Efron fixture should initialize");
+
+        fit.fit().expect("collinear Efron fixture should fit");
+        let (beta, _means, _u, variance, loglik, _sctest, flag, iter) = fit.results();
+
+        assert_eq!(flag, 2);
+        assert_eq!(iter, 4);
+        let expected_beta = [-2.3468678070137803, 0.5775928193386433, 0.0];
+        let expected_variance = [
+            [3.9806704210981683, -4.116538359266848, 0.0],
+            [-4.116538359266848, 6.056737323572425, 0.0],
+            [0.0, 0.0, 0.0],
+        ];
+        for i in 0..3 {
+            assert!((beta[i] - expected_beta[i]).abs() < 1e-10);
+            for j in 0..3 {
+                assert!((variance[(i, j)] - expected_variance[i][j]).abs() < 1e-10);
+            }
+        }
+        assert!((loglik[0] - -11.079060882340368).abs() < 1e-12);
+        assert!((loglik[1] - -9.002136268091796).abs() < 1e-12);
     }
 
     #[test]

--- a/src/regression/coxph_model.rs
+++ b/src/regression/coxph_model.rs
@@ -723,7 +723,7 @@ impl CoxPHModel {
             return (0..nvar)
                 .map(|idx| {
                     let value = variance[(idx, idx)];
-                    if value.is_finite() && value > 0.0 {
+                    if value.is_finite() && value >= 0.0 {
                         value.sqrt()
                     } else {
                         0.1
@@ -1107,6 +1107,31 @@ mod tests {
             assert_relative_close(lower[idx], expected[idx].1, 3e-4, 3e-6);
             assert_relative_close(upper[idx], expected[idx].2, 3e-4, 3e-6);
         }
+    }
+
+    #[test]
+    fn aliased_covariate_keeps_zero_standard_error_and_confidence_interval() {
+        let time = vec![1.0, 1.0, 2.0, 3.0, 3.0, 4.0, 5.0, 5.0];
+        let status = vec![1, 1, 0, 1, 1, 0, 1, 0];
+        let x = [0.2, 0.8, 0.4, 1.1, 0.7, 0.3, 1.3, 0.5];
+        let covariates = x
+            .into_iter()
+            .map(|value| vec![value, 2.0 * value])
+            .collect();
+        let mut model = CoxPHModel::new_with_data(covariates, time, status)
+            .expect("collinear fixture should be valid");
+
+        model.fit(50).expect("collinear fit should converge");
+
+        let variance = model.vcov();
+        assert_eq!(variance[0][1], 0.0);
+        assert_eq!(variance[1], vec![0.0, 0.0]);
+        assert_eq!(model.std_errors()[1], 0.0);
+
+        let (hazard_ratios, lower, upper) = model.hazard_ratios_with_ci(0.95);
+        assert_eq!(hazard_ratios[1], 1.0);
+        assert_eq!(lower[1], 1.0);
+        assert_eq!(upper[1], 1.0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- replace ridge-regularized generic Cox information solves with an allocation-free, rank-aware in-place factor/solve/generalized-inverse sequence
- factor every likelihood evaluation, including the accepted-coefficient recomputation after iteration exhaustion
- return exact zero covariance rows and columns for aliased covariates while preserving finite low-level coefficients and predictions
- remove the obsolete matrix checker and impossible decomposition error variants
- add reference fixtures for Breslow, Efron, and exact ties plus dependent-column, indefinite, tolerance-boundary, and accepted-state coverage

## Motivation

The prior ridge inverse perturbed full-rank covariance estimates and treated dependent columns as full rank. Collinear fits could run to the iteration limit with large opposing coefficients and covariance entries. The new factorization reports numerical rank, solves only estimable directions, and forms the corresponding generalized inverse without regularization.

This is stacked on #262 because the exhausted-iteration coherence check builds on that PR's accepted-coefficient recomputation.

## Validation

- `cargo test --no-default-features -- --quiet` — 1,288 passed
- `cargo test --features python,ml -- --quiet` — 1,499 passed
- `python -m pytest python/tests -q` — 746 passed
- strict Clippy for lean and Python/ML feature sets
- Rust formatting check
- Ruff lint and formatting checks
- mypy — 37 source files clean
- generated binding manifest check
- release extension build
- `git diff --check`