### PR TITLE
Linearize tied-event concordance counting

### DIFF
--- a/benches/survival_benchmarks.rs
+++ b/benches/survival_benchmarks.rs
@@ -183,6 +183,18 @@ mod concordance_bench {
 
         bencher.bench_local(|| concordance1(&y, &weights, &indx, ntree));
     }
+
+    #[divan::bench(args = [100, 1000, 5000])]
+    fn concordance_tied_events(bencher: divan::Bencher, n: usize) {
+        let mut y = vec![1.0; n];
+        y.extend(vec![1.0; n]);
+
+        let weights: Vec<f64> = (0..n).map(|i| 0.5 + (i % 7) as f64 * 0.1).collect();
+        let ntree = 16i32;
+        let indx: Vec<i32> = (0..n).map(|i| (i % ntree as usize) as i32).collect();
+
+        bencher.bench_local(|| concordance1(&y, &weights, &indx, ntree));
+    }
 }
 
 mod cox_regression {

--- a/python/tests/test_concordance_additional.py
+++ b/python/tests/test_concordance_additional.py
@@ -183,6 +183,23 @@ def test_perform_concordance_calculation():
     assert "concordance_index" in result
 
 
+def test_concordance1_large_weighted_event_tie_counts_each_pair_once():
+    n = 32
+    weights = [0.5 + (idx % 7) * 0.125 for idx in range(n)]
+    expected = sum(
+        weights[left] * weights[right] for left in range(n) for right in range(left + 1, n)
+    )
+
+    result = survival.perform_concordance1_calculation(
+        [1.0] * n + [1.0] * n,
+        weights,
+        [idx % 16 for idx in range(n)],
+        16,
+    )
+
+    assert result["tied_y"] == pytest.approx(expected)
+
+
 def test_low_level_concordance_wrappers_validate_index_inputs():
     time_data = [1.0, 2.0, 3.0, 1.0, 1.0, 0.0]
     weights = [1.0, 1.0, 1.0]

--- a/src/concordance/concordance1.rs
+++ b/src/concordance/concordance1.rs
@@ -10,6 +10,18 @@ fn node_weight(nwt: &[f64], index: usize, ntree: usize) -> f64 {
     if index >= ntree { 0.0 } else { nwt[index] }
 }
 
+#[inline]
+fn tied_event_weight_sums(indices: &[usize], weights: &[f64]) -> (f64, f64) {
+    let mut total_weight = 0.0;
+    let mut pair_weight = 0.0;
+    for &index in indices {
+        let weight = weights[index];
+        pair_weight += total_weight * weight;
+        total_weight += weight;
+    }
+    (total_weight, pair_weight)
+}
+
 pub fn concordance1(y: &[f64], wt: &[f64], indx: &[i32], ntree: i32) -> Vec<f64> {
     let n = wt.len();
     let ntree = ntree as usize;
@@ -36,21 +48,17 @@ pub fn concordance1(y: &[f64], wt: &[f64], indx: &[i32], ntree: i32) -> Vec<f64>
             j = temp_j;
 
             let num_tied = tied_indices.len();
+            let (tied_weight, tied_pair_weight) = tied_event_weight_sums(&tied_indices, wt);
+            ndeath = tied_weight;
+            count[3] += tied_pair_weight;
 
             if num_tied > 10 {
-                let parallel_counts: (f64, f64, f64, f64, f64) = tied_indices
+                let parallel_counts: (f64, f64, f64) = tied_indices
                     .par_iter()
-                    .enumerate()
-                    .map(|(idx_in_tied, &j_idx)| {
+                    .map(|&j_idx| {
                         let mut local_count0 = 0.0;
                         let mut local_count1 = 0.0;
                         let mut local_count2 = 0.0;
-                        let mut local_count3 = 0.0;
-                        let local_ndeath = wt[j_idx];
-
-                        for &k_idx in tied_indices.iter().skip(idx_in_tied + 1) {
-                            local_count3 += wt[j_idx] * wt[k_idx];
-                        }
 
                         let index = indx[j_idx] as usize;
                         local_count2 += wt[j_idx] * node_weight(&twt[ntree..], index, ntree);
@@ -75,32 +83,16 @@ pub fn concordance1(y: &[f64], wt: &[f64], indx: &[i32], ntree: i32) -> Vec<f64>
                             current = parent;
                         }
 
-                        (
-                            local_count0,
-                            local_count1,
-                            local_count2,
-                            local_count3,
-                            local_ndeath,
-                        )
+                        (local_count0, local_count1, local_count2)
                     })
-                    .reduce(
-                        || (0.0, 0.0, 0.0, 0.0, 0.0),
-                        |a, b| (a.0 + b.0, a.1 + b.1, a.2 + b.2, a.3 + b.3, a.4 + b.4),
-                    );
+                    .reduce(|| (0.0, 0.0, 0.0), |a, b| (a.0 + b.0, a.1 + b.1, a.2 + b.2));
 
                 count[0] += parallel_counts.0;
                 count[1] += parallel_counts.1;
                 count[2] += parallel_counts.2;
-                count[3] += parallel_counts.3;
-                ndeath = parallel_counts.4;
             } else {
-                for (idx_in_tied, &j_idx) in tied_indices.iter().enumerate() {
-                    ndeath += wt[j_idx];
+                for &j_idx in &tied_indices {
                     let index = indx[j_idx] as usize;
-
-                    for &k_idx in tied_indices.iter().skip(idx_in_tied + 1) {
-                        count[3] += wt[j_idx] * wt[k_idx];
-                    }
 
                     count[2] += wt[j_idx] * node_weight(&twt[ntree..], index, ntree);
 
@@ -233,6 +225,48 @@ mod tests {
         let result = concordance1(&y, &wt, &indx, ntree);
         assert_eq!(result.len(), CONCORDANCE_COUNT_SIZE);
         assert!(result[3] >= 0.0);
+    }
+
+    #[test]
+    fn weighted_tied_event_pairs_match_naive_sum_across_parallel_threshold() {
+        for n in [10, 11, 64] {
+            let mut y = vec![1.0; n];
+            y.extend(vec![1.0; n]);
+            let weights: Vec<f64> = (0..n)
+                .map(|idx| {
+                    if idx % 9 == 0 {
+                        0.0
+                    } else {
+                        0.5 + idx as f64 * 0.125
+                    }
+                })
+                .collect();
+            let indices: Vec<i32> = (0..n).map(|idx| (idx % 16) as i32).collect();
+            let expected_pair_weight: f64 = weights
+                .iter()
+                .enumerate()
+                .map(|(idx, &weight)| weight * weights.iter().skip(idx + 1).sum::<f64>())
+                .sum();
+
+            let result = concordance1(&y, &weights, &indices, 16);
+
+            assert!((result[3] - expected_pair_weight).abs() < 1e-10);
+            assert_eq!(&result[..3], &[0.0, 0.0, 0.0]);
+        }
+    }
+
+    #[test]
+    fn tied_event_pairs_do_not_cross_time_groups() {
+        let time = [1.0, 1.0, 1.0, 2.0, 2.0];
+        let status = [1.0; 5];
+        let weights = [0.5, 1.25, 2.0, 3.5, 4.0];
+        let mut y = time.to_vec();
+        y.extend(status);
+        let expected = 0.5 * 1.25 + 0.5 * 2.0 + 1.25 * 2.0 + 3.5 * 4.0;
+
+        let result = concordance1(&y, &weights, &[0, 1, 2, 3, 4], 8);
+
+        assert!((result[3] - expected).abs() < 1e-12);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- replace quadratic nested scans over tied deaths with a linear weighted-prefix accumulation
- reuse the prepass for both serial and Rayon paths, reducing the parallel reduction payload
- cover fractional and zero weights across the 10/11 execution threshold and across distinct event times
- add a dedicated worst-case tied-event benchmark and Python binding regression

## Complexity

For tie groups of sizes `d_g`, the kernel changes from:

`O(n log(ntree) + sum(d_g^2))`

to:

`O(n log(ntree))`

The running-prefix form computes each unordered product `w_i * w_j` once without the cancellation risk of a squared-sum identity.

## Benchmark

Local Divan medians:

| tied events | before | after | change |
| ---: | ---: | ---: | ---: |
| 100 | 30.66 µs | 31.10 µs | within noise |
| 1,000 | 71.81 µs | 40.89 µs | 1.76x faster |
| 5,000 | 1.036 ms | 78.99 µs | 13.1x faster |

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo test --lib --all-features` — 1,519 passed
- `cargo test --lib --no-default-features` — 1,308 passed
- full Python suite — 778 passed, 18 skipped
- full R bridge suite
- Ruff format and lint checks
- Python stub type check
- generated binding manifest check
- `git diff --check`
