### PR TITLE
Preserve formula term metadata across Python and R

### DIFF
--- a/python/survival/__init__.py
+++ b/python/survival/__init__.py
@@ -96,6 +96,7 @@ _R_EXPORTS = [
     "model_formula",
     "model_frame",
     "model_matrix",
+    "model_term_names",
     "model_weights",
     "model_summary",
     "nobs",

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -73,6 +73,7 @@ __all__ = [
     "model_summary",
     "model_frame",
     "model_matrix",
+    "model_term_names",
     "model_weights",
     "neardate",
     "nobs",
@@ -149,6 +150,7 @@ _MISSING = _MissingArgument()
 class _CovariateTerm:
     column: str
     categorical: bool = False
+    categorical_wrapper: str | None = None
     transform: str | None = None
     arithmetic: str | None = None
 
@@ -231,6 +233,7 @@ class _FormulaDesign:
     response: _SurvResponseSpec
     covariates: tuple[_DesignTerm, ...]
     offsets: tuple[_CovariateTerm, ...]
+    term_assignments: tuple[int, ...] = ()
     strata: tuple[str, ...] = ()
     strata_levels: tuple[Any, ...] = ()
     intercept: bool = False
@@ -2423,7 +2426,11 @@ def _parse_covariate_atom(term: str) -> _CovariateTerm:
             raise ValueError(f"{wrapper}() requires exactly one column")
         if any(_unsupported_formula_name(column, quoted) for column, quoted in column_items):
             raise ValueError(f"unsupported formula term(s): {columns[0]}")
-        return _CovariateTerm(columns[0], categorical=True)
+        return _CovariateTerm(
+            columns[0],
+            categorical=True,
+            categorical_wrapper=wrapper,
+        )
 
     for wrapper in ("I", "identity"):
         prefix = f"{wrapper}("
@@ -2925,10 +2932,19 @@ def _fit_formula_design(
     include_intercept: bool = False,
 ) -> _FormulaDesign:
     strata_values = _combined_columns(data, terms.strata, n) if terms.strata else []
+    term_assignments: dict[_CovariateSpec, int] = {}
+    term_index = 0
+    for model_term in terms.model_terms:
+        if isinstance(model_term, _ModelCovariateTerm):
+            term_index += 1
+            term_assignments[model_term.term] = term_index
+        elif isinstance(model_term, _ModelStrataTerm):
+            term_index += 1
     return _FormulaDesign(
         response=response_spec,
         covariates=tuple(_fit_design_term(data, term, n) for term in terms.covariates),
         offsets=tuple(terms.offsets),
+        term_assignments=tuple(term_assignments[term] for term in terms.covariates),
         strata=tuple(terms.strata),
         strata_levels=_label_levels(strata_values, "strata") if terms.strata else (),
         intercept=include_intercept and terms.intercept,
@@ -2974,13 +2990,16 @@ def _design_rows_from_spec(data: Any, design: _FormulaDesign, n: int) -> list[li
     return [[column[i] for column in columns] for i in range(n)]
 
 
-def _display_single_design_term(spec: _SingleDesignTerm) -> str:
-    term = spec.term
+def _covariate_term_name(term: _CovariateTerm) -> str:
     if term.transform is not None:
         return f"{term.transform}({term.column})"
-    if isinstance(spec, _CategoricalDesignTerm):
-        return f"factor({term.column})"
+    if term.categorical_wrapper is not None:
+        return f"{term.categorical_wrapper}({term.column})"
     return term.column
+
+
+def _display_single_design_term(spec: _SingleDesignTerm) -> str:
+    return _covariate_term_name(spec.term)
 
 
 def _design_term_name(spec: _DesignTerm) -> str:
@@ -2992,10 +3011,9 @@ def _design_term_name(spec: _DesignTerm) -> str:
 def _single_design_term_output_names(spec: _SingleDesignTerm) -> list[str]:
     term = spec.term
     if isinstance(spec, _CategoricalDesignTerm):
-        return [f"{term.column}{level}" for level in spec.levels[1:]]
-    if term.transform is not None:
-        return [f"{term.transform}({term.column})"]
-    return [term.column]
+        prefix = _covariate_term_name(term)
+        return [f"{prefix}{level}" for level in spec.levels[1:]]
+    return [_covariate_term_name(term)]
 
 
 def _design_term_output_names(spec: _DesignTerm) -> list[str]:
@@ -5550,9 +5568,7 @@ def _survobrien_transform_values(
 
 
 def _survobrien_term_name(term: _CovariateTerm) -> str:
-    if term.transform is not None:
-        return f"{term.transform}({term.column})"
-    return term.column
+    return _covariate_term_name(term)
 
 
 def _survobrien_formula_terms(
@@ -6072,13 +6088,7 @@ def _survcondense_legacy_call(
 def _survcondense_term_name(term: _CovariateSpec) -> str:
     if isinstance(term, _InteractionTerm):
         return ":".join(_survcondense_term_name(factor) for factor in term.factors)
-    if term.arithmetic is not None:
-        return term.arithmetic
-    if term.transform is not None:
-        return f"{term.transform}({term.column})"
-    if term.categorical:
-        return f"factor({term.column})"
-    return term.column
+    return _covariate_term_name(term)
 
 
 def _survcondense_strata_name(columns: Sequence[str]) -> str:
@@ -11485,20 +11495,6 @@ def _cox_deviance_from_martingale(martingale: list[float], status: list[float]) 
     return residuals
 
 
-def _cox_term_contributions(fit: Any, n: int) -> list[list[float]]:
-    beta = _cox_beta(fit)
-    nvar = len(beta)
-    covariates = getattr(fit, "covariates", None)
-    if covariates is None:
-        raise TypeError("model does not expose fitted covariates")
-    rows = [list(row) for row in covariates]
-    if len(rows) != n:
-        raise ValueError("fitted Cox model covariates do not match residual length")
-    if any(len(row) != nvar for row in rows):
-        raise ValueError("fitted Cox model covariates do not match coefficient width")
-    return [[float(row[col_idx]) * beta[col_idx] for col_idx in range(nvar)] for row in rows]
-
-
 def _cox_predict_term_groups(fit: Any, nvar: int) -> list[tuple[str, list[int]]]:
     design = _formula_design_for_fit(fit)
     if design is None:
@@ -11594,22 +11590,12 @@ def _cox_partial_residuals(
             residual * float(weight)
             for residual, weight in zip(martingale, martingale_weights, strict=True)
         ]
-    contributions = _cox_term_contributions(fit, len(martingale))
-    if terms is None:
-        return [
-            [martingale[row_idx] + term for term in row_terms]
-            for row_idx, row_terms in enumerate(contributions)
-        ]
-
-    groups = _cox_predict_term_groups(fit, len(_cox_beta(fit)))
-    selected = _predict_terms_selection(terms, [name for name, _columns in groups])
+    contributions = _cox_predict_terms(fit, None, terms, "sample", None)
+    if len(contributions) != len(martingale):
+        raise ValueError("Cox term predictions do not match martingale residual length")
     return [
-        [
-            martingale[row_idx]
-            + sum(contributions[row_idx][col_idx] for col_idx in groups[group_idx][1])
-            for group_idx in selected
-        ]
-        for row_idx in range(len(martingale))
+        [martingale[row_idx] + contribution for contribution in row]
+        for row_idx, row in enumerate(contributions)
     ]
 
 
@@ -12128,6 +12114,25 @@ def model_formula(fit: Any) -> str:
     raise TypeError("model_formula requires a formula-based fitted model")
 
 
+def model_term_names(fit: Any, terms: Any | None = None) -> list[str]:
+    """Return one label for each fitted model term, excluding the intercept."""
+
+    _require_model_fit(fit, "model_term_names")
+    groups = _cox_predict_term_groups(fit, len(_location_beta(fit)))
+    names = [name for name, _columns in groups]
+    return [names[idx] for idx in _predict_terms_selection(terms, names)]
+
+
+def predict_terms_constant(fit: Any) -> float:
+    """Return the sample-reference constant used by Cox term predictions."""
+
+    if not _is_coxph_fit(fit):
+        raise TypeError("predict_terms_constant requires a fitted coxph model")
+    beta = _cox_beta(fit)
+    means = _cox_reference_means(fit, "sample")
+    return sum(value * coefficient for value, coefficient in zip(means, beta, strict=True))
+
+
 def model_weights(fit: Any) -> list[float] | None:
     """Return explicit case weights for a fitted model, or ``None`` when absent."""
 
@@ -12156,6 +12161,21 @@ def _model_matrix_column_names(fit: Any, width: int) -> list[str]:
     return _fallback_coef_names(width)
 
 
+def _model_matrix_assignments(fit: Any, width: int) -> list[int]:
+    design = _formula_design_for_fit(fit)
+    if design is not None and len(design.term_assignments) == len(design.covariates):
+        assignments = [0] if design.intercept else []
+        for term, assignment in zip(
+            design.covariates,
+            design.term_assignments,
+            strict=True,
+        ):
+            assignments.extend([assignment] * len(_design_term_output_names(term)))
+        if len(assignments) == width:
+            return assignments
+    return list(range(1, width + 1))
+
+
 def model_matrix(fit: Any) -> dict[str, Any]:
     """Return the training design matrix and column names for a fitted model."""
 
@@ -12172,6 +12192,7 @@ def model_matrix(fit: Any) -> dict[str, Any]:
     return {
         "data": matrix,
         "columns": _model_matrix_column_names(fit, width),
+        "assign": _model_matrix_assignments(fit, width),
     }
 
 
@@ -16255,7 +16276,10 @@ def residuals(
         return _cox_deviance_from_martingale(martingale, status)
 
     if residual_type == "partial" and (
-        terms is not None or use_weights or not _collapse_is_false(collapse)
+        _formula_design_for_fit(fit) is not None
+        or terms is not None
+        or use_weights
+        or not _collapse_is_false(collapse)
     ):
         result = _cox_partial_residuals(
             fit,

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -6823,7 +6823,12 @@ def test_model_generic_helpers_report_formula_coefficient_names():
         eps=1e-5,
     )
 
-    assert survival.coef_names(cox) == ["x1", "groupB", "groupC", "x1:x2"]
+    assert survival.coef_names(cox) == [
+        "x1",
+        "factor(group)B",
+        "factor(group)C",
+        "x1:x2",
+    ]
     assert survival.coef_names(aft) == ["(Intercept)", "x1", "x2"]
     assert survival.coef_names(aft, complete=True) == [
         "(Intercept)",
@@ -6835,6 +6840,58 @@ def test_model_generic_helpers_report_formula_coefficient_names():
     ]
     assert len(survival.coef_names(aft, complete=True)) == len(aft.coefficients)
     assert len(survival.coef_names(aft)) == len(survival.coef(aft))
+
+
+def test_formula_metadata_preserves_categorical_spelling_and_assignments():
+    data = _factor_data()
+    data["group"] = ["A", "A", "B", "B", "C", "C", "A", "B"]
+    data["band"] = [0, 1, 2, 0, 1, 2, 0, 1]
+    formula = "Surv(time, status) ~ group + factor(dose) + as.factor(band) + x1"
+    term_names = ["group", "factor(dose)", "as.factor(band)", "x1"]
+    cox_columns = [
+        "groupB",
+        "groupC",
+        "factor(dose)1",
+        "factor(dose)2",
+        "as.factor(band)1",
+        "as.factor(band)2",
+        "x1",
+    ]
+
+    cox = survival.coxph(formula, data=data, max_iter=0)
+    aft = survival.survreg(formula, data=data, max_iter=1)
+
+    assert survival.model_term_names(cox) == term_names
+    assert survival.model_term_names(aft) == term_names
+    assert survival.r_api.model_term_names(cox, [3, 1]) == [
+        "as.factor(band)",
+        "group",
+    ]
+    assert survival.coef_names(cox) == cox_columns
+    assert survival.coef_names(aft) == ["(Intercept)", *cox_columns]
+
+    cox_matrix = survival.model_matrix(cox)
+    assert cox_matrix["columns"] == cox_columns
+    assert cox_matrix["assign"] == [1, 1, 2, 2, 3, 3, 4]
+
+    aft_matrix = survival.model_matrix(aft)
+    assert aft_matrix["columns"] == ["(Intercept)", *cox_columns]
+    assert aft_matrix["assign"] == [0, 1, 1, 2, 2, 3, 3, 4]
+
+
+def test_model_matrix_assignments_keep_strata_term_positions():
+    data = _factor_data()
+    data["group"] = ["A", "A", "B", "B", "A", "B", "A", "B"]
+    fit = survival.coxph(
+        "Surv(time, status) ~ x1 + strata(group) + as.factor(dose)",
+        data=data,
+        max_iter=0,
+    )
+
+    matrix = survival.model_matrix(fit)
+    assert survival.model_term_names(fit) == ["x1", "as.factor(dose)"]
+    assert matrix["columns"] == ["x1", "as.factor(dose)1", "as.factor(dose)2"]
+    assert matrix["assign"] == [1, 3, 3]
 
 
 def test_direct_model_matrix_preserves_tabular_column_names():
@@ -8133,7 +8190,7 @@ def test_cox_zph_formula_terms_group_multi_column_factors():
 
     assert by_term.variable_names == ["factor(dose)", "x1"]
     assert by_term.df == [2, 1]
-    assert by_column.variable_names == ["dose1", "dose2", "x1"]
+    assert by_column.variable_names == ["factor(dose)1", "factor(dose)2", "x1"]
     assert by_column.df == [1, 1, 1]
     assert single_df.df == [1, 1]
     assert len(by_term.y[0]) == 2
@@ -8146,18 +8203,11 @@ def test_cox_zph_formula_terms_group_multi_column_factors():
 def test_coxph_partial_residuals_add_terms_to_martingales():
     fit = survival.coxph("Surv(time, status) ~ x1 + x2", data=_toy_data(), max_iter=10, eps=1e-5)
     martingale = fit.martingale_residuals()
-    beta = fit.coefficients[0]
+    term_predictions = survival.predict(fit, type="terms")
     expected = [
-        [
-            martingale[row_idx] + fit.covariates[row_idx][col_idx] * beta[col_idx]
-            for col_idx in range(2)
-        ]
-        for row_idx in range(len(martingale))
+        [martingale[row_idx] + term for term in row] for row_idx, row in enumerate(term_predictions)
     ]
 
-    partial = fit.partial_residuals()
-    for actual, expected_row in zip(partial, expected, strict=True):
-        assert actual == pytest.approx(expected_row)
     for alias in ("partial", "partials", "p"):
         for actual, expected_row in zip(
             survival.r_api.residuals(fit, type=alias),
@@ -8177,6 +8227,61 @@ def test_coxph_partial_residuals_add_terms_to_martingales():
         survival.r_api.residuals(fit, type="partial", terms="missing")
 
 
+def test_coxph_partial_residuals_group_factor_coefficients_by_formula_term():
+    data = _factor_data()
+    fit = survival.coxph(
+        "Surv(time, status) ~ as.factor(dose) + x1",
+        data=data,
+        initial_beta=[0.2, -0.1, 0.3],
+        max_iter=0,
+    )
+    martingale = fit.martingale_residuals()
+    term_predictions = survival.predict(fit, type="terms")
+
+    partial = survival.r_api.residuals(fit, type="partial")
+    selected = survival.r_api.residuals(
+        fit,
+        type="partial",
+        terms="as.factor(dose)",
+    )
+
+    assert survival.model_term_names(fit) == ["as.factor(dose)", "x1"]
+    assert all(len(row) == 2 for row in partial)
+    for row_idx, actual in enumerate(partial):
+        assert actual == pytest.approx(
+            [martingale[row_idx] + value for value in term_predictions[row_idx]]
+        )
+        assert selected[row_idx] == pytest.approx([actual[0]])
+
+
+def test_predict_terms_constant_restores_zero_reference_linear_predictor():
+    fit = survival.coxph(
+        "Surv(time, status) ~ x1 + x2",
+        data=_toy_data(),
+        initial_beta=[0.25, -0.4],
+        max_iter=0,
+    )
+    constant = survival.r_api.predict_terms_constant(fit)
+    term_predictions = survival.predict(fit, type="terms")
+    zero_reference = survival.predict(fit, reference="zero")
+
+    assert constant == pytest.approx(
+        sum(
+            mean * coefficient
+            for mean, coefficient in zip(fit.means, fit.coefficients[0], strict=True)
+        )
+    )
+    assert [sum(row) + constant for row in term_predictions] == pytest.approx(zero_reference)
+
+    aft = survival.survreg(
+        "Surv(time, status) ~ x1",
+        data=_toy_data(),
+        max_iter=1,
+    )
+    with pytest.raises(TypeError, match="coxph"):
+        survival.r_api.predict_terms_constant(aft)
+
+
 def test_coxph_counting_process_partial_residuals_keep_training_row_order():
     data = _counting_cox_data()
     fit = survival.coxph(
@@ -8187,10 +8292,9 @@ def test_coxph_counting_process_partial_residuals_keep_training_row_order():
         max_iter=0,
     )
     martingale = fit.martingale_residuals()
-    beta = fit.coefficients[0]
+    term_predictions = survival.predict(fit, type="terms")
     expected = [
-        [martingale[row_idx] + fit.covariates[row_idx][0] * beta[0]]
-        for row_idx in range(len(martingale))
+        [martingale[row_idx] + term_predictions[row_idx][0]] for row_idx in range(len(martingale))
     ]
 
     partial = survival.r_api.residuals(fit, type="partial")
@@ -8230,10 +8334,7 @@ def test_coxph_residuals_honor_case_weighting_rules():
         assert unweighted_row == pytest.approx(raw_row)
         assert default_row == pytest.approx([value * weights[row_idx] for value in raw_row])
 
-    terms = [
-        [fit.covariates[row_idx][col_idx] * fit.coefficients[0][col_idx] for col_idx in range(2)]
-        for row_idx in range(len(martingale))
-    ]
+    terms = survival.predict(fit, type="terms")
     partial = survival.r_api.residuals(fit, type="partial", weighted=True)
     for row_idx, actual in enumerate(partial):
         assert actual == pytest.approx(
@@ -8272,7 +8373,7 @@ def test_coxph_residuals_collapse_training_rows_by_label():
     for actual, expected_row in zip(collapsed_score, expected_score, strict=True):
         assert actual == pytest.approx(expected_row)
 
-    partial = fit.partial_residuals()
+    partial = survival.r_api.residuals(fit, type="partial")
     collapsed_partial = survival.r_api.residuals(fit, type="partial", collapse=collapse)
     expected_partial = [
         [sum(partial[idx][0] for idx, label in enumerate(collapse) if label == group)]
@@ -12977,6 +13078,12 @@ def test_survreg_formula_as_factor_treatment_codes_numeric_covariates():
 
     assert fit.coefficients == pytest.approx(low_level.coefficients)
     assert fit.log_likelihood == pytest.approx(low_level.log_likelihood)
+    assert survival.coef_names(fit) == [
+        "(Intercept)",
+        "as.factor(dose)1",
+        "as.factor(dose)2",
+        "x2",
+    ]
 
 
 def test_survreg_matrix_input_applies_subset_to_row_aligned_arrays():
@@ -13126,7 +13233,7 @@ def test_survreg_formula_treatment_codes_categorical_covariates():
 
     assert fit.coefficients == pytest.approx(low_level.coefficients)
     newdata = {"group": ["B", "A"], "x1": [0.5, 0.8]}
-    term_se = survival.predict(fit, newdata, type="terms", terms="factor(group)", se_fit=True)
+    term_se = survival.predict(fit, newdata, type="terms", terms="group", se_fit=True)
     group_var = fit.variance_matrix[1][1]
     group_mean = sum(1.0 if value == "B" else 0.0 for value in data["group"]) / len(data["group"])
     for actual, expected in zip(

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -715,6 +715,14 @@ attrassign.lm <- function(object, ...) {
 .as_model_matrix <- function(result) {
   values <- .as_numeric_matrix(result[["data"]])
   colnames(values) <- as.character(result[["columns"]])
+  assign <- result[["assign"]]
+  if (!is.null(assign)) {
+    assign <- as.integer(unlist(assign, recursive = TRUE, use.names = FALSE))
+    if (length(assign) != ncol(values)) {
+      stop("model matrix assign metadata must match its column count", call. = FALSE)
+    }
+    attr(values, "assign") <- assign
+  }
   values
 }
 
@@ -985,12 +993,8 @@ attrassign.lm <- function(object, ...) {
   .as_prediction_value(value, matrix_result = matrix_result, col.names = col.names)
 }
 
-.model_term_names <- function(object) {
-  values <- as.character(.call_r_api("coef_names", object))
-  if (inherits(object, "survival_py_survreg")) {
-    values <- values[values != "(Intercept)"]
-  }
-  values
+.model_term_names <- function(object, terms = NULL) {
+  as.character(.call_r_api("model_term_names", object, terms = terms))
 }
 
 .predict_matrix_result <- function(type) {
@@ -1001,15 +1005,48 @@ attrassign.lm <- function(object, ...) {
   startsWith("terms", value) || startsWith("quantile", value) || startsWith("uquantile", value)
 }
 
-.predict_column_names <- function(object, type) {
+.predict_column_names <- function(object, type, terms = NULL) {
   if (is.null(type)) {
     return(NULL)
   }
   value <- tolower(gsub("-", "_", trimws(type)))
   if (startsWith("terms", value)) {
-    return(.model_term_names(object))
+    return(.model_term_names(object, terms = terms))
   }
   NULL
+}
+
+.attach_term_prediction_constant <- function(value, object, type, reference = NULL) {
+  if (is.null(type) || !inherits(object, "survival_py_coxph")) {
+    return(value)
+  }
+  type_key <- tolower(gsub("-", "_", trimws(type)))
+  if (!startsWith("terms", type_key)) {
+    return(value)
+  }
+  reference_key <- if (is.null(reference)) {
+    "sample"
+  } else {
+    tolower(gsub("-", "_", trimws(as.character(reference)[[1L]])))
+  }
+  if (identical(reference_key, "strata")) {
+    return(value)
+  }
+  if (identical(reference_key, "zero")) {
+    constant <- 0
+  } else {
+    module <- .survival_python_module()
+    if (!reticulate::py_has_attr(module, "predict_terms_constant")) {
+      return(value)
+    }
+    constant <- as.numeric(.call_r_api("predict_terms_constant", object))[[1L]]
+  }
+  if (is.list(value) && all(c("fit", "se.fit") %in% names(value))) {
+    attr(value$fit, "constant") <- constant
+  } else {
+    attr(value, "constant") <- constant
+  }
+  value
 }
 
 .residual_type_key <- function(type) {
@@ -1030,9 +1067,12 @@ attrassign.lm <- function(object, ...) {
   value
 }
 
-.residual_column_names <- function(object, key) {
+.residual_column_names <- function(object, key, terms = NULL) {
+  if (inherits(object, "survival_py_coxph") && identical(key, "partial")) {
+    return(.model_term_names(object, terms = terms))
+  }
   if (inherits(object, "survival_py_coxph") &&
-      key %in% c("score", "schoenfeld", "scaledsch", "partial")) {
+      key %in% c("score", "schoenfeld", "scaledsch")) {
     return(as.character(.call_r_api("coef_names", object)))
   }
   if (inherits(object, "survival_py_survreg") && identical(key, "matrix")) {
@@ -1041,7 +1081,7 @@ attrassign.lm <- function(object, ...) {
   NULL
 }
 
-.as_residual_result <- function(object, value, type) {
+.as_residual_result <- function(object, value, type, terms = NULL) {
   key <- .residual_type_key(type)
   matrix_result <- FALSE
   drop_single_column <- FALSE
@@ -1058,7 +1098,7 @@ attrassign.lm <- function(object, ...) {
     value,
     matrix_result = matrix_result,
     drop_single_column = drop_single_column,
-    col.names = .residual_column_names(object, key)
+    col.names = .residual_column_names(object, key, terms = terms)
   )
 }
 
@@ -7233,6 +7273,7 @@ model.frame.survival_py_survfit <- function(formula, ...) {
 }
 
 fitted.survival_py_model <- function(object, ..., type = NULL, se.fit = FALSE) {
+  dots <- list(...)
   result <- .call_r_api(
     "fitted",
     object,
@@ -7240,11 +7281,12 @@ fitted.survival_py_model <- function(object, ..., type = NULL, se.fit = FALSE) {
     `se.fit` = se.fit,
     ...
   )
-  .as_prediction_result(
+  value <- .as_prediction_result(
     result,
     matrix_result = .predict_matrix_result(type),
-    col.names = .predict_column_names(object, type)
+    col.names = .predict_column_names(object, type, terms = dots[["terms"]])
   )
+  .attach_term_prediction_constant(value, object, type, reference = dots[["reference"]])
 }
 
 summary.survival_py_model <- function(object, ...) {
@@ -7255,6 +7297,7 @@ summary.survival_py_model <- function(object, ...) {
 }
 
 predict.survival_py_model <- function(object, newdata = NULL, ..., type = NULL, se.fit = FALSE) {
+  dots <- list(...)
   result <- .call_r_api(
     "predict",
     object,
@@ -7263,16 +7306,18 @@ predict.survival_py_model <- function(object, newdata = NULL, ..., type = NULL, 
     `se.fit` = se.fit,
     ...
   )
-  .as_prediction_result(
+  value <- .as_prediction_result(
     result,
     matrix_result = .predict_matrix_result(type),
-    col.names = .predict_column_names(object, type)
+    col.names = .predict_column_names(object, type, terms = dots[["terms"]])
   )
+  .attach_term_prediction_constant(value, object, type, reference = dots[["reference"]])
 }
 
 residuals.survival_py_model <- function(object, ..., type = "martingale") {
+  dots <- list(...)
   result <- .call_r_api("residuals", object, type = type, ...)
-  .as_residual_result(object, result, type)
+  .as_residual_result(object, result, type, terms = dots[["terms"]])
 }
 
 anova.survival_py_model <- function(object, ..., test = "Chisq") {

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -2227,6 +2227,157 @@ test_that("R formula wrappers delegate to the Python survival package", {
   expect_equal(nrow(aft_dfbeta), nrow(data))
 })
 
+test_that("model term metadata matches native Cox formula outputs", {
+  skip_if_not_installed("reticulate")
+  skip_if_not_installed("survival")
+  skip_if_not(
+    reticulate::py_module_available("survival"),
+    "Python survival package is unavailable"
+  )
+
+  set.seed(1729)
+  n <- 60L
+  data <- data.frame(
+    time = stats::rexp(n) + 0.1,
+    status = stats::rbinom(n, 1L, 0.75),
+    g = factor(rep(c("a", "b", "c"), length.out = n), levels = c("a", "b", "c")),
+    x = stats::rnorm(n)
+  )
+  cases <- list(
+    bare = list(
+      rhs = "g + x",
+      coefficients = c("gb", "gc", "x"),
+      terms = c("g", "x"),
+      assign = c(1L, 1L, 2L)
+    ),
+    factor = list(
+      rhs = "factor(g) + x",
+      coefficients = c("factor(g)b", "factor(g)c", "x"),
+      terms = c("factor(g)", "x"),
+      assign = c(1L, 1L, 2L)
+    ),
+    as_factor = list(
+      rhs = "as.factor(g) + x",
+      coefficients = c("as.factor(g)b", "as.factor(g)c", "x"),
+      terms = c("as.factor(g)", "x"),
+      assign = c(1L, 1L, 2L)
+    ),
+    interaction = list(
+      rhs = "g * x",
+      coefficients = c("gb", "gc", "x", "gb:x", "gc:x"),
+      terms = c("g", "x", "g:x"),
+      assign = c(1L, 1L, 2L, 3L, 3L)
+    )
+  )
+
+  for (case in cases) {
+    bridged_formula <- stats::as.formula(paste("Surv(time, status) ~", case$rhs))
+    reference_formula <- stats::as.formula(
+      paste("survival::Surv(time, status) ~", case$rhs)
+    )
+    bridged <- coxph(
+      bridged_formula,
+      data = data,
+      max_iter = 50,
+      eps = 1e-09,
+      toler = 1e-10
+    )
+    reference <- survival::coxph(
+      reference_formula,
+      data = data,
+      x = TRUE,
+      y = TRUE,
+      control = survival::coxph.control(iter.max = 50, eps = 1e-09, toler.chol = 1e-10)
+    )
+
+    expect_equal(names(coef(bridged)), case$coefficients)
+    expect_equal(names(coef(reference)), case$coefficients)
+    expect_equal(rownames(summary(bridged)$coefficients), case$coefficients)
+
+    bridged_matrix <- model.matrix(bridged)
+    reference_matrix <- stats::model.matrix(reference)
+    expect_equal(dim(bridged_matrix), dim(reference_matrix))
+    expect_equal(colnames(bridged_matrix), case$coefficients)
+    expect_equal(colnames(reference_matrix), case$coefficients)
+    expect_equal(attr(bridged_matrix, "assign"), case$assign)
+    expect_equal(attr(reference_matrix, "assign"), case$assign)
+    expect_equal(as.numeric(bridged_matrix), as.numeric(reference_matrix), tolerance = 1e-12)
+    expect_equal(
+      attrassign(bridged_matrix, terms(bridged)),
+      survival::attrassign(reference_matrix, terms(reference))
+    )
+
+    bridged_terms <- predict(bridged, type = "terms")
+    reference_terms <- stats::predict(reference, type = "terms")
+    expect_equal(dim(bridged_terms), dim(reference_terms))
+    expect_equal(colnames(bridged_terms), case$terms)
+    expect_equal(colnames(reference_terms), case$terms)
+    expect_equal(
+      attr(bridged_terms, "constant"),
+      attr(reference_terms, "constant"),
+      tolerance = 2e-04
+    )
+
+    selected_terms <- rev(case$terms)
+    bridged_selected <- predict(bridged, type = "terms", terms = selected_terms)
+    reference_selected <- stats::predict(
+      reference,
+      type = "terms",
+      terms = selected_terms
+    )
+    expect_equal(dim(bridged_selected), dim(reference_selected))
+    expect_equal(colnames(bridged_selected), selected_terms)
+    expect_equal(colnames(reference_selected), selected_terms)
+
+    bridged_with_se <- predict(bridged, type = "terms", se.fit = TRUE)
+    reference_with_se <- stats::predict(reference, type = "terms", se.fit = TRUE)
+    expect_equal(colnames(bridged_with_se$fit), case$terms)
+    expect_equal(colnames(bridged_with_se$se.fit), case$terms)
+    expect_equal(colnames(reference_with_se$fit), case$terms)
+    expect_equal(colnames(reference_with_se$se.fit), case$terms)
+    expect_equal(
+      attr(bridged_with_se$fit, "constant"),
+      attr(reference_with_se$fit, "constant"),
+      tolerance = 2e-04
+    )
+    expect_null(attr(bridged_with_se$se.fit, "constant"))
+
+    bridged_partial <- residuals(bridged, type = "partial")
+    reference_partial <- stats::residuals(reference, type = "partial")
+    expect_equal(dim(bridged_partial), dim(reference_partial))
+    expect_equal(colnames(bridged_partial), case$terms)
+    expect_equal(colnames(reference_partial), case$terms)
+    expected_partial <- sweep(
+      unclass(bridged_terms),
+      1L,
+      as.numeric(residuals(bridged, type = "martingale")),
+      "+"
+    )
+    expect_equal(
+      as.numeric(bridged_partial),
+      as.numeric(expected_partial),
+      tolerance = 1e-10
+    )
+
+    bridged_score <- residuals(bridged, type = "score")
+    reference_score <- stats::residuals(reference, type = "score")
+    expect_equal(colnames(bridged_score), colnames(reference_score))
+
+    bridged_zph_terms <- as.data.frame(cox.zph(bridged, transform = "rank", terms = TRUE))
+    reference_zph_terms <- survival::cox.zph(reference, transform = "rank", terms = TRUE)
+    expect_equal(bridged_zph_terms$name, rownames(reference_zph_terms$table))
+    bridged_zph_columns <- as.data.frame(
+      cox.zph(bridged, transform = "rank", terms = FALSE)
+    )
+    reference_zph_columns <- survival::cox.zph(
+      reference,
+      transform = "rank",
+      terms = FALSE
+    )
+    expect_equal(bridged_zph_columns$name, rownames(reference_zph_columns$table))
+  }
+})
+
 test_that("data-prep helpers match R survival shapes", {
   skip_if_not_installed("reticulate")
   skip_if_not_installed("survival")


### PR DESCRIPTION
## Summary
- preserve bare, `factor(...)`, and `as.factor(...)` categorical expressions in coefficient and term labels
- expose authoritative term names and model-matrix assignments, including intercept and strata positions
- align Cox term predictions, constants, partial residuals, diagnostics, and R bridge metadata

## Testing
- `.venv/bin/python -m pytest -q python/tests` (744 passed)
- `cargo test --lib --no-default-features` (1279 passed)
- full R bridge test file
- `R CMD check --no-manual --no-build-vignettes r/survivalr` (1 standard source-package NOTE)
- Ruff check and format check
- `git diff --check`