### PR TITLE
Reject case weights for exact Cox fits

### DIFF
--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -10172,6 +10172,54 @@ def test_coxph_exact_ties_handles_tied_events():
     assert exact.coefficients[0][0] != pytest.approx(efron.coefficients[0][0])
 
 
+def test_coxph_exact_rejects_case_weights_across_interfaces():
+    data = _tied_cox_data()
+    rows = [[value] for value in data["x1"]]
+    weights = [1.0, 2.0, *([1.0] * (len(data["time"]) - 2))]
+    error = "Case weights are not supported for the exact method"
+
+    with pytest.raises(ValueError, match=error):
+        survival.regression.coxph_fit(
+            time=data["time"],
+            status=data["status"],
+            covariates=rows,
+            weights=weights,
+            method="exact",
+        )
+    with pytest.raises(ValueError, match=error):
+        survival.coxph(
+            "Surv(time, status) ~ x1",
+            data=data,
+            weights=weights,
+            ties="exact",
+        )
+    with pytest.raises(ValueError, match=error):
+        survival.coxph(
+            survival.Surv(data["time"], data["status"]),
+            x=rows,
+            weights=weights,
+            ties="exact",
+        )
+
+    omitted = survival.regression.coxph_fit(
+        time=data["time"],
+        status=data["status"],
+        covariates=rows,
+        method="exact",
+        max_iter=0,
+    )
+    explicit_units = survival.regression.coxph_fit(
+        time=data["time"],
+        status=data["status"],
+        covariates=rows,
+        weights=[1.0] * len(data["time"]),
+        method="exact",
+        max_iter=0,
+    )
+    assert explicit_units.log_likelihood == pytest.approx(omitted.log_likelihood)
+    assert explicit_units.score_vector == pytest.approx(omitted.score_vector)
+
+
 def test_low_level_coxph_tie_methods_match_hand_likelihood_at_initial_beta():
     data = _tied_cox_data()
     for method in ("efron", "breslow", "exact"):

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -1794,6 +1794,16 @@ test_that("R formula wrappers delegate to the Python survival package", {
   expect_null(weights(fit))
   weighted_fit <- coxph(Surv(time, status) ~ x, data = data, weights = wt, max_iter = 0)
   expect_equal(weights(weighted_fit), data$wt)
+  expect_error(
+    coxph(
+      Surv(time, status) ~ x,
+      data = data,
+      weights = wt,
+      method = "exact",
+      max_iter = 0
+    ),
+    "Case weights are not supported for the exact method"
+  )
   fitted_values <- fitted(fit)
   expect_true(is.numeric(unlist(fitted_values, use.names = FALSE)))
   expect_equal(length(unlist(fitted_values, use.names = FALSE)), nrow(data))

--- a/src/regression/coxph.rs
+++ b/src/regression/coxph.rs
@@ -556,6 +556,17 @@ fn validate_case_weights(weights: &[f64]) -> PyResult<()> {
     Ok(())
 }
 
+fn validate_method_weights(method: CoxMethod, weights: Option<&[f64]>) -> PyResult<()> {
+    if matches!(method, CoxMethod::Exact)
+        && weights.is_some_and(|values| values.iter().any(|&value| value != 1.0))
+    {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "Case weights are not supported for the exact method",
+        ));
+    }
+    Ok(())
+}
+
 #[pyfunction]
 #[pyo3(signature = (time, status, covariates, strata=None, weights=None, offset=None, initial_beta=None, max_iter=None, eps=None, toler=None, method=None, entry_times=None, nocenter=None))]
 #[allow(clippy::too_many_arguments)]
@@ -670,6 +681,7 @@ pub fn coxph_fit(
     }
 
     let cox_method = parse_cox_method(method)?;
+    validate_method_weights(cox_method, weights.as_deref())?;
     let method_name = match cox_method {
         CoxMethod::Breslow => "breslow",
         CoxMethod::Efron => "efron",
@@ -788,6 +800,15 @@ pub fn coxph_fit(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn exact_method_rejects_non_unit_case_weights() {
+        assert!(validate_method_weights(CoxMethod::Exact, None).is_ok());
+        assert!(validate_method_weights(CoxMethod::Exact, Some(&[1.0, 1.0])).is_ok());
+        assert!(validate_method_weights(CoxMethod::Exact, Some(&[1.0, 2.0])).is_err());
+        assert!(validate_method_weights(CoxMethod::Breslow, Some(&[1.0, 2.0])).is_ok());
+        assert!(validate_method_weights(CoxMethod::Efron, Some(&[0.5, 2.0])).is_ok());
+    }
 
     fn baseline_test_fit(method: &str) -> CoxPHFit {
         CoxPHFit {


### PR DESCRIPTION
## Summary

- reject non-unit case weights when the exact Cox likelihood is selected
- enforce the rule at the shared Rust fit boundary so low-level Python, formula/matrix Python, and R calls behave consistently
- preserve omitted and explicit unit weights, and leave Breslow/Efron weighted fits unchanged
- match the native R error message

## Rationale

The exact denominator enumerates subsets using the integer number of event rows. Combining that enumeration with weighted risks produces a hybrid likelihood that does not have R-compatible semantics. Native `survival::coxph` rejects case weights for `ties = "exact"`, even when the observed data have no tied failures.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo test --lib --all-features` — 1,518 passed
- `cargo test --lib --no-default-features` — 1,307 passed
- full Python suite — 778 passed, 18 skipped
- full R bridge suite
- Ruff format and lint checks
- Python stub type check
- generated binding manifest check
- `git diff --check`
