### PR TITLE
Accelerate Uno concordance calculation

### DIFF
--- a/benches/survival_benchmarks.rs
+++ b/benches/survival_benchmarks.rs
@@ -2,7 +2,7 @@ use std::hint::black_box;
 use survival::regression::{CoxPHModel, coxph_fit, finegray, survreg};
 use survival::{
     KaplanMeierConfig, WeightType, compute_brier, compute_rmst, compute_survfitkm, concordance1,
-    nelson_aalen, weighted_logrank_test,
+    nelson_aalen, uno_c_index, weighted_logrank_test,
 };
 
 fn generate_survival_data(n: usize) -> (Vec<f64>, Vec<f64>, Vec<i32>) {
@@ -194,6 +194,50 @@ mod concordance_bench {
         let indx: Vec<i32> = (0..n).map(|i| (i % ntree as usize) as i32).collect();
 
         bencher.bench_local(|| concordance1(&y, &weights, &indx, ntree));
+    }
+}
+
+mod uno_c_index_bench {
+    use super::*;
+
+    #[divan::bench(args = [100, 1000, 5000, 20000])]
+    fn mixed_censoring_and_tied_risk(bencher: divan::Bencher, n: usize) {
+        let time: Vec<f64> = (0..n)
+            .map(|idx| 1.0 + (idx % 250) as f64 * 0.25 + (idx / 250) as f64 * 0.01)
+            .collect();
+        let status: Vec<i32> = (0..n).map(|idx| i32::from(idx % 4 != 0)).collect();
+        let risk_score: Vec<f64> = (0..n)
+            .map(|idx| ((idx.wrapping_mul(37) + 11) % 64) as f64 / 16.0)
+            .collect();
+        let inputs = (time, status, risk_score);
+
+        bencher
+            .with_inputs(|| inputs.clone())
+            .bench_local_values(|(time, status, risk_score)| {
+                black_box(
+                    uno_c_index(time, status, risk_score, None)
+                        .expect("benchmark Uno C-index inputs should be valid"),
+                )
+            });
+    }
+
+    #[divan::bench(args = [100, 1000, 5000, 20000])]
+    fn mixed_censoring_and_distinct_risk(bencher: divan::Bencher, n: usize) {
+        let time: Vec<f64> = (0..n)
+            .map(|idx| 1.0 + (idx % 250) as f64 * 0.25 + (idx / 250) as f64 * 0.01)
+            .collect();
+        let status: Vec<i32> = (0..n).map(|idx| i32::from(idx % 4 != 0)).collect();
+        let risk_score: Vec<f64> = (0..n).map(|idx| idx as f64).collect();
+        let inputs = (time, status, risk_score);
+
+        bencher
+            .with_inputs(|| inputs.clone())
+            .bench_local_values(|(time, status, risk_score)| {
+                black_box(
+                    uno_c_index(time, status, risk_score, None)
+                        .expect("benchmark Uno C-index inputs should be valid"),
+                )
+            });
     }
 }
 

--- a/src/validation/uno_c_index/mod.rs
+++ b/src/validation/uno_c_index/mod.rs
@@ -1,6 +1,7 @@
 use crate::constants::{
     IPCW_SURVIVAL_FLOOR, PARALLEL_THRESHOLD_LARGE, clamped_normal_ci_95, normal_ci_95, same_time,
 };
