### PR TITLE
Repair exact counting-process Cox fitting

### DIFF
--- a/benches/survival_benchmarks.rs
+++ b/benches/survival_benchmarks.rs
@@ -1,5 +1,5 @@
 use std::hint::black_box;
-use survival::regression::{CoxPHModel, coxph_fit, finegray, survreg};
+use survival::regression::{CoxPHModel, agexact, coxph_fit, finegray, survreg};
 use survival::{
     KaplanMeierConfig, WeightType, compute_brier, compute_rmst, compute_survfitkm, concordance1,
     nelson_aalen, weighted_logrank_test,
@@ -236,6 +236,102 @@ mod finegray_interval_expansion {
                 black_box(
                     finegray(tstart, tstop, ctime, cprob, extend, keep)
                         .expect("benchmark Fine-Gray inputs should be valid"),
+                )
+            },
+        );
+    }
+}
+
+mod exact_counting_process_cox {
+    use super::*;
+
+    #[divan::bench(args = [1000, 2000, 4000])]
+    fn untied_scaling(bencher: divan::Bencher, n: usize) {
+        #[cfg(feature = "python")]
+        pyo3::Python::initialize();
+
+        let start = vec![0.0; n];
+        let stop: Vec<f64> = (1..=n).map(|value| value as f64).collect();
+        let event = vec![1; n];
+        let covar: Vec<f64> = (0..n).map(|value| (value % 17) as f64).collect();
+        let offset = vec![0.0; n];
+        let strata = vec![0; n];
+        let work = vec![0.0; n + 4];
+        let work2 = vec![0; 2 * n];
+        let inputs = (start, stop, event, covar, offset, strata, work, work2);
+
+        bencher.with_inputs(|| inputs.clone()).bench_local_values(
+            |(start, stop, event, covar, offset, strata, work, work2)| {
+                black_box(
+                    agexact(
+                        0,
+                        n as i32,
+                        1,
+                        start,
+                        stop,
+                        event,
+                        covar,
+                        offset,
+                        strata,
+                        vec![0.0],
+                        vec![0.0],
+                        vec![0.0],
+                        vec![0.0],
+                        vec![0.0; 2],
+                        work,
+                        work2,
+                        1e-9,
+                        1e-9,
+                        vec![0],
+                    )
+                    .expect("untied exact counting-process benchmark should succeed"),
+                )
+            },
+        );
+    }
+
+    #[divan::bench]
+    fn tied_24_of_12(bencher: divan::Bencher) {
+        #[cfg(feature = "python")]
+        pyo3::Python::initialize();
+
+        const N: usize = 24;
+        const DEATHS: usize = 12;
+        let start = vec![0.0; N];
+        let stop = vec![1.0; N];
+        let event: Vec<i32> = (0..N).map(|person| i32::from(person < DEATHS)).collect();
+        let covar: Vec<f64> = (0..N).map(|value| value as f64).collect();
+        let offset = vec![0.0; N];
+        let strata = vec![0; N];
+        let work = vec![0.0; N + 4];
+        let work2 = vec![0; 2 * N];
+        let inputs = (start, stop, event, covar, offset, strata, work, work2);
+
+        bencher.with_inputs(|| inputs.clone()).bench_local_values(
+            |(start, stop, event, covar, offset, strata, work, work2)| {
+                black_box(
+                    agexact(
+                        0,
+                        N as i32,
+                        1,
+                        start,
+                        stop,
+                        event,
+                        covar,
+                        offset,
+                        strata,
+                        vec![0.0],
+                        vec![0.0],
+                        vec![0.0],
+                        vec![0.0],
+                        vec![0.0; 2],
+                        work,
+                        work2,
+                        1e-9,
+                        1e-9,
+                        vec![0],
+                    )
+                    .expect("benchmark exact counting-process fit should succeed"),
                 )
             },
         );

--- a/python/tests/test_utilities.py
+++ b/python/tests/test_utilities.py
@@ -452,6 +452,34 @@ def test_agexact_public_api_and_validation():
     assert result["loglik"] == pytest.approx([0.0, 0.0])
     assert result["flag"] == 0
 
+    fitted = survival_package.agexact(
+        20,
+        6,
+        1,
+        [0.0] * 6,
+        [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+        [1, 0, 1, 1, 0, 1],
+        [0.2, 1.1, -0.4, 0.8, 1.5, -0.2],
+        [0.0] * 6,
+        [0] * 6,
+        [0.0],
+        [0.0],
+        [0.0],
+        [0.0],
+        [0.0, 0.0],
+        [0.0] * 10,
+        [0] * 12,
+        1e-9,
+        1e-9,
+        [1],
+    )
+    assert fitted["beta"] == pytest.approx([-0.716230334066463], abs=1e-10)
+    assert fitted["loglik"] == pytest.approx([-4.276666119016055, -3.923517065659742], abs=1e-10)
+    assert fitted["imat"] == pytest.approx([0.8099422437616611], abs=1e-10)
+    assert fitted["sctest"] == pytest.approx(0.6770036246476036, abs=1e-10)
+    assert fitted["maxiter"] == 4
+    assert fitted["flag"] == 1
+
     with pytest.raises(ValueError, match="work must have length at least 5"):
         survival_package.agexact(
             1,

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -62,6 +62,21 @@ if (getRversion() >= "2.15.1") {
   reticulate::py_get_attr(.survival_regression_module(), name)
 }
 
+.survival_residuals_module <- local({
+  module <- NULL
+
+  function() {
+    if (is.null(module)) {
+      module <<- reticulate::import("survival.residuals", convert = TRUE)
+    }
+    module
+  }
+})
+
+.residuals_attr <- function(name) {
+  reticulate::py_get_attr(.survival_residuals_module(), name)
+}
+
 .compact_null <- function(values) {
   values[!vapply(values, is.null, logical(1))]
 }
@@ -5433,13 +5448,190 @@ agreg.fit <- function(x, y, strata, offset, init, control, weights, method,
 
 agexact.fit <- function(x, y, strata, offset, init, control, weights, method,
                         rownames, resid = TRUE, nocenter = NULL) {
+  if (!is.matrix(x)) {
+    stop("Invalid formula for cox fitting function", call. = FALSE)
+  }
+  if (inherits(y, "survival_py_surv")) {
+    y <- .as_native_surv(y)
+  }
+  if (!inherits(y, "Surv") || !is.matrix(y)) {
+    stop("y must be a Surv object", call. = FALSE)
+  }
   if (!missing(weights) && !is.null(weights) && any(as.numeric(weights) != 1)) {
     stop("Case weights are not supported for the exact method", call. = FALSE)
   }
-  .coxph_fit_core(x, y, strata, offset, init, control, rep(1, nrow(as.matrix(x))), "exact",
-                  rownames, resid = resid, nocenter = nocenter,
-                  include_class = FALSE, method_label = "coxph",
-                  linear_predictors_matrix = TRUE)
+
+  n <- nrow(x)
+  nvar <- ncol(x)
+  if (nvar == 0L) {
+    stop("Cannot handle a null model + exact calculation (yet)", call. = FALSE)
+  }
+  if (!missing(weights) && !is.null(weights) && length(weights) != n) {
+    stop("weights and y have different numbers of rows", call. = FALSE)
+  }
+  if (ncol(y) == 3L) {
+    start <- as.numeric(y[, 1L])
+    stopp <- as.numeric(y[, 2L])
+    event <- as.integer(y[, 3L])
+  } else if (ncol(y) == 2L) {
+    start <- rep(0, n)
+    stopp <- as.numeric(y[, 1L])
+    event <- as.integer(y[, 2L])
+  } else {
+    stop("y must have 2 or 3 columns", call. = FALSE)
+  }
+  if (length(stopp) != n) {
+    stop("x and y have different numbers of rows", call. = FALSE)
+  }
+
+  has_strata <- !(missing(strata) || is.null(strata) || length(strata) == 0L)
+  if (!has_strata) {
+    sorted <- order(stopp, -event)
+    newstrat <- integer(n)
+  } else {
+    if (length(strata) != n) {
+      stop("strata and y have different numbers of rows", call. = FALSE)
+    }
+    strata_codes <- match(strata, unique(strata))
+    sorted <- order(strata_codes, stopp, -event)
+    newstrat <- as.integer(c(diff(strata_codes[sorted]) != 0, 1))
+  }
+
+  if (missing(offset) || is.null(offset)) {
+    offset <- rep(0, n)
+  }
+  offset <- as.numeric(offset)
+  if (length(offset) != n) {
+    stop("offset and y have different numbers of rows", call. = FALSE)
+  }
+  if (missing(init) || is.null(init)) {
+    init <- rep(0, nvar)
+  }
+  init <- as.numeric(init)
+  if (length(init) != nvar) {
+    stop("Wrong length for inital values", call. = FALSE)
+  }
+  if (missing(control) || is.null(control)) {
+    control <- coxph.control()
+  }
+  if (missing(rownames) || is.null(rownames)) {
+    rownames <- rownames(y)
+    if (is.null(rownames)) {
+      rownames <- as.character(seq_len(n))
+    }
+  }
+  if (length(rownames) != n) {
+    stop("rownames and y have different lengths", call. = FALSE)
+  }
+
+  zero_one <- if (is.null(nocenter)) {
+    rep(FALSE, nvar)
+  } else {
+    apply(x, 2L, function(column) all(column %in% nocenter))
+  }
+  sstart <- as.double(start[sorted])
+  sstop <- as.double(stopp[sorted])
+  sstat <- as.integer(event[sorted])
+  python_sequence <- function(values) {
+    if (length(values) == 1L) as.list(values) else values
+  }
+  agfit <- do.call(
+    .regression_attr("agexact"),
+    list(
+      maxiter = as.integer(control[["iter.max"]]),
+      nused = as.integer(n),
+      nvar = as.integer(nvar),
+      start = python_sequence(sstart),
+      stop = python_sequence(sstop),
+      event = python_sequence(sstat),
+      covar = python_sequence(as.numeric(x[sorted, , drop = FALSE])),
+      offset = python_sequence(as.double(offset[sorted])),
+      strata = python_sequence(newstrat),
+      means = python_sequence(double(nvar)),
+      beta = python_sequence(as.double(init)),
+      u = python_sequence(double(nvar)),
+      imat = python_sequence(double(nvar * nvar)),
+      loglik = python_sequence(double(2L)),
+      work = python_sequence(double(2L * nvar * nvar + 4L * nvar + n)),
+      work2 = python_sequence(integer(2L * n)),
+      eps = as.double(control[["eps"]]),
+      tol_chol = as.double(control[["toler.chol"]]),
+      nocenter = python_sequence(as.integer(ifelse(zero_one, 0L, 1L)))
+    )
+  )
+
+  variance <- matrix(.as_numeric_vector(.result_field(agfit, "imat")), nvar, nvar)
+  coefficients <- .as_numeric_vector(.result_field(agfit, "beta"))
+  score_vector <- .as_numeric_vector(.result_field(agfit, "u"))
+  means <- .as_numeric_vector(.result_field(agfit, "means"))
+  flag <- as.integer(.result_field(agfit, "flag"))
+  which_singular <- if (flag < nvar) diag(variance) == 0 else rep(FALSE, nvar)
+  infs <- abs(score_vector %*% variance)
+  if (control[["iter.max"]] > 1L) {
+    if (flag == 1000L) {
+      warning("Ran out of iterations and did not converge", call. = FALSE)
+    } else {
+      infs <- (infs > control[["eps"]]) &
+        infs > control[["toler.inf"]] * abs(coefficients)
+      if (any(infs)) {
+        warning(
+          paste(
+            "Loglik converged before variable ",
+            paste(seq_len(nvar)[infs], collapse = ","),
+            "; beta may be infinite. "
+          ),
+          call. = FALSE
+        )
+      }
+    }
+  }
+
+  names(coefficients) <- colnames(x)
+  linear_predictors <- x %*% coefficients + offset - sum(coefficients * means)
+  risk_score <- as.double(exp(linear_predictors[sorted]))
+  coefficients[which_singular] <- NA_real_
+  out <- list(
+    coefficients = coefficients,
+    var = variance,
+    loglik = .as_numeric_vector(.result_field(agfit, "loglik")),
+    score = as.numeric(.result_field(agfit, "sctest")),
+    iter = as.integer(.result_field(agfit, "maxiter")),
+    linear.predictors = linear_predictors,
+    means = means,
+    method = "coxph"
+  )
+
+  if (isTRUE(resid)) {
+    counting <- do.call(
+      .core_attr("CountingProcessData"),
+      list(
+        start = python_sequence(sstart),
+        stop = python_sequence(sstop),
+        event = python_sequence(sstat)
+      )
+    )
+    residual_input <- do.call(
+      .core_attr("AndersenGillInput"),
+      list(
+        counting = counting,
+        score = python_sequence(risk_score),
+        strata = python_sequence(newstrat)
+      )
+    )
+    sorted_residuals <- .as_numeric_vector(do.call(
+      .residuals_attr("agmart"),
+      list(input = residual_input, method = 0L)
+    ))
+    martingale <- double(n)
+    martingale[sorted] <- sorted_residuals
+    names(martingale) <- rownames
+    out$residuals <- martingale
+    out <- out[c(
+      "coefficients", "var", "loglik", "score", "iter",
+      "linear.predictors", "residuals", "means", "method"
+    )]
+  }
+  out
 }
 
 survreg.control <- function(maxiter = 30, rel.tolerance = 1e-09,

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -5471,29 +5471,29 @@ agexact.fit <- function(x, y, strata, offset, init, control, weights, method,
   }
   if (ncol(y) == 3L) {
     start <- as.numeric(y[, 1L])
-    stopp <- as.numeric(y[, 2L])
+    stop_time <- as.numeric(y[, 2L])
     event <- as.integer(y[, 3L])
   } else if (ncol(y) == 2L) {
     start <- rep(0, n)
-    stopp <- as.numeric(y[, 1L])
+    stop_time <- as.numeric(y[, 1L])
     event <- as.integer(y[, 2L])
   } else {
     stop("y must have 2 or 3 columns", call. = FALSE)
   }
-  if (length(stopp) != n) {
+  if (length(stop_time) != n) {
     stop("x and y have different numbers of rows", call. = FALSE)
   }
 
   has_strata <- !(missing(strata) || is.null(strata) || length(strata) == 0L)
   if (!has_strata) {
-    sorted <- order(stopp, -event)
+    sorted <- order(stop_time, -event)
     newstrat <- integer(n)
   } else {
     if (length(strata) != n) {
       stop("strata and y have different numbers of rows", call. = FALSE)
     }
     strata_codes <- match(strata, unique(strata))
-    sorted <- order(strata_codes, stopp, -event)
+    sorted <- order(strata_codes, stop_time, -event)
     newstrat <- as.integer(c(diff(strata_codes[sorted]) != 0, 1))
   }
 
@@ -5509,7 +5509,7 @@ agexact.fit <- function(x, y, strata, offset, init, control, weights, method,
   }
   init <- as.numeric(init)
   if (length(init) != nvar) {
-    stop("Wrong length for inital values", call. = FALSE)
+    stop("Wrong length for initial values", call. = FALSE)
   }
   if (missing(control) || is.null(control)) {
     control <- coxph.control()
@@ -5530,7 +5530,7 @@ agexact.fit <- function(x, y, strata, offset, init, control, weights, method,
     apply(x, 2L, function(column) all(column %in% nocenter))
   }
   sstart <- as.double(start[sorted])
-  sstop <- as.double(stopp[sorted])
+  sstop <- as.double(stop_time[sorted])
   sstat <- as.integer(event[sorted])
   python_sequence <- function(values) {
     if (length(values) == 1L) as.list(values) else values

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -4599,3 +4599,305 @@ test_that("Kaplan-Meier and log-rank bridge results agree with R survival", {
     "Cannot have both an offset and groups"
   )
 })
+
+test_that("agexact.fit matches tied counting-process reference output", {
+  skip_if_not_installed("reticulate")
+  skip_if_not_installed("survival")
+  skip_if_not(
+    reticulate::py_module_available("survival"),
+    "Python survival package is unavailable"
+  )
+
+  n <- 10L
+  x <- matrix(
+    c(
+      -0.8, 0.3, 1.1, -0.2, 0.7, 1.4, -1.0, 0.5, 1.0, -0.4,
+      0.2, 1.3, -0.5, 0.8, -1.1, 0.4, 1.2, -0.7, 0.6, 1.0
+    ),
+    nrow = n,
+    ncol = 2L
+  )
+  colnames(x) <- c("x1", "x2")
+  start <- c(0, 0, 0.5, 0.5, 1, 1, 1.5, 2, 2.5, 3)
+  stop <- c(2, 3, 3, 3, 4, 4.5, 5, 5, 5, 6)
+  event <- c(1, 1, 1, 0, 0, 1, 1, 1, 0, 1)
+  offset <- c(0.1, -0.2, 0.05, 0.3, -0.1, 0.15, -0.25, 0.2, -0.05, 0.1)
+  y <- survival::Surv(start, stop, event)
+  row_labels <- paste0("row", seq_len(n))
+
+  bridged <- agexact.fit(
+    x,
+    y,
+    strata = NULL,
+    offset = offset,
+    init = c(0.25, -0.15),
+    control = coxph.control(iter.max = 20L, eps = 1e-09),
+    weights = rep(1, n),
+    method = "exact",
+    rownames = row_labels
+  )
+  reference <- survival::agexact.fit(
+    x,
+    y,
+    strata = NULL,
+    offset = offset,
+    init = c(0.25, -0.15),
+    control = survival::coxph.control(iter.max = 20L, eps = 1e-09),
+    weights = rep(1, n),
+    method = "exact",
+    rownames = row_labels
+  )
+
+  expect_equal(names(bridged), names(reference))
+  expect_equal(bridged$coefficients, reference$coefficients, tolerance = 1e-10)
+  expect_equal(bridged$var, reference$var, tolerance = 1e-10)
+  expect_equal(bridged$loglik, reference$loglik, tolerance = 1e-10)
+  expect_equal(bridged$score, reference$score, tolerance = 1e-10)
+  expect_equal(bridged$iter, reference$iter)
+  expect_equal(bridged$linear.predictors, reference$linear.predictors, tolerance = 1e-10)
+  expect_equal(bridged$residuals, reference$residuals, tolerance = 1e-10)
+  expect_equal(bridged$means, reference$means, tolerance = 1e-12)
+
+  bridged_wrapped_response <- agexact.fit(
+    x,
+    Surv(start, stop, event),
+    strata = NULL,
+    offset = offset,
+    init = c(0.25, -0.15),
+    control = coxph.control(iter.max = 20L, eps = 1e-09),
+    weights = rep(1, n),
+    method = "exact",
+    rownames = row_labels
+  )
+  expect_equal(bridged_wrapped_response, bridged, tolerance = 1e-10)
+
+  negative_y <- survival::Surv(start - 4, stop - 4, event)
+  bridged_negative_times <- agexact.fit(
+    x,
+    negative_y,
+    strata = NULL,
+    offset = offset,
+    init = c(0.25, -0.15),
+    control = coxph.control(iter.max = 20L, eps = 1e-09),
+    weights = rep(1, n),
+    method = "exact",
+    rownames = row_labels
+  )
+  reference_negative_times <- survival::agexact.fit(
+    x,
+    negative_y,
+    strata = NULL,
+    offset = offset,
+    init = c(0.25, -0.15),
+    control = survival::coxph.control(iter.max = 20L, eps = 1e-09),
+    weights = rep(1, n),
+    method = "exact",
+    rownames = row_labels
+  )
+  expect_equal(
+    bridged_negative_times$residuals,
+    reference_negative_times$residuals,
+    tolerance = 1e-10
+  )
+
+  strata_labels <- c(rep("north", 5L), rep("south", 5L))
+  strata_factor <- factor(strata_labels, levels = c("south", "north"))
+  zero_iteration_control <- coxph.control(iter.max = 0L, eps = 1e-09)
+  bridged_factor_strata <- agexact.fit(
+    x,
+    y,
+    strata = strata_factor,
+    offset = offset,
+    init = c(0.25, -0.15),
+    control = zero_iteration_control,
+    weights = rep(1, n),
+    method = "exact",
+    rownames = row_labels
+  )
+  bridged_character_strata <- agexact.fit(
+    x,
+    y,
+    strata = strata_labels,
+    offset = offset,
+    init = c(0.25, -0.15),
+    control = zero_iteration_control,
+    weights = rep(1, n),
+    method = "exact",
+    rownames = row_labels
+  )
+  reference_factor_strata <- survival::agexact.fit(
+    x,
+    y,
+    strata = strata_factor,
+    offset = offset,
+    init = c(0.25, -0.15),
+    control = survival::coxph.control(iter.max = 0L, eps = 1e-09),
+    weights = rep(1, n),
+    method = "exact",
+    rownames = row_labels
+  )
+  comparable_fields <- c(
+    "coefficients", "var", "loglik", "score", "iter",
+    "linear.predictors", "residuals", "means", "method"
+  )
+  for (field in comparable_fields) {
+    expect_equal(
+      bridged_factor_strata[[field]],
+      reference_factor_strata[[field]],
+      tolerance = 1e-10
+    )
+    expect_equal(
+      bridged_character_strata[[field]],
+      bridged_factor_strata[[field]],
+      tolerance = 1e-12
+    )
+  }
+
+  large_n <- 80L
+  large_x <- matrix(
+    sin(seq_len(large_n) * 0.73) + cos(seq_len(large_n) * 0.19),
+    ncol = 1L
+  )
+  large_y <- survival::Surv(
+    rep(0, large_n),
+    seq_len(large_n),
+    rep(c(1L, 1L, 0L), length.out = large_n)
+  )
+  large_rows <- as.character(seq_len(large_n))
+  bridged_large <- agexact.fit(
+    large_x,
+    large_y,
+    strata = NULL,
+    offset = rep(0, large_n),
+    init = 0,
+    control = coxph.control(iter.max = 20L, eps = 1e-09),
+    weights = rep(1, large_n),
+    method = "exact",
+    rownames = large_rows,
+    resid = FALSE
+  )
+  reference_large <- survival::agexact.fit(
+    large_x,
+    large_y,
+    strata = NULL,
+    offset = rep(0, large_n),
+    init = 0,
+    control = survival::coxph.control(iter.max = 20L, eps = 1e-09),
+    weights = rep(1, large_n),
+    method = "exact",
+    rownames = large_rows,
+    resid = FALSE
+  )
+  expect_equal(bridged_large$coefficients, reference_large$coefficients, tolerance = 1e-10)
+  expect_equal(bridged_large$var, reference_large$var, tolerance = 1e-10)
+  expect_equal(bridged_large$loglik, reference_large$loglik, tolerance = 1e-10)
+  expect_equal(bridged_large$score, reference_large$score, tolerance = 1e-10)
+  expect_equal(bridged_large$iter, reference_large$iter)
+})
+
+test_that("agexact.fit preserves exact iteration and final-trial semantics", {
+  skip_if_not_installed("reticulate")
+  skip_if_not_installed("survival")
+  skip_if_not(
+    reticulate::py_module_available("survival"),
+    "Python survival package is unavailable"
+  )
+
+  halving_start <- c(0, 0, 0, 2, 6, 5, 8, 1, 5, 10)
+  halving_stop <- c(1, 2, 2, 6, 7, 7, 10, 10, 11, 11)
+  halving_event <- c(1, 1, 0, 0, 0, 0, 1, 0, 1, 1)
+  halving_x <- matrix(c(
+    -0.7949017577222064, -0.971412993595188, -0.8973640249385726,
+    -0.31173291990153856, -0.9513748122177565, 1.204533321642762,
+    2.883351093087066, -0.8851941617914357, 0.9821570019435617,
+    0.251309986747342
+  ), ncol = 1L)
+  halving_offset <- c(
+    0.3211436207164723, -0.1703476212015294, 0.2757700305715469,
+    0.22219156001732224, 0.1257485571910997, -0.18593546677480463,
+    0.3816069176371731, -0.694971257421976, 0.496755599155065,
+    0.17014843430288
+  )
+  halving_y <- survival::Surv(halving_start, halving_stop, halving_event)
+  halving_rows <- as.character(seq_along(halving_start))
+  bridged_halving <- agexact.fit(
+    halving_x,
+    halving_y,
+    strata = NULL,
+    offset = halving_offset,
+    init = 5.85354416465122,
+    control = coxph.control(iter.max = 40L, eps = 1e-09),
+    weights = rep(1, length(halving_start)),
+    method = "exact",
+    rownames = halving_rows,
+    resid = FALSE
+  )
+  reference_halving <- survival::agexact.fit(
+    halving_x,
+    halving_y,
+    strata = NULL,
+    offset = halving_offset,
+    init = 5.85354416465122,
+    control = survival::coxph.control(iter.max = 40L, eps = 1e-09),
+    weights = rep(1, length(halving_start)),
+    method = "exact",
+    rownames = halving_rows,
+    resid = FALSE
+  )
+  expect_equal(bridged_halving$coefficients, reference_halving$coefficients, tolerance = 1e-09)
+  expect_equal(bridged_halving$var, reference_halving$var, tolerance = 1e-08)
+  expect_equal(bridged_halving$loglik, reference_halving$loglik, tolerance = 1e-09)
+  expect_equal(bridged_halving$score, reference_halving$score, tolerance = 1e-09)
+  expect_equal(bridged_halving$iter, reference_halving$iter)
+
+  separated_start <- c(0, 0, 0, 1, 2, 2, 3)
+  separated_stop <- c(1, 1, 1, 3, 3, 4, 5)
+  separated_event <- c(1, 0, 0, 0, 0, 1, 0)
+  separated_x <- matrix(c(
+    -0.10627590772801489, -1.415108390302514, -0.5982619079224836,
+    3.279520010161916, -1.334405338827207, 2.4961790201596363,
+    0.1897036691116272
+  ), ncol = 1L)
+  separated_offset <- c(
+    1.4884172952401737, -0.37680328079335645, -0.3108565122880977,
+    -1.0850166921555693, 1.234396256848731, 0.42712866434784125,
+    -0.15961611577080256
+  )
+  separated_y <- survival::Surv(separated_start, separated_stop, separated_event)
+  separated_rows <- as.character(seq_along(separated_start))
+  bridged_separated <- expect_warning(
+    agexact.fit(
+      separated_x,
+      separated_y,
+      strata = NULL,
+      offset = separated_offset,
+      init = 0.7083443262910332,
+      control = coxph.control(iter.max = 20L, eps = 1e-09),
+      weights = rep(1, length(separated_start)),
+      method = "exact",
+      rownames = separated_rows,
+      resid = FALSE
+    ),
+    "Ran out of iterations and did not converge"
+  )
+  reference_separated <- expect_warning(
+    survival::agexact.fit(
+      separated_x,
+      separated_y,
+      strata = NULL,
+      offset = separated_offset,
+      init = 0.7083443262910332,
+      control = survival::coxph.control(iter.max = 20L, eps = 1e-09),
+      weights = rep(1, length(separated_start)),
+      method = "exact",
+      rownames = separated_rows,
+      resid = FALSE
+    ),
+    "Ran out of iterations and did not converge"
+  )
+  expect_equal(bridged_separated$coefficients, reference_separated$coefficients, tolerance = 5e-07)
+  expect_equal(bridged_separated$var, reference_separated$var, tolerance = 1e-06)
+  expect_equal(bridged_separated$loglik, reference_separated$loglik, tolerance = 1e-09)
+  expect_equal(bridged_separated$score, reference_separated$score, tolerance = 1e-09)
+  expect_equal(bridged_separated$iter, reference_separated$iter)
+})

--- a/src/internal/typed_inputs.rs
+++ b/src/internal/typed_inputs.rs
@@ -226,8 +226,6 @@ impl CountingProcessData {
         validate_no_nan(&stop, "stop")?;
         validate_finite(&start, "start")?;
         validate_finite(&stop, "stop")?;
-        validate_non_negative(&start, "start")?;
-        validate_non_negative(&stop, "stop")?;
         validate_status_values(&event, "event")?;
 
         for (index, (&start, &stop)) in start.iter().zip(stop.iter()).enumerate() {
@@ -589,5 +587,14 @@ mod tests {
         assert!(matches!(ag_input.strata_or_default_cow(), Cow::Owned(_)));
         assert_eq!(ag_input.weights_or_unit_cow().as_ref(), [1.0, 1.0]);
         assert_eq!(ag_input.strata_or_default_cow().as_ref(), [0, 0]);
+    }
+
+    #[test]
+    fn counting_process_data_accepts_signed_time_origins() {
+        let counting = CountingProcessData::try_new(vec![-3.0, -1.0], vec![-1.0, 2.0], vec![1, 0])
+            .expect("counting-process intervals may use a negative time origin");
+
+        assert_eq!(counting.start, vec![-3.0, -1.0]);
+        assert_eq!(counting.stop, vec![-1.0, 2.0]);
     }
 }

--- a/src/regression/agexact.rs
+++ b/src/regression/agexact.rs
@@ -1,7 +1,10 @@
-use crate::constants::{CONVERGENCE_FLAG, PARALLEL_THRESHOLD_LARGE};
+use std::convert::Infallible;
+
+use ndarray::{Array1, Array2};
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
-use rayon::prelude::*;
+
+use super::cox_optimizer::{CoxFit, Method};
 
 pub(crate) struct AgexactData {
     pub start: Vec<f64>,
@@ -29,6 +32,18 @@ pub(crate) struct AgexactParams {
     pub nvar: i32,
     pub eps: f64,
     pub tol_chol: f64,
+}
+
+struct AgexactResult {
+    maxiter: i32,
+    covar: Vec<f64>,
+    means: Vec<f64>,
+    beta: Vec<f64>,
+    u: Vec<f64>,
+    imat: Vec<f64>,
+    loglik: Vec<f64>,
+    flag: i32,
+    sctest: f64,
 }
 
 fn validate_agexact_inputs(
@@ -165,508 +180,142 @@ pub fn agexact(
     agexact_impl(data, state, params)
 }
 
-fn agexact_impl(
-    data: AgexactData,
-    state: AgexactState,
-    params: AgexactParams,
-) -> PyResult<Py<PyDict>> {
+fn take_infallible<T>(result: Result<T, Infallible>) -> T {
+    match result {
+        Ok(value) => value,
+        Err(never) => match never {},
+    }
+}
+
+fn center_column_major(covar: &mut [f64], means: &mut [f64], nocenter: &[i32], n: usize) {
+    for (variable, mean) in means.iter_mut().enumerate() {
+        if nocenter[variable] == 0 || n == 0 {
+            *mean = 0.0;
+            continue;
+        }
+
+        let column = &mut covar[variable * n..(variable + 1) * n];
+        *mean = column.iter().sum::<f64>() / n as f64;
+        for value in column {
+            *value -= *mean;
+        }
+    }
+}
+
+fn column_major_to_row_major(covar: &[f64], n: usize, p: usize) -> Vec<f64> {
+    let mut row_major = Vec::with_capacity(n * p);
+    for person in 0..n {
+        for variable in 0..p {
+            row_major.push(covar[variable * n + person]);
+        }
+    }
+    row_major
+}
+
+fn flatten_matrix(matrix: &Array2<f64>) -> Vec<f64> {
+    let mut flat = Vec::with_capacity(matrix.len());
+    for row in 0..matrix.nrows() {
+        for column in 0..matrix.ncols() {
+            flat.push(matrix[(row, column)]);
+        }
+    }
+    flat
+}
+
+fn fit_agexact(data: AgexactData, state: AgexactState, params: AgexactParams) -> AgexactResult {
     let AgexactData {
         start,
         stop,
         event,
         mut covar,
         offset,
-        strata,
+        mut strata,
         nocenter,
     } = data;
     let AgexactState {
         mut means,
-        mut beta,
-        mut u,
-        mut imat,
-        mut loglik,
-        mut work,
-        mut work2,
+        beta,
+        u: _,
+        imat: _,
+        loglik: _loglik,
+        work: _,
+        work2: _,
     } = state;
     let AgexactParams {
-        mut maxiter,
+        maxiter,
         nused,
         nvar,
         eps,
         tol_chol,
     } = params;
     let n = nused as usize;
-    let nvar_usize = nvar as usize;
-    let p = nvar_usize;
-    let (cmat, rest) = work.split_at_mut(p * p);
-    let (a, rest) = rest.split_at_mut(p);
-    let (newbeta, rest) = rest.split_at_mut(p);
-    let (score, newvar) = rest.split_at_mut(n);
-    let atrisk = &mut work2[n..2 * n];
-    if nvar_usize > 4 {
-        let mean_updates: Vec<(usize, f64)> = (0..nvar_usize)
-            .into_par_iter()
-            .filter_map(|i| {
-                if nocenter[i] == 0 {
-                    Some((i, 0.0))
-                } else {
-                    let sum: f64 = (0..n).map(|j| covar[i * n + j]).sum();
-                    Some((i, sum / n as f64))
-                }
-            })
-            .collect();
-        for (i, mean_val) in mean_updates {
-            means[i] = mean_val;
-            if nocenter[i] != 0 {
-                for j in 0..n {
-                    covar[i * n + j] -= mean_val;
-                }
-            }
-        }
-    } else {
-        for i in 0..nvar_usize {
-            if nocenter[i] == 0 {
-                means[i] = 0.0;
-            } else {
-                let mut sum = 0.0;
-                for j in 0..n {
-                    sum += covar[i * n + j];
-                }
-                means[i] = sum / n as f64;
-                let mean_val = means[i];
-                for j in 0..n {
-                    covar[i * n + j] -= mean_val;
-                }
-            }
-        }
-    }
-    if n > PARALLEL_THRESHOLD_LARGE {
-        let scores: Vec<f64> = (0..n)
-            .into_par_iter()
-            .map(|person| {
-                let mut zbeta = 0.0;
-                for i in 0..nvar_usize {
-                    zbeta += beta[i] * covar[i * n + person];
-                }
-                (zbeta + offset[person]).exp()
-            })
-            .collect();
-        score.copy_from_slice(&scores);
-    } else {
-        for person in 0..n {
-            let mut zbeta = 0.0;
-            for i in 0..nvar_usize {
-                zbeta += beta[i] * covar[i * n + person];
-            }
-            score[person] = (zbeta + offset[person]).exp();
-        }
-    }
-    if loglik.len() < 2 {
-        loglik.resize(2, 0.0);
-    }
-    loglik[1] = 0.0;
-    u.fill(0.0);
-    imat.fill(0.0);
-    let mut person = 0;
-    while person < n {
-        if event[person] == 0 {
-            person += 1;
-        } else {
-            let time = stop[person];
-            let mut deaths = 0;
-            let mut nrisk = 0;
-            let mut k = person;
-            while k < n {
-                if stop[k] == time {
-                    deaths += event[k];
-                }
-                if start[k] < time {
-                    atrisk[nrisk] = k as i32;
-                    nrisk += 1;
-                }
-                if strata[k] == 1 {
-                    break;
-                }
-                k += 1;
-            }
-            let mut denom = 0.0;
-            a.fill(0.0);
-            cmat.fill(0.0);
-            if deaths == 1 {
-                for &at_risk_idx in atrisk.iter().take(nrisk) {
-                    let k = at_risk_idx as usize;
-                    let weight = score[k];
-                    denom += weight;
-                    for i in 0..nvar_usize {
-                        let covar_ik = covar[i * n + k];
-                        a[i] += weight * covar_ik;
-                        for j in 0..=i {
-                            let covar_jk = covar[j * n + k];
-                            cmat[i * p + j] += weight * covar_ik * covar_jk;
-                        }
-                    }
-                }
-            } else {
-                for indices in iter_combinations(0, nrisk, deaths as usize) {
-                    newvar.fill(0.0);
-                    let mut weight = 1.0;
-                    for &idx in &indices {
-                        let k = atrisk[idx] as usize;
-                        weight *= score[k];
-                        for i in 0..nvar_usize {
-                            newvar[i] += covar[i * n + k];
-                        }
-                    }
-                    denom += weight;
-                    for i in 0..nvar_usize {
-                        a[i] += weight * newvar[i];
-                        for j in 0..=i {
-                            cmat[i * p + j] += weight * newvar[i] * newvar[j];
-                        }
-                    }
-                }
-            }
-            loglik[1] -= denom.ln();
-            for i in 0..nvar_usize {
-                u[i] -= a[i] / denom;
-                for j in 0..=i {
-                    let cmat_ij = cmat[i * p + j];
-                    let term = (cmat_ij - a[i] * a[j] / denom) / denom;
-                    imat[j * p + i] += term;
-                }
-            }
-            let mut k = person;
-            while k < n && stop[k] == time {
-                if event[k] == 1 {
-                    loglik[1] += score[k].ln();
-                    for i in 0..nvar_usize {
-                        u[i] += covar[i * n + k];
-                    }
-                }
-                person += 1;
-                if strata[k] == 1 {
-                    break;
-                }
-                k += 1;
-            }
-        }
-    }
-    loglik[0] = loglik[1];
-    let mut a_copy = a.to_vec();
-    cholesky2(&mut imat[..p * p], p, tol_chol);
-    chsolve2(&mut imat[..p * p], p, &mut a_copy);
-    let sctest = a_copy.iter().zip(u.iter()).map(|(a, u)| a * u).sum::<f64>();
-    if maxiter == 0 {
-        chinv2(&mut imat[..p * p], p);
-        for i in 0..p {
-            for j in 0..i {
-                imat[i * p + j] = imat[j * p + i];
-            }
-        }
-        let final_flag = 0;
-        Python::attach(|py| {
-            let dict = PyDict::new(py);
-            dict.set_item("maxiter", maxiter)?;
-            dict.set_item("covar", covar.to_vec())?;
-            dict.set_item("means", means.to_vec())?;
-            dict.set_item("beta", beta.to_vec())?;
-            dict.set_item("u", u.to_vec())?;
-            dict.set_item("imat", imat.to_vec())?;
-            dict.set_item("loglik", loglik.to_vec())?;
-            dict.set_item("flag", final_flag)?;
-            dict.set_item("sctest", sctest)?;
-            Ok(dict.into())
-        })
-    } else {
-        let mut iter = 0;
-        let mut halving = false;
-        let mut newbeta_vec = newbeta.to_vec();
-        let mut newlk = 0.0;
-        while iter < maxiter {
-            iter += 1;
-            newlk = 0.0;
-            u.fill(0.0);
-            imat.fill(0.0);
-            for person in 0..n {
-                let mut zbeta = 0.0;
-                for i in 0..nvar_usize {
-                    zbeta += newbeta_vec[i] * covar[i * n + person];
-                }
-                score[person] = (zbeta + offset[person]).exp();
-            }
-            let mut person = 0;
-            while person < n {
-                if event[person] == 0 {
-                    person += 1;
-                } else {
-                    let time = stop[person];
-                    let mut deaths = 0;
-                    let mut nrisk = 0;
-                    let mut k = person;
-                    while k < n {
-                        if stop[k] == time {
-                            deaths += event[k];
-                        }
-                        if start[k] < time {
-                            atrisk[nrisk] = k as i32;
-                            nrisk += 1;
-                        }
-                        if strata[k] == 1 {
-                            break;
-                        }
-                        k += 1;
-                    }
-                    let mut denom = 0.0;
-                    a.fill(0.0);
-                    cmat.fill(0.0);
-                    if deaths == 1 {
-                        for &at_risk_idx in atrisk.iter().take(nrisk) {
-                            let k = at_risk_idx as usize;
-                            let weight = score[k];
-                            denom += weight;
-                            for i in 0..nvar_usize {
-                                let covar_ik = covar[i * n + k];
-                                a[i] += weight * covar_ik;
-                                for j in 0..=i {
-                                    cmat[i * p + j] += weight * covar_ik * covar[j * n + k];
-                                }
-                            }
-                        }
-                    } else {
-                        for indices in iter_combinations(0, nrisk, deaths as usize) {
-                            newvar.fill(0.0);
-                            let mut weight = 1.0;
-                            for &idx in &indices {
-                                let k = atrisk[idx] as usize;
-                                weight *= score[k];
-                                for i in 0..nvar_usize {
-                                    newvar[i] += covar[i * n + k];
-                                }
-                            }
-                            denom += weight;
-                            for i in 0..nvar_usize {
-                                a[i] += weight * newvar[i];
-                                for j in 0..=i {
-                                    cmat[i * p + j] += weight * newvar[i] * newvar[j];
-                                }
-                            }
-                        }
-                    }
-                    newlk -= denom.ln();
-                    for i in 0..nvar_usize {
-                        u[i] -= a[i] / denom;
-                        for j in 0..=i {
-                            let cmat_ij = cmat[i * p + j];
-                            let term = (cmat_ij - a[i] * a[j] / denom) / denom;
-                            imat[j * p + i] += term;
-                        }
-                    }
-                    let mut k = person;
-                    while k < n && stop[k] == time {
-                        if event[k] == 1 {
-                            newlk += score[k].ln();
-                            for i in 0..nvar_usize {
-                                u[i] += covar[i * n + k];
-                            }
-                        }
-                        person += 1;
-                        if strata[k] == 1 {
-                            break;
-                        }
-                        k += 1;
-                    }
-                }
-            }
-            if (1.0 - (loglik[1] / newlk)).abs() <= eps && !halving {
-                loglik[1] = newlk;
-                chinv2(&mut imat[..p * p], p);
-                for i in 0..p {
-                    for j in 0..i {
-                        imat[i * p + j] = imat[j * p + i];
-                    }
-                }
-                beta.copy_from_slice(&newbeta_vec);
-                maxiter = iter;
-                return Python::attach(|py| {
-                    let dict = PyDict::new(py);
-                    dict.set_item("maxiter", maxiter)?;
-                    dict.set_item("covar", covar.to_vec())?;
-                    dict.set_item("means", means.to_vec())?;
-                    dict.set_item("beta", beta.to_vec())?;
-                    dict.set_item("u", u.to_vec())?;
-                    dict.set_item("imat", imat.to_vec())?;
-                    dict.set_item("loglik", loglik.to_vec())?;
-                    dict.set_item("flag", 0)?;
-                    dict.set_item("sctest", sctest)?;
-                    Ok(dict.into())
-                });
-            } else {
-                if iter == maxiter {
-                    break;
-                }
-                if newlk < loglik[1] {
-                    halving = true;
-                    for i in 0..nvar_usize {
-                        newbeta_vec[i] = (newbeta_vec[i] + beta[i]) / 2.0;
-                    }
-                } else {
-                    halving = false;
-                    loglik[1] = newlk;
-                    let mut u_copy = u.to_vec();
-                    chsolve2(&mut imat[..p * p], p, &mut u_copy);
-                    beta[..nvar_usize].copy_from_slice(&newbeta_vec[..nvar_usize]);
-                    for i in 0..nvar_usize {
-                        newbeta_vec[i] += u_copy[i];
-                    }
-                }
-            }
-        }
-        loglik[1] = newlk;
-        chinv2(&mut imat[..p * p], p);
-        for i in 0..p {
-            for j in 0..i {
-                imat[i * p + j] = imat[j * p + i];
-            }
-        }
-        beta.copy_from_slice(&newbeta_vec);
-        let final_flag = CONVERGENCE_FLAG;
-        Python::attach(|py| {
-            let dict = PyDict::new(py);
-            dict.set_item("maxiter", maxiter)?;
-            dict.set_item("covar", covar.to_vec())?;
-            dict.set_item("means", means.to_vec())?;
-            dict.set_item("beta", beta.to_vec())?;
-            dict.set_item("u", u.to_vec())?;
-            dict.set_item("imat", imat.to_vec())?;
-            dict.set_item("loglik", loglik.to_vec())?;
-            dict.set_item("flag", final_flag)?;
-            dict.set_item("sctest", sctest)?;
-            Ok(dict.into())
-        })
-    }
-}
-#[inline]
-fn iter_combinations(start: usize, end: usize, k: usize) -> IndexCombinations {
-    IndexCombinations::new(start, end, k)
-}
+    let p = nvar as usize;
 
-struct IndexCombinations {
-    start: usize,
-    len: usize,
-    k: usize,
-    current: Vec<usize>,
-    first: bool,
-    done: bool,
-}
+    center_column_major(&mut covar, &mut means, &nocenter, n);
+    let row_major = column_major_to_row_major(&covar, n, p);
+    let covariates = Array2::from_shape_vec((n, p), row_major)
+        .expect("validated exact Cox covariates have a valid matrix shape");
 
-impl IndexCombinations {
-    fn new(start: usize, end: usize, k: usize) -> Self {
-        let len = end.saturating_sub(start);
-        let done = k > len;
-        Self {
-            start,
-            len,
-            k,
-            current: (0..k).map(|i| start + i).collect(),
-            first: !done,
-            done,
-        }
+    // The original entry point treats the final row as a stratum boundary even
+    // when the caller leaves the marker vector at its all-zero default.
+    if let Some(last) = strata.last_mut() {
+        *last = 1;
+    }
+
+    // Centering is performed above to preserve the compatibility output. The
+    // shared optimizer therefore receives already-centered, unscaled columns.
+    let mut fit = take_infallible(CoxFit::new_with_entry_times(
+        Array1::from_vec(stop),
+        Array1::from_vec(event),
+        covariates,
+        Some(Array1::from_vec(start)),
+        Array1::from_vec(strata),
+        Array1::from_vec(offset),
+        Array1::ones(n),
+        Method::Exact,
+        maxiter as usize,
+        eps,
+        tol_chol,
+        vec![false; p],
+        beta,
+    ));
+    take_infallible(fit.fit_agexact_compatibility());
+    let (beta, _optimizer_means, u, imat, loglik, sctest, optimizer_flag, iterations) =
+        fit.results();
+    let flag = if maxiter == 0 { 0 } else { optimizer_flag };
+
+    AgexactResult {
+        maxiter: iterations as i32,
+        covar,
+        means,
+        beta,
+        u,
+        imat: flatten_matrix(&imat),
+        loglik: loglik.to_vec(),
+        flag,
+        sctest,
     }
 }
 
-impl Iterator for IndexCombinations {
-    type Item = Vec<usize>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.done {
-            return None;
-        }
-        if self.first {
-            self.first = false;
-            return Some(self.current.clone());
-        }
-        if self.k == 0 {
-            self.done = true;
-            return None;
-        }
-
-        for i in (0..self.k).rev() {
-            let max_at_i = self.start + self.len - self.k + i;
-            if self.current[i] < max_at_i {
-                self.current[i] += 1;
-                for j in (i + 1)..self.k {
-                    self.current[j] = self.current[j - 1] + 1;
-                }
-                return Some(self.current.clone());
-            }
-        }
-
-        self.done = true;
-        None
-    }
-}
-#[inline]
-fn cholesky2(matrix: &mut [f64], n: usize, tol: f64) -> i32 {
-    for i in 0..n {
-        for j in i..n {
-            let mut temp = matrix[i * n + j];
-            for k in 0..i {
-                temp -= matrix[i * n + k] * matrix[j * n + k];
-            }
-            if j == i {
-                if temp <= 0.0 {
-                    matrix[i * n + i] = 0.0;
-                    return (i + 1) as i32;
-                }
-                if temp < tol * matrix[i * n + i].abs() {
-                    temp = 0.0;
-                }
-                matrix[i * n + i] = temp.sqrt();
-            } else {
-                matrix[j * n + i] = temp / matrix[i * n + i];
-            }
-        }
-    }
-    0
-}
-#[inline]
-fn chsolve2(chol: &mut [f64], n: usize, b: &mut [f64]) {
-    for i in 0..n {
-        let mut sum = b[i];
-        for j in 0..i {
-            sum -= chol[i * n + j] * b[j];
-        }
-        b[i] = sum / chol[i * n + i];
-    }
-    for i in (0..n).rev() {
-        let mut sum = b[i];
-        for j in (i + 1)..n {
-            sum -= chol[j * n + i] * b[j];
-        }
-        b[i] = sum / chol[i * n + i];
-    }
-}
-#[inline]
-fn chinv2(chol: &mut [f64], n: usize) {
-    for i in 0..n {
-        chol[i * n + i] = 1.0 / chol[i * n + i];
-        for j in (i + 1)..n {
-            let mut sum = 0.0;
-            for k in i..j {
-                sum += chol[j * n + k] * chol[k * n + i];
-            }
-            chol[j * n + i] = -sum * chol[j * n + j];
-        }
-    }
-    for i in 0..n {
-        for j in i..n {
-            let mut sum = 0.0;
-            for k in j..n {
-                sum += chol[k * n + i] * chol[k * n + j];
-            }
-            chol[i * n + j] = sum;
-        }
-    }
+fn agexact_impl(
+    data: AgexactData,
+    state: AgexactState,
+    params: AgexactParams,
+) -> PyResult<Py<PyDict>> {
+    let result = fit_agexact(data, state, params);
+    Python::attach(|py| {
+        let dict = PyDict::new(py);
+        dict.set_item("maxiter", result.maxiter)?;
+        dict.set_item("covar", result.covar)?;
+        dict.set_item("means", result.means)?;
+        dict.set_item("beta", result.beta)?;
+        dict.set_item("u", result.u)?;
+        dict.set_item("imat", result.imat)?;
+        dict.set_item("loglik", result.loglik)?;
+        dict.set_item("flag", result.flag)?;
+        dict.set_item("sctest", result.sctest)?;
+        Ok(dict.into())
+    })
 }
 
 #[cfg(test)]
@@ -681,6 +330,40 @@ mod tests {
             nvar,
             eps: 1e-9,
             tol_chol: 1e-9,
+        }
+    }
+
+    fn workspace(n: usize, p: usize) -> AgexactState {
+        AgexactState {
+            means: vec![0.0; p],
+            beta: vec![0.0; p],
+            u: vec![0.0; p],
+            imat: vec![0.0; p * p],
+            loglik: vec![0.0; 2],
+            work: vec![0.0; p * p + 3 * p + n],
+            work2: vec![0; 2 * n],
+        }
+    }
+
+    fn assert_close(actual: f64, expected: f64, tolerance: f64) {
+        assert!(
+            (actual - expected).abs() < tolerance,
+            "expected {expected:.16e}, got {actual:.16e}"
+        );
+    }
+
+    fn tied_data(offset: Vec<f64>) -> AgexactData {
+        AgexactData {
+            start: vec![0.0, 0.0, 0.5, 0.5, 1.0, 1.0, 1.5, 2.0, 2.5, 3.0],
+            stop: vec![2.0, 3.0, 3.0, 3.0, 4.0, 4.5, 5.0, 5.0, 5.0, 6.0],
+            event: vec![1, 1, 1, 0, 0, 1, 1, 1, 0, 1],
+            covar: vec![
+                -0.8, 0.3, 1.1, -0.2, 0.7, 1.4, -1.0, 0.5, 1.0, -0.4, 0.2, 1.3, -0.5, 0.8, -1.1,
+                0.4, 1.2, -0.7, 0.6, 1.0,
+            ],
+            offset,
+            strata: vec![0; 10],
+            nocenter: vec![1, 1],
         }
     }
 
@@ -726,15 +409,7 @@ mod tests {
             strata: vec![0, 1],
             nocenter: vec![1],
         };
-        let state = AgexactState {
-            means: vec![0.0],
-            beta: vec![0.0],
-            u: vec![0.0],
-            imat: vec![1.0],
-            loglik: vec![0.0, 0.0],
-            work: vec![0.0, 0.0, 0.0, 0.0, 0.0],
-            work2: vec![0, 0, 0, 0],
-        };
+        let state = workspace(2, 1);
         let params = sample_params(2, 1);
 
         let err = validate_agexact_inputs(&data, &state, &params).unwrap_err();
@@ -746,23 +421,357 @@ mod tests {
     }
 
     #[test]
-    fn iter_combinations_yields_lexicographic_combinations() {
-        let combinations: Vec<Vec<usize>> = iter_combinations(0, 4, 2).collect();
-        assert_eq!(
-            combinations,
-            vec![
-                vec![0, 1],
-                vec![0, 2],
-                vec![0, 3],
-                vec![1, 2],
-                vec![1, 3],
-                vec![2, 3],
-            ]
-        );
+    fn exact_counting_process_fit_matches_reference() {
+        let n = 6;
+        let data = AgexactData {
+            start: vec![0.0; n],
+            stop: vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+            event: vec![1, 0, 1, 1, 0, 1],
+            covar: vec![0.2, 1.1, -0.4, 0.8, 1.5, -0.2],
+            offset: vec![0.0; n],
+            strata: vec![0; n],
+            nocenter: vec![1],
+        };
+        let mut params = sample_params(n as i32, 1);
+        params.maxiter = 20;
 
-        let empty_combination: Vec<Vec<usize>> = iter_combinations(2, 5, 0).collect();
-        assert_eq!(empty_combination, vec![Vec::<usize>::new()]);
+        let result = fit_agexact(data, workspace(n, 1), params);
 
-        assert!(iter_combinations(0, 2, 3).next().is_none());
+        assert!((result.beta[0] - -0.716_230_334_1).abs() < 1e-9);
+        assert!((result.loglik[0] - -4.276_666_119_0).abs() < 1e-9);
+        assert!((result.loglik[1] - -3.923_517_065_7).abs() < 1e-9);
+        assert!((result.sctest - 0.677_003_624_6).abs() < 1e-9);
+        assert!((result.imat[0] - 0.809_942_243_8).abs() < 1e-9);
+        assert_eq!(result.maxiter, 4);
+        assert_eq!(result.flag, 1);
+        assert_eq!(result.means, vec![0.5]);
+        for (actual, expected) in result.covar.iter().zip([-0.3, 0.6, -0.9, 0.3, 1.0, -0.7]) {
+            assert!((actual - expected).abs() < 1e-12);
+        }
+    }
+
+    #[test]
+    fn tied_exact_fit_matches_reference() {
+        let n = 10;
+        let mut params = sample_params(n as i32, 2);
+        params.maxiter = 20;
+
+        let result = fit_agexact(tied_data(vec![0.0; n]), workspace(n, 2), params);
+
+        for (actual, expected) in result
+            .beta
+            .iter()
+            .zip([-0.115_430_521_359_233_32, -0.213_265_368_013_505_2])
+        {
+            assert_close(*actual, expected, 1e-10);
+        }
+        for (actual, expected) in result
+            .loglik
+            .iter()
+            .zip([-8.679_312_040_892_672, -8.627_187_346_318_79])
+        {
+            assert_close(*actual, expected, 1e-10);
+        }
+        for (actual, expected) in result.imat.iter().zip([
+            0.441_606_639_173_011_4,
+            0.230_754_719_570_179_73,
+            0.230_754_719_570_179_73,
+            0.432_843_140_053_174_1,
+        ]) {
+            assert_close(*actual, expected, 1e-10);
+        }
+        assert_close(result.sctest, 0.105_617_248_301_556_97, 1e-10);
+        assert_eq!(result.maxiter, 3);
+        assert_eq!(result.flag, 2);
+    }
+
+    #[test]
+    fn stratified_exact_fit_matches_reference() {
+        let n = 12;
+        let data = AgexactData {
+            start: vec![0.0, 0.2, 0.5, 1.0, 1.2, 2.0, 0.0, 0.1, 0.4, 0.8, 1.5, 2.2],
+            stop: vec![1.5, 2.5, 3.0, 3.0, 4.5, 5.5, 1.0, 2.0, 2.8, 3.8, 4.2, 5.0],
+            event: vec![1, 0, 1, 1, 0, 1, 0, 1, 1, 0, 1, 1],
+            covar: vec![
+                -0.7, 0.4, 1.2, -0.1, 0.8, 1.5, 0.5, -1.1, 0.9, 1.3, -0.4, 0.2, 1.0, -0.5, 0.3,
+                1.4, -0.8, 0.6, -1.2, 0.7, 1.1, -0.2, 0.5, 1.6,
+            ],
+            offset: vec![0.0; n],
+            strata: vec![0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1],
+            nocenter: vec![1, 1],
+        };
+        let mut params = sample_params(n as i32, 2);
+        params.maxiter = 20;
+
+        let result = fit_agexact(data, workspace(n, 2), params);
+
+        for (actual, expected) in result
+            .beta
+            .iter()
+            .zip([-1.491_575_625_028_017_2, 0.651_994_589_955_765_1])
+        {
+            assert_close(*actual, expected, 1e-8);
+        }
+        for (actual, expected) in result
+            .loglik
+            .iter()
+            .zip([-6.866_933_284_461_882, -4.782_313_934_490_155])
+        {
+            assert_close(*actual, expected, 1e-9);
+        }
+        for (actual, expected) in result.imat.iter().zip([
+            1.110_235_034_638_227_7,
+            -0.217_479_161_166_214_63,
+            -0.217_479_161_166_214_63,
+            0.811_063_057_618_197_3,
+        ]) {
+            assert_close(*actual, expected, 1e-8);
+        }
+        assert_eq!(result.maxiter, 5);
+        assert_eq!(result.flag, 2);
+    }
+
+    #[test]
+    fn zero_iteration_fit_preserves_initial_coefficients() {
+        let n = 10;
+        let offset = vec![0.1, -0.2, 0.05, 0.3, -0.1, 0.15, -0.25, 0.2, -0.05, 0.1];
+        let mut state = workspace(n, 2);
+        state.beta = vec![0.25, -0.15];
+        let mut params = sample_params(n as i32, 2);
+        params.maxiter = 0;
+
+        let result = fit_agexact(tied_data(offset), state, params);
+
+        assert_eq!(result.beta, vec![0.25, -0.15]);
+        assert_eq!(result.maxiter, 0);
+        assert_eq!(result.flag, 0);
+        assert_eq!(result.loglik[0], result.loglik[1]);
+        assert_close(result.loglik[0], -8.984_551_377_142_534, 1e-10);
+        assert_close(result.sctest, 0.527_340_441_191_537_9, 1e-10);
+        for (actual, expected) in result
+            .u
+            .iter()
+            .zip([-1.198_072_004_593_938_6, 0.582_535_379_350_987_8])
+        {
+            assert_close(*actual, expected, 1e-10);
+        }
+        for (actual, expected) in result.imat.iter().zip([
+            0.453_757_442_304_586_64,
+            0.194_510_928_931_332_07,
+            0.194_510_928_931_332_07,
+            0.434_756_546_357_564_44,
+        ]) {
+            assert_close(*actual, expected, 1e-10);
+        }
+    }
+
+    #[test]
+    fn one_iteration_from_nonzero_initial_values_matches_reference() {
+        let n = 10;
+        let offset = vec![0.1, -0.2, 0.05, 0.3, -0.1, 0.15, -0.25, 0.2, -0.05, 0.1];
+        let mut state = workspace(n, 2);
+        state.beta = vec![0.25, -0.15];
+        let mut params = sample_params(n as i32, 2);
+        params.maxiter = 1;
+
+        let result = fit_agexact(tied_data(offset), state, params);
+
+        for (actual, expected) in result
+            .beta
+            .iter()
+            .zip([-0.180_324_590_728_348, -0.129_777_028_882_461])
+        {
+            assert_close(*actual, expected, 1e-10);
+        }
+        for (actual, expected) in result
+            .loglik
+            .iter()
+            .zip([-8.984_551_377_142_53, -8.735_543_533_097_94])
+        {
+            assert_close(*actual, expected, 1e-10);
+        }
+        for (actual, expected) in result.imat.iter().zip([
+            0.445_743_377_908_897,
+            0.234_376_633_135_133,
+            0.234_376_633_135_133,
+            0.452_933_208_616_838,
+        ]) {
+            assert_close(*actual, expected, 1e-10);
+        }
+        assert_eq!(result.maxiter, 1);
+        assert_eq!(result.flag, 1_000);
+    }
+
+    #[test]
+    fn delayed_entry_exact_fit_avoids_risk_sum_cancellation() {
+        let n = 3;
+        let data = AgexactData {
+            start: vec![0.0, 0.0, 1.0],
+            stop: vec![1.0, 2.0, 2.0],
+            event: vec![1, 0, 0],
+            covar: vec![0.0, 0.0, 100.0],
+            offset: vec![0.0; n],
+            strata: vec![0; n],
+            nocenter: vec![1],
+        };
+        let mut state = workspace(n, 1);
+        state.beta = vec![1.0];
+        let mut params = sample_params(n as i32, 1);
+        params.maxiter = 0;
+
+        let result = fit_agexact(data, state, params);
+
+        assert_close(result.loglik[0], -std::f64::consts::LN_2, 1e-12);
+        assert_eq!(result.loglik[0], result.loglik[1]);
+        assert_eq!(result.u, vec![0.0]);
+        assert_eq!(result.imat, vec![0.0]);
+        assert_eq!(result.sctest, 0.0);
+        assert_eq!(result.flag, 0);
+    }
+
+    #[test]
+    fn complete_tied_risk_set_has_zero_conditional_information() {
+        let n = 3;
+        let data = AgexactData {
+            start: vec![0.0; n],
+            stop: vec![1.0; n],
+            event: vec![1; n],
+            covar: (0..n)
+                .map(|value| ((value as f64 - 0.37).powi(2)) / 7.0)
+                .collect(),
+            offset: vec![0.0; n],
+            strata: vec![0; n],
+            nocenter: vec![1],
+        };
+        let mut state = workspace(n, 1);
+        state.beta = vec![0.7];
+        let mut params = sample_params(n as i32, 1);
+        params.maxiter = 0;
+
+        let result = fit_agexact(data, state, params);
+
+        assert_eq!(result.loglik, vec![0.0, 0.0]);
+        assert_eq!(result.u, vec![0.0]);
+        assert_eq!(result.imat, vec![0.0]);
+        assert_eq!(result.sctest, 0.0);
+        assert_eq!(result.flag, 0);
+    }
+
+    #[test]
+    fn step_halving_uses_exact_compatibility_policy() {
+        let n = 10;
+        let data = AgexactData {
+            start: vec![0.0, 0.0, 0.0, 2.0, 6.0, 5.0, 8.0, 1.0, 5.0, 10.0],
+            stop: vec![1.0, 2.0, 2.0, 6.0, 7.0, 7.0, 10.0, 10.0, 11.0, 11.0],
+            event: vec![1, 1, 0, 0, 0, 0, 1, 0, 1, 1],
+            covar: vec![
+                -0.794_901_757_722_206_4,
+                -0.971_412_993_595_188,
+                -0.897_364_024_938_572_6,
+                -0.311_732_919_901_538_56,
+                -0.951_374_812_217_756_5,
+                1.204_533_321_642_762,
+                2.883_351_093_087_066,
+                -0.885_194_161_791_435_7,
+                0.982_157_001_943_561_7,
+                0.251_309_986_747_342,
+            ],
+            offset: vec![
+                0.321_143_620_716_472_3,
+                -0.170_347_621_201_529_4,
+                0.275_770_030_571_546_9,
+                0.222_191_560_017_322_24,
+                0.125_748_557_191_099_7,
+                -0.185_935_466_774_804_63,
+                0.381_606_917_637_173_1,
+                -0.694_971_257_421_976,
+                0.496_755_599_155_065,
+                0.170_148_434_302_88,
+            ],
+            strata: vec![0; n],
+            nocenter: vec![1],
+        };
+        let mut state = workspace(n, 1);
+        state.beta = vec![5.853_544_164_651_22];
+        let mut params = sample_params(n as i32, 1);
+        params.maxiter = 40;
+
+        let result = fit_agexact(data, state, params);
+
+        assert_close(result.beta[0], 4.633_619_571_940_176, 1e-9);
+        assert_close(result.loglik[0], -2.034_562_528_770_813, 1e-9);
+        assert_close(result.loglik[1], -2.030_219_922_496_827_6, 1e-9);
+        assert_close(result.imat[0], 161.077_101_202_556_04, 1e-7);
+        assert_eq!(result.maxiter, 3);
+        assert_eq!(result.flag, 1);
+    }
+
+    #[test]
+    fn nonconverged_exact_fit_returns_final_trial_state() {
+        let n = 7;
+        let data = AgexactData {
+            start: vec![0.0, 0.0, 0.0, 1.0, 2.0, 2.0, 3.0],
+            stop: vec![1.0, 1.0, 1.0, 3.0, 3.0, 4.0, 5.0],
+            event: vec![1, 0, 0, 0, 0, 1, 0],
+            covar: vec![
+                -0.106_275_907_728_014_89,
+                -1.415_108_390_302_514,
+                -0.598_261_907_922_483_6,
+                3.279_520_010_161_916,
+                -1.334_405_338_827_207,
+                2.496_179_020_159_636_3,
+                0.189_703_669_111_627_2,
+            ],
+            offset: vec![
+                1.488_417_295_240_173_7,
+                -0.376_803_280_793_356_45,
+                -0.310_856_512_288_097_7,
+                -1.085_016_692_155_569_3,
+                1.234_396_256_848_731,
+                0.427_128_664_347_841_25,
+                -0.159_616_115_770_802_56,
+            ],
+            strata: vec![0; n],
+            nocenter: vec![1],
+        };
+        let mut state = workspace(n, 1);
+        state.beta = vec![0.708_344_326_291_033_2];
+        let mut params = sample_params(n as i32, 1);
+        params.maxiter = 20;
+
+        let result = fit_agexact(data, state, params);
+
+        assert_close(result.beta[0], 36.550_680_230_661_33, 5e-7);
+        assert_close(result.loglik[0], -0.266_892_412_518_194_4, 1e-12);
+        assert_close(result.loglik[1], -2.564_007_672_845_036_7e-9, 1e-12);
+        assert_close(result.imat[0], 1_611_299_433.054_453_4, 300.0);
+        assert_eq!(result.maxiter, 20);
+        assert_eq!(result.flag, 1_000);
+    }
+
+    #[test]
+    fn large_tied_risk_set_uses_dynamic_programming() {
+        let n = 64;
+        let deaths = 32;
+        let data = AgexactData {
+            start: vec![0.0; n],
+            stop: vec![1.0; n],
+            event: (0..n).map(|person| i32::from(person < deaths)).collect(),
+            covar: (0..n).map(|value| value as f64).collect(),
+            offset: vec![0.0; n],
+            strata: vec![0; n],
+            nocenter: vec![0],
+        };
+        let mut params = sample_params(n as i32, 1);
+        params.maxiter = 0;
+
+        let result = fit_agexact(data, workspace(n, 1), params);
+
+        assert_close(result.loglik[0], -42.052_280_570_411_12, 1e-10);
+        assert_close(result.u[0], -512.0, 1e-10);
+        assert_close(result.imat[0], 3.0 / 16_640.0, 1e-15);
+        assert_close(result.sctest, 3_072.0 / 65.0, 1e-10);
+        assert_eq!(result.maxiter, 0);
+        assert_eq!(result.flag, 0);
     }
 }

--- a/src/regression/cox_optimizer.rs
+++ b/src/regression/cox_optimizer.rs
@@ -5,6 +5,10 @@ use crate::constants::{
 use ndarray::{Array1, Array2};
 use rayon::prelude::*;
 
+use super::exact_ties::{ExactRiskAccumulator, exact_tied_moments};
+
+const EXACT_COMPATIBILITY_DIRECT_THRESHOLD: usize = 64;
+
 #[derive(Debug, Clone)]
 pub(crate) struct CoxFitConfig {
     pub method: Method,
@@ -33,6 +37,12 @@ pub(crate) enum Method {
     Breslow,
     Efron,
     Exact,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum FitMode {
+    Standard,
+    AgexactCompatibility,
 }
 pub(crate) type CoxFitResults = (
     Vec<f64>,
@@ -73,58 +83,61 @@ fn sort_entry_order(order: &mut [usize], entry_times: &Array1<f64>) {
     });
 }
 
-pub(crate) fn exact_tied_moments(
-    risk_indices: &[usize],
-    deaths: usize,
-    risk_vals: &[f64],
+#[allow(clippy::too_many_arguments)]
+fn apply_exact_event_moments(
     covar: &Array2<f64>,
-) -> (f64, Vec<f64>, Array2<f64>) {
-    let nvar = covar.ncols();
-    let cmat_len = nvar * nvar;
-    let mut denom = vec![0.0; deaths + 1];
-    let mut a = vec![vec![0.0; nvar]; deaths + 1];
-    let mut cmat = vec![vec![0.0; cmat_len]; deaths + 1];
-    denom[0] = 1.0;
-
-    for (seen, &person) in risk_indices.iter().enumerate() {
-        let risk = risk_vals[person];
-        let max_size = deaths.min(seen + 1);
-        for size in (1..=max_size).rev() {
-            let base = denom[size - 1];
-            if base == 0.0 {
-                continue;
-            }
-            let (prev_a_rows, current_a_rows) = a.split_at_mut(size);
-            let prev_a = &prev_a_rows[size - 1];
-            let current_a = &mut current_a_rows[0];
-            let (prev_cmat_rows, current_cmat_rows) = cmat.split_at_mut(size);
-            let prev_cmat = &prev_cmat_rows[size - 1];
-            let current_cmat = &mut current_cmat_rows[0];
-            denom[size] += risk * base;
-            for i in 0..nvar {
-                let xi = covar[(person, i)];
-                current_a[i] += risk * (prev_a[i] + base * xi);
-                for j in 0..=i {
-                    let xj = covar[(person, j)];
-                    current_cmat[i * nvar + j] += risk
-                        * (prev_cmat[i * nvar + j]
-                            + xi * prev_a[j]
-                            + xj * prev_a[i]
-                            + base * xi * xj);
-                }
-            }
+    weights: &Array1<f64>,
+    u: &mut [f64],
+    imat: &mut Array2<f64>,
+    death_indices: &[usize],
+    linear_predictors: &[f64],
+    log_denom: f64,
+    mean: &[f64],
+    covariance: &Array2<f64>,
+) -> f64 {
+    let mut contribution = -log_denom;
+    for &person in death_indices {
+        contribution += weights[person] * linear_predictors[person];
+        for (variable, value) in u.iter_mut().enumerate() {
+            *value += weights[person] * covar[(person, variable)];
         }
     }
-
-    let tied_a = a.pop().expect("exact tied score row must exist");
-    let tied_cmat = cmat.pop().expect("exact tied information row must exist");
-    let mut cmat_array = Array2::zeros((nvar, nvar));
-    for i in 0..nvar {
-        for j in 0..=i {
-            cmat_array[(i, j)] = tied_cmat[i * nvar + j];
+    for (variable, value) in u.iter_mut().enumerate() {
+        *value -= mean[variable];
+        for other in 0..covar.ncols() {
+            imat[(variable, other)] += covariance[(variable, other)];
         }
     }
-    (denom[deaths], tied_a, cmat_array)
+    contribution
+}
+
+#[allow(clippy::too_many_arguments)]
+fn add_exact_event_contribution(
+    covar: &Array2<f64>,
+    weights: &Array1<f64>,
+    u: &mut [f64],
+    imat: &mut Array2<f64>,
+    death_indices: &[usize],
+    risk_indices: &[usize],
+    linear_predictors: &[f64],
+    log_risk: &[f64],
+) -> f64 {
+    if death_indices.len() == risk_indices.len() {
+        return 0.0;
+    }
+
+    let moments = exact_tied_moments(risk_indices, death_indices.len(), log_risk, covar);
+    apply_exact_event_moments(
+        covar,
+        weights,
+        u,
+        imat,
+        death_indices,
+        linear_predictors,
+        moments.log_denom,
+        &moments.mean,
+        &moments.covariance,
+    )
 }
 
 pub(crate) struct CoxFit {
@@ -287,6 +300,10 @@ impl CoxFit {
         initial_beta: Vec<f64>,
     ) -> Result<Self, CoxError> {
         let nvar = covar.ncols();
+        let mut strata = strata;
+        if let Some(last) = strata.last_mut() {
+            *last = 1;
+        }
         let entry_order = entry_times.as_ref().map(|entry_times| {
             let mut order: Vec<usize> = (0..entry_times.len()).collect();
             let mut stratum_start = 0;
@@ -484,7 +501,333 @@ impl CoxFit {
         self.beta = new_beta;
         Ok(())
     }
+
+    fn exact_predictors(&self, beta: &[f64]) -> (Vec<f64>, Vec<f64>) {
+        let evaluate = |person: usize| {
+            let linear_predictor = self.offset[person]
+                + beta
+                    .iter()
+                    .enumerate()
+                    .fold(0.0, |sum, (variable, &coefficient)| {
+                        sum + coefficient * self.covar[(person, variable)]
+                    });
+            (
+                linear_predictor,
+                linear_predictor + self.weights[person].ln(),
+            )
+        };
+        if self.covar.nrows() > PARALLEL_THRESHOLD_MEDIUM {
+            (0..self.covar.nrows())
+                .into_par_iter()
+                .map(evaluate)
+                .unzip()
+        } else {
+            (0..self.covar.nrows()).map(evaluate).unzip()
+        }
+    }
+
+    fn iterate_right_censored_exact(&mut self, beta: &[f64]) -> Result<f64, CoxError> {
+        self.u.fill(0.0);
+        self.imat.fill(0.0);
+        let (linear_predictors, log_risk) = self.exact_predictors(beta);
+        let mut loglik = 0.0;
+        let mut stratum_start = 0usize;
+
+        for stratum_end in 0..self.covar.nrows() {
+            if self.strata[stratum_end] != 1 {
+                continue;
+            }
+
+            let mut risk_indices = Vec::with_capacity(stratum_end - stratum_start + 1);
+            let mut death_indices = Vec::new();
+            let mut singleton_moments = ExactRiskAccumulator::new(self.covar.ncols());
+            let mut time_end = stratum_end;
+            loop {
+                let event_time = self.time[time_end];
+                let mut time_start = time_end;
+                while time_start > stratum_start && self.time[time_start - 1] == event_time {
+                    time_start -= 1;
+                }
+                risk_indices.extend(time_start..=time_end);
+                for (offset, &log_weight) in log_risk[time_start..=time_end].iter().enumerate() {
+                    singleton_moments.add(time_start + offset, log_weight, &self.covar);
+                }
+                death_indices.clear();
+                death_indices
+                    .extend((time_start..=time_end).filter(|&person| self.status[person] != 0));
+                if !death_indices.is_empty() {
+                    loglik += if death_indices.len() == 1 && risk_indices.len() > 1 {
+                        apply_exact_event_moments(
+                            &self.covar,
+                            &self.weights,
+                            &mut self.u,
+                            &mut self.imat,
+                            &death_indices,
+                            &linear_predictors,
+                            singleton_moments.log_denom,
+                            &singleton_moments.mean,
+                            &singleton_moments.covariance,
+                        )
+                    } else {
+                        add_exact_event_contribution(
+                            &self.covar,
+                            &self.weights,
+                            &mut self.u,
+                            &mut self.imat,
+                            &death_indices,
+                            &risk_indices,
+                            &linear_predictors,
+                            &log_risk,
+                        )
+                    };
+                }
+
+                if time_start == stratum_start {
+                    break;
+                }
+                time_end = time_start - 1;
+            }
+            stratum_start = stratum_end + 1;
+        }
+        Ok(loglik)
+    }
+
+    fn iterate_counting_process_exact(&mut self, beta: &[f64]) -> Result<f64, CoxError> {
+        let Some(entry_times) = self.entry_times.as_ref() else {
+            return self.iterate_right_censored_exact(beta);
+        };
+        let entry_order = self
+            .entry_order
+            .as_ref()
+            .expect("entry order must accompany counting-process entry times");
+        let nvar = self.covar.ncols();
+        self.u.fill(0.0);
+        self.imat.fill(0.0);
+        let (linear_predictors, log_risk) = self.exact_predictors(beta);
+        let raw_risk: Vec<f64> = log_risk.iter().map(|value| value.exp()).collect();
+        let mut loglik = 0.0;
+        let mut stratum_start = 0usize;
+
+        for stratum_end in 0..self.covar.nrows() {
+            if self.strata[stratum_end] != 1 {
+                continue;
+            }
+
+            let start_order = &entry_order[stratum_start..=stratum_end];
+            let mut stop_denom = 0.0;
+            let mut stop_a = vec![0.0; nvar];
+            let mut stop_cmat = Array2::zeros((nvar, nvar));
+            let mut unentered_denom = 0.0;
+            let mut unentered_a = vec![0.0; nvar];
+            let mut unentered_cmat = Array2::zeros((nvar, nvar));
+            let mut stop_count = 0usize;
+            let mut unentered_count = 0usize;
+            let mut stop_ptr = stratum_end as isize;
+            let mut start_ptr = 0usize;
+            let mut death_indices = Vec::new();
+            let mut risk_indices = Vec::new();
+            let mut mean = vec![0.0; nvar];
+            let mut covariance = Array2::zeros((nvar, nvar));
+            let mut time_end = stratum_end;
+
+            loop {
+                let event_time = self.time[time_end];
+                while stop_ptr >= stratum_start as isize
+                    && self.time[stop_ptr as usize] >= event_time
+                {
+                    let person = stop_ptr as usize;
+                    add_risk_sums(
+                        &self.covar,
+                        nvar,
+                        person,
+                        raw_risk[person],
+                        &mut stop_denom,
+                        &mut stop_a,
+                        &mut stop_cmat,
+                    );
+                    stop_count += 1;
+                    stop_ptr -= 1;
+                }
+                while start_ptr < start_order.len()
+                    && entry_times[start_order[start_ptr]] >= event_time
+                {
+                    let person = start_order[start_ptr];
+                    add_risk_sums(
+                        &self.covar,
+                        nvar,
+                        person,
+                        raw_risk[person],
+                        &mut unentered_denom,
+                        &mut unentered_a,
+                        &mut unentered_cmat,
+                    );
+                    unentered_count += 1;
+                    start_ptr += 1;
+                }
+
+                let mut time_start = time_end;
+                while time_start > stratum_start && self.time[time_start - 1] == event_time {
+                    time_start -= 1;
+                }
+                death_indices.clear();
+                death_indices
+                    .extend((time_start..=time_end).filter(|&person| self.status[person] != 0));
+                if !death_indices.is_empty() {
+                    let active_count = stop_count - unentered_count;
+                    if death_indices.len() != active_count {
+                        let denom = stop_denom - unentered_denom;
+                        let cancellation_scale = stop_denom.abs() + unentered_denom.abs();
+                        let mut reliable_singleton = death_indices.len() == 1
+                            && denom.is_finite()
+                            && denom > 0.0
+                            && (cancellation_scale == 0.0
+                                || denom > 64.0 * f64::EPSILON * cancellation_scale);
+
+                        if reliable_singleton {
+                            for variable in 0..nvar {
+                                let active_sum = stop_a[variable] - unentered_a[variable];
+                                let cancellation_scale =
+                                    stop_a[variable].abs() + unentered_a[variable].abs();
+                                if cancellation_scale != 0.0
+                                    && active_sum.abs() <= 64.0 * f64::EPSILON * cancellation_scale
+                                {
+                                    reliable_singleton = false;
+                                }
+                                mean[variable] = active_sum / denom;
+                            }
+                            for row in 0..nvar {
+                                for column in 0..=row {
+                                    let active_sum =
+                                        stop_cmat[(row, column)] - unentered_cmat[(row, column)];
+                                    let cancellation_scale = stop_cmat[(row, column)].abs()
+                                        + unentered_cmat[(row, column)].abs();
+                                    if cancellation_scale != 0.0
+                                        && active_sum.abs()
+                                            <= 64.0 * f64::EPSILON * cancellation_scale
+                                    {
+                                        reliable_singleton = false;
+                                    }
+                                    let active_first_moment = stop_a[column] - unentered_a[column];
+                                    let mut value =
+                                        (active_sum - mean[row] * active_first_moment) / denom;
+                                    if row == column && value < 0.0 {
+                                        if value
+                                            >= -64.0 * f64::EPSILON * (active_sum / denom).abs()
+                                        {
+                                            value = 0.0;
+                                        } else {
+                                            reliable_singleton = false;
+                                        }
+                                    }
+                                    covariance[(row, column)] = value;
+                                    covariance[(column, row)] = value;
+                                    reliable_singleton &= value.is_finite();
+                                }
+                            }
+                        }
+
+                        loglik += if reliable_singleton {
+                            apply_exact_event_moments(
+                                &self.covar,
+                                &self.weights,
+                                &mut self.u,
+                                &mut self.imat,
+                                &death_indices,
+                                &linear_predictors,
+                                denom.ln(),
+                                &mean,
+                                &covariance,
+                            )
+                        } else {
+                            risk_indices.clear();
+                            risk_indices.extend((stratum_start..=stratum_end).filter(|&person| {
+                                entry_times[person] < event_time && self.time[person] >= event_time
+                            }));
+                            add_exact_event_contribution(
+                                &self.covar,
+                                &self.weights,
+                                &mut self.u,
+                                &mut self.imat,
+                                &death_indices,
+                                &risk_indices,
+                                &linear_predictors,
+                                &log_risk,
+                            )
+                        };
+                    }
+                }
+
+                if time_start == stratum_start {
+                    break;
+                }
+                time_end = time_start - 1;
+            }
+            stratum_start = stratum_end + 1;
+        }
+        Ok(loglik)
+    }
+
+    fn iterate_counting_process_exact_compatibility(
+        &mut self,
+        beta: &[f64],
+    ) -> Result<f64, CoxError> {
+        let Some(entry_times) = self.entry_times.as_ref() else {
+            return self.iterate_right_censored_exact(beta);
+        };
+        self.u.fill(0.0);
+        self.imat.fill(0.0);
+        let (linear_predictors, log_risk) = self.exact_predictors(beta);
+        let mut loglik = 0.0;
+        let mut stratum_start = 0usize;
+
+        for stratum_end in 0..self.covar.nrows() {
+            if self.strata[stratum_end] != 1 {
+                continue;
+            }
+
+            let mut death_indices = Vec::new();
+            let mut risk_indices = Vec::new();
+            let mut time_end = stratum_end;
+            loop {
+                let event_time = self.time[time_end];
+                let mut time_start = time_end;
+                while time_start > stratum_start && self.time[time_start - 1] == event_time {
+                    time_start -= 1;
+                }
+                death_indices.clear();
+                death_indices
+                    .extend((time_start..=time_end).filter(|&person| self.status[person] != 0));
+                if !death_indices.is_empty() {
+                    risk_indices.clear();
+                    risk_indices.extend((stratum_start..=stratum_end).filter(|&person| {
+                        entry_times[person] < event_time && self.time[person] >= event_time
+                    }));
+                    loglik += add_exact_event_contribution(
+                        &self.covar,
+                        &self.weights,
+                        &mut self.u,
+                        &mut self.imat,
+                        &death_indices,
+                        &risk_indices,
+                        &linear_predictors,
+                        &log_risk,
+                    );
+                }
+
+                if time_start == stratum_start {
+                    break;
+                }
+                time_end = time_start - 1;
+            }
+            stratum_start = stratum_end + 1;
+        }
+        Ok(loglik)
+    }
+
     fn iterate_right_censored(&mut self, beta: &[f64]) -> Result<f64, CoxError> {
+        if matches!(self.method, Method::Exact) {
+            return self.iterate_right_censored_exact(beta);
+        }
         let nvar = self.covar.ncols();
         let nused = self.covar.nrows();
         let method = self.method;
@@ -496,7 +839,6 @@ impl CoxFit {
         let mut cmat2 = Array2::zeros((nvar, nvar));
         let mut loglik = 0.0;
         let mut denom = 0.0;
-        let mut risk_indices: Vec<usize> = Vec::new();
 
         let (zbeta_vals, risk_vals): (Vec<f64>, Vec<f64>) = if nused > PARALLEL_THRESHOLD_MEDIUM {
             (0..nused)
@@ -530,7 +872,6 @@ impl CoxFit {
                 a.fill(0.0);
                 cmat.fill(0.0);
                 denom = 0.0;
-                risk_indices.clear();
             }
             let dtime = self.time[person_idx];
             let mut ndead = 0;
@@ -542,7 +883,6 @@ impl CoxFit {
                 _nrisk += 1;
                 let zbeta = zbeta_vals[person_i];
                 let risk = risk_vals[person_i];
-                risk_indices.push(person_i);
                 if self.status[person_i] == 0 {
                     denom += risk;
                     for i in 0..nvar {
@@ -574,29 +914,7 @@ impl CoxFit {
                 }
             }
             if ndead > 0 {
-                if matches!(method, Method::Exact) && ndead > 1 {
-                    let (exact_denom, exact_a, exact_cmat) =
-                        exact_tied_moments(&risk_indices, ndead, &risk_vals, &self.covar);
-                    loglik -= exact_denom.ln();
-                    for i in 0..nvar {
-                        let temp = exact_a[i] / exact_denom;
-                        self.u[i] -= temp;
-                        for j in 0..=i {
-                            let val = (exact_cmat[(i, j)] - temp * exact_a[j]) / exact_denom;
-                            self.imat[(j, i)] += val;
-                            if i != j {
-                                self.imat[(i, j)] += val;
-                            }
-                        }
-                    }
-                    denom += denom2;
-                    for i in 0..nvar {
-                        a[i] += a2[i];
-                        for j in 0..=i {
-                            cmat[(i, j)] += cmat2[(i, j)];
-                        }
-                    }
-                } else if matches!(method, Method::Breslow) || ndead == 1 {
+                if matches!(method, Method::Breslow) || ndead == 1 {
                     denom += denom2;
                     loglik -= deadwt * denom.ln();
                     for i in 0..nvar {
@@ -642,6 +960,9 @@ impl CoxFit {
     }
 
     fn iterate_counting_process(&mut self, beta: &[f64]) -> Result<f64, CoxError> {
+        if matches!(self.method, Method::Exact) {
+            return self.iterate_counting_process_exact(beta);
+        }
         let Some(entry_times) = self.entry_times.as_ref() else {
             return self.iterate_right_censored(beta);
         };
@@ -702,7 +1023,6 @@ impl CoxFit {
             let mut death_cmat: Array2<f64> = Array2::zeros((nvar, nvar));
             let mut event_a = vec![0.0; nvar];
             let mut event_cmat: Array2<f64> = Array2::zeros((nvar, nvar));
-            let mut risk_indices: Vec<usize> = Vec::new();
 
             loop {
                 let event_time = self.time[time_end];
@@ -779,26 +1099,7 @@ impl CoxFit {
                             event_cmat[(i, j)] = stop_cmat[(i, j)] - unentered_cmat[(i, j)];
                         }
                     }
-                    if matches!(method, Method::Exact) && ndead > 1 {
-                        risk_indices.clear();
-                        risk_indices.extend((stratum_start..=stratum_end).filter(|&idx| {
-                            entry_times[idx] < event_time && self.time[idx] >= event_time
-                        }));
-                        let (exact_denom, exact_a, exact_cmat) =
-                            exact_tied_moments(&risk_indices, ndead, &risk_vals, &self.covar);
-                        loglik -= exact_denom.ln();
-                        for i in 0..nvar {
-                            let temp = exact_a[i] / exact_denom;
-                            self.u[i] -= temp;
-                            for j in 0..=i {
-                                let val = (exact_cmat[(i, j)] - temp * exact_a[j]) / exact_denom;
-                                self.imat[(j, i)] += val;
-                                if i != j {
-                                    self.imat[(i, j)] += val;
-                                }
-                            }
-                        }
-                    } else if matches!(method, Method::Breslow) || ndead == 1 {
+                    if matches!(method, Method::Breslow) || ndead == 1 {
                         loglik -= deadwt * denom.ln();
                         for i in 0..nvar {
                             let temp = event_a[i] / denom;
@@ -863,14 +1164,39 @@ impl CoxFit {
         }
     }
 
+    fn iterate_with_mode(&mut self, beta: &[f64], mode: FitMode) -> Result<f64, CoxError> {
+        if mode == FitMode::AgexactCompatibility
+            && self.entry_times.is_some()
+            && matches!(self.method, Method::Exact)
+            && self.covar.nrows() <= EXACT_COMPATIBILITY_DIRECT_THRESHOLD
+        {
+            // Small compatibility fits use the sequential log-space fold to
+            // preserve the legacy floating-point iteration trajectory. Larger
+            // fits use the linear risk-set sweep below, with stable fallbacks
+            // whenever delayed-entry subtraction loses precision.
+            self.iterate_counting_process_exact_compatibility(beta)
+        } else {
+            self.iterate(beta)
+        }
+    }
+
     pub(crate) fn fit(&mut self) -> Result<(), CoxError> {
+        self.fit_with_mode(FitMode::Standard)
+    }
+
+    pub(crate) fn fit_agexact_compatibility(&mut self) -> Result<(), CoxError> {
+        self.fit_with_mode(FitMode::AgexactCompatibility)
+    }
+
+    fn fit_with_mode(&mut self, mode: FitMode) -> Result<(), CoxError> {
+        let agexact_compatibility = mode == FitMode::AgexactCompatibility;
         let nvar = self.beta.len();
         let mut newbeta = vec![0.0; nvar];
         let mut a = vec![0.0; nvar];
         let mut halving = 0;
         let mut _notfinite;
         let beta_copy = self.beta.clone();
-        self.loglik[0] = self.iterate(&beta_copy)?;
+        self.loglik[0] = self.iterate_with_mode(&beta_copy, mode)?;
         self.loglik[1] = self.loglik[0];
         if nvar == 0 {
             self.flag = 0;
@@ -883,6 +1209,9 @@ impl CoxFit {
         if self.max_iter == 0 || !self.loglik[0].is_finite() {
             Self::chinv(&mut self.imat);
             self.rescale_params();
+            if agexact_compatibility && self.max_iter == 0 {
+                self.flag = 0;
+            }
             return Ok(());
         }
         newbeta.copy_from_slice(&self.beta);
@@ -890,9 +1219,10 @@ impl CoxFit {
             newbeta[i] += a[i];
         }
         self.loglik[1] = self.loglik[0];
+        let mut newlk = self.loglik[1];
         for iter in 1..=self.max_iter {
             self.iter = iter;
-            let newlk = match self.iterate(&newbeta) {
+            newlk = match self.iterate_with_mode(&newbeta, mode) {
                 Ok(lk) if lk.is_finite() => lk,
                 _ => {
                     _notfinite = true;
@@ -915,22 +1245,31 @@ impl CoxFit {
                     }
                 }
             }
-            if !_notfinite && (1.0 - self.loglik[1] / newlk).abs() <= self.eps {
+            if !_notfinite
+                && (1.0 - self.loglik[1] / newlk).abs() <= self.eps
+                && (!agexact_compatibility || halving == 0)
+            {
                 self.loglik[1] = newlk;
                 self.beta.copy_from_slice(&newbeta);
                 Self::chinv(&mut self.imat);
                 self.rescale_params();
-                if halving > 0 {
+                if !agexact_compatibility && halving > 0 {
                     self.flag = -2;
                 }
                 return Ok(());
+            }
+            if agexact_compatibility && iter == self.max_iter {
+                break;
             }
             if _notfinite || newlk < self.loglik[1] {
                 halving += 1;
                 for (newbeta_elem, beta_elem) in newbeta.iter_mut().zip(self.beta.iter()).take(nvar)
                 {
-                    *newbeta_elem =
-                        (*newbeta_elem + (halving as f64) * beta_elem) / (halving as f64 + 1.0);
+                    *newbeta_elem = if agexact_compatibility {
+                        (*newbeta_elem + beta_elem) / 2.0
+                    } else {
+                        (*newbeta_elem + (halving as f64) * beta_elem) / (halving as f64 + 1.0)
+                    };
                 }
             } else {
                 halving = 0;
@@ -947,8 +1286,16 @@ impl CoxFit {
                 }
             }
         }
+        if agexact_compatibility {
+            self.loglik[1] = newlk;
+            self.beta.copy_from_slice(&newbeta);
+            Self::chinv(&mut self.imat);
+            self.rescale_params();
+            self.flag = CONVERGENCE_FLAG;
+            return Ok(());
+        }
         let beta_final = self.beta.clone();
-        self.loglik[1] = self.iterate(&beta_final)?;
+        self.loglik[1] = self.iterate_with_mode(&beta_final, mode)?;
         self.flag = Self::cholesky(&mut self.imat, self.toler);
         Self::chinv(&mut self.imat);
         self.rescale_params();
@@ -1148,6 +1495,27 @@ mod tests {
     }
 
     #[test]
+    fn exact_builder_treats_default_strata_as_one_complete_stratum() {
+        let mut fit = CoxFitBuilder::new(
+            Array1::from_vec(vec![1.0, 2.0, 3.0]),
+            Array1::from_vec(vec![1, 1, 0]),
+            Array2::from_shape_vec((3, 1), vec![0.0, 1.0, 2.0]).unwrap(),
+        )
+        .method(Method::Exact)
+        .max_iter(0)
+        .build()
+        .expect("default-stratum exact fit should initialize");
+
+        fit.fit()
+            .expect("default-stratum exact fit should evaluate");
+        let (_beta, _means, score, variance, loglik, ..) = fit.results();
+
+        assert!(loglik[0] < 0.0);
+        assert!(score[0].is_finite());
+        assert!(variance[(0, 0)].is_finite());
+    }
+
+    #[test]
     fn test_cox_fit_and_results() {
         let time = Array1::from_vec(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]);
         let status = Array1::from_vec(vec![1, 0, 1, 0, 1, 0, 1, 0]);
@@ -1241,20 +1609,6 @@ mod tests {
     }
 
     #[test]
-    fn exact_tied_moments_match_hand_computed_two_death_set() {
-        let covar = Array2::from_shape_vec((3, 2), vec![1.0, 0.0, 0.0, 2.0, 3.0, 4.0]).unwrap();
-
-        let (denom, score, information) =
-            exact_tied_moments(&[0, 1, 2], 2, &[2.0, 3.0, 5.0], &covar);
-
-        assert_eq!(denom, 31.0);
-        assert_eq!(score, vec![91.0, 142.0]);
-        assert_eq!(information[(0, 0)], 301.0);
-        assert_eq!(information[(1, 0)], 442.0);
-        assert_eq!(information[(1, 1)], 724.0);
-    }
-
-    #[test]
     fn counting_process_tied_methods_fit_with_entry_times() {
         for method in [Method::Efron, Method::Exact] {
             let mut cox = CoxFit::new_with_entry_times(
@@ -1314,6 +1668,74 @@ mod tests {
         assert_eq!(fit.u, first_score);
         assert_eq!(fit.imat, first_information);
         assert_eq!(fit.entry_order, cached_order);
+    }
+
+    #[test]
+    fn exact_counting_process_falls_back_when_moment_subtraction_cancels() {
+        let mut fit = CoxFit::new_with_entry_times(
+            Array1::from_vec(vec![1.0, 2.0, 2.0]),
+            Array1::from_vec(vec![1, 0, 0]),
+            Array2::from_shape_vec((3, 1), vec![1.0, 1.0, 1e16]).unwrap(),
+            Some(Array1::from_vec(vec![0.0, 0.0, 1.0])),
+            Array1::from_vec(vec![0, 0, 1]),
+            Array1::zeros(3),
+            Array1::ones(3),
+            Method::Exact,
+            0,
+            1e-9,
+            1e-9,
+            vec![false],
+            vec![0.0],
+        )
+        .expect("cancellation fixture should initialize");
+
+        let loglik = fit
+            .iterate(&[0.0])
+            .expect("exact cancellation fixture should evaluate");
+
+        assert!((loglik + 2.0_f64.ln()).abs() < 1e-14);
+        assert_eq!(fit.u, vec![0.0]);
+        assert_eq!(fit.imat[(0, 0)], 0.0);
+    }
+
+    #[test]
+    fn large_compatibility_sweep_matches_sequential_exact_evaluation() {
+        let n = EXACT_COMPATIBILITY_DIRECT_THRESHOLD + 1;
+        let build = || {
+            CoxFit::new_with_entry_times(
+                Array1::from_vec((1..=n).map(|value| value as f64).collect()),
+                Array1::ones(n),
+                Array2::from_shape_vec(
+                    (n, 1),
+                    (0..n).map(|value| (value % 11) as f64 - 5.0).collect(),
+                )
+                .unwrap(),
+                Some(Array1::zeros(n)),
+                Array1::from_vec(vec![0; n]),
+                Array1::from_vec((0..n).map(|value| (value % 5) as f64 / 20.0).collect()),
+                Array1::ones(n),
+                Method::Exact,
+                0,
+                1e-9,
+                1e-9,
+                vec![false],
+                vec![0.0],
+            )
+            .expect("large exact comparison fixture should initialize")
+        };
+        let beta = [0.15];
+        let mut swept = build();
+        let swept_loglik = swept
+            .iterate_counting_process_exact(&beta)
+            .expect("swept exact evaluation should succeed");
+        let mut sequential = build();
+        let sequential_loglik = sequential
+            .iterate_counting_process_exact_compatibility(&beta)
+            .expect("sequential exact evaluation should succeed");
+
+        assert!((swept_loglik - sequential_loglik).abs() < 1e-12);
+        assert!((swept.u[0] - sequential.u[0]).abs() < 1e-12);
+        assert!((swept.imat[(0, 0)] - sequential.imat[(0, 0)]).abs() < 1e-11);
     }
 
     #[test]

--- a/src/regression/coxph_diagnostics.rs
+++ b/src/regression/coxph_diagnostics.rs
@@ -1,9 +1,10 @@
 use crate::constants::{EXP_CLAMP_MAX, EXP_CLAMP_MIN, same_time};
-use crate::regression::cox_optimizer::{Method as CoxMethod, exact_tied_moments};
+use crate::regression::cox_optimizer::Method as CoxMethod;
 use crate::regression::coxph::CoxPHFit;
 use crate::regression::coxph_support::{
     ActiveRiskSet, CoxSweepRow, StratifiedBaselineLookup, cumulative_step_at,
 };
+use crate::regression::exact_ties::{exact_inclusion_probabilities, exact_tied_moments};
 use crate::scoring::coxscore2::{CoxScoreData, CoxScoreParams, compute_cox_score_residuals};
 use ndarray::Array2;
 use pyo3::prelude::*;
@@ -508,60 +509,6 @@ impl CoxPHFit {
         }
     }
 
-    fn exact_inclusion_weights(
-        risk_indices: &[usize],
-        deaths: usize,
-        risk: &[f64],
-    ) -> Option<Vec<(usize, f64)>> {
-        if deaths == 0 || deaths > risk_indices.len() {
-            return None;
-        }
-        let n_risk = risk_indices.len();
-        let mut prefix = vec![vec![0.0; deaths + 1]; n_risk + 1];
-        prefix[0][0] = 1.0;
-        for pos in 0..n_risk {
-            let (previous_rows, current_rows) = prefix.split_at_mut(pos + 1);
-            let previous = &previous_rows[pos];
-            let current = &mut current_rows[0];
-            current.copy_from_slice(previous);
-            let value = risk[risk_indices[pos]];
-            for size in 1..=deaths.min(pos + 1) {
-                current[size] += value * previous[size - 1];
-            }
-        }
-        let mut suffix = vec![vec![0.0; deaths + 1]; n_risk + 1];
-        suffix[n_risk][0] = 1.0;
-        for pos in (0..n_risk).rev() {
-            let (current_rows, following_rows) = suffix.split_at_mut(pos + 1);
-            let current = &mut current_rows[pos];
-            let following = &following_rows[0];
-            current.copy_from_slice(following);
-            let value = risk[risk_indices[pos]];
-            for size in 1..=deaths.min(n_risk - pos) {
-                current[size] += value * following[size - 1];
-            }
-        }
-        let denom = prefix[n_risk][deaths];
-        if denom <= 0.0 {
-            return None;
-        }
-        Some(
-            (0..n_risk)
-                .map(|pos| {
-                    let mut excluded = 0.0;
-                    for (left_size, prefix_value) in prefix[pos].iter().take(deaths).enumerate() {
-                        let right_size = deaths - 1 - left_size;
-                        excluded += *prefix_value * suffix[pos + 1][right_size];
-                    }
-                    (
-                        risk_indices[pos],
-                        risk[risk_indices[pos]] * excluded / denom,
-                    )
-                })
-                .collect(),
-        )
-    }
-
     pub(crate) fn score_residuals_internal(&self) -> PyResult<Vec<Vec<f64>>> {
         let beta = self.coefficients.first().ok_or_else(|| {
             pyo3::exceptions::PyValueError::new_err("model has no fitted coefficients")
@@ -602,6 +549,14 @@ impl CoxPHFit {
         y.extend(order.iter().map(|&idx| self.event_times[idx]));
         y.extend(order.iter().map(|&idx| self.status[idx] as f64));
         let strata: Vec<i32> = order.iter().map(|&idx| self.strata[idx]).collect();
+        let weights: Vec<f64> = order.iter().map(|&idx| self.weights[idx]).collect();
+        if matches!(tie_method, CoxMethod::Exact) {
+            let log_risk: Vec<f64> = order
+                .iter()
+                .map(|&idx| self.linear_predictors[idx] + self.weights[idx].ln())
+                .collect();
+            return Ok(self.score_residuals_exact_right_censored(nvar, &order, &log_risk));
+        }
         let score: Vec<f64> = order
             .iter()
             .map(|&idx| {
@@ -610,16 +565,10 @@ impl CoxPHFit {
                     .exp()
             })
             .collect();
-        let weights: Vec<f64> = order.iter().map(|&idx| self.weights[idx]).collect();
         let mut covar = Vec::with_capacity(n * nvar);
         for &idx in &order {
             covar.extend(self.covariates[idx].iter().copied());
         }
-
-        if matches!(tie_method, CoxMethod::Exact) {
-            return Ok(self.score_residuals_exact_right_censored(nvar, &order, &score, &weights));
-        }
-
         let flat = compute_cox_score_residuals(
             CoxScoreData {
                 y: &y,
@@ -643,15 +592,9 @@ impl CoxPHFit {
         &self,
         nvar: usize,
         order: &[usize],
-        score: &[f64],
-        weights: &[f64],
+        log_risk: &[f64],
     ) -> Vec<Vec<f64>> {
         let n = self.event_times.len();
-        let risk: Vec<f64> = order
-            .iter()
-            .enumerate()
-            .map(|(sorted_idx, _)| score[sorted_idx] * weights[sorted_idx])
-            .collect();
         let mut residuals = vec![vec![0.0; nvar]; n];
         let mut stratum_start = 0usize;
         while stratum_start < order.len() {
@@ -687,7 +630,7 @@ impl CoxPHFit {
                         }
                     }
                     if let Some(inclusion_weights) =
-                        Self::exact_inclusion_weights(&risk_indices, deaths.len(), &risk)
+                        exact_inclusion_probabilities(&risk_indices, deaths.len(), log_risk)
                     {
                         for (sorted_idx, inclusion_weight) in inclusion_weights {
                             let original_idx = order[sorted_idx];
@@ -727,6 +670,21 @@ impl CoxPHFit {
             ));
         }
 
+        let order = diagnostic_order(&self.strata, &self.event_times);
+
+        if method == 2 {
+            let log_risk: Vec<f64> = (0..n)
+                .map(|idx| self.linear_predictors[idx] + self.weights[idx].ln())
+                .collect();
+            return Ok(self.score_residuals_counting_process_by_scan(
+                nvar,
+                method,
+                &log_risk,
+                &order,
+                entry_times,
+            ));
+        }
+
         let risk: Vec<f64> = (0..n)
             .map(|idx| {
                 self.linear_predictors[idx]
@@ -735,18 +693,6 @@ impl CoxPHFit {
                     * self.weights[idx]
             })
             .collect();
-        let order = diagnostic_order(&self.strata, &self.event_times);
-
-        if method == 2 {
-            return Ok(self.score_residuals_counting_process_by_scan(
-                nvar,
-                method,
-                &risk,
-                &order,
-                entry_times,
-            ));
-        }
-
         Ok(self.score_residuals_counting_process_sweep(nvar, method, &risk, &order, entry_times))
     }
 
@@ -795,8 +741,7 @@ impl CoxPHFit {
                     risk_indices.extend(stratum_indices.iter().copied().filter(|&idx| {
                         entry_times[idx] < event_time && self.event_times[idx] >= event_time
                     }));
-                    let denom: f64 = risk_indices.iter().map(|&idx| risk[idx]).sum();
-                    if denom > 0.0 {
+                    if method == 2 {
                         for &idx in &deaths {
                             for (col_idx, residual) in
                                 residuals[idx].iter_mut().enumerate().take(nvar)
@@ -804,50 +749,59 @@ impl CoxPHFit {
                                 *residual += self.weights[idx] * self.covariates[idx][col_idx];
                             }
                         }
-                        if method == 2 {
-                            if let Some(inclusion_weights) =
-                                Self::exact_inclusion_weights(&risk_indices, deaths.len(), risk)
-                            {
-                                for (idx, inclusion_weight) in inclusion_weights {
-                                    for (col_idx, residual) in
-                                        residuals[idx].iter_mut().enumerate().take(nvar)
-                                    {
-                                        *residual -=
-                                            inclusion_weight * self.covariates[idx][col_idx];
-                                    }
-                                }
-                            }
-                        } else if method == 0 || deaths.len() == 1 {
-                            let deadwt: f64 = deaths.iter().map(|&idx| self.weights[idx]).sum();
-                            for &idx in &risk_indices {
-                                let factor = risk[idx] * deadwt / denom;
+                        if let Some(inclusion_weights) =
+                            exact_inclusion_probabilities(&risk_indices, deaths.len(), risk)
+                        {
+                            for (idx, inclusion_weight) in inclusion_weights {
                                 for (col_idx, residual) in
                                     residuals[idx].iter_mut().enumerate().take(nvar)
                                 {
-                                    *residual -= factor * self.covariates[idx][col_idx];
+                                    *residual -= inclusion_weight * self.covariates[idx][col_idx];
                                 }
                             }
-                        } else {
-                            let death_count = deaths.len();
-                            let deaths_f = death_count as f64;
-                            let deadwt: f64 = deaths.iter().map(|&idx| self.weights[idx]).sum();
-                            let weight_average = deadwt / deaths_f;
-                            let death_risk: f64 = deaths.iter().map(|&idx| risk[idx]).sum();
-                            for step in 0..death_count {
-                                let fraction = step as f64 / deaths_f;
-                                let step_denom = denom - fraction * death_risk;
-                                if step_denom <= 0.0 {
-                                    continue;
+                        }
+                    } else {
+                        let denom: f64 = risk_indices.iter().map(|&idx| risk[idx]).sum();
+                        if denom > 0.0 {
+                            for &idx in &deaths {
+                                for (col_idx, residual) in
+                                    residuals[idx].iter_mut().enumerate().take(nvar)
+                                {
+                                    *residual += self.weights[idx] * self.covariates[idx][col_idx];
                                 }
+                            }
+                            if method == 0 || deaths.len() == 1 {
+                                let deadwt: f64 = deaths.iter().map(|&idx| self.weights[idx]).sum();
                                 for &idx in &risk_indices {
-                                    let multiplier =
-                                        if is_death[idx] { 1.0 - fraction } else { 1.0 };
-                                    let factor =
-                                        weight_average * risk[idx] * multiplier / step_denom;
+                                    let factor = risk[idx] * deadwt / denom;
                                     for (col_idx, residual) in
                                         residuals[idx].iter_mut().enumerate().take(nvar)
                                     {
                                         *residual -= factor * self.covariates[idx][col_idx];
+                                    }
+                                }
+                            } else {
+                                let death_count = deaths.len();
+                                let deaths_f = death_count as f64;
+                                let deadwt: f64 = deaths.iter().map(|&idx| self.weights[idx]).sum();
+                                let weight_average = deadwt / deaths_f;
+                                let death_risk: f64 = deaths.iter().map(|&idx| risk[idx]).sum();
+                                for step in 0..death_count {
+                                    let fraction = step as f64 / deaths_f;
+                                    let step_denom = denom - fraction * death_risk;
+                                    if step_denom <= 0.0 {
+                                        continue;
+                                    }
+                                    for &idx in &risk_indices {
+                                        let multiplier =
+                                            if is_death[idx] { 1.0 - fraction } else { 1.0 };
+                                        let factor =
+                                            weight_average * risk[idx] * multiplier / step_denom;
+                                        for (col_idx, residual) in
+                                            residuals[idx].iter_mut().enumerate().take(nvar)
+                                        {
+                                            *residual -= factor * self.covariates[idx][col_idx];
+                                        }
                                     }
                                 }
                             }
@@ -1146,6 +1100,10 @@ impl CoxPHFit {
                     * self.weights[idx]
             })
             .collect();
+        let sorted_log_risk: Vec<f64> = order
+            .iter()
+            .map(|&idx| self.linear_predictors[idx] + self.weights[idx].ln())
+            .collect();
         let mut covar = Array2::<f64>::zeros((n, nvar));
         for (row_idx, &source_idx) in order.iter().enumerate() {
             for col_idx in 0..nvar {
@@ -1185,17 +1143,15 @@ impl CoxPHFit {
                         sorted_start[idx] < event_time && sorted_time[idx] >= event_time
                     }));
                     mean.fill(0.0);
-                    if matches!(method, CoxMethod::Exact) && death_indices.len() > 1 {
-                        let (denom, a, _cmat) = exact_tied_moments(
+                    if matches!(method, CoxMethod::Exact) {
+                        let moments = exact_tied_moments(
                             &risk_indices,
                             death_indices.len(),
-                            &sorted_risk,
+                            &sorted_log_risk,
                             &covar,
                         );
-                        if denom > 0.0 {
-                            for col_idx in 0..nvar {
-                                mean[col_idx] = a[col_idx] / denom / death_indices.len() as f64;
-                            }
+                        for (value, &expected_sum) in mean.iter_mut().zip(&moments.mean) {
+                            *value = expected_sum / death_indices.len() as f64;
                         }
                     } else {
                         let mut denom = 0.0;
@@ -1600,7 +1556,8 @@ mod tests {
 
     #[test]
     fn exact_inclusion_weights_match_pairwise_tie_probabilities() {
-        let inclusion = CoxPHFit::exact_inclusion_weights(&[0, 1, 2], 2, &[2.0, 3.0, 5.0])
+        let log_risk = [2.0_f64.ln(), 3.0_f64.ln(), 5.0_f64.ln()];
+        let inclusion = exact_inclusion_probabilities(&[0, 1, 2], 2, &log_risk)
             .expect("two deaths among three risk scores should compute");
 
         assert_eq!(inclusion.len(), 3);
@@ -1608,5 +1565,68 @@ mod tests {
         assert!((inclusion[1].1 - 21.0 / 31.0).abs() < 1e-12);
         assert!((inclusion[2].1 - 25.0 / 31.0).abs() < 1e-12);
         assert!((inclusion.iter().map(|(_, value)| value).sum::<f64>() - 2.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn exact_diagnostics_are_invariant_to_common_large_log_risk_shifts() {
+        let fit = CoxPHFit {
+            coefficients: vec![vec![0.0]],
+            means: vec![0.0],
+            score_vector: vec![0.0],
+            information_matrix: vec![vec![0.0]],
+            log_likelihood: vec![0.0, 0.0],
+            score_test: 0.0,
+            convergence_flag: 0,
+            iterations: 0,
+            risk_scores: vec![0.0; 3],
+            event_times: vec![1.0, 1.0, 1.0],
+            status: vec![1, 1, 0],
+            linear_predictors: vec![1_000.0, 900.0, 800.0],
+            entry_times: None,
+            weights: vec![1.0; 3],
+            covariates: vec![vec![0.0], vec![1.0], vec![2.0]],
+            strata: vec![0; 3],
+            method: "exact".to_string(),
+            nocenter: Vec::new(),
+        };
+        let mut shifted = fit.clone();
+        for value in &mut shifted.linear_predictors {
+            *value -= 1_000.0;
+        }
+
+        let schoenfeld = fit
+            .schoenfeld_residuals_internal()
+            .expect("large exact Schoenfeld residuals should compute");
+        let shifted_schoenfeld = shifted
+            .schoenfeld_residuals_internal()
+            .expect("shifted exact Schoenfeld residuals should compute");
+        let score = fit
+            .score_residuals_internal()
+            .expect("large exact score residuals should compute");
+        let shifted_score = shifted
+            .score_residuals_internal()
+            .expect("shifted exact score residuals should compute");
+        let mut counting = fit.clone();
+        counting.entry_times = Some(vec![0.0; 3]);
+        let mut shifted_counting = shifted.clone();
+        shifted_counting.entry_times = Some(vec![0.0; 3]);
+        let counting_score = counting
+            .score_residuals_internal()
+            .expect("large counting-process exact score residuals should compute");
+        let shifted_counting_score = shifted_counting
+            .score_residuals_internal()
+            .expect("shifted counting-process exact score residuals should compute");
+
+        assert!((schoenfeld[0][0] + 0.5).abs() < 1e-12);
+        assert!((schoenfeld[1][0] - 0.5).abs() < 1e-12);
+        for (actual, expected) in schoenfeld.iter().zip(&shifted_schoenfeld) {
+            assert!((actual[0] - expected[0]).abs() < 1e-12);
+        }
+        for (actual, expected) in score.iter().zip(&shifted_score) {
+            assert!((actual[0] - expected[0]).abs() < 1e-12);
+        }
+        for (actual, expected) in counting_score.iter().zip(&shifted_counting_score) {
+            assert!((actual[0] - expected[0]).abs() < 1e-12);
+        }
     }
 }

--- a/src/regression/exact_ties.rs
+++ b/src/regression/exact_ties.rs
@@ -1,0 +1,333 @@
+use ndarray::Array2;
+
+pub(crate) struct ExactTiedMoments {
+    pub log_denom: f64,
+    pub mean: Vec<f64>,
+    pub covariance: Array2<f64>,
+}
+
+pub(crate) struct ExactRiskAccumulator {
+    pub log_denom: f64,
+    pub mean: Vec<f64>,
+    pub covariance: Array2<f64>,
+    delta: Vec<f64>,
+}
+
+impl ExactRiskAccumulator {
+    pub fn new(nvar: usize) -> Self {
+        Self {
+            log_denom: f64::NEG_INFINITY,
+            mean: vec![0.0; nvar],
+            covariance: Array2::zeros((nvar, nvar)),
+            delta: vec![0.0; nvar],
+        }
+    }
+
+    pub fn add(&mut self, person: usize, log_weight: f64, covar: &Array2<f64>) {
+        if self.log_denom == f64::NEG_INFINITY {
+            self.log_denom = log_weight;
+            for variable in 0..self.mean.len() {
+                self.mean[variable] = covar[(person, variable)];
+            }
+            return;
+        }
+
+        let total_log_weight = log_add_exp(self.log_denom, log_weight);
+        let added_fraction = (log_weight - total_log_weight).exp();
+        let existing_fraction = 1.0 - added_fraction;
+        for (variable, difference) in self.delta.iter_mut().enumerate() {
+            *difference = covar[(person, variable)] - self.mean[variable];
+        }
+        for row in 0..self.mean.len() {
+            for column in 0..self.mean.len() {
+                self.covariance[(row, column)] = existing_fraction * self.covariance[(row, column)]
+                    + existing_fraction * added_fraction * self.delta[row] * self.delta[column];
+            }
+        }
+        for (mean, &difference) in self.mean.iter_mut().zip(&self.delta) {
+            *mean += added_fraction * difference;
+        }
+        self.log_denom = total_log_weight;
+    }
+}
+
+fn log_add_exp(lhs: f64, rhs: f64) -> f64 {
+    if lhs == f64::NEG_INFINITY {
+        return rhs;
+    }
+    if rhs == f64::NEG_INFINITY {
+        return lhs;
+    }
+    let largest = lhs.max(rhs);
+    largest + ((lhs - largest).exp() + (rhs - largest).exp()).ln()
+}
+
+/// Marginal probability that each row is included in an exact tied-death set.
+pub(crate) fn exact_inclusion_probabilities(
+    risk_indices: &[usize],
+    deaths: usize,
+    log_risk: &[f64],
+) -> Option<Vec<(usize, f64)>> {
+    if deaths == 0 || deaths > risk_indices.len() {
+        return None;
+    }
+    let shift = risk_indices
+        .iter()
+        .map(|&person| log_risk[person])
+        .fold(f64::NEG_INFINITY, f64::max);
+    if !shift.is_finite() {
+        return None;
+    }
+
+    let n_risk = risk_indices.len();
+    let mut prefix = vec![vec![f64::NEG_INFINITY; deaths + 1]; n_risk + 1];
+    prefix[0][0] = 0.0;
+    for pos in 0..n_risk {
+        let (previous_rows, current_rows) = prefix.split_at_mut(pos + 1);
+        let previous = &previous_rows[pos];
+        let current = &mut current_rows[0];
+        current.copy_from_slice(previous);
+        let log_weight = log_risk[risk_indices[pos]] - shift;
+        for size in 1..=deaths.min(pos + 1) {
+            current[size] = log_add_exp(current[size], previous[size - 1] + log_weight);
+        }
+    }
+
+    let mut suffix = vec![vec![f64::NEG_INFINITY; deaths + 1]; n_risk + 1];
+    suffix[n_risk][0] = 0.0;
+    for pos in (0..n_risk).rev() {
+        let (current_rows, following_rows) = suffix.split_at_mut(pos + 1);
+        let current = &mut current_rows[pos];
+        let following = &following_rows[0];
+        current.copy_from_slice(following);
+        let log_weight = log_risk[risk_indices[pos]] - shift;
+        for size in 1..=deaths.min(n_risk - pos) {
+            current[size] = log_add_exp(current[size], following[size - 1] + log_weight);
+        }
+    }
+
+    let log_denom = prefix[n_risk][deaths];
+    if !log_denom.is_finite() {
+        return None;
+    }
+    Some(
+        (0..n_risk)
+            .map(|pos| {
+                let mut excluded_log_weight = f64::NEG_INFINITY;
+                for (left_size, &left_log_weight) in prefix[pos].iter().take(deaths).enumerate() {
+                    let right_size = deaths - 1 - left_size;
+                    excluded_log_weight = log_add_exp(
+                        excluded_log_weight,
+                        left_log_weight + suffix[pos + 1][right_size],
+                    );
+                }
+                let log_weight = log_risk[risk_indices[pos]] - shift;
+                (
+                    risk_indices[pos],
+                    (log_weight + excluded_log_weight - log_denom)
+                        .exp()
+                        .clamp(0.0, 1.0),
+                )
+            })
+            .collect(),
+    )
+}
+
+/// Exact conditional moments for selecting `deaths` rows from a risk set.
+///
+/// The dynamic program stores each subset-size distribution as a log total,
+/// mean, and central covariance. This avoids enumerating subsets, raw moment
+/// cancellation, and overflow when the number of possible subsets is large.
+pub(crate) fn exact_tied_moments(
+    risk_indices: &[usize],
+    deaths: usize,
+    log_risk: &[f64],
+    covar: &Array2<f64>,
+) -> ExactTiedMoments {
+    let nvar = covar.ncols();
+    let states = deaths + 1;
+    let mut log_denoms = vec![f64::NEG_INFINITY; states];
+    let mut means = vec![0.0; states * nvar];
+    let mut covariances = vec![0.0; states * nvar * nvar];
+    let mut delta = vec![0.0; nvar];
+    log_denoms[0] = 0.0;
+
+    for (seen, &person) in risk_indices.iter().enumerate() {
+        let max_size = deaths.min(seen + 1);
+        for size in (1..=max_size).rev() {
+            let added_log_weight = log_denoms[size - 1] + log_risk[person];
+            if added_log_weight == f64::NEG_INFINITY {
+                continue;
+            }
+
+            let existing_log_weight = log_denoms[size];
+            let total_log_weight = log_add_exp(existing_log_weight, added_log_weight);
+            let added_fraction = (added_log_weight - total_log_weight).exp();
+            let existing_fraction = 1.0 - added_fraction;
+            let current_mean_offset = size * nvar;
+            let previous_mean_offset = (size - 1) * nvar;
+
+            for variable in 0..nvar {
+                delta[variable] = means[previous_mean_offset + variable]
+                    + covar[(person, variable)]
+                    - means[current_mean_offset + variable];
+            }
+
+            let current_covariance_offset = size * nvar * nvar;
+            let previous_covariance_offset = (size - 1) * nvar * nvar;
+            for row in 0..nvar {
+                for column in 0..nvar {
+                    let current = current_covariance_offset + row * nvar + column;
+                    let previous = previous_covariance_offset + row * nvar + column;
+                    covariances[current] = existing_fraction * covariances[current]
+                        + added_fraction * covariances[previous]
+                        + existing_fraction * added_fraction * delta[row] * delta[column];
+                }
+            }
+            for variable in 0..nvar {
+                means[current_mean_offset + variable] += added_fraction * delta[variable];
+            }
+            log_denoms[size] = total_log_weight;
+        }
+    }
+
+    let mean_offset = deaths * nvar;
+    let covariance_offset = deaths * nvar * nvar;
+    let mut covariance = Array2::zeros((nvar, nvar));
+    for row in 0..nvar {
+        for column in 0..nvar {
+            covariance[(row, column)] = covariances[covariance_offset + row * nvar + column];
+        }
+    }
+
+    ExactTiedMoments {
+        log_denom: log_denoms[deaths],
+        mean: means[mean_offset..mean_offset + nvar].to_vec(),
+        covariance,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_close(actual: f64, expected: f64, tolerance: f64) {
+        assert!(
+            (actual - expected).abs() < tolerance,
+            "expected {expected:.16e}, got {actual:.16e}"
+        );
+    }
+
+    #[test]
+    fn moments_match_hand_computed_two_death_set() {
+        let covar = Array2::from_shape_vec((3, 2), vec![1.0, 0.0, 0.0, 2.0, 3.0, 4.0]).unwrap();
+        let log_risk = [2.0_f64.ln(), 3.0_f64.ln(), 5.0_f64.ln()];
+
+        let moments = exact_tied_moments(&[0, 1, 2], 2, &log_risk, &covar);
+
+        assert_close(moments.log_denom, 31.0_f64.ln(), 1e-14);
+        assert_close(moments.mean[0], 91.0 / 31.0, 1e-14);
+        assert_close(moments.mean[1], 142.0 / 31.0, 1e-14);
+        assert_close(
+            moments.covariance[(0, 0)],
+            301.0 / 31.0 - (91.0 / 31.0_f64).powi(2),
+            1e-14,
+        );
+        assert_close(
+            moments.covariance[(1, 0)],
+            442.0 / 31.0 - 91.0 * 142.0 / 31.0_f64.powi(2),
+            1e-14,
+        );
+        assert_close(
+            moments.covariance[(1, 1)],
+            724.0 / 31.0 - (142.0 / 31.0_f64).powi(2),
+            1e-14,
+        );
+    }
+
+    #[test]
+    fn log_weight_shift_changes_only_the_denominator() {
+        let covar = Array2::from_shape_vec((4, 1), vec![-1.0, 0.5, 2.0, 4.0]).unwrap();
+        let base_logs = vec![-2.0, -0.5, 0.25, 1.5];
+        let shifted_logs: Vec<f64> = base_logs.iter().map(|value| value + 1_000.0).collect();
+
+        let base = exact_tied_moments(&[0, 1, 2, 3], 2, &base_logs, &covar);
+        let shifted = exact_tied_moments(&[0, 1, 2, 3], 2, &shifted_logs, &covar);
+
+        assert_close(shifted.log_denom - base.log_denom, 2_000.0, 1e-12);
+        assert_close(shifted.mean[0], base.mean[0], 1e-12);
+        assert_close(shifted.covariance[(0, 0)], base.covariance[(0, 0)], 1e-12);
+    }
+
+    #[test]
+    fn singleton_accumulator_matches_dynamic_programming() {
+        let covar = Array2::from_shape_vec((4, 2), vec![-1.0, 0.25, 0.5, 2.0, 2.0, -0.5, 4.0, 1.5])
+            .unwrap();
+        let log_risk = vec![998.0, 999.5, 1_000.25, 1_001.5];
+        let expected = exact_tied_moments(&[0, 1, 2, 3], 1, &log_risk, &covar);
+        let mut actual = ExactRiskAccumulator::new(2);
+        for (person, &log_weight) in log_risk.iter().enumerate() {
+            actual.add(person, log_weight, &covar);
+        }
+
+        assert_close(actual.log_denom, expected.log_denom, 1e-12);
+        for variable in 0..2 {
+            assert_close(actual.mean[variable], expected.mean[variable], 1e-12);
+            for other in 0..2 {
+                assert_close(
+                    actual.covariance[(variable, other)],
+                    expected.covariance[(variable, other)],
+                    1e-12,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn inclusion_probabilities_match_pairwise_weights_and_log_shifts() {
+        let base_logs = vec![2.0_f64.ln(), 3.0_f64.ln(), 5.0_f64.ln()];
+        let shifted_logs: Vec<f64> = base_logs.iter().map(|value| value + 1_000.0).collect();
+        let expected = [16.0 / 31.0, 21.0 / 31.0, 25.0 / 31.0];
+
+        let base = exact_inclusion_probabilities(&[0, 1, 2], 2, &base_logs)
+            .expect("pairwise inclusion probabilities should compute");
+        let shifted = exact_inclusion_probabilities(&[0, 1, 2], 2, &shifted_logs)
+            .expect("shifted inclusion probabilities should compute");
+
+        for (((_, base_value), (_, shifted_value)), expected_value) in
+            base.iter().zip(&shifted).zip(expected)
+        {
+            assert_close(*base_value, expected_value, 1e-12);
+            assert_close(*shifted_value, expected_value, 1e-12);
+        }
+        assert_close(base.iter().map(|(_, value)| value).sum(), 2.0, 1e-12);
+    }
+
+    #[test]
+    fn selecting_the_entire_risk_set_has_zero_covariance() {
+        let covar = Array2::from_shape_vec((3, 1), vec![0.2, 1.5, -0.4]).unwrap();
+        let log_risk = vec![700.0, -700.0, 0.0];
+
+        let moments = exact_tied_moments(&[0, 1, 2], 3, &log_risk, &covar);
+
+        assert_close(moments.log_denom, 0.0, 1e-12);
+        assert_close(moments.mean[0], 1.3, 1e-12);
+        assert_eq!(moments.covariance[(0, 0)], 0.0);
+    }
+
+    #[test]
+    fn large_balanced_tie_remains_finite() {
+        let n = 1_050;
+        let deaths = n / 2;
+        let covar =
+            Array2::from_shape_vec((n, 1), (0..n).map(|idx| (idx % 2) as f64).collect()).unwrap();
+        let log_risk = vec![0.0; n];
+
+        let moments = exact_tied_moments(&(0..n).collect::<Vec<_>>(), deaths, &log_risk, &covar);
+
+        assert!(moments.log_denom.is_finite());
+        assert!(moments.mean[0].is_finite());
+        assert!(moments.covariance[(0, 0)].is_finite());
+        assert!(moments.covariance[(0, 0)] > 0.0);
+    }
+}

--- a/src/regression/mod.rs
+++ b/src/regression/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod coxph_model;
 pub(crate) mod coxph_support;
 pub(crate) mod cure_models;
 pub(crate) mod elastic_net;
+pub(crate) mod exact_ties;
 #[path = "fast_cox/mod.rs"]
 pub(crate) mod fast_cox_module;
 pub(crate) mod finegray_data;


### PR DESCRIPTION
## Summary
- replace the low-level exact counting-process fitter with a compatibility adapter over the shared Cox optimizer
- add stable log-space tied-set moments and inclusion probabilities, plus a linear singleton sweep with cancellation fallbacks
- route the R `agexact.fit` bridge through the compatibility path while preserving residuals, signed times, strata, and iteration warnings
- stabilize exact Schoenfeld and score residuals for extreme finite linear predictors
- add reference fixtures and tied/untied performance benchmarks

## Root cause
The previous low-level fitter skipped the initial Newton update, evaluated the score test from the wrong state, and enumerated tied subsets. Shared exact diagnostics also converted or clamped risks before exact calculations, losing relative-risk information at extreme predictors.

## Impact
Exact tied fits now avoid combinatorial enumeration, large untied fits use a near-linear sweep, delayed-entry cancellation falls back to stable log-space evaluation, and Python/R outputs follow the reference iteration semantics.

## Performance
- tied 24-row risk set with 12 deaths: about 5.6 µs median
- untied 1,000 / 2,000 / 4,000 rows: about 66 / 111 / 175 µs medians

## Validation
- `cargo test --no-default-features` — 1,334 passed
- `cargo test --features ml` — 1,543 passed
- `PYO3_PYTHON=.venv/bin/python cargo test --features python,ml` — 1,545 passed
- `.venv/bin/python -m pytest python/tests -q` — 802 passed
- `cargo clippy` across core, ML, and Python+ML feature sets
- Rust formatting, documentation warnings, Ruff, mypy, and generated binding checks
- benchmark target compilation
- `R CMD check --no-manual --no-build-vignettes r/survivalr` — tests pass; expected source-package note only