### PR TITLE
Add formula-based Fine-Gray expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,31 @@ print(f"Number at risk: {result.n_risk}")
 ### Fine-Gray Competing Risks Model
 
 ```python
+from survival import finegray
+
+data = {
+    "time": [1.0, 2.0, 3.0, 4.0],
+    "event": ["target", "competing", "censor", "target"],
+    "x": [0.2, 0.4, 0.1, 0.8],
+}
+
+# String labels use a recognized censor label as the censoring state. For
+# pandas categoricals, the declared category order is preserved exactly.
+expanded = finegray(
+    "Surv(time, event) ~ x",
+    data=data,
+    etype="target",
+    count="replication",
+)
+
+print(expanded.event)
+print(expanded["fgstart"], expanded["fgstop"], expanded["fgwt"])
+```
+
+The checked six-vector interval splitter remains available for lower-level
+workflows:
+
+```python
 from survival import regression
 
 # Example competing risks data

--- a/python/survival/__init__.py
+++ b/python/survival/__init__.py
@@ -52,6 +52,7 @@ _R_EXPORTS = [
     "Surv",
     "Surv2",
     "Surv2data",
+    "FineGrayFrame",
     "FineGrayOutput",
     "RateTable",
     "PyearsResult",

--- a/python/survival/__init__.pyi
+++ b/python/survival/__init__.pyi
@@ -26,6 +26,7 @@ from . import spatial as spatial
 from . import surv_analysis as surv_analysis
 from . import validation as validation
 from .r_api import (
+    FineGrayFrame,
     FineGrayOutput,
     PyearsResult,
     RateTable,

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -10,6 +10,7 @@ from datetime import date as _Date  # noqa: N812
 from datetime import datetime as _DateTime  # noqa: N812
 from functools import lru_cache
 from itertools import combinations, product
+from numbers import Real
 from operator import index
 from statistics import NormalDist
 from typing import Any, NoReturn
@@ -27,6 +28,7 @@ __all__ = [
     "CoxPHDetailResult",
     "CoxPHWTestResult",
     "CoxZPHResult",
+    "FineGrayFrame",
     "FineGrayOutput",
     "PredictResult",
     "PyearsResult",
@@ -431,6 +433,29 @@ class PyearsResult:
     event: list[float] | None = None
     expected: list[float] | None = None
     tcut: bool = False
+
+
+class FineGrayFrame(dict[str, list[Any]]):
+    """Column-oriented Fine-Gray expansion with the selected endpoint attached."""
+
+    event: Any
+
+    def __init__(
+        self,
+        columns: Mapping[str, Sequence[Any]] | None = None,
+        *,
+        event: Any = None,
+    ) -> None:
+        super().__init__()
+        if columns is not None:
+            for name, values in columns.items():
+                self[str(name)] = values if isinstance(values, list) else list(values)
+        self.event = event
+
+    def copy(self) -> FineGrayFrame:
+        """Return a shallow copy that retains the selected endpoint."""
+
+        return FineGrayFrame(self, event=self.event)
 
 
 @dataclass(frozen=True)
@@ -1617,7 +1642,7 @@ def _parse_formula_literal(value: str) -> Any:
 
 def _unwrap_response_identity(expression: str) -> str:
     expression = expression.strip()
-    for wrapper in ("I", "identity"):
+    for wrapper in ("I", "identity", "factor", "as.factor"):
         prefix = f"{wrapper}("
         if expression.startswith(prefix) and expression.endswith(")"):
             return expression[len(prefix) : -1].strip()
@@ -1796,6 +1821,8 @@ def _parse_formula_type_option(value: str) -> str:
     value = value.strip()
     if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
         value = value[1:-1]
+    if value.strip().lower() == "mstate":
+        return "mstate"
     return _normalize_surv_type(value)
 
 
@@ -5560,24 +5587,773 @@ def pyears(
     return _pyears_result_frame(result) if data_frame else result
 
 
-def finegray(
-    tstart: Any,
-    tstop: Any,
-    ctime: Any,
-    cprob: Any,
-    extend: Any,
-    keep: Any,
-) -> FineGrayOutput:
-    """Expand intervals for Fine-Gray competing-risk data, like R's internal kernel."""
+@dataclass(frozen=True)
+class _FineGrayResponse:
+    start: list[float]
+    stop: list[float]
+    status: list[int]
+    states: tuple[Any, ...]
+    counting: bool
 
-    return _core.finegray(
-        _float_vector(tstart, "tstart"),
-        _float_vector(tstop, "tstop"),
-        _float_vector(ctime, "ctime"),
-        _float_vector(cprob, "cprob"),
-        _bool_vector(extend, "extend"),
-        _bool_vector(keep, "keep"),
+
+@dataclass(frozen=True)
+class _FineGrayInputs:
+    response: _FineGrayResponse
+    model_columns: list[tuple[str, list[Any]]]
+    user_weights: list[Any] | None
+    numeric_weights: list[float]
+    id_values: list[Any] | None
+    strata: list[Any] | None
+    strata_levels: tuple[Any, ...] | None
+
+
+@dataclass(frozen=True)
+class _FineGraySplit:
+    row: list[int]
+    start: list[float]
+    end: list[float]
+    wt: list[float]
+    add: list[int]
+
+
+def _finegray_raw_column(data: Any, name: str) -> Any:
+    if isinstance(data, Mapping):
+        try:
+            return data[name]
+        except KeyError as exc:
+            raise KeyError(f"column {name!r} not found in data") from exc
+    try:
+        return data[name]
+    except Exception as exc:
+        raise KeyError(f"column {name!r} not found in data") from exc
+
+
+def _finegray_categorical_levels(values: Any) -> tuple[Any, ...] | None:
+    categories = getattr(getattr(values, "dtype", None), "categories", None)
+    if categories is None:
+        try:
+            categories = values.categories
+        except (AttributeError, TypeError):
+            categories = None
+    if categories is None:
+        try:
+            accessor = values.cat
+        except (AttributeError, TypeError):
+            accessor = None
+        if accessor is not None:
+            categories = getattr(accessor, "categories", None)
+            if categories is None:
+                get_categories = getattr(accessor, "get_categories", None)
+                if callable(get_categories):
+                    categories = get_categories()
+    if categories is None:
+        return None
+    return tuple(_materialize_1d(categories, "event categories"))
+
+
+def _finegray_declared_levels(data: Any, spec: _SurvResponseSpec) -> tuple[Any, ...] | None:
+    if len(spec.arguments) < 2:
+        return None
+    expression = _unwrap_response_identity(spec.arguments[-1])
+    if _top_level_comparison(expression) is not None or _response_rep_call(expression) is not None:
+        return None
+    try:
+        operand = _response_operand(expression, allow_literal=False)
+    except ValueError:
+        return None
+    if operand.column is None:
+        return None
+    raw_values = _finegray_raw_column(data, operand.column)
+    declared = _finegray_categorical_levels(raw_values)
+    if _finegray_factor_response(spec):
+        if declared is None:
+            declared = _finegray_factor_levels(
+                [
+                    value
+                    for value in _materialize_1d(raw_values, "event")
+                    if not _is_missing_value(value)
+                ]
+            )
+        else:
+            declared = tuple(_finegray_factor_label(value) for value in declared)
+    elif declared is None:
+        observed = [
+            value for value in _materialize_1d(raw_values, "event") if not _is_missing_value(value)
+        ]
+        if observed and all(isinstance(value, str) for value in observed):
+            declared = _finegray_event_levels(observed, None)
+    return declared
+
+
+def _finegray_factor_response(spec: _SurvResponseSpec) -> bool:
+    if len(spec.arguments) < 2:
+        return False
+    expression = spec.arguments[-1].strip()
+    return any(
+        expression.startswith(f"{wrapper}(") and expression.endswith(")")
+        for wrapper in ("factor", "as.factor")
     )
+
+
+def _finegray_factor_label(value: Any) -> str:
+    return _strata_value_label(value)
+
+
+def _finegray_factor_levels(values: list[Any]) -> tuple[str, ...]:
+    levels = _finegray_unique_levels(values, "event")
+    if all(isinstance(value, str) for value in levels) or all(
+        isinstance(value, bool) for value in levels
+    ):
+        ordered = sorted(levels)
+    elif all(isinstance(value, Real) and not isinstance(value, bool) for value in levels):
+        ordered = sorted(levels, key=float)
+    else:
+        ordered = sorted(levels, key=lambda value: _finegray_factor_label(value))
+    return tuple(_finegray_factor_label(value) for value in ordered)
+
+
+def _finegray_unique_levels(values: Sequence[Any], name: str) -> tuple[Any, ...]:
+    levels: dict[Any, None] = {}
+    for value in values:
+        if _is_missing_value(value):
+            raise ValueError(f"{name} must not contain missing values")
+        try:
+            levels.setdefault(value, None)
+        except TypeError as exc:
+            raise TypeError(f"{name} must contain hashable labels") from exc
+    return tuple(levels)
+
+
+def _finegray_event_levels(
+    event: list[Any],
+    declared_levels: tuple[Any, ...] | None,
+) -> tuple[Any, ...]:
+    if declared_levels is not None:
+        levels = _finegray_unique_levels(declared_levels, "event categories")
+    else:
+        if any(not isinstance(value, str) for value in event if not _is_missing_value(value)):
+            raise ValueError(
+                "Fine-Gray formula status must be categorical; use string labels or an "
+                "ordered categorical column"
+            )
+        levels = _finegray_unique_levels(event, "event")
+        censor_names = {
+            "(censor)",
+            "0",
+            "censor",
+            "censored",
+            "censoring",
+            "no event",
+            "no_event",
+        }
+        censor = next(
+            (
+                value
+                for value in levels
+                if isinstance(value, str) and value.strip().lower() in censor_names
+            ),
+            None,
+        )
+        if censor is not None and levels[0] != censor:
+            levels = (censor, *(value for value in levels if value != censor))
+    if len(levels) < 3:
+        raise ValueError("survival time has only a single state")
+    for state in levels[1:]:
+        if _is_missing_value(state) or (isinstance(state, str) and not state):
+            raise ValueError("each state must have a non-blank name")
+    return levels
+
+
+def _finegray_response_from_formula(
+    data: Any,
+    spec: _SurvResponseSpec,
+    declared_levels: tuple[Any, ...] | None,
+    *,
+    timefix: bool,
+) -> _FineGrayResponse:
+    response_columns = _formula_response_values(data, spec)
+    if len(response_columns) not in {2, 3}:
+        raise ValueError("Fine-Gray formula response must contain time and categorical status")
+    counting = len(response_columns) == 3
+    expected_type = "counting" if counting else "right"
+    if spec.type in {"right", "counting"} and spec.type != expected_type:
+        raise ValueError("Wrong number of args for this type of survival data")
+    if spec.type not in {None, "mstate", expected_type}:
+        raise ValueError("Fine-Gray model requires a multi-state survival")
+    if counting:
+        raw_start, raw_stop, raw_event = response_columns
+    else:
+        raw_stop, raw_event = response_columns
+        raw_start = []
+    n = len(raw_stop)
+    if n == 0:
+        raise ValueError("No (non-missing) observations")
+    if len(raw_event) != n or (counting and len(raw_start) != n):
+        raise ValueError("formula response columns must have the same length")
+
+    stop = [_finite_float(value, "time") - spec.origin for value in raw_stop]
+    start = [_finite_float(value, "start") - spec.origin for value in raw_start] if counting else []
+    if counting:
+        for idx, (left, right) in enumerate(zip(start, stop, strict=True)):
+            if left >= right:
+                raise ValueError(f"stop must be greater than start at index {idx}")
+        if timefix:
+            adjusted_start, adjusted_stop = _aeq_adjust_time_columns((start, stop), None)
+            _raise_if_aeq_zero_interval(start, stop, adjusted_start, adjusted_stop)
+            start, stop = adjusted_start, adjusted_stop
+    elif timefix:
+        (stop,) = _aeq_adjust_time_columns((stop,), None)
+
+    event = (
+        [
+            value if _is_missing_value(value) else _finegray_factor_label(value)
+            for value in raw_event
+        ]
+        if _finegray_factor_response(spec)
+        else list(raw_event)
+    )
+    levels = _finegray_event_levels(event, declared_levels)
+    try:
+        level_codes = {value: idx for idx, value in enumerate(levels)}
+        status = [level_codes[value] for value in event]
+    except TypeError as exc:
+        raise TypeError("event must contain hashable labels") from exc
+    except KeyError as exc:
+        raise ValueError(f"event contains undeclared category {exc.args[0]!r}") from exc
+    return _FineGrayResponse(
+        start=start,
+        stop=stop,
+        status=status,
+        states=levels[1:],
+        counting=counting,
+    )
+
+
+def _finegray_model_columns(
+    data: Any,
+    terms: _FormulaTerms,
+    n: int,
+) -> list[tuple[str, list[Any]]]:
+    columns: list[tuple[str, list[Any]]] = []
+    seen: set[str] = set()
+
+    def append_term(term: _CovariateTerm) -> None:
+        name = _covariate_term_name(term)
+        if name not in seen:
+            seen.add(name)
+            values = (
+                _term_raw_values(data, term, n)
+                if term.transform in {"I", "identity"} and term.arithmetic is None
+                else _term_values(data, term, n)
+            )
+            columns.append((name, values))
+
+    model_terms: Sequence[_FormulaModelTerm]
+    model_terms = terms.model_terms or [_ModelCovariateTerm(term) for term in terms.covariates]
+    for model_term in model_terms:
+        if isinstance(model_term, _ModelCovariateTerm):
+            if isinstance(model_term.term, _InteractionTerm):
+                for factor in model_term.term.factors:
+                    append_term(factor)
+            else:
+                append_term(model_term.term)
+        elif isinstance(model_term, _ModelOffsetTerm):
+            name = f"offset({_covariate_term_name(model_term.term)})"
+            if name not in seen:
+                seen.add(name)
+                values = _numeric_term_values(
+                    _term_raw_values(data, model_term.term, n),
+                    model_term.term,
+                )
+                columns.append((name, values))
+    return columns
+
+
+def _finegray_declared_strata_levels(
+    data: Any,
+    terms: _FormulaTerms,
+) -> list[tuple[Any, ...] | None]:
+    return [
+        _finegray_categorical_levels(_finegray_raw_column(data, column)) for column in terms.strata
+    ]
+
+
+def _finegray_strata_values_and_levels(
+    data: Any,
+    terms: _FormulaTerms,
+    n: int,
+    declared_levels: list[tuple[Any, ...] | None],
+) -> tuple[list[Any] | None, tuple[Any, ...] | None]:
+    if not terms.strata:
+        return None, None
+    columns = [_column(data, term) for term in terms.strata]
+    if any(len(column) != n for column in columns):
+        raise ValueError("formula columns must have the same length as the Surv response")
+    if any(_is_missing_value(value) for column in columns for value in column):
+        raise ValueError("strata must not contain missing values")
+
+    column_levels: list[tuple[Any, ...]] = []
+    for column, declared in zip(columns, declared_levels, strict=True):
+        observed = _finegray_unique_levels(column, "strata")
+        levels = declared or _r_formula_ordered_levels(column, "finegray strata")
+        if any(value not in levels for value in observed):
+            raise ValueError("strata contains a value outside the declared categories")
+        column_levels.append(tuple(value for value in levels if value in observed))
+
+    strata = _combine_aligned_columns(columns, n)
+    levels = column_levels[0] if len(column_levels) == 1 else tuple(product(*column_levels))
+    observed_strata = _finegray_unique_levels(strata, "strata")
+    return strata, tuple(level for level in levels if level in observed_strata)
+
+
+def _finegray_formula_inputs(
+    formula: str,
+    data: Any,
+    weights: Any | None,
+    subset: Any | None,
+    na_action: str | None,
+    id_values: Any | None,
+    *,
+    timefix: bool,
+) -> _FineGrayInputs:
+    if data is None:
+        raise ValueError("data is required when finegray response is a formula")
+    spec = _formula_response_spec(formula)
+    declared_levels = _finegray_declared_levels(data, spec)
+    _lhs, _sep, rhs = formula.partition("~")
+    initial_terms = _split_terms(rhs, _dot_terms(data, list(spec.columns)))
+    declared_strata_levels = _finegray_declared_strata_levels(data, initial_terms)
+    weights = _column_or_values(data, weights, "weights") if weights is not None else None
+    id_values = _column_or_values(data, id_values, "id") if id_values is not None else None
+    if subset is not None:
+        data, aligned = _subset_formula_inputs(
+            formula,
+            data,
+            subset,
+            weights=weights,
+            id=id_values,
+        )
+        weights = aligned["weights"]
+        id_values = aligned["id"]
+    data, aligned = _apply_formula_na_action(
+        formula,
+        data,
+        na_action,
+        weights=weights,
+        id=id_values,
+    )
+    weights = aligned["weights"]
+    id_values = aligned["id"]
+    response = _finegray_response_from_formula(
+        data,
+        spec,
+        declared_levels,
+        timefix=timefix,
+    )
+    n = len(response.stop)
+    terms = _split_terms(rhs, _dot_terms(data, list(spec.columns)))
+    if terms.clusters:
+        raise ValueError("a cluster() term is not valid")
+    model_columns = _finegray_model_columns(data, terms, n)
+
+    user_weights = None if weights is None else _materialize_1d(weights, "weights")
+    if user_weights is not None and len(user_weights) != n:
+        raise ValueError("weights must have the same length as the response")
+    numeric_weights = (
+        [1.0] * n
+        if user_weights is None
+        else [_finite_float(value, "weights") for value in user_weights]
+    )
+
+    materialized_id = None if id_values is None else _materialize_labels(id_values, "id")
+    if materialized_id is not None and len(materialized_id) != n:
+        raise ValueError("id must have the same length as the response")
+    strata, strata_levels = _finegray_strata_values_and_levels(
+        data,
+        terms,
+        n,
+        declared_strata_levels,
+    )
+    return _FineGrayInputs(
+        response=response,
+        model_columns=model_columns,
+        user_weights=user_weights,
+        numeric_weights=numeric_weights,
+        id_values=materialized_id,
+        strata=strata,
+        strata_levels=strata_levels,
+    )
+
+
+def _finegray_selected_state(states: tuple[Any, ...], etype: Any | None) -> tuple[int, Any]:
+    def state_index(value: Any) -> int | None:
+        for idx, state in enumerate(states):
+            try:
+                equal = bool(value == state)
+            except (TypeError, ValueError):
+                equal = False
+            if equal:
+                return idx
+        return None
+
+    if etype is None:
+        selected = [states[0]]
+    elif isinstance(etype, str | bytes) or (
+        isinstance(etype, tuple) and state_index(etype) is not None
+    ):
+        selected = [etype]
+    else:
+        try:
+            selected = _materialize_1d(etype, "etype")
+        except TypeError:
+            selected = [etype]
+
+    selected_indices: list[int] = []
+    for value in selected:
+        match = state_index(value)
+        if match is None:
+            raise ValueError("etype argument has a state that is not in the data")
+        selected_indices.append(match)
+    if not selected:
+        raise ValueError("etype argument has a state that is not in the data")
+    if len(selected) > 1:
+        warnings.warn("only the first endpoint was used", RuntimeWarning, stacklevel=2)
+    endpoint = selected[0]
+    return selected_indices[0] + 1, endpoint
+
+
+def _finegray_counting_layout(
+    response: _FineGrayResponse,
+    id_values: list[Any] | None,
+) -> tuple[list[bool], list[bool], bool]:
+    n = len(response.stop)
+    if not response.counting:
+        return [False] * n, [True] * n, False
+    if id_values is None:
+        raise ValueError("(start, stop] data requires a subject id")
+    groups: dict[Any, list[int]] = {}
+    for idx, value in enumerate(id_values):
+        if _is_missing_value(value):
+            raise ValueError("id must not contain missing values")
+        try:
+            groups.setdefault(value, []).append(idx)
+        except TypeError as exc:
+            raise TypeError("id must contain hashable labels") from exc
+
+    first = [False] * n
+    last = [False] * n
+    first_rows: list[int] = []
+    for rows in groups.values():
+        ordered = sorted(rows, key=lambda idx: (response.stop[idx], idx))
+        first[ordered[0]] = True
+        last[ordered[-1]] = True
+        first_rows.append(ordered[0])
+        for idx in ordered[:-1]:
+            if response.status[idx] != 0:
+                raise ValueError("a subject has a transition before their last time point")
+        for left, right in zip(ordered, ordered[1:], strict=False):
+            if response.stop[left] != response.start[right]:
+                raise ValueError("a subject has gaps in time")
+    minimum_stop = min(response.stop)
+    delayed = any(response.start[idx] > minimum_stop for idx in first_rows)
+    return first, last, delayed
+
+
+def _finegray_censor_curve(
+    start: list[float],
+    stop: list[float],
+    event: list[bool],
+) -> tuple[list[float], list[float]]:
+    event_counts: dict[float, int] = {}
+    for time, observed in zip(stop, event, strict=True):
+        if observed:
+            event_counts[time] = event_counts.get(time, 0) + 1
+    if not event_counts:
+        return [], []
+    sorted_start = sorted(start)
+    sorted_stop = sorted(stop)
+    survival = 1.0
+    curve_time: list[float] = []
+    curve_survival: list[float] = []
+    for time in sorted(event_counts):
+        risk = bisect_left(sorted_start, time) - bisect_left(sorted_stop, time)
+        deaths = event_counts[time]
+        if risk <= 0 or deaths > risk:
+            raise ValueError("invalid censoring risk set in Fine-Gray expansion")
+        survival *= 1.0 - deaths / risk
+        curve_time.append(time)
+        curve_survival.append(survival)
+    return curve_time, curve_survival
+
+
+def _finegray_rank_time(utime: list[float], rank: float) -> float:
+    index_value = int(rank)
+    if float(index_value) != rank or not 1 <= index_value <= len(utime):
+        raise ValueError("invalid ranked time in Fine-Gray expansion")
+    return utime[index_value - 1]
+
+
+def _finegray_censoring_grid(
+    start_rank: list[float],
+    stop_rank: list[float],
+    status: list[int],
+    first: list[bool],
+    last: list[bool],
+    utime: list[float],
+    maximum_time: float,
+    target_times: list[float],
+    *,
+    delayed: bool,
+) -> tuple[list[float], list[float], list[bool]]:
+    gtime, gsurv = _finegray_censor_curve(
+        start_rank,
+        stop_rank,
+        [is_last and value == 0 for is_last, value in zip(last, status, strict=True)],
+    )
+    if delayed:
+        htime, hsurv = _finegray_censor_curve(
+            [-value for value in stop_rank],
+            [-value for value in start_rank],
+            first,
+        )
+        dtime = list(reversed([-value for value in htime]))
+        dprob = list(reversed(hsurv))[1:] + [1.0]
+        combined = sorted(set(dtime + gtime))
+        ctime = [_finegray_rank_time(utime, value) for value in combined]
+        gprob = [1.0, *gsurv]
+        cprob = []
+        for value in combined:
+            dindex = bisect_right(dtime, value)
+            hvalue = dprob[max(dindex - 1, 0)]
+            gvalue = gprob[bisect_right(gtime, value)]
+            cprob.append(hvalue * gvalue)
+    else:
+        ctime = [_finegray_rank_time(utime, value) for value in gtime]
+        cprob = list(gsurv)
+
+    cut_times = [*ctime, maximum_time]
+    cut_probabilities = [1.0, *cprob]
+    keep = [False] * len(cut_times)
+    keep[0] = True
+    for target_time in target_times:
+        position = bisect_left(cut_times, target_time)
+        if position < len(keep):
+            keep[position] = True
+    return cut_times, cut_probabilities, keep
+
+
+def _finegray_split_intervals(
+    start: list[float],
+    stop: list[float],
+    cut_time: list[float],
+    cut_probability: list[float],
+    extend: list[bool],
+    keep: list[bool],
+) -> FineGrayOutput | _FineGraySplit:
+    if all(probability > 0.0 for probability in cut_probability):
+        return _core.finegray(start, stop, cut_time, cut_probability, extend, keep)
+
+    # The checked low-level splitter rejects zero probabilities. At the formula
+    # level a zero can still be harmless when it only truncates an original row;
+    # handle those sparse cases without weakening the public kernel contract.
+    rows: list[int] = []
+    output_start: list[float] = []
+    output_end: list[float] = []
+    output_weight: list[float] = []
+    output_add: list[int] = []
+    kept_indices = [idx for idx, value in enumerate(keep) if value]
+    for row_idx, (left, right, should_extend) in enumerate(zip(start, stop, extend, strict=True)):
+        cut_idx = bisect_left(cut_time, right) if should_extend else len(cut_time)
+        current_end = cut_time[cut_idx] if cut_idx < len(cut_time) else right
+        rows.append(row_idx + 1)
+        output_start.append(left)
+        output_end.append(current_end)
+        output_weight.append(1.0)
+        output_add.append(0)
+        if not should_extend or cut_idx >= len(cut_time):
+            continue
+
+        later_kept = kept_indices[bisect_right(kept_indices, cut_idx) :]
+        denominator = cut_probability[cut_idx]
+        if later_kept and denominator == 0.0:
+            raise ValueError("censoring probability is zero before a selected event")
+        for add, next_idx in enumerate(later_kept, start=1):
+            rows.append(row_idx + 1)
+            output_start.append(cut_time[next_idx - 1])
+            output_end.append(cut_time[next_idx])
+            output_weight.append(cut_probability[next_idx] / denominator)
+            output_add.append(add)
+    return _FineGraySplit(
+        row=rows,
+        start=output_start,
+        end=output_end,
+        wt=output_weight,
+        add=output_add,
+    )
+
+
+_R_RESERVED_NAMES = {
+    "break",
+    "else",
+    "FALSE",
+    "for",
+    "function",
+    "if",
+    "Inf",
+    "NA",
+    "NA_character_",
+    "NA_complex_",
+    "NA_integer_",
+    "NA_real_",
+    "NaN",
+    "next",
+    "NULL",
+    "repeat",
+    "TRUE",
+    "while",
+}
+
+
+def _finegray_make_name(value: Any) -> str:
+    if not isinstance(value, str):
+        raise TypeError("count must be a string or None")
+    name = "".join(char if char.isalnum() or char in {".", "_"} else "." for char in value)
+    if not name or not (name[0].isalpha() or (name[0] == "." and not name[1:2].isdigit())):
+        name = f"X{name}"
+    if name in _R_RESERVED_NAMES:
+        name += "."
+    return name
+
+
+def finegray(
+    formula: str,
+    data: Any | None = None,
+    *,
+    weights: Any | None = None,
+    subset: Any | None = None,
+    na_action: str | None = "pass",
+    etype: Any | None = None,
+    prefix: str = "fg",
+    count: str | None = None,
+    id: Any | None = None,  # noqa: A002
+    timefix: bool = True,
+    **kwargs: Any,
+) -> FineGrayFrame:
+    """Create Fine-Gray weighted interval data from a multi-state ``Surv`` formula."""
+
+    na_action = _pop_dotted_keyword(kwargs, "na.action", "na_action", na_action, "pass")
+    if kwargs:
+        unexpected = ", ".join(sorted(kwargs))
+        raise TypeError(f"finegray got unexpected keyword argument(s): {unexpected}")
+
+    if not isinstance(formula, str):
+        raise TypeError("finegray formula must be a string")
+
+    fix_time = _normalize_bool_option(timefix, "timefix")
+    if not isinstance(prefix, str):
+        raise TypeError("prefix must be a string")
+    inputs = _finegray_formula_inputs(
+        formula,
+        data,
+        weights,
+        subset,
+        _normalize_na_action(na_action),
+        id,
+        timefix=fix_time,
+    )
+    response = inputs.response
+    endpoint_code, endpoint = _finegray_selected_state(response.states, etype)
+    first, last, delayed = _finegray_counting_layout(response, inputs.id_values)
+
+    if response.counting:
+        start = list(response.start)
+    else:
+        minimum_stop = min(response.stop)
+        zero = 0.0 if minimum_stop > 0.0 else 2.0 * minimum_stop - 1.0
+        start = [zero] * len(response.stop)
+    stop = list(response.stop)
+    utime = sorted(set(start + stop))
+    start_rank = [float(bisect_right(utime, value)) for value in start]
+    stop_rank = [float(bisect_right(utime, value)) for value in stop]
+    for idx, value in enumerate(response.status):
+        if value != 0:
+            stop_rank[idx] -= 0.2
+
+    n = len(stop)
+    if inputs.strata is None:
+        groups = [(None, list(range(n)))]
+    else:
+        groups = list(_group_indices(inputs.strata, n, levels=inputs.strata_levels).items())
+
+    source_rows: list[int] = []
+    expanded_start: list[float] = []
+    expanded_stop: list[float] = []
+    expanded_status: list[float] = []
+    expanded_weight: list[float] = []
+    expanded_add: list[int] = []
+    for _level, rows in groups:
+        target_times = sorted({stop[idx] for idx in rows if response.status[idx] == endpoint_code})
+        if not target_times:
+            continue
+        local_start = [start[idx] for idx in rows]
+        local_stop = [stop[idx] for idx in rows]
+        local_status = [response.status[idx] for idx in rows]
+        local_first = [first[idx] for idx in rows]
+        local_last = [last[idx] for idx in rows]
+        cut_time, cut_probability, keep = _finegray_censoring_grid(
+            [start_rank[idx] for idx in rows],
+            [stop_rank[idx] for idx in rows],
+            local_status,
+            local_first,
+            local_last,
+            utime,
+            max(local_stop),
+            target_times,
+            delayed=delayed,
+        )
+        raw = _finegray_split_intervals(
+            local_start,
+            local_stop,
+            cut_time,
+            cut_probability,
+            [
+                value != 0 and value != endpoint_code and is_last
+                for value, is_last in zip(local_status, local_last, strict=True)
+            ],
+            keep,
+        )
+        for raw_row, left, right, weight, add in zip(
+            raw.row,
+            raw.start,
+            raw.end,
+            raw.wt,
+            raw.add,
+            strict=True,
+        ):
+            local_idx = int(raw_row) - 1
+            source_idx = rows[local_idx]
+            source_rows.append(source_idx)
+            expanded_start.append(float(left))
+            expanded_stop.append(float(right))
+            expanded_status.append(float(response.status[source_idx] == endpoint_code))
+            expanded_weight.append(float(weight) * inputs.numeric_weights[source_idx])
+            expanded_add.append(int(add))
+
+    if not source_rows:
+        raise ValueError("selected endpoint has no events")
+    columns: dict[str, list[Any]] = {
+        name: [values[idx] for idx in source_rows] for name, values in inputs.model_columns
+    }
+    if inputs.user_weights is not None:
+        columns["(weights)"] = [inputs.user_weights[idx] for idx in source_rows]
+    output_names = [f"{prefix}{suffix}" for suffix in ("start", "stop", "status", "wt")]
+    columns[output_names[0]] = expanded_start
+    columns[output_names[1]] = expanded_stop
+    columns[output_names[2]] = expanded_status
+    columns[output_names[3]] = expanded_weight
+    if count is not None:
+        columns[_finegray_make_name(count)] = expanded_add
+    return FineGrayFrame(columns, event=endpoint)
 
 
 def _survobrien_default_transform(values: Sequence[float]) -> list[float]:
@@ -13034,6 +13810,8 @@ def as_data_frame(result: Any) -> dict[str, list[Any]]:
         return _concordance_frame(result)
     if isinstance(result, PyearsResult):
         return _pyears_result_frame(result)
+    if isinstance(result, FineGrayFrame):
+        return {name: list(values) for name, values in result.items()}
     if isinstance(result, FineGrayOutput):
         return _finegray_frame(result)
     if isinstance(result, Mapping):

--- a/python/survival/r_api.pyi
+++ b/python/survival/r_api.pyi
@@ -1,5 +1,6 @@
 # ruff: noqa: N802
 
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 from ._survival import SplineBasisResult as _SplineBasisResult
@@ -92,6 +93,16 @@ class FineGrayOutput:
     end: list[float]
     wt: list[float]
     add: list[int]
+
+class FineGrayFrame(dict[str, list[Any]]):
+    event: Any
+    def __init__(
+        self,
+        columns: Mapping[str, Sequence[Any]] | None = None,
+        *,
+        event: Any = None,
+    ) -> None: ...
+    def copy(self) -> FineGrayFrame: ...
 
 class TcutResult:
     codes: list[int]
@@ -187,13 +198,19 @@ def pyears(
     data_frame: Any = False,
 ) -> PyearsResult | dict[str, list[Any]]: ...
 def finegray(
-    tstart: Any,
-    tstop: Any,
-    ctime: Any,
-    cprob: Any,
-    extend: Any,
-    keep: Any,
-) -> FineGrayOutput: ...
+    formula: str,
+    data: Any | None = None,
+    *,
+    weights: Any | None = None,
+    subset: Any | None = None,
+    na_action: str | None = "pass",
+    etype: Any | None = None,
+    prefix: str = "fg",
+    count: str | None = None,
+    id: Any | None = None,
+    timefix: bool = True,
+    **kwargs: Any,
+) -> FineGrayFrame: ...
 def cipoisson(
     k: Any,
     time: Any = 1.0,

--- a/python/tests/test_binding_contract.py
+++ b/python/tests/test_binding_contract.py
@@ -11102,6 +11102,7 @@ def test_package_root_marks_curated_and_legacy_exports():
     assert "regression" in survival.__all__
     assert "StrataFactor" in survival.__all__
     assert "Surv" in survival.__all__
+    assert "FineGrayFrame" in survival.__all__
     assert "FineGrayOutput" in survival.__all__
     assert "RateTable" in survival.__all__
     assert "PyearsResult" in survival.__all__
@@ -11169,6 +11170,7 @@ def test_package_root_marks_curated_and_legacy_exports():
     assert "ridge_fit" not in vars(survival)
     assert survival.StrataFactor is survival.r_api.StrataFactor
     assert survival.Surv is survival.r_api.Surv
+    assert survival.FineGrayFrame is survival.r_api.FineGrayFrame
     assert survival.FineGrayOutput is survival.r_api.FineGrayOutput
     assert survival.RateTable is survival.r_api.RateTable
     assert survival.PyearsResult is survival.r_api.PyearsResult
@@ -11631,9 +11633,25 @@ def test_r_api_stub_tracks_finegray_public_signature():
     survival = importlib.import_module("survival")
     stub_path = PACKAGE_ROOT / "r_api.pyi"
 
-    expected = ["tstart", "tstop", "ctime", "cprob", "extend", "keep"]
-    assert list(inspect.signature(survival.r_api.finegray).parameters) == expected
-    assert _pyi_function_arg_names(stub_path, "finegray") == expected
+    expected = [
+        "formula",
+        "data",
+        "weights",
+        "subset",
+        "na_action",
+        "etype",
+        "prefix",
+        "count",
+        "id",
+        "timefix",
+        "kwargs",
+    ]
+    runtime_params = inspect.signature(survival.r_api.finegray).parameters
+    assert list(runtime_params) == expected
+    for name in expected[2:-1]:
+        assert runtime_params[name].kind is inspect.Parameter.KEYWORD_ONLY
+    assert _pyi_function_arg_names(stub_path, "finegray") == expected[:-1]
+    assert _pyi_function_kwarg_name(stub_path, "finegray") == "kwargs"
 
 
 def test_r_api_stub_tracks_survobrien_public_signature():

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -1989,6 +1989,354 @@ def test_r_style_pyears_tabulates_surv_inputs():
         survival.pyears([1.0], scale=0)
 
 
+def test_r_style_finegray_matches_right_multistate_fixture():
+    data = {
+        "id": list(range(1, 9)),
+        "time": list(range(1, 9)),
+        "event": [
+            "target",
+            "compete",
+            "censor",
+            "compete",
+            "target",
+            "censor",
+            "compete",
+            "target",
+        ],
+        "x": [0.2, 0.4, 0.1, 0.8, 0.5, 0.3, 0.7, 0.6],
+    }
+
+    result = survival.finegray(
+        "Surv(time, event) ~ x",
+        data=data,
+        etype="target",
+        count="dup",
+    )
+
+    assert isinstance(result, survival.FineGrayFrame)
+    assert result.event == "target"
+    assert result["x"] == pytest.approx([0.2, 0.4, 0.4, 0.4, 0.1, 0.8, 0.8, 0.5, 0.3, 0.7, 0.6])
+    assert result["fgstart"] == pytest.approx([0, 0, 3, 6, 0, 0, 6, 0, 0, 0, 0])
+    assert result["fgstop"] == pytest.approx([1, 3, 6, 8, 3, 6, 8, 5, 6, 8, 8])
+    assert result["fgstatus"] == [1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1]
+    assert result["fgwt"] == pytest.approx([1, 1, 5 / 6, 5 / 9, 1, 1, 2 / 3, 1, 1, 1, 1])
+    assert result["dup"] == [0, 0, 1, 2, 0, 0, 1, 0, 0, 0, 0]
+    assert survival.as_data_frame(result) == dict(result)
+    copied = result.copy()
+    assert isinstance(copied, survival.FineGrayFrame)
+    assert copied == result
+    assert copied.event == "target"
+    assert copied["x"] is result["x"]
+
+
+def test_r_style_finegray_keeps_model_frame_terms_weights_and_stratum_order():
+    data = {
+        "time": [1, 2, 3, 1, 2, 3],
+        "event": ["target", "censor", "compete"] * 2,
+        "x": [10.0, 11.0, 12.0, 20.0, 21.0, 22.0],
+        "z": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+        "group": ["z", "z", "z", "a", "a", "a"],
+        "case_weight": [101.0, 102.0, 103.0, 201.0, 202.0, 203.0],
+    }
+
+    result = survival.finegray(
+        "Surv(time, event) ~ I(x^2) + x:z + offset(z) + strata(group)",
+        data=data,
+        weights="case_weight",
+        etype="target",
+        prefix="cr",
+        count="added rows",
+    )
+
+    assert list(result) == [
+        "I(x^2)",
+        "x",
+        "z",
+        "offset(z)",
+        "(weights)",
+        "crstart",
+        "crstop",
+        "crstatus",
+        "crwt",
+        "added.rows",
+    ]
+    assert result["x"][:3] == pytest.approx([20.0, 21.0, 22.0])
+    assert result["I(x^2)"][:3] == pytest.approx([400.0, 441.0, 484.0])
+    assert result["offset(z)"][:3] == pytest.approx([4.0, 5.0, 6.0])
+    assert result["(weights)"][:3] == pytest.approx([201.0, 202.0, 203.0])
+    assert result["crwt"][:3] == pytest.approx([201.0, 202.0, 203.0])
+    assert result["added.rows"] == [0] * 6
+
+
+def test_r_style_finegray_matches_counting_and_delayed_entry_fixture():
+    data = {
+        "id": [1, 1, 2, 2, 3, 4],
+        "start": [0, 1, 0, 2, 0, 0],
+        "stop": [1, 3, 2, 4, 5, 6],
+        "event": ["censor", "target", "censor", "compete", "censor", "target"],
+        "x": [10, 11, 20, 21, 30, 40],
+    }
+
+    result = survival.finegray(
+        "Surv(start, stop, event) ~ x",
+        data=data,
+        id="id",
+        etype="target",
+        count="dup",
+    )
+
+    assert result["x"] == [10, 11, 20, 21, 21, 30, 40]
+    assert result["fgstart"] == pytest.approx([0, 1, 0, 2, 5, 0, 0])
+    assert result["fgstop"] == pytest.approx([1, 3, 2, 5, 6, 5, 6])
+    assert result["fgstatus"] == [0, 1, 0, 0, 0, 0, 1]
+    assert result["fgwt"] == pytest.approx([1, 1, 1, 1, 0.5, 1, 1])
+    assert result["dup"] == [0, 0, 0, 0, 1, 0, 0]
+
+    delayed = {
+        "id": [1, 2, 3, 4, 5],
+        "start": [0, 2, 4, 6, 0],
+        "stop": [6, 5, 8, 10, 7],
+        "event": ["target", "compete", "censor", "target", "censor"],
+        "x": [1, 2, 3, 4, 5],
+    }
+    delayed_result = survival.finegray(
+        "Surv(start, stop, event) ~ x",
+        data=delayed,
+        id="id",
+        etype="target",
+        count="extra",
+    )
+    assert delayed_result["x"] == [1, 2, 2, 3, 4, 5]
+    assert delayed_result["fgstart"] == pytest.approx([0, 2, 8, 4, 6, 0])
+    assert delayed_result["fgstop"] == pytest.approx([6, 6, 10, 8, 10, 7])
+    assert delayed_result["fgwt"] == pytest.approx([1, 1, 0.5, 1, 1, 1])
+    assert delayed_result["extra"] == [0, 0, 1, 0, 0, 0]
+
+
+def test_r_style_finegray_preserves_declared_levels_and_timefix():
+    pandas = pytest.importorskip("pandas")
+    frame = pandas.DataFrame(
+        {
+            "time": [1.0, 2.0, 3.0, 4.0],
+            "event": pandas.Categorical(
+                ["target", "censor", "target", "compete"],
+                categories=["censor", "target", "compete"],
+                ordered=True,
+            ),
+            "x": [1, 2, 3, 4],
+        }
+    )
+    subset_result = survival.finegray(
+        "Surv(time, event, type='mstate') ~ x",
+        data=frame,
+        subset=[True, True, True, False],
+        etype="target",
+    )
+    assert subset_result["x"] == [1, 2, 3]
+    with pytest.raises(ValueError, match="selected endpoint has no events"):
+        survival.finegray(
+            "Surv(time, event) ~ x",
+            data=frame,
+            subset=[True, True, True, False],
+            etype="compete",
+        )
+
+    plain_levels = {
+        "time": [1.0, 2.0, 3.0, 4.0],
+        "event": ["censor", "target", "compete", "target"],
+        "x": [1, 2, 3, 4],
+    }
+    plain_subset = survival.finegray(
+        "Surv(time, event) ~ x",
+        data=plain_levels,
+        subset=[True, False, True, True],
+    )
+    assert plain_subset.event == "target"
+
+    near_ties = {
+        "time": [1.0, 1.0 + 1e-10, 2.0, 3.0],
+        "event": ["target", "target", "censor", "compete"],
+        "x": [1, 2, 3, 4],
+    }
+    fixed = survival.finegray("Surv(time, event) ~ x", data=near_ties)
+    exact = survival.finegray("Surv(time, event) ~ x", data=near_ties, timefix=False)
+    assert fixed["fgstop"][:2] == pytest.approx([1.0, 1.0])
+    assert exact["fgstop"][:2] == pytest.approx([1.0, 1.0 + 1e-10], abs=0.0, rel=0.0)
+
+    ordered_strata = pandas.DataFrame(
+        {
+            "time": [1, 2, 3, 1, 2, 3],
+            "event": ["target", "censor", "compete"] * 2,
+            "x": [10, 11, 12, 20, 21, 22],
+            "group": pandas.Categorical(
+                ["z", "z", "z", "a", "a", "a"],
+                categories=["z", "a"],
+                ordered=True,
+            ),
+        }
+    )
+    ordered_result = survival.finegray(
+        "Surv(time, event) ~ x + strata(group)",
+        data=ordered_strata,
+    )
+    assert ordered_result["x"] == [10, 11, 12, 20, 21, 22]
+
+    two_strata = pandas.DataFrame(
+        {
+            "time": [1, 2, 3] * 4,
+            "event": ["target", "censor", "compete"] * 4,
+            "x": [10, 11, 12, 20, 21, 22, 30, 31, 32, 40, 41, 42],
+            "g1": pandas.Categorical(
+                ["b"] * 3 + ["a"] * 3 + ["b"] * 3 + ["a"] * 3,
+                categories=["b", "a"],
+                ordered=True,
+            ),
+            "g2": pandas.Categorical(
+                ["y"] * 6 + ["x"] * 6,
+                categories=["y", "x"],
+                ordered=True,
+            ),
+        }
+    )
+    two_strata_result = survival.finegray(
+        "Surv(time, event) ~ x + strata(g1) + strata(g2)",
+        data=two_strata,
+    )
+    assert two_strata_result["x"] == [
+        10,
+        11,
+        12,
+        30,
+        31,
+        32,
+        20,
+        21,
+        22,
+        40,
+        41,
+        42,
+    ]
+
+    numpy = pytest.importorskip("numpy")
+    array_endpoint = survival.finegray(
+        "Surv(time, event) ~ x",
+        data=frame,
+        etype=numpy.array(["target"]),
+    )
+    assert isinstance(array_endpoint.event, str)
+    assert array_endpoint.event == "target"
+
+    factor_data = {
+        "time": [1.0, 2.0, 3.0, 4.0],
+        "event": [1, 2, 0, 1],
+        "label": ["a", "b", "c", "d"],
+        "other": ["w", "x", "y", "z"],
+    }
+    factor_result = survival.finegray(
+        "Surv(time, factor(event)) ~ I(label) + identity(other)",
+        data=factor_data,
+        etype="1",
+        count="NA_integer_",
+    )
+    assert factor_result.event == "1"
+    assert factor_result["I(label)"] == ["a", "b", "b", "c", "d"]
+    assert factor_result["identity(other)"] == ["w", "x", "x", "y", "z"]
+    assert "NA_integer_." in factor_result
+
+    character_factor = {
+        "time": [1, 2, 3, 4, 5, 6],
+        "event": ["10", "0", "2", "10", "0", "2"],
+        "x": [1, 2, 3, 4, 5, 6],
+    }
+    character_result = survival.finegray(
+        "Surv(time, factor(event)) ~ x",
+        data=character_factor,
+    )
+    assert character_result.event == "10"
+
+
+def test_r_style_finegray_validates_multistate_formula_contract():
+    data = {
+        "id": [1, 1, 2, 2],
+        "start": [0, 1, 0, 1],
+        "stop": [1, 2, 1, 2],
+        "event": ["censor", "target", "compete", "target"],
+        "x": [1, 2, 3, 4],
+    }
+
+    with pytest.raises(ValueError, match="requires a subject id"):
+        survival.finegray("Surv(start, stop, event) ~ x", data=data)
+    with pytest.raises(ValueError, match=r"cluster\(\)"):
+        survival.finegray(
+            "Surv(stop, event) ~ x + cluster(id)",
+            data=data,
+        )
+    with pytest.raises(ValueError, match="categorical"):
+        survival.finegray(
+            "Surv(stop, event) ~ x",
+            data={**data, "event": [0, 1, 2, 1]},
+        )
+    with pytest.raises(ValueError, match="not in the data"):
+        survival.finegray(
+            "Surv(stop, event) ~ x",
+            data=data,
+            etype="unknown",
+        )
+    with pytest.raises(ValueError, match="Wrong number of args"):
+        survival.finegray(
+            "Surv(stop, event, type='counting') ~ x",
+            data=data,
+        )
+    with pytest.raises(ValueError, match="Wrong number of args"):
+        survival.finegray(
+            "Surv(start, stop, event, type='right') ~ x",
+            data=data,
+            id="id",
+        )
+
+    zero_tail = {
+        "time": [1.0, 2.0, 3.0],
+        "event": ["target", "censor", "compete"],
+        "x": [1, 2, 3],
+    }
+    assert survival.finegray("Surv(time, event) ~ x", data=zero_tail)["fgstop"] == [
+        1.0,
+        2.0,
+        3.0,
+    ]
+
+    zero_before_target = {
+        "id": [1, 2, 3, 4],
+        "start": [0.0, 0.0, 0.0, 3.0],
+        "stop": [1.0, 1.5, 2.0, 5.0],
+        "event": ["target", "compete", "censor", "target"],
+        "x": [1, 2, 3, 4],
+    }
+    with pytest.raises(ValueError, match="probability is zero"):
+        survival.finegray(
+            "Surv(start, stop, event) ~ x",
+            data=zero_before_target,
+            id="id",
+        )
+
+    harmless_zero = {
+        "id": [1, 2, 3, 4],
+        "start": [0.0, 0.0, 0.0, 3.0],
+        "stop": [1.0, 2.0, 2.0, 5.0],
+        "event": ["compete", "target", "censor", "compete"],
+        "x": [1, 2, 3, 4],
+    }
+    harmless_result = survival.finegray(
+        "Surv(start, stop, event) ~ x",
+        data=harmless_zero,
+        id="id",
+        etype="target",
+    )
+    assert harmless_result["fgstart"] == pytest.approx([0, 0, 0, 3])
+    assert harmless_result["fgstop"] == pytest.approx([2, 2, 2, 5])
+    assert harmless_result["fgwt"] == pytest.approx([1, 1, 1, 1])
+
+
 def test_r_style_survobrien_uses_direct_vectors():
     result = survival.survobrien(
         [1.0, 2.0, 3.0, 4.0],

--- a/python/tests/test_specialized.py
+++ b/python/tests/test_specialized.py
@@ -291,7 +291,7 @@ def test_finegray():
     extend = [True, True, False, False]
     keep = [True, True, True, True]
 
-    result = survival.finegray(
+    result = survival.regression.finegray(
         tstart=tstart,
         tstop=tstop,
         ctime=ctime,
@@ -316,16 +316,16 @@ def test_finegray():
 
 def test_finegray_validates_public_inputs():
     with pytest.raises(ValueError, match="tstop length"):
-        survival.finegray([0.0], [], [], [], [True], [])
+        survival.regression.finegray([0.0], [], [], [], [True], [])
 
     with pytest.raises(ValueError, match="exceeds tstop"):
-        survival.finegray([2.0], [1.0], [], [], [True], [])
+        survival.regression.finegray([2.0], [1.0], [], [], [True], [])
 
     with pytest.raises(ValueError, match="ctime must be sorted"):
-        survival.finegray([0.0], [1.0], [2.0, 1.0], [1.0, 1.0], [True], [True, True])
+        survival.regression.finegray([0.0], [1.0], [2.0, 1.0], [1.0, 1.0], [True], [True, True])
 
     with pytest.raises(ValueError, match="cprob must contain values"):
-        survival.finegray([0.0], [1.0], [1.0], [0.0], [True], [True])
+        survival.regression.finegray([0.0], [1.0], [1.0], [0.0], [True], [True])
 
 
 def test_finegray_regression_and_cif_public_api():

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -1290,6 +1290,10 @@ attrassign.lm <- function(object, ...) {
   do.call(.data_prep_attr(name), .compact_null(list(...)))
 }
 
+.call_regression <- function(name, ...) {
+  do.call(.regression_attr(name), .compact_null(list(...)))
+}
+
 .core_nsk_basis <- function(x, df, knots, intercept, boundary_knots) {
   constructor <- .core_attr("NaturalSplineKnot")
   boundary_knots <- do.call(reticulate::tuple, as.list(as.numeric(boundary_knots)))
@@ -3428,7 +3432,7 @@ pyears <- function(formula, data, weights, subset, na.action, rmap, ratetable,
     ckeep[index] <- TRUE
     expand <- (Y[keep, 3L] != 0 & Y[keep, 3L] != enum & last[keep])
     keep_arg <- c(TRUE, ckeep)[seq_along(ct2)]
-    split <- .call_r_api(
+    split <- .call_regression(
       "finegray",
       .finegray_python_vector(Y[keep, 1L]),
       .finegray_python_vector(Y[keep, 2L]),
@@ -3492,7 +3496,7 @@ finegray <- function(formula, data, weights, subset, na.action = na.pass,
   if (missing(tstop) || missing(ctime) || missing(cprob) || missing(extend) || missing(keep)) {
     stop("direct finegray bridge requires tstart, tstop, ctime, cprob, extend, and keep", call. = FALSE)
   }
-  result <- .call_r_api(
+  result <- .call_regression(
     "finegray",
     .finegray_python_vector(direct_start),
     .finegray_python_vector(tstop),


### PR DESCRIPTION
## Summary
- expose an R-style formula/data Fine-Gray transformer at the package root while keeping the checked vector splitter in `survival.regression`
- support categorical competing-risk states, strata, case weights, counting-process IDs, delayed entry, time fixing, model-frame columns, and R-compatible output naming
- preserve endpoint metadata with a typed mapping result and cover native fixtures plus difficult categorical and zero-support cases
- route the R bridge's low-level calls through the regression module

## Intentional corrections
- use stratum-local case weights instead of the current upstream global-index lookup
- detect delayed entry from sorted subject rows instead of input positions
- raise clearly when zero censoring support would be used in a later risk interval

## Testing
- `PYTHONPATH=python .venv/bin/python -m pytest python/tests -q` (807 passed)
- `.venv/bin/ruff format python/ test/ --check`
- `.venv/bin/ruff check python/ test/`
- `.venv/bin/mypy python/survival/__init__.pyi python/survival/_survival.pyi --ignore-missing-imports`
- `.venv/bin/python scripts/generate_binding_manifest.py --check`
- `RETICULATE_PYTHON=/Users/cameron/survival/.venv/bin/python R CMD check --no-manual r/survivalr` (tests pass; source-build NOTE only)
- `git diff --check`