### PR TITLE
Add Cox summary inference statistics

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -12495,6 +12495,7 @@ def model_summary(fit: Any) -> dict[str, Any]:
         model = _unwrap_formula_fit(fit)
         logliks = _cox_loglik_values(model)
         result["null_loglik"] = logliks[0]
+        result["score_test"] = float(model.score_test)
         result["n_event"] = sum(1 for event in model.status if int(event) == 1)
         result["method"] = str(getattr(model, "method", "breslow"))
     return result

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -6960,6 +6960,8 @@ def test_model_summary_reports_named_coefficient_table():
     assert cox_summary["df"] == 2
     assert cox_summary["loglik"] == pytest.approx(cox.log_likelihood[-1])
     assert cox_summary["null_loglik"] == pytest.approx(cox.log_likelihood[0])
+    assert cox_summary["score_test"] == pytest.approx(cox.score_test)
+    assert plain_cox_summary["score_test"] == pytest.approx(plain_cox.score_test)
     assert [row["name"] for row in cox_summary["coefficients"]] == ["x1", "x2"]
     assert cox_summary["coefficient_names"] == ["x1", "x2"]
     for idx, (row, coefficient, variance_row, naive_variance_row) in enumerate(
@@ -7016,6 +7018,22 @@ def test_model_summary_reports_named_coefficient_table():
         assert row["z"] == pytest.approx(row["statistic"])
         assert row["p"] == pytest.approx(2.0 * NormalDist().cdf(-abs(row["z"])))
         assert 0.0 <= row["p"] <= 1.0
+
+
+def test_model_summary_reports_zero_coefficient_cox_inference_payload():
+    data = _toy_data()
+    fit = survival.coxph("Surv(time, status) ~ 1", data=data, max_iter=0)
+
+    summary = survival.model_summary(fit)
+
+    assert summary["coefficients"] == []
+    assert summary["coefficient_names"] == []
+    assert summary["df"] == 0
+    assert summary["loglik"] == pytest.approx(fit.log_likelihood[-1])
+    assert summary["null_loglik"] == pytest.approx(fit.log_likelihood[0])
+    assert summary["score_test"] == pytest.approx(fit.score_test)
+    assert summary["score_test"] == pytest.approx(0.0)
+    assert summary["n_event"] == sum(data["status"])
 
 
 def test_model_summary_survreg_scale_rows_and_robust_standard_errors():

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -504,10 +504,12 @@ attrassign.lm <- function(object, ...) {
   matrix(unlist(rows, use.names = FALSE), nrow = n_row, ncol = n_col, byrow = TRUE)
 }
 
-.as_coefficient_table <- function(rows, model_type = "coxph", robust = FALSE) {
+.as_coefficient_table <- function(rows, model_type = "coxph", robust = FALSE,
+                                  scale = 1) {
   model_type <- as.character(model_type)[[1L]]
   robust <- length(robust) > 0L && isTRUE(as.logical(robust)[[1L]])
   is_survreg <- identical(model_type, "survreg")
+  cox_scale <- if (is_survreg) 1 else as.numeric(scale)[[1L]]
   columns <- if (is_survreg) {
     if (robust) {
       c("Value", "Std. Err", "(Naive SE)", "z", "p")
@@ -537,8 +539,8 @@ attrassign.lm <- function(object, ...) {
   }
   row_values <- function(row) {
     coefficient <- row_numeric(row, "coef")
-    statistic <- row_numeric(row, "z", fallback_name = "statistic")
     if (is_survreg) {
+      statistic <- row_numeric(row, "z", fallback_name = "statistic")
       values <- c(
         row_numeric(row, "value", fallback_name = "coef"),
         if (robust) {
@@ -553,20 +555,27 @@ attrassign.lm <- function(object, ...) {
       return(c(values, statistic, row_numeric(row, "p")))
     }
 
+    coefficient <- coefficient * cox_scale
+    active_se <- row_numeric(
+      row,
+      if (robust) "robust_se" else "se",
+      fallback_name = "se"
+    ) * cox_scale
+    statistic <- coefficient / active_se
     values <- c(
       coefficient,
-      row_numeric(row, "exp_coef", default = exp(coefficient))
+      exp(coefficient)
     )
     if (robust) {
       values <- c(
         values,
         row_numeric(row, "naive_se", fallback_name = "se"),
-        row_numeric(row, "robust_se", fallback_name = "se")
+        active_se
       )
     } else {
-      values <- c(values, row_numeric(row, "se"))
+      values <- c(values, active_se)
     }
-    c(values, statistic, row_numeric(row, "p"))
+    c(values, statistic, stats::pchisq(statistic^2, 1, lower.tail = FALSE))
   }
 
   coefficient_names <- vapply(rows, function(row) as.character(row[["name"]]), character(1))
@@ -578,6 +587,45 @@ attrassign.lm <- function(object, ...) {
   )
   dimnames(values) <- list(coefficient_names, columns)
   values
+}
+
+.as_cox_confint_table <- function(coefficient_table, conf.int) {
+  coefficient <- coefficient_table[, "coef"]
+  se_column <- if ("robust se" %in% colnames(coefficient_table)) {
+    "robust se"
+  } else {
+    "se(coef)"
+  }
+  standard_error <- coefficient_table[, se_column]
+  z <- stats::qnorm((1 + conf.int) / 2)
+  values <- cbind(
+    exp(coefficient),
+    exp(-coefficient),
+    exp(coefficient - z * standard_error),
+    exp(coefficient + z * standard_error)
+  )
+  dimnames(values) <- list(
+    rownames(coefficient_table),
+    c(
+      "exp(coef)",
+      "exp(-coef)",
+      paste("lower .", round(100 * conf.int, 2), sep = ""),
+      paste("upper .", round(100 * conf.int, 2), sep = "")
+    )
+  )
+  values
+}
+
+.cox_summary_test <- function(test, df, round.test = FALSE) {
+  if (length(test) == 0L) {
+    return(c(df = df))
+  }
+  raw_test <- as.numeric(test)[[1L]]
+  c(
+    test = if (round.test) round(raw_test, 2) else raw_test,
+    df = df,
+    pvalue = stats::pchisq(raw_test, df, lower.tail = FALSE)
+  )
 }
 
 .as_confint_matrix <- function(rows, level) {
@@ -7303,14 +7351,15 @@ fitted.survival_py_model <- function(object, ..., type = NULL, se.fit = FALSE) {
   )
 }
 
-summary.survival_py_model <- function(object, ...) {
-  result <- .call_r_api("model_summary", object, ...)
+summary.survival_py_model <- function(object, conf.int = 0.95, scale = 1, ...) {
+  result <- .call_r_api("model_summary", object)
   model_type <- as.character(result$model_type)[[1L]]
   robust <- length(result$robust) > 0L && isTRUE(as.logical(result$robust)[[1L]])
   coefficient_table <- .as_coefficient_table(
     result$coefficients,
     model_type = model_type,
-    robust = robust
+    robust = robust,
+    scale = scale
   )
   if (identical(model_type, "survreg")) {
     location_coefficients <- result$location_coefficients
@@ -7351,6 +7400,39 @@ summary.survival_py_model <- function(object, ...) {
     } else {
       result$coefficients <- coefficient_table
       result$used.robust <- robust
+      if (conf.int) {
+        result$conf.int <- .as_cox_confint_table(coefficient_table, conf.int)
+      } else {
+        result$conf.int <- NULL
+      }
+
+      null_loglik <- as.numeric(result$null_loglik)[[1L]]
+      full_loglik <- as.numeric(result$loglik)[[1L]]
+      result$loglik <- c(null_loglik, full_loglik)
+      result$nevent <- as.numeric(result$n_event)[[1L]]
+
+      df <- sum(!is.na(coefficient_table[, "coef"]))
+      likelihood_test <- -2 * (null_loglik - full_loglik)
+      result$logtest <- .cox_summary_test(likelihood_test, df)
+      result$sctest <- .cox_summary_test(result$score_test, df)
+      result$rsq <- c(
+        rsq = 1 - exp(-likelihood_test / result$n),
+        maxrsq = 1 - exp(2 * null_loglik / result$n)
+      )
+
+      unscaled_coefficients <- stats::coef(object)
+      keep <- !is.na(unscaled_coefficients)
+      if (any(keep)) {
+        active_variance <- stats::vcov(object, complete = TRUE)[keep, keep, drop = FALSE]
+        wald <- coxph.wtest(
+          active_variance,
+          unname(as.list(unscaled_coefficients[keep]))
+        )
+        wald_test <- wald$test
+      } else {
+        wald_test <- numeric()
+      }
+      result$waldtest <- .cox_summary_test(wald_test, df, round.test = TRUE)
     }
   }
   class(result) <- c("summary.survival_py_model", class(result))
@@ -7700,14 +7782,91 @@ print.survival_py_object <- function(x, ...) {
   invisible(x)
 }
 
-print.summary.survival_py_model <- function(x, ...) {
+print.summary.survival_py_model <- function(
+    x,
+    digits = max(getOption("digits") - 3, 3),
+    signif.stars = getOption("show.signif.stars"),
+    expand = FALSE,
+    ...) {
+  if (identical(x$model_type, "coxph")) {
+    if (!is.null(x$call)) {
+      cat("Call:\n")
+      dput(x$call)
+      cat("\n")
+    }
+    if (!is.null(x$fail)) {
+      cat(" Coxreg failed.", x$fail, "\n")
+      return(invisible(x))
+    }
+
+    saved_digits <- options(digits = digits)
+    on.exit(options(saved_digits))
+    cat("  n=", x$n)
+    if (!is.null(x$nevent)) {
+      cat(", number of events=", x$nevent, "\n")
+    } else {
+      cat("\n")
+    }
+    if (is.null(x$coefficients)) {
+      cat("   Null model\n")
+      return(invisible(x))
+    }
+
+    cat("\n")
+    stats::printCoefmat(
+      x$coefficients,
+      digits = digits,
+      signif.stars = signif.stars,
+      ...
+    )
+    if (!is.null(x$conf.int)) {
+      cat("\n")
+      print(x$conf.int)
+    }
+
+    p_digits <- max(1, getOption("digits") - 4)
+    cat("\n")
+    cat(
+      "Likelihood ratio test= ",
+      format(round(x$logtest["test"], 2)),
+      "  on ", x$logtest["df"], " df,",
+      "   p=", format.pval(x$logtest["pvalue"], digits = p_digits),
+      "\n",
+      sep = ""
+    )
+    cat(
+      "Wald test            = ",
+      format(round(x$waldtest["test"], 2)),
+      "  on ", x$waldtest["df"], " df,",
+      "   p=", format.pval(x$waldtest["pvalue"], digits = p_digits),
+      "\n",
+      sep = ""
+    )
+    cat(
+      "Score (logrank) test = ",
+      format(round(x$sctest["test"], 2)),
+      "  on ", x$sctest["df"], " df,",
+      "   p=", format.pval(x$sctest["pvalue"], digits = p_digits),
+      "\n\n",
+      sep = ""
+    )
+    if (isTRUE(x$used.robust)) {
+      cat(
+        "  (Note: the likelihood ratio and score tests assume independence of\n",
+        "     observations within a cluster, the Wald and robust score tests do not).\n",
+        sep = ""
+      )
+    }
+    return(invisible(x))
+  }
+
   cat(x$model_type, "model summary\n", sep = "")
   coefficient_table <- if (identical(x$model_type, "survreg") && !is.null(x$table)) {
     x$table
   } else {
     x$coefficients
   }
-  print(coefficient_table, ...)
+  print(coefficient_table, digits = digits, ...)
   cat("logLik=", x$loglik, " df=", x$df, " n=", x$n, "\n", sep = "")
   invisible(x)
 }

--- a/r/survivalr/man/survivalr.Rd
+++ b/r/survivalr/man/survivalr.Rd
@@ -731,7 +731,7 @@ neardate(id1, id2, y1, y2, best = c("after", "prior"),
 
 \method{fitted}{survival_py_model}(object, ..., type = NULL, se.fit = FALSE)
 
-\method{summary}{survival_py_model}(object, ...)
+\method{summary}{survival_py_model}(object, conf.int = 0.95, scale = 1, ...)
 
 \method{summary}{survival_py_survfit}(object, times, censored = FALSE,
   scale = 1, extend = FALSE, rmean = getOption("survfit.rmean"),
@@ -810,7 +810,9 @@ neardate(id1, id2, y1, y2, best = c("after", "prior"),
 
 \method{print}{survival_py_anova}(x, ...)
 
-\method{print}{summary.survival_py_model}(x, ...)
+\method{print}{summary.survival_py_model}(x,
+  digits = max(getOption("digits") - 3, 3),
+  signif.stars = getOption("show.signif.stars"), expand = FALSE, ...)
 }
 \arguments{
 \item{time, time2, event}{Survival response vectors. \code{time} is also
@@ -986,8 +988,9 @@ long data frame instead of a matrix.}
 log-survival scale for \code{survfit_confint}.}
 \item{conf.type}{Confidence interval transform for \code{survfit_confint}
 and \code{survfitKM}.}
-\item{conf.int}{Confidence level for \code{survfit_confint}, or logical flag
-controlling confidence bounds in \code{quantile.survival_py_survfit}.}
+\item{conf.int}{Confidence level for \code{survfit_confint} and Cox model
+summaries, or logical flag controlling confidence bounds in survival
+quantiles and Cox summaries.}
 \item{selow}{Optional lower-side standard-error vector for asymmetric
 \code{survfit_confint} bounds.}
 \item{ulimit}{Logical flag controlling upper-bound clipping in
@@ -1007,7 +1010,12 @@ convergence tolerance used when \code{ridge}, \code{frailty.*}, or
 \item{dlist}{Distribution-list object for \code{survregDtest}.}
 \item{row.names, optional, make.names}{Standard \code{as.data.frame}
 arguments.}
-\item{digits}{Number of significant digits used by \code{print.concordance}.}
+\item{digits}{Number of significant digits used by concordance and model
+summary printers.}
+\item{signif.stars}{Logical flag controlling significance stars in printed
+Cox coefficient tables.}
+\item{expand}{Logical multi-state Cox print expansion flag, accepted for
+compatibility.}
 \item{quote}{Logical flag controlling whether printed survival-time labels are
 quoted.}
 \item{i, j, name, exact, drop}{Row and column subset controls for native
@@ -1040,11 +1048,11 @@ survtype, vartype, unlist}{Low-level delegated Cox survival-curve inputs.}
 \item{stype, ctype, conf.lower, start.time, entry, time0, robust}{Low-level
 \code{survfitKM} controls matching the R \pkg{survival} entry point where
 supported.}
-\item{scale}{Scale parameter for \code{survreg} distribution helpers, the
-standard \code{extractAIC} scale argument, divisor for survival quantile and
-\code{summary.survival_py_survfit} times, or a logical flag controlling
-whether \code{ridge} scales the penalty
-by column variance.}
+\item{scale}{Scale parameter for \code{survreg} distribution helpers, Cox
+summary coefficients, the standard \code{extractAIC} scale argument, divisor
+for survival quantile and \code{summary.survival_py_survfit} times, or a
+logical flag controlling whether \code{ridge} scales the penalty by column
+variance.}
 \item{k}{Penalty multiplier for \code{extractAIC}, or observed Poisson event
 count for \code{cipoisson}.}
 \item{test}{Test name for bridged model analysis of variance, \code{aareg}

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -2316,10 +2316,50 @@ test_that("model summaries match native Cox and survreg coefficient tables", {
     )
     expect_identical(bridged$used.robust, case$robust)
     expect_identical(reference$used.robust, case$robust)
+    expect_equal(bridged$loglik, reference$loglik, tolerance = 1e-08)
+    expect_identical(bridged$nevent, reference$nevent)
+    expect_identical(colnames(bridged$conf.int), colnames(reference$conf.int))
+    expect_equal(bridged$conf.int, reference$conf.int, tolerance = 1e-06)
+    for (field in c("logtest", "sctest", "waldtest")) {
+      expect_named(bridged[[field]], c("test", "df", "pvalue"))
+      expect_equal(bridged[[field]], reference[[field]], tolerance = 1e-06)
+    }
+    expect_named(bridged$rsq, c("rsq", "maxrsq"))
+    expect_equal(bridged$rsq, reference$rsq, tolerance = 1e-08)
 
     printed <- paste(capture.output(print(bridged)), collapse = "\n")
     expect_true(grepl("exp(coef)", printed, fixed = TRUE))
     expect_identical(grepl("robust se", printed, fixed = TRUE), case$robust)
+    expect_true(grepl("number of events", printed, fixed = TRUE))
+    expect_true(grepl("Likelihood ratio test=", printed, fixed = TRUE))
+    expect_true(grepl("Wald test            =", printed, fixed = TRUE))
+    expect_true(grepl("Score (logrank) test =", printed, fixed = TRUE))
+    expect_identical(
+      grepl("assume independence", printed, fixed = TRUE),
+      case$robust
+    )
+  }
+
+  for (case in cox_cases) {
+    bridged <- summary(case$bridged, conf.int = 0.9, scale = 2)
+    reference <- summary(case$reference, conf.int = 0.9, scale = 2)
+    expect_identical(
+      colnames(bridged$conf.int),
+      c("exp(coef)", "exp(-coef)", "lower .90", "upper .90")
+    )
+    expect_equal(bridged$coefficients, reference$coefficients, tolerance = 1e-06)
+    expect_equal(bridged$conf.int, reference$conf.int, tolerance = 1e-06)
+    expect_equal(bridged$logtest, reference$logtest, tolerance = 1e-06)
+    expect_equal(bridged$sctest, reference$sctest, tolerance = 1e-06)
+    expect_equal(bridged$waldtest, reference$waldtest, tolerance = 1e-06)
+    expect_equal(bridged$rsq, reference$rsq, tolerance = 1e-08)
+
+    without_confidence <- summary(case$bridged, conf.int = FALSE)
+    reference_without_confidence <- summary(case$reference, conf.int = FALSE)
+    expect_null(without_confidence$conf.int)
+    expect_null(reference_without_confidence$conf.int)
+    printed <- paste(capture.output(print(without_confidence)), collapse = "\n")
+    expect_false(grepl("lower .", printed, fixed = TRUE))
   }
 
   for (formula in list(
@@ -2329,8 +2369,16 @@ test_that("model summaries match native Cox and survreg coefficient tables", {
     bridged_formula <- stats::as.formula(
       sub("survival::Surv", "Surv", deparse1(formula), fixed = TRUE)
     )
-    bridged <- summary(coxph(bridged_formula, data = data))
-    reference <- summary(survival::coxph(formula, data = data))
+    bridged <- summary(
+      coxph(bridged_formula, data = data),
+      conf.int = 0.9,
+      scale = 2
+    )
+    reference <- summary(
+      survival::coxph(formula, data = data),
+      conf.int = 0.9,
+      scale = 2
+    )
     expect_null(bridged$coefficients)
     expect_null(reference$coefficients)
     expect_null(bridged$used.robust)


### PR DESCRIPTION
## Summary
- expose the cached Cox score statistic in the Python summary payload
- add native-shaped likelihood-ratio, score, Wald, R-squared, confidence-interval, and event-count fields to R summaries
- honor Cox `conf.int` and `scale`, including robust active-SE and unscaled naive-SE behavior
- print native-style coefficient, confidence, global-test, and clustered-independence blocks

## Stack
- depends on #276

## Testing
- `.venv/bin/python -m pytest -q python/tests` (745 passed)
- full `r/survivalr/tests/testthat/test-python-bridge.R`
- `R CMD check --no-manual --no-build-vignettes r/survivalr` (1 expected source-package NOTE; offline repository warnings)
- Ruff check and format check
- `git diff --check`