### PR TITLE
Correct Cox score residuals at mixed ties

### DIFF
--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -9264,6 +9264,93 @@ def test_coxph_score_and_dfbeta_residuals_use_fitted_information():
             assert dfbetas_row[col_idx] == pytest.approx(dfbeta[row_idx][col_idx] / scale)
 
 
+@pytest.mark.parametrize(
+    ("method", "expected_score", "expected_dfbeta", "expected_robust_variance"),
+    [
+        (
+            "breslow",
+            [
+                -0.566205435493211,
+                0.118975338134561,
+                -0.247269050248814,
+                -0.385057268840082,
+                -0.244685141396534,
+                1.32424155784408,
+            ],
+            [
+                -0.145720034481586,
+                0.0306197879579248,
+                -0.0636377757431793,
+                -0.0990992932519008,
+                -0.0629727745555388,
+                0.34081009007428,
+            ],
+            0.15615942412013,
+        ),
+        (
+            "efron",
+            [
+                -0.629825947484865,
+                0.116681966051309,
+                -0.218899195194712,
+                -0.400556408828364,
+                -0.25072229332147,
+                1.3833218787781,
+            ],
+            [
+                -0.158565652518724,
+                0.0293759762645186,
+                -0.0551102949322474,
+                -0.10084450885211,
+                -0.0631221120696446,
+                0.348266592108208,
+            ],
+            0.164486793924122,
+        ),
+    ],
+)
+def test_coxph_mixed_event_censor_ties_match_r_score_inference(
+    method,
+    expected_score,
+    expected_dfbeta,
+    expected_robust_variance,
+):
+    data = {
+        "time": [1.0, 1.0, 2.0, 2.0, 3.0, 4.0],
+        "status": [1, 1, 1, 0, 1, 0],
+        "x": [0.0, 1.0, 0.5, 1.5, 2.0, -0.5],
+        "id": list(range(6)),
+    }
+    fit = survival.coxph(
+        "Surv(time, status) ~ x",
+        data=data,
+        ties=method,
+        max_iter=50,
+        eps=1e-9,
+        toler=1e-9,
+    )
+    robust_fit = survival.coxph(
+        "Surv(time, status) ~ x",
+        data=data,
+        ties=method,
+        cluster=data["id"],
+        max_iter=50,
+        eps=1e-9,
+        toler=1e-9,
+    )
+
+    score = [row[0] for row in fit.score_residuals()]
+    dfbeta = [row[0] for row in fit.dfbeta()]
+
+    assert score == pytest.approx(expected_score, abs=1e-12)
+    assert dfbeta == pytest.approx(expected_dfbeta, abs=1e-12)
+    assert sum(score) == pytest.approx(fit.score_vector[0], abs=1e-12)
+    assert robust_fit.variance_matrix[0][0] == pytest.approx(
+        expected_robust_variance,
+        abs=1e-12,
+    )
+
+
 def test_coxph_counting_process_score_and_dfbeta_residuals_sum_to_score_vector():
     data = _counting_cox_data()
     for method in ("breslow", "efron", "exact"):

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -2241,6 +2241,52 @@ test_that("R formula wrappers delegate to the Python survival package", {
   expect_equal(nrow(aft_dfbeta), nrow(data))
 })
 