+use crate::internal::fenwick::FenwickTree;
 use crate::internal::statistical::{compute_censoring_km, km_step_prob_at, normal_cdf};
 use crate::internal::validation::{
     validate_binary_i32, validate_finite, validate_no_nan, validate_non_empty,

--- a/src/validation/uno_c_index/tests.rs
+++ b/src/validation/uno_c_index/tests.rs
@@ -2,6 +2,73 @@
 mod tests {
     use super::*;
 
+    fn assert_close(actual: f64, expected: f64) {
+        let scale = actual.abs().max(expected.abs()).max(1.0);
+        assert!(
+            (actual - expected).abs() <= 1e-11 * scale,
+            "actual={actual:?}, expected={expected:?}"
+        );
+    }
+
+    fn assert_uno_accumulators_close(
+        actual: &UnoCIndexAccumulator,
+        expected: &UnoCIndexAccumulator,
+    ) {
+        assert_close(actual.concordant, expected.concordant);
+        assert_close(actual.discordant, expected.discordant);
+        assert_close(actual.tied, expected.tied);
+        assert_close(actual.total_weight, expected.total_weight);
+        assert_eq!(actual.influence_sums.len(), expected.influence_sums.len());
+        for (&actual_value, &expected_value) in actual
+            .influence_sums
+            .iter()
+            .zip(&expected.influence_sums)
+        {
+            assert_close(actual_value, expected_value);
+        }
+        assert_close(
+            actual.concordant + actual.discordant + actual.tied,
+            actual.total_weight,
+        );
+        let influence_sum = actual.influence_sums.iter().sum::<f64>();
+        assert!(
+            influence_sum.abs() <= 1e-11 * actual.total_weight.max(1.0),
+            "influence sum={influence_sum:?}, total weight={:?}",
+            actual.total_weight
+        );
+    }
+
+    fn assert_uno_results_close(actual: &UnoCIndexResult, expected: &UnoCIndexResult) {
+        assert_close(actual.c_index, expected.c_index);
+        assert_close(actual.concordant, expected.concordant);
+        assert_close(actual.discordant, expected.discordant);
+        assert_close(actual.tied_risk, expected.tied_risk);
+        assert_close(actual.comparable_pairs, expected.comparable_pairs);
+        assert_close(actual.variance, expected.variance);
+        assert_close(actual.std_error, expected.std_error);
+        assert_close(actual.ci_lower, expected.ci_lower);
+        assert_close(actual.ci_upper, expected.ci_upper);
+        assert_close(actual.tau, expected.tau);
+    }
+
+    fn assert_ranked_uno_matches_quadratic(
+        time: &[f64],
+        status: &[i32],
+        risk_score: &[f64],
+        tau: Option<f64>,
+    ) {
+        let tau_value = tau.unwrap_or_else(|| time.iter().copied().fold(0.0, f64::max));
+        let (km_times, km_values) = compute_censoring_km(time, status);
+        let event_weights = uno_event_weights(time, status, &km_times, &km_values, tau_value);
+        let ranked = uno_c_index_ranked_accumulator(time, risk_score, &event_weights);
+        let quadratic = uno_c_index_quadratic_accumulator(time, risk_score, &event_weights);
+        assert_uno_accumulators_close(&ranked, &quadratic);
+        assert_uno_results_close(
+            &uno_c_index_core(time, status, risk_score, tau),
+            &uno_c_index_core_quadratic(time, status, risk_score, tau),
+        );
+    }
+
     #[test]
     fn test_uno_c_index_basic() {
         let time = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
@@ -59,7 +126,115 @@ mod tests {
     }
 
     #[test]
-    fn test_uno_c_index_parallel_path_is_finite() {
+    fn test_ranked_uno_matches_quadratic_at_time_tau_and_risk_boundaries() {
+        let epsilon = crate::constants::TIME_EPSILON;
+        let time = vec![
+            1.0,
+            1.0 + 0.5 * epsilon,
+            1.0 + epsilon,
+            1.0 + 1.5 * epsilon,
+            2.0,
+            2.0,
+            3.0,
+            4.0,
+        ];
+        let status = vec![1, 1, 1, 0, 1, 0, 1, 0];
+        let risk_score = vec![-0.0, 0.0, 1.0, 1.0, -1.0, 2.0, -1.0, 0.5];
+
+        for tau in [
+            None,
+            Some(0.0),
+            Some(1.0),
+            Some(1.0 + 0.5 * epsilon),
+            Some(1.0 + epsilon),
+            Some(2.5),
+        ] {
+            assert_ranked_uno_matches_quadratic(&time, &status, &risk_score, tau);
+        }
+    }
+
+    #[test]
+    fn test_ranked_uno_matches_quadratic_at_ipcw_survival_floor() {
+        let n = 202;
+        let time: Vec<f64> = (1..=n).map(|value| value as f64).collect();
+        let mut status = vec![0; n];
+        status[n - 2] = 1;
+        status[n - 1] = 1;
+        let risk_score: Vec<f64> = (0..n).map(|idx| ((idx * 37) % n) as f64).collect();
+
+        let (km_times, km_values) = compute_censoring_km(&time, &status);
+        let event_weights = uno_event_weights(
+            &time,
+            &status,
+            &km_times,
+            &km_values,
+            *time.last().expect("fixture is non-empty"),
+        );
+        assert_close(
+            event_weights[n - 2],
+            1.0 / (IPCW_SURVIVAL_FLOOR * IPCW_SURVIVAL_FLOOR),
+        );
+        assert_ranked_uno_matches_quadratic(&time, &status, &risk_score, None);
+    }
+
+    #[test]
+    fn test_ranked_uno_matches_quadratic_on_deterministic_random_inputs() {
+        let epsilon = crate::constants::TIME_EPSILON;
+        let mut state = 0x6a09_e667_f3bc_c909_u64;
+        for n in 1..=64 {
+            for case_idx in 0..12 {
+                let mut time = Vec::with_capacity(n);
+                let mut status = Vec::with_capacity(n);
+                let mut risk_score = Vec::with_capacity(n);
+                for _ in 0..n {
+                    crate::internal::statistical::lcg64_next(&mut state);
+                    let bucket = (state % 11) as f64;
+                    let offset = match (state >> 8) % 4 {
+                        0 => 0.0,
+                        1 => 0.5 * epsilon,
+                        2 => epsilon,
+                        _ => 1.5 * epsilon,
+                    };
+                    time.push(bucket + offset);
+                    status.push(i32::from((state >> 16).is_multiple_of(3)));
+                    let risk = match (state >> 24) % 9 {
+                        0 => -0.0,
+                        1 => 0.0,
+                        value => value as f64 - 5.0,
+                    };
+                    risk_score.push(risk);
+                }
+                let tau = match case_idx % 4 {
+                    0 => None,
+                    1 => Some(4.0),
+                    2 => Some(4.0 + 0.5 * epsilon),
+                    _ => Some(4.0 + epsilon),
+                };
+                assert_ranked_uno_matches_quadratic(&time, &status, &risk_score, tau);
+            }
+        }
+    }
+
+    #[test]
+    fn test_ranked_uno_matches_quadratic_across_old_parallel_threshold() {
+        for n in [
+            PARALLEL_THRESHOLD_LARGE - 1,
+            PARALLEL_THRESHOLD_LARGE,
+            PARALLEL_THRESHOLD_LARGE + 1,
+        ] {
+            let time: Vec<f64> = (0..n)
+                .map(|idx| 1.0 + (idx % 127) as f64 * 0.25 + (idx / 127) as f64 * 0.01)
+                .collect();
+            let status: Vec<i32> = (0..n).map(|idx| i32::from(idx % 5 != 0)).collect();
+            let risk_score: Vec<f64> = (0..n)
+                .map(|idx| ((idx.wrapping_mul(37) + 7) % 41) as f64)
+                .collect();
+            assert_ranked_uno_matches_quadratic(&time, &status, &risk_score, Some(20.0));
+        }
+    }
+
+    #[test]
+    fn test_uno_c_index_large_input_is_finite() {
         let n = PARALLEL_THRESHOLD_LARGE + 5;
         let time: Vec<f64> = (0..n).map(|i| i as f64 + 1.0).collect();
         let status = vec![1; n];

--- a/src/validation/uno_c_index/uno.rs
+++ b/src/validation/uno_c_index/uno.rs
@@ -74,133 +74,170 @@ impl UnoCIndexAccumulator {
             influence_sums: vec![0.0; n],
         }
     }
-
-    fn merge(&mut self, other: Self) {
-        self.concordant += other.concordant;
-        self.discordant += other.discordant;
-        self.tied += other.tied;
-        self.total_weight += other.total_weight;
-        for (left, right) in self
-            .influence_sums
-            .iter_mut()
-            .zip(other.influence_sums.iter())
-        {
-            *left += right;
-        }
-    }
 }
 
-struct UnoCIndexContext<'a> {
-    time: &'a [f64],
-    status: &'a [i32],
-    risk_score: &'a [f64],
-    km_times: &'a [f64],
-    km_values: &'a [f64],
-    tau: f64,
-    min_g: f64,
+#[inline]
+fn uno_rank_counts(tree: &FenwickTree, rank: usize) -> (f64, f64, f64) {
+    let below = if rank == 0 {
+        0.0
+    } else {
+        tree.prefix_sum(rank - 1)
+    };
+    let inclusive = tree.prefix_sum(rank);
+    (below, inclusive - below, tree.total() - inclusive)
 }
 
-fn accumulate_uno_c_index_row(
-    accumulator: &mut UnoCIndexAccumulator,
-    context: &UnoCIndexContext<'_>,
-    i: usize,
-) {
-    if context.status[i] != 1 || !at_or_before_tau(context.time[i], context.tau) {
-        return;
-    }
-
-    let g_ti = km_step_prob_at(context.time[i], context.km_times, context.km_values).max(context.min_g);
-    let weight = 1.0 / (g_ti * g_ti);
-
-    for j in 0..context.time.len() {
-        if i == j {
-            continue;
-        }
-
-        if !after_event_time(context.time[j], context.time[i]) {
-            continue;
-        }
-
-        accumulator.total_weight += weight;
-
-        if context.risk_score[i] > context.risk_score[j] {
-            accumulator.concordant += weight;
-            accumulator.influence_sums[i] += weight;
-            accumulator.influence_sums[j] -= weight;
-        } else if context.risk_score[i] < context.risk_score[j] {
-            accumulator.discordant += weight;
-            accumulator.influence_sums[i] -= weight;
-            accumulator.influence_sums[j] += weight;
-        } else {
-            accumulator.tied += weight;
-        }
-    }
+fn uno_risk_ranks(risk_score: &[f64]) -> (usize, Vec<usize>) {
+    let mut levels = risk_score.to_vec();
+    levels.sort_by(f64::total_cmp);
+    levels.dedup_by(|left, right| *left == *right);
+    let ranks = risk_score
+        .iter()
+        .map(|&score| levels.partition_point(|&level| level < score))
+        .collect();
+    (levels.len(), ranks)
 }
 
-pub(crate) fn uno_c_index_core(
+fn uno_event_weights(
     time: &[f64],
     status: &[i32],
+    km_times: &[f64],
+    km_values: &[f64],
+    tau: f64,
+) -> Vec<f64> {
+    time.iter()
+        .enumerate()
+        .map(|(idx, &event_time)| {
+            if status[idx] != 1 || !at_or_before_tau(event_time, tau) {
+                return 0.0;
+            }
+            let censoring_survival =
+                km_step_prob_at(event_time, km_times, km_values).max(IPCW_SURVIVAL_FLOOR);
+            1.0 / (censoring_survival * censoring_survival)
+        })
+        .collect()
+}
+
+fn uno_c_index_ranked_accumulator(
+    time: &[f64],
     risk_score: &[f64],
-    tau: Option<f64>,
-) -> UnoCIndexResult {
+    event_weights: &[f64],
+) -> UnoCIndexAccumulator {
     let n = time.len();
+    let (n_ranks, risk_ranks) = uno_risk_ranks(risk_score);
+    let mut subjects_desc: Vec<usize> = (0..n).collect();
+    subjects_desc.sort_by(|&left, &right| {
+        time[right]
+            .total_cmp(&time[left])
+            .then_with(|| left.cmp(&right))
+    });
+    let mut events_desc: Vec<usize> = (0..n)
+        .filter(|&idx| event_weights[idx] > 0.0)
+        .collect();
+    events_desc.sort_by(|&left, &right| {
+        time[right]
+            .total_cmp(&time[left])
+            .then_with(|| left.cmp(&right))
+    });
 
-    if n == 0 {
-        return UnoCIndexResult {
-            c_index: 0.5,
-            concordant: 0.0,
-            discordant: 0.0,
-            tied_risk: 0.0,
-            comparable_pairs: 0.0,
-            variance: 0.0,
-            std_error: 0.0,
-            ci_lower: 0.5,
-            ci_upper: 0.5,
-            tau: 0.0,
-        };
-    }
+    // Sweep backward through event times, adding only subjects far enough in
+    // the future to satisfy the package's epsilon-aware comparability rule.
+    let mut accumulator = {
+        let mut later_risk_counts = FenwickTree::new(n_ranks);
+        let mut subject_cursor = 0;
+        let mut pair_counts = vec![(0.0, 0.0, 0.0); n];
+        for &event_idx in &events_desc {
+            while subject_cursor < n
+                && after_event_time(
+                    time[subjects_desc[subject_cursor]],
+                    time[event_idx],
+                )
+            {
+                let subject_idx = subjects_desc[subject_cursor];
+                later_risk_counts.update(risk_ranks[subject_idx], 1.0);
+                subject_cursor += 1;
+            }
+            pair_counts[event_idx] = uno_rank_counts(&later_risk_counts, risk_ranks[event_idx]);
+        }
 
-    let tau_val = tau.unwrap_or_else(|| time.iter().copied().fold(f64::NEG_INFINITY, f64::max));
-
-    let (km_times, km_values) = compute_censoring_km(time, status);
-
-    let min_g = IPCW_SURVIVAL_FLOOR;
-
-    let context = UnoCIndexContext {
-        time,
-        status,
-        risk_score,
-        km_times: &km_times,
-        km_values: &km_values,
-        tau: tau_val,
-        min_g,
-    };
-
-    let accumulator = if n > PARALLEL_THRESHOLD_LARGE {
-        (0..n)
-            .into_par_iter()
-            .fold(
-                || UnoCIndexAccumulator::new(n),
-                |mut accumulator, i| {
-                    accumulate_uno_c_index_row(&mut accumulator, &context, i);
-                    accumulator
-                },
-            )
-            .reduce(
-                || UnoCIndexAccumulator::new(n),
-                |mut left, right| {
-                    left.merge(right);
-                    left
-                },
-            )
-    } else {
+        // Preserve the old row-order accumulation for stable floating-point
+        // behavior while replacing each row's pair scan with its rank counts.
         let mut accumulator = UnoCIndexAccumulator::new(n);
-        for i in 0..n {
-            accumulate_uno_c_index_row(&mut accumulator, &context, i);
+        for idx in 0..n {
+            let weight = event_weights[idx];
+            if weight == 0.0 {
+                continue;
+            }
+            let (lower, tied, higher) = pair_counts[idx];
+            accumulator.concordant += weight * lower;
+            accumulator.discordant += weight * higher;
+            accumulator.tied += weight * tied;
+            accumulator.total_weight += weight * (lower + tied + higher);
+            accumulator.influence_sums[idx] += weight * (lower - higher);
         }
         accumulator
     };
 
+    // Sweep forward to recover every later subject's signed influence from
+    // the IPCW weights of earlier comparable events.
+    subjects_desc.reverse();
+    events_desc.reverse();
+    let mut earlier_event_weights = FenwickTree::new(n_ranks);
+    let mut event_cursor = 0;
+    for &subject_idx in &subjects_desc {
+        while event_cursor < events_desc.len()
+            && after_event_time(time[subject_idx], time[events_desc[event_cursor]])
+        {
+            let event_idx = events_desc[event_cursor];
+            earlier_event_weights.update(risk_ranks[event_idx], event_weights[event_idx]);
+            event_cursor += 1;
+        }
+        let (lower, _tied, higher) =
+            uno_rank_counts(&earlier_event_weights, risk_ranks[subject_idx]);
+        accumulator.influence_sums[subject_idx] += lower - higher;
+    }
+
+    accumulator
+}
+
+#[cfg(test)]
+fn uno_c_index_quadratic_accumulator(
+    time: &[f64],
+    risk_score: &[f64],
+    event_weights: &[f64],
+) -> UnoCIndexAccumulator {
+    let mut accumulator = UnoCIndexAccumulator::new(time.len());
+    for i in 0..time.len() {
+        let weight = event_weights[i];
+        if weight == 0.0 {
+            continue;
+        }
+        for j in 0..time.len() {
+            if i == j || !after_event_time(time[j], time[i]) {
+                continue;
+            }
+            accumulator.total_weight += weight;
+            if risk_score[i] > risk_score[j] {
+                accumulator.concordant += weight;
+                accumulator.influence_sums[i] += weight;
+                accumulator.influence_sums[j] -= weight;
+            } else if risk_score[i] < risk_score[j] {
+                accumulator.discordant += weight;
+                accumulator.influence_sums[i] -= weight;
+                accumulator.influence_sums[j] += weight;
+            } else {
+                accumulator.tied += weight;
+            }
+        }
+    }
+    accumulator
+}
+
+fn uno_c_index_result(
+    accumulator: UnoCIndexAccumulator,
+    n: usize,
+    tau: f64,
+) -> UnoCIndexResult {
     let c_index = if accumulator.total_weight > 0.0 {
         (accumulator.concordant + 0.5 * accumulator.tied) / accumulator.total_weight
     } else {
@@ -234,8 +271,51 @@ pub(crate) fn uno_c_index_core(
         std_error,
         ci_lower,
         ci_upper,
-        tau: tau_val,
+        tau,
     }
+}
+
+pub(crate) fn uno_c_index_core(
+    time: &[f64],
+    status: &[i32],
+    risk_score: &[f64],
+    tau: Option<f64>,
+) -> UnoCIndexResult {
+    let n = time.len();
+    if n == 0 {
+        return uno_c_index_result(UnoCIndexAccumulator::new(0), 0, 0.0);
+    }
+
+    let tau_val = tau.unwrap_or_else(|| time.iter().copied().fold(f64::NEG_INFINITY, f64::max));
+    let (km_times, km_values) = compute_censoring_km(time, status);
+    let event_weights = uno_event_weights(time, status, &km_times, &km_values, tau_val);
+    uno_c_index_result(
+        uno_c_index_ranked_accumulator(time, risk_score, &event_weights),
+        n,
+        tau_val,
+    )
+}
+
+#[cfg(test)]
+fn uno_c_index_core_quadratic(
+    time: &[f64],
+    status: &[i32],
+    risk_score: &[f64],
+    tau: Option<f64>,
+) -> UnoCIndexResult {
+    let n = time.len();
+    if n == 0 {
+        return uno_c_index_result(UnoCIndexAccumulator::new(0), 0, 0.0);
+    }
+
+    let tau_val = tau.unwrap_or_else(|| time.iter().copied().fold(f64::NEG_INFINITY, f64::max));
+    let (km_times, km_values) = compute_censoring_km(time, status);
+    let event_weights = uno_event_weights(time, status, &km_times, &km_values, tau_val);
+    uno_c_index_result(
+        uno_c_index_quadratic_accumulator(time, risk_score, &event_weights),
+        n,
+        tau_val,
+    )
 }
 
 #[pyfunction]


### PR DESCRIPTION
## Summary
- replace the quadratic Uno IPCW concordance pair scan with two rank-based Fenwick sweeps
- retain exact time, tau, risk-tie, IPCW, influence, variance, and confidence-interval semantics
- remove per-fold full-size influence buffers and release first-sweep storage before the forward sweep
- retain a quadratic test oracle with randomized epsilon-boundary, IPCW-floor, signed-zero, and threshold differential coverage
- benchmark both heavily tied and distinct score distributions

## Why
The previous implementation scanned every possible later subject for each eligible event, giving worst-case quadratic runtime. Its parallel path also allocated a full-size influence vector for every fold. The new offline sweeps reduce the calculation to O(n log n) time with O(n) auxiliary memory while preserving public results.

## Performance
Mixed censoring and tied scores, median of 10 samples:
- n=100: 10.39 µs → 3.874 µs (2.7× faster)
- n=1,000: 1.046 ms → 69.93 µs (15.0× faster)
- n=5,000: 5.002 ms → 464.5 µs (10.8× faster)
- n=20,000: 2.229 ms after optimization

With distinct scores, the optimized path reaches 2.970 ms at n=20,000.

## Validation
- `cargo test --lib --no-default-features` — 1,319 passed
- `cargo test --lib --features ml` — 1,528 passed
- `PYO3_PYTHON=.venv/bin/python cargo test --lib --features python,ml` — 1,530 passed
- `cargo test --doc`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `PYTHONPATH=python .venv/bin/python -m pytest python/tests -q` — 802 passed
- `.venv/bin/python scripts/generate_binding_manifest.py --check`
- `git diff --check`
- `cargo bench --bench survival_benchmarks uno_c_index_bench -- --sample-count 10`