### PR TITLE
Add R-compatible Python clogit

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ from survival import (
     aic,
     as_data_frame,
     basehaz,
+    clogit,
     coxph,
     fitted,
     predict,
@@ -151,6 +152,9 @@ to produce model-based survival curves.
 `survdiff` uses the same right-censored and delayed-entry response forms.
 `coxph` uses Efron's tie handling by default, matching R, and also accepts
 `ties="breslow"` or the compatibility alias `method="breslow"`.
+`clogit("case ~ exposure + strata(set)", data=...)` fits matched case-control
+models through the exact stratified Cox likelihood; `method="approximate"`
+maps to Breslow handling as it does in R.
 R-style `coxph.control(...)` and `survreg.control(...)` helpers are available
 in the bridge and pass named control lists through to the Python API.
 The R-style `predict(...)` and `fitted(...)` generics support Cox linear

--- a/docs/repo-layout.md
+++ b/docs/repo-layout.md
@@ -35,7 +35,7 @@ The Python package in `python/survival/` mirrors the Rust domains:
 - `population`, `monitoring`, `ml`
 - `bayesian`, `causal`, `joint`, `interpretability`, `spatial`, and related domains
 - `r_api`: R-style formula façade for `Surv`, `survfit`, `survdiff`, `coxph`,
-  `survreg`, Cox `predict`, and residual dispatch
+  `clogit`, `survreg`, Cox `predict`, and residual dispatch
 
 Preferred usage is module-oriented:
 
@@ -49,7 +49,7 @@ rmst = validation.rmst(...)
 
 Top-level imports remain available lazily for compatibility, but new code should
 prefer the domain modules unless it is using the intentional R-style façade
-(`from survival import Surv, survfit, coxph, survreg`).
+(`from survival import Surv, survfit, coxph, clogit, survreg`).
 
 Python source builds use the lean `extension-module` feature set by default.
 Build with `--features extension-module,ml` when the optional ML bindings should

--- a/python/survival/__init__.py
+++ b/python/survival/__init__.py
@@ -76,6 +76,7 @@ _R_EXPORTS = [
     "coef_names",
     "confint",
     "concordance",
+    "clogit",
     "coxph",
     "coxph_detail",
     "coxph_wtest",

--- a/python/survival/__init__.pyi
+++ b/python/survival/__init__.pyi
@@ -50,6 +50,7 @@ from .r_api import (
     blogit,
     bprobit,
     cipoisson,
+    clogit,
     coef,
     coef_names,
     concordance,

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -5,7 +5,7 @@ import random
 import warnings
 from bisect import bisect_left, bisect_right
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import date as _Date  # noqa: N812
 from datetime import datetime as _DateTime  # noqa: N812
 from functools import lru_cache
@@ -49,6 +49,7 @@ __all__ = [
     "coef_names",
     "confint",
     "concordance",
+    "clogit",
     "coxph",
     "coxph_detail",
     "coxph_wtest",
@@ -257,8 +258,28 @@ class _FormulaFit:
     y_response: Surv | None = None
     model_frame: dict[str, Any] | None = None
     score_values: list[float] | None = None
+    conditional_logistic: bool = False
 
     def __getattr__(self, name: str) -> Any:
+        if self.conditional_logistic and name in {
+            "basehaz",
+            "basehaz_with_strata",
+            "survival_curve",
+            "survival_curve_with_strata",
+        }:
+            raise ValueError("predicted survival curves are not defined for a clogit model")
+        if self.conditional_logistic and getattr(self.fit, "method", None) == "exact":
+            unavailable = {
+                "score_residuals": "score",
+                "schoenfeld_residuals": "schoenfeld",
+                "scaled_schoenfeld_residuals": "scaledsch",
+                "dfbeta": "dfbeta",
+                "dfbetas": "dfbetas",
+            }
+            if name in unavailable:
+                raise ValueError(
+                    f"{unavailable[name]} residuals are not available for the exact method"
+                )
         if name == "id" and self.id_values is not None:
             return self.id_values
         if name == "x" and self.x_matrix is not None:
@@ -10155,6 +10176,9 @@ def survfit(
 ):
     """Fit Kaplan-Meier curves or Cox-model survival curves."""
 
+    if _is_clogit_fit(response):
+        raise ValueError("predicted survival curves are not defined for a clogit model")
+
     conf_int = _pop_dotted_keyword(kwargs, "conf.int", "conf_int", conf_int, None)
     conf_type = _pop_dotted_keyword(kwargs, "conf.type", "conf_type", conf_type, "log")
     se_fit = _pop_dotted_keyword(kwargs, "se.fit", "se_fit", se_fit, True)
@@ -11067,6 +11091,9 @@ def basehaz(
 ):
     """Return Cox baseline cumulative hazard, like R's basehaz."""
 
+    if _is_clogit_fit(fit):
+        raise ValueError("predicted survival curves are not defined for a clogit model")
+
     centered_value = _normalize_bool_option(centered, "centered")
     if time is not None:
         if newdata is not None:
@@ -11159,6 +11186,8 @@ def cox_zph(
     if kwargs:
         unexpected = ", ".join(sorted(kwargs))
         raise TypeError(f"unexpected cox_zph argument(s): {unexpected}")
+    if _is_clogit_fit(fit) and getattr(_unwrap_formula_fit(fit), "method", None) == "exact":
+        raise ValueError("schoenfeld residuals are not available for the exact method")
     if _is_survreg_fit(fit) or not hasattr(fit, "schoenfeld_residuals"):
         raise TypeError("cox_zph requires a fitted Cox model")
     group_terms = _normalize_bool_option(terms, "terms")
@@ -11835,6 +11864,10 @@ def _cox_beta(fit: Any) -> list[float]:
 
 def _unwrap_formula_fit(fit: Any) -> Any:
     return fit.fit if isinstance(fit, _FormulaFit) else fit
+
+
+def _is_clogit_fit(fit: Any) -> bool:
+    return isinstance(fit, _FormulaFit) and fit.conditional_logistic
 
 
 def _cox_event_count(fit: Any) -> int:
@@ -13645,6 +13678,18 @@ def _cox_robust_variance_matrix(
     cluster_codes = _encode_labels(cluster_values, "cluster")
     robust = _core.clustered_sandwich_variance(score, weights, cluster_codes, naive)
     return robust, naive, cluster_values
+
+
+def _cox_has_repeated_event_id(response: Surv, id_values: Sequence[Any]) -> bool:
+    seen: set[Any] = set()
+    for event, id_value in zip(response.event, id_values, strict=True):
+        if int(event) != 1:
+            continue
+        key = _hashable_group_value(id_value)
+        if key in seen:
+            return True
+        seen.add(key)
+    return False
 
 
 def _survreg_robust_variance_matrix(
@@ -16455,6 +16500,12 @@ def residuals(
         raise AssertionError(f"unhandled survreg residual type {residual_type!r}")
 
     residual_type = _normalize_residual_type(type)
+    if (
+        _is_clogit_fit(fit)
+        and getattr(_unwrap_formula_fit(fit), "method", None) == "exact"
+        and residual_type in {"score", "schoenfeld", "dfbeta", "dfbetas", "scaledsch"}
+    ):
+        raise ValueError(f"{residual_type} residuals are not available for the exact method")
     if terms is not None and residual_type != "partial":
         raise ValueError("terms is only supported for Cox partial residuals")
     method_names = {
@@ -16886,11 +16937,32 @@ def coxph(
         raise ValueError(
             "coxph design matrix is singular; use singular_ok=True to allow dependent covariates"
         )
-    robust_cluster = cluster if cluster is not None else id_values
-    if robust_value is True and robust_cluster is None:
-        robust_cluster = list(range(n))
-    if robust_value is False and robust_cluster is not None:
-        raise ValueError("cluster or id cannot be combined with robust=False")
+    has_fractional_weights = fit_weights is not None and any(
+        not float(weight).is_integer() for weight in fit_weights
+    )
+    has_repeated_event_id = id_values is not None and _cox_has_repeated_event_id(
+        response,
+        id_values,
+    )
+    automatically_robust = cluster is not None or has_fractional_weights or has_repeated_event_id
+    use_robust_variance = automatically_robust if robust_value is None else robust_value
+    if cluster is not None and not use_robust_variance:
+        warnings.warn(
+            "cluster specified with robust=FALSE, cluster ignored",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        cluster = None
+
+    robust_cluster = None
+    if use_robust_variance:
+        robust_cluster = cluster if cluster is not None else id_values
+        if robust_cluster is None:
+            if response.start is not None and robust_value is True:
+                raise ValueError("one of cluster or id is needed for robust variance")
+            robust_cluster = list(range(n))
+        if method_name == "exact":
+            raise ValueError("dfbeta residuals are not available for the exact method")
     robust_variance = None
     naive_variance = None
     cluster_values = None
@@ -16921,6 +16993,65 @@ def coxph(
             model_frame=model_frame,
         )
     return fit
+
+
+def clogit(
+    formula: str,
+    data: Any | None = None,
+    *,
+    weights: Any | None = None,
+    subset: Any | None = None,
+    na_action: str | None = "fail",
+    method: str = "exact",
+    **kwargs: Any,
+) -> Any:
+    """Fit a conditional logistic model through stratified Cox regression."""
+
+    na_action = _pop_dotted_keyword(kwargs, "na.action", "na_action", na_action, "fail")
+    if not isinstance(formula, str):
+        raise TypeError("clogit formula must be a string")
+    response, separator, rhs = formula.partition("~")
+    response = response.strip()
+    rhs = rhs.strip()
+    if not separator or not response or not rhs:
+        raise ValueError("clogit formula must contain a response and '~'")
+
+    method_name = _match_string_arg(
+        method,
+        "method",
+        ("exact", "approximate", "efron", "breslow"),
+        "clogit method must be 'exact', 'approximate', 'efron', or 'breslow'",
+    )
+    cox_method = "breslow" if method_name == "approximate" else method_name
+    cox_formula = f"Surv(rep(1, n), {response}) ~ {rhs}"
+    response_columns = _response_arg_columns(response)
+    terms = _split_terms(rhs, _dot_terms(data, response_columns))
+
+    if cox_method == "exact":
+        if terms.clusters:
+            raise ValueError("robust variance plus the exact method is not supported")
+        if weights is not None:
+            warnings.warn(
+                "weights ignored: not possible for the exact method",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            weights = None
+
+    if kwargs.get("eps") is None and kwargs.get("control") is None:
+        kwargs["eps"] = 1e-9
+    fit = coxph(
+        cox_formula,
+        data=data,
+        weights=weights,
+        subset=subset,
+        na_action=na_action,
+        method=cox_method,
+        **kwargs,
+    )
+    if not isinstance(fit, _FormulaFit):
+        raise AssertionError("clogit formula fit did not preserve formula metadata")
+    return replace(fit, conditional_logistic=True)
 
 
 def survreg(

--- a/python/survival/r_api.pyi
+++ b/python/survival/r_api.pyi
@@ -733,6 +733,16 @@ def coxph(
     control: Any | None = None,
     **kwargs: Any,
 ) -> Any: ...
+def clogit(
+    formula: str,
+    data: Any | None = None,
+    *,
+    weights: Any | None = None,
+    subset: Any | None = None,
+    na_action: str | None = "fail",
+    method: str = "exact",
+    **kwargs: Any,
+) -> Any: ...
 def predict(
     fit: Any,
     newdata: Any | None = None,

--- a/python/tests/test_binding_contract.py
+++ b/python/tests/test_binding_contract.py
@@ -11119,6 +11119,7 @@ def test_package_root_marks_curated_and_legacy_exports():
     assert "bprobit" in survival.__all__
     assert "coef" in survival.__all__
     assert "coef_names" in survival.__all__
+    assert "clogit" in survival.__all__
     assert "confint" in survival.__all__
     assert "cox_zph" in survival.__all__
     assert "coxph_detail" in survival.__all__
@@ -11186,6 +11187,7 @@ def test_package_root_marks_curated_and_legacy_exports():
     assert survival.coef is survival.r_api.coef
     assert survival.survfit0 is survival.r_api.survfit0
     assert survival.coef_names is survival.r_api.coef_names
+    assert survival.clogit is survival.r_api.clogit
     assert survival.confint is survival.r_api.confint
     assert survival.cox_zph is survival.r_api.cox_zph
     assert survival.coxph_detail is survival.r_api.coxph_detail
@@ -11878,6 +11880,14 @@ def test_r_api_stub_tracks_fit_control_public_signatures():
     stub_path = PACKAGE_ROOT / "r_api.pyi"
 
     expected_by_name = {
+        "clogit": [
+            "formula",
+            "data",
+            "weights",
+            "subset",
+            "na_action",
+            "method",
+        ],
         "coxph": [
             "response",
             "data",

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -1139,6 +1139,15 @@ def _tied_cox_data():
     }
 
 
+def _clogit_data():
+    return {
+        "case": [1, 0, 1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0],
+        "set": [1, 1, 1, 1, 2, 2, 2, 3, 3, 3, 3, 3, 4, 4, 4, 4],
+        "x": [0.2, 0.8, 1.1, 0.4, 0.5, 1.2, 0.9, 0.1, 0.7, 1.0, 0.3, 1.3, 0.6, 0.2, 1.4, 0.9],
+        "z": [1.0, 0.3, 0.8, 1.4, 0.2, 1.1, 0.6, 0.9, 0.5, 1.2, 0.1, 0.7, 1.3, 0.4, 0.8, 0.2],
+    }
+
+
 def _counting_cox_data():
     return {
         "start": [0.0, 0.0, 1.5, 2.5, 0.0, 3.0],
@@ -6592,6 +6601,212 @@ def test_coxph_formula_accepts_rep_constant_response_argument():
     assert survival.coef(inferred_length) == pytest.approx(survival.coef(direct))
     assert survival.loglik(formula) == pytest.approx(survival.loglik(direct))
     assert survival.nobs(formula) == sum(data["case"])
+
+
+def test_clogit_exact_matches_r_reference_for_multiple_cases_per_set():
+    data = _clogit_data()
+    fit = survival.clogit(
+        "case ~ x + z + strata(set)",
+        data=data,
+        control={"iter.max": 50, "eps": 1e-9},
+    )
+    equivalent_cox = survival.coxph(
+        "Surv(rep(1, nrow(data)), case) ~ x + z + strata(set)",
+        data=data,
+        method="exact",
+        control={"iter.max": 50, "eps": 1e-9},
+    )
+    expected_variance = [
+        [1.6714828664413921, -0.20436032396075088],
+        [-0.20436032396075085, 1.5517480346884],
+    ]
+
+    assert survival.coef(fit) == pytest.approx(
+        [-0.8457808761181879, 1.4766531964610223], rel=0, abs=1e-10
+    )
+    for actual, expected in zip(survival.vcov(fit), expected_variance, strict=True):
+        assert actual == pytest.approx(expected, rel=0, abs=1e-10)
+    assert fit.log_likelihood == pytest.approx(
+        [-6.579251212010101, -5.679859460220504], rel=0, abs=1e-10
+    )
+    assert fit.score_test == pytest.approx(1.804139493304423, rel=0, abs=1e-10)
+    assert fit.iterations == 3
+    assert fit.method == "exact"
+    assert survival.model_formula(fit) == "Surv(rep(1, n), case) ~ x + z + strata(set)"
+    assert survival.coef(fit) == pytest.approx(survival.coef(equivalent_cox))
+    for actual, expected in zip(survival.vcov(fit), survival.vcov(equivalent_cox), strict=True):
+        assert actual == pytest.approx(expected)
+    with pytest.raises(ValueError, match="survival curves are not defined for a clogit model"):
+        survival.basehaz(fit)
+    with pytest.raises(ValueError, match="survival curves are not defined for a clogit model"):
+        survival.survfit(fit)
+    with pytest.raises(ValueError, match="survival curves are not defined for a clogit model"):
+        fit.basehaz()
+    with pytest.raises(ValueError, match="survival curves are not defined for a clogit model"):
+        fit.survival_curve()
+    for residual_type in ("score", "schoenfeld", "dfbeta", "dfbetas", "scaledsch"):
+        with pytest.raises(ValueError, match=f"{residual_type} residuals are not available"):
+            survival.r_api.residuals(fit, type=residual_type)
+    with pytest.raises(ValueError, match="score residuals are not available"):
+        fit.score_residuals()
+    assert len(survival.r_api.residuals(fit, type="martingale")) == len(data["case"])
+    with pytest.raises(ValueError, match="schoenfeld residuals are not available"):
+        survival.cox_zph(fit)
+
+
+def test_clogit_method_and_exact_inference_rules_match_r():
+    data = {**_clogit_data(), "id": list(range(16))}
+    formula = "case ~ x + z + strata(set)"
+    exact = survival.clogit(formula, data=data)
+    explicit_exact = survival.clogit(formula, data=data, method="exact")
+    approximate = survival.clogit(formula, data=data, method="ap")
+    breslow = survival.clogit(formula, data=data, method="breslow")
+
+    assert survival.coef(exact) == pytest.approx(survival.coef(explicit_exact))
+    assert survival.coef(approximate) == pytest.approx(survival.coef(breslow))
+    assert approximate.method == breslow.method == "breslow"
+
+    with pytest.warns(RuntimeWarning, match="weights ignored"):
+        weighted = survival.clogit(formula, data=data, weights=[2.0] * len(data["case"]))
+    assert survival.coef(weighted) == pytest.approx(survival.coef(exact))
+    assert survival.model_weights(weighted) is None
+
+    breslow_weights = [0.5 + 0.1 * (idx % 5) for idx in range(len(data["case"]))]
+    weighted_breslow = survival.clogit(
+        formula,
+        data=data,
+        method="breslow",
+        weights=breslow_weights,
+    )
+    assert survival.model_weights(weighted_breslow) == pytest.approx(breslow_weights)
+    assert weighted_breslow.robust is True
+    expected_weighted_variance = [
+        [0.720954464895698, 0.00931434307520126],
+        [0.00931434307520126, 0.7781943393567565],
+    ]
+    expected_weighted_naive = [
+        [1.6761284190128223, -0.19215580825836115],
+        [-0.19215580825836115, 1.8422617494368836],
+    ]
+    for actual, expected in zip(
+        survival.vcov(weighted_breslow), expected_weighted_variance, strict=True
+    ):
+        assert actual == pytest.approx(expected, rel=0, abs=1e-10)
+    for actual, expected in zip(weighted_breslow.naive_var, expected_weighted_naive, strict=True):
+        assert actual == pytest.approx(expected, rel=0, abs=1e-10)
+
+    integer_weighted = survival.clogit(
+        formula,
+        data=data,
+        method="breslow",
+        weights=[2.0] * len(data["case"]),
+    )
+    assert integer_weighted.robust is False
+
+    id_exact = survival.clogit(formula, data=data, id=data["id"])
+    id_breslow = survival.clogit(formula, data=data, method="breslow", id=data["id"])
+    robust_id_breslow = survival.clogit(
+        formula,
+        data=data,
+        method="breslow",
+        id=data["id"],
+        robust=True,
+    )
+    assert survival.coef(id_exact) == pytest.approx(survival.coef(exact))
+    assert id_exact.robust is False
+    for actual, expected in zip(survival.vcov(id_breslow), survival.vcov(breslow), strict=True):
+        assert actual == pytest.approx(expected)
+    assert id_breslow.robust is False
+    assert robust_id_breslow.robust is True
+
+    repeated_event_ids = [
+        "a",
+        "b",
+        "a",
+        "c",
+        "d",
+        "e",
+        "f",
+        "a",
+        "g",
+        "a",
+        "h",
+        "i",
+        "j",
+        "k",
+        "l",
+        "m",
+    ]
+    repeated_id_breslow = survival.clogit(
+        formula,
+        data=data,
+        method="breslow",
+        id=repeated_event_ids,
+    )
+    expected_id_variance = [
+        [0.5065837992703215, 0.1113609349577885],
+        [0.1113609349577885, 0.5874222540961469],
+    ]
+    assert repeated_id_breslow.robust is True
+    for actual, expected in zip(
+        survival.vcov(repeated_id_breslow), expected_id_variance, strict=True
+    ):
+        assert actual == pytest.approx(expected, rel=0, abs=1e-10)
+
+    with pytest.raises(ValueError, match="dfbeta residuals are not available"):
+        survival.clogit(formula, data=data, id=repeated_event_ids)
+    for kwargs in ({"robust": True}, {"cluster": data["id"]}):
+        with pytest.raises(ValueError, match="dfbeta residuals are not available"):
+            survival.clogit(formula, data=data, **kwargs)
+    with pytest.warns(RuntimeWarning, match="cluster specified with robust=FALSE"):
+        ignored_cluster = survival.clogit(
+            formula,
+            data=data,
+            cluster=data["id"],
+            robust=False,
+        )
+    assert survival.coef(ignored_cluster) == pytest.approx(survival.coef(exact))
+    with pytest.warns(RuntimeWarning, match="cluster specified with robust=FALSE"):
+        ignored_breslow_cluster = survival.clogit(
+            formula,
+            data=data,
+            method="breslow",
+            cluster=data["id"],
+            robust=False,
+        )
+    assert ignored_breslow_cluster.robust is False
+    for actual, expected in zip(
+        survival.vcov(ignored_breslow_cluster), survival.vcov(breslow), strict=True
+    ):
+        assert actual == pytest.approx(expected)
+    with pytest.raises(ValueError, match="robust variance plus the exact method"):
+        survival.clogit(f"{formula} + cluster(id)", data=data)
+    with pytest.raises(ValueError, match="survival curves are not defined for a clogit model"):
+        survival.survfit(breslow)
+
+
+def test_clogit_delegates_subset_and_missing_value_alignment():
+    data = _clogit_data()
+    filtered = _take(data, list(range(1, len(data["case"]))))
+    subset_fit = survival.clogit(
+        "case ~ x + z + strata(set)",
+        data=data,
+        subset=list(range(1, len(data["case"]))),
+    )
+    filtered_fit = survival.clogit("case ~ x + z + strata(set)", data=filtered)
+
+    with_missing = {key: list(values) for key, values in data.items()}
+    with_missing["z"][0] = None
+    omitted_fit = survival.clogit(
+        "case ~ x + z + strata(set)",
+        data=with_missing,
+        na_action="omit",
+    )
+
+    assert survival.coef(subset_fit) == pytest.approx(survival.coef(filtered_fit))
+    assert survival.loglik(subset_fit) == pytest.approx(survival.loglik(filtered_fit))
+    assert survival.coef(omitted_fit) == pytest.approx(survival.coef(filtered_fit))
+    assert survival.loglik(omitted_fit) == pytest.approx(survival.loglik(filtered_fit))
 
 
 def test_coxph_formula_cluster_computes_robust_variance():
@@ -14569,13 +14784,13 @@ def test_r_api_rejects_unsupported_formula_features():
     with pytest.raises(ValueError, match="id must have length"):
         survival.coxph("Surv(time, status) ~ x1", data=_toy_data(), id=["a"])
 
-    with pytest.raises(ValueError, match="cluster or id"):
-        survival.coxph(
-            "Surv(time, status) ~ x1",
-            data=_toy_data(),
-            id=_toy_data()["group"],
-            robust=False,
-        )
+    nonrobust_id = survival.coxph(
+        "Surv(time, status) ~ x1",
+        data=_toy_data(),
+        id=_toy_data()["group"],
+        robust=False,
+    )
+    assert nonrobust_id.robust is False
 
     with pytest.raises(NotImplementedError, match="istate"):
         survival.coxph("Surv(time, status) ~ x1", data=_toy_data(), istate=_toy_data()["status"])


### PR DESCRIPTION
## Summary
- add a typed root and `r_api` `clogit` façade backed by stratified Cox regression
- preserve exact, approximate/Breslow, Efron, weight, cluster, ID, subset, and missing-value behavior from R
- mark conditional-logistic fits so curve helpers and exact-only diagnostics fail compatibly
- align Cox automatic robust covariance selection for fractional weights and duplicated event IDs
- document the API and add native R coefficient, likelihood, covariance, export, and signature fixtures

## Validation
- `.venv/bin/python -m pytest python/tests -q` — 800 passed
- `cargo test --lib --all-features --quiet` — 1,521 passed
- `cargo test --lib --no-default-features --quiet` — 1,310 passed
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- Ruff format and lint checks
- mypy stub check
- binding-manifest check
- `R CMD check --no-manual --no-build-vignettes r/survivalr` — tests passed; source-build NOTE only