+test_that("Cox score inference matches native fits at mixed event and censor ties", {
+  skip_if_not_installed("reticulate")
+  skip_if_not_installed("survival")
+  skip_if_not(
+    reticulate::py_module_available("survival"),
+    "Python survival package is unavailable"
+  )
+
+  data <- data.frame(
+    time = c(1, 1, 2, 2, 3, 4),
+    status = c(1, 1, 1, 0, 1, 0),
+    x = c(0, 1, 0.5, 1.5, 2, -0.5),
+    id = seq_len(6L)
+  )
+
+  for (method in c("breslow", "efron")) {
+    bridged <- coxph(
+      Surv(time, status) ~ x,
+      data = data,
+      cluster = data$id,
+      ties = method,
+      max_iter = 50,
+      eps = 1e-09,
+      toler = 1e-10
+    )
+    reference <- survival::coxph(
+      survival::Surv(time, status) ~ x,
+      data = data,
+      cluster = data$id,
+      ties = method,
+      control = survival::coxph.control(
+        iter.max = 50,
+        eps = 1e-09,
+        toler.chol = 1e-10
+      )
+    )
+
+    expect_equal(
+      unname(residuals(bridged, type = "score")),
+      unname(stats::residuals(reference, type = "score")),
+      tolerance = 1e-10
+    )
+    expect_equal(unname(vcov(bridged)), unname(vcov(reference)), tolerance = 1e-10)
+  }
+})
+
 test_that("model summaries match native Cox and survreg coefficient tables", {
   skip_if_not_installed("reticulate")
   skip_if_not_installed("survival")

--- a/src/scoring/coxscore2.rs
+++ b/src/scoring/coxscore2.rs
@@ -92,6 +92,14 @@ fn find_strata_boundaries(strata: &[i32], n: usize) -> Vec<(usize, usize)> {
     boundaries.push((start, n - 1));
     boundaries
 }
+
+#[inline]
+fn death_rows_in_bucket(status: &[f64], start: i32, end: i32) -> impl Iterator<Item = usize> + '_ {
+    (start..=end)
+        .map(|row| row as usize)
+        .filter(|&row| status[row] == 1.0)
+}
+
 #[allow(clippy::too_many_arguments)]
 fn process_stratum(
     start: usize,
@@ -156,8 +164,7 @@ fn process_stratum(
                 for var in 0..nvar {
                     let xbar = a[var] / denom;
                     xhaz[var] += xbar * hazard;
-                    for k in processed_start..=processed_end {
-                        let k_usize = k as usize;
+                    for k_usize in death_rows_in_bucket(status, processed_start, processed_end) {
                         let local_idx = k_usize - start;
                         partial_resid[local_idx][var] += covar[k_usize * nvar + var] - xbar;
                     }
@@ -172,8 +179,8 @@ fn process_stratum(
                     for var in 0..nvar {
                         let xbar = (a[var] - downwt * a2[var]) / temp;
                         xhaz[var] += xbar * hazard;
-                        for k in processed_start..=processed_end {
-                            let k_usize = k as usize;
+                        for k_usize in death_rows_in_bucket(status, processed_start, processed_end)
+                        {
                             let local_idx = k_usize - start;
                             let temp2 = covar[k_usize * nvar + var] - xbar;
                             partial_resid[local_idx][var] += temp2 / deaths;
@@ -291,8 +298,7 @@ pub(crate) fn compute_cox_score_residuals(data: CoxScoreData, params: CoxScorePa
                 {
                     let xbar = a_elem / denom;
                     *xhaz_elem += xbar * hazard;
-                    for k in processed_start..=processed_end {
-                        let k_usize = k as usize;
+                    for k_usize in death_rows_in_bucket(status, processed_start, processed_end) {
                         let idx = k_usize * params.nvar + var;
                         resid[idx] += data.covar[idx] - xbar;
                     }
@@ -307,8 +313,8 @@ pub(crate) fn compute_cox_score_residuals(data: CoxScoreData, params: CoxScorePa
                     for var in 0..params.nvar {
                         let xbar = (a[var] - downwt * a2[var]) / temp;
                         xhaz[var] += xbar * hazard;
-                        for k in processed_start..=processed_end {
-                            let k_usize = k as usize;
+                        for k_usize in death_rows_in_bucket(status, processed_start, processed_end)
+                        {
                             let idx = k_usize * params.nvar + var;
                             let temp2 = data.covar[idx] - xbar;
                             resid[idx] += temp2 / deaths;
@@ -370,6 +376,45 @@ pub fn cox_score_residuals(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn repeated_mixed_tie_residuals(method: i32, strata_count: usize) -> Vec<f64> {
+        let n = 4 * strata_count;
+        let mut time = Vec::with_capacity(n);
+        let mut status = Vec::with_capacity(n);
+        let mut strata = Vec::with_capacity(n);
+        let mut covar = Vec::with_capacity(n);
+        for stratum in 0..strata_count {
+            time.extend([1.0, 1.0, 1.0, 2.0]);
+            status.extend([1.0, 1.0, 0.0, 0.0]);
+            strata.extend([stratum as i32; 4]);
+            covar.extend([0.0, 2.0, 4.0, 6.0]);
+        }
+        let mut y = time;
+        y.extend(status);
+        let score = vec![1.0; n];
+        let weights = vec![1.0; n];
+
+        compute_cox_score_residuals(
+            CoxScoreData {
+                y: &y,
+                strata: &strata,
+                covar: &covar,
+                score: &score,
+                weights: &weights,
+            },
+            CoxScoreParams { method, n, nvar: 1 },
+        )
+    }
+
+    fn assert_values_close(actual: &[f64], expected: &[f64]) {
+        assert_eq!(actual.len(), expected.len());
+        for (idx, (&actual, &expected)) in actual.iter().zip(expected).enumerate() {
+            assert!(
+                (actual - expected).abs() < 1e-12,
+                "value {idx}: expected {expected}, got {actual}"
+            );
+        }
+    }
 
     #[test]
     fn single_stratum_output_length() {
@@ -445,6 +490,91 @@ mod tests {
             .zip(efron.iter())
             .any(|(a, b)| (a - b).abs() > 1e-15);
         assert!(differs);
+    }
+
+    #[test]
+    fn breslow_excludes_tied_censor_from_event_contribution() {
+        let residuals = repeated_mixed_tie_residuals(0, 1);
+
+        assert_values_close(&residuals, &[-1.5, -0.5, -0.5, -1.5]);
+        assert!((residuals.iter().sum::<f64>() + 4.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn efron_excludes_tied_censor_from_event_and_death_adjustments() {
+        let residuals = repeated_mixed_tie_residuals(1, 1);
+        let expected = [-71.0 / 36.0, -29.0 / 36.0, -13.0 / 36.0, -55.0 / 36.0];
+
+        assert_values_close(&residuals, &expected);
+        assert!((residuals.iter().sum::<f64>() + 14.0 / 3.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn stratified_mixed_ties_preserve_each_stratum_score_sum() {
+        for (method, expected, expected_score) in [
+            (0, vec![-1.5, -0.5, -0.5, -1.5], -4.0),
+            (
+                1,
+                vec![-71.0 / 36.0, -29.0 / 36.0, -13.0 / 36.0, -55.0 / 36.0],
+                -14.0 / 3.0,
+            ),
+        ] {
+            let residuals = repeated_mixed_tie_residuals(method, 2);
+            for stratum_residuals in residuals.chunks_exact(4) {
+                assert_values_close(stratum_residuals, &expected);
+                assert!((stratum_residuals.iter().sum::<f64>() - expected_score).abs() < 1e-12);
+            }
+        }
+    }
+
+    #[test]
+    fn weighted_residual_sum_matches_partial_likelihood_score() {
+        let n = 4;
+        let covar = vec![0.0, 2.0, 4.0, 6.0];
+        let score = vec![1.0, 1.25, 0.8, 1.1];
+        let weights = vec![1.5, 0.75, 2.0, 0.5];
+        let y = vec![1.0, 1.0, 1.0, 2.0, 1.0, 1.0, 0.0, 0.0];
+        let strata = vec![0; n];
+        let risk: Vec<f64> = score
+            .iter()
+            .zip(&weights)
+            .map(|(&score, &weight)| score * weight)
+            .collect();
+        let denom: f64 = risk.iter().sum();
+        let risk_x: f64 = risk.iter().zip(&covar).map(|(&risk, &x)| risk * x).sum();
+        let death_denom = risk[0] + risk[1];
+        let death_risk_x = risk[0] * covar[0] + risk[1] * covar[1];
+        let death_weight = weights[0] + weights[1];
+        let observed = weights[0] * covar[0] + weights[1] * covar[1];
+
+        for method in [0, 1] {
+            let residuals = compute_cox_score_residuals(
+                CoxScoreData {
+                    y: &y,
+                    strata: &strata,
+                    covar: &covar,
+                    score: &score,
+                    weights: &weights,
+                },
+                CoxScoreParams { method, n, nvar: 1 },
+            );
+            let expected_score = if method == 0 {
+                observed - death_weight * risk_x / denom
+            } else {
+                let mean_death_weight = death_weight / 2.0;
+                observed
+                    - mean_death_weight * risk_x / denom
+                    - mean_death_weight * (risk_x - 0.5 * death_risk_x)
+                        / (denom - 0.5 * death_denom)
+            };
+            let residual_score: f64 = residuals
+                .iter()
+                .zip(&weights)
+                .map(|(&residual, &weight)| residual * weight)
+                .sum();
+
+            assert!((residual_score - expected_score).abs() < 1e-12);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- restrict failure-only Cox score-residual contributions to event rows within mixed event/censor time buckets
- keep censored observations in the risk-set accumulation for both Breslow and Efron ties
- cover single- and multi-stratum kernels with exact Rust fixtures and weighted score invariants
- add fixed and live parity tests for score residuals, DFBETA, and clustered robust covariance

## Root cause

The score-residual kernels applied the direct failure contribution to every observation sharing an event time. A censored observation at that same time belongs in the risk set, but must not receive the failure-only term. That contaminated score residuals and downstream DFBETA, DFBETAS, and robust covariance calculations.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo test --lib --all-features` — 1,521 passed
- `cargo test --lib --no-default-features` — 1,310 passed
- full Python suite — 779 passed, 18 skipped
- full R bridge suite
- Ruff format and lint checks
- Python stub type check
- generated binding manifest check
- `git diff --check`
