### PR TITLE
Add R-compatible multi-state survfit curves

### DIFF
--- a/python/survival/__init__.py
+++ b/python/survival/__init__.py
@@ -59,6 +59,7 @@ _R_EXPORTS = [
     "SurvObrienResult",
     "SurvExpResult",
     "SurvfitConfidenceIntervalResult",
+    "SurvfitMultiStateResult",
     "TcutResult",
     "YatesPairwiseResult",
     "YatesResult",

--- a/python/survival/__init__.pyi
+++ b/python/survival/__init__.pyi
@@ -36,6 +36,7 @@ from .r_api import (
     Surv2data,
     SurvExpResult,
     SurvfitConfidenceIntervalResult,
+    SurvfitMultiStateResult,
     SurvObrienResult,
     TcutResult,
     YatesPairwiseResult,

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -131,7 +131,8 @@ _EXP_CLAMP_MAX = 709.0
 _SURVFIT_TIME_EPSILON = 1e-9
 _VARIANCE_SCALE_FLOOR = 1e-12
 _COX_DFBETAS_SCALE_FLOOR = 1e-10
-_SURV_TYPES = ("right", "left", "interval", "counting", "interval2")
+_SURV_TYPES = ("right", "left", "interval", "counting", "interval2", "mstate")
+_SURV_RESPONSE_TYPES = (*_SURV_TYPES[:-1], "mright", "mcounting")
 
 FineGrayOutput = _core.FineGrayOutput
 RateTable = _core.RateTable
@@ -811,6 +812,47 @@ def _event_vector(values: Any, name: str) -> list[int]:
     if observed <= {1, 2}:
         return [int(value == 2) for value in events]
     raise ValueError(f"{name} must use 0/1 or 1/2 event coding")
+
+
+def _mstate_event_label(value: Any) -> str:
+    if isinstance(value, bool):
+        return "TRUE" if value else "FALSE"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        return _surv_format_number(value)
+    return str(value)
+
+
+def _mstate_inferred_levels(values: Sequence[Any]) -> list[str]:
+    observed = [value for value in values if not _is_missing_value(value)]
+    labels = {_mstate_event_label(value) for value in observed}
+    if observed and all(
+        isinstance(value, int | float) and not isinstance(value, bool) for value in observed
+    ):
+        return sorted(labels, key=float)
+    return sorted(labels)
+
+
+def _mstate_event_vector(values: Any, name: str) -> tuple[list[int | None], tuple[str, ...]]:
+    raw = _materialize_1d(values, name)
+    categories = getattr(values, "categories", None)
+    if categories is None:
+        categories = getattr(getattr(values, "dtype", None), "categories", None)
+    if categories is None:
+        levels = _mstate_inferred_levels(raw)
+    else:
+        levels = [
+            _mstate_event_label(value)
+            for value in _materialize_1d(categories, f"{name} categories")
+            if not _is_missing_value(value)
+        ]
+    level_index = {level: idx for idx, level in enumerate(levels)}
+    events = [
+        None if _is_missing_value(value) else level_index[_mstate_event_label(value)]
+        for value in raw
+    ]
+    return events, tuple(levels[1:])
 
 
 def _interval_status_vector(values: Any, name: str) -> list[int]:
@@ -1837,7 +1879,9 @@ def _normalize_surv_type(value: Any) -> str:
         return matches[0]
     if len(matches) > 1:
         raise ValueError("Surv type is ambiguous; use a full type name")
-    raise ValueError("Surv type must be 'right', 'left', 'counting', 'interval', or 'interval2'")
+    raise ValueError(
+        "Surv type must be 'right', 'left', 'counting', 'interval', 'interval2', or 'mstate'"
+    )
 
 
 def _parse_formula_origin_option(value: str) -> float:
@@ -4466,10 +4510,11 @@ class Surv:
     """Survival response container, like R's Surv."""
 
     time: tuple[float, ...]
-    event: tuple[int, ...]
+    event: tuple[int | None, ...]
     start: tuple[float, ...] | None
     time2: tuple[float, ...] | None
     type: str
+    states: tuple[str, ...]
 
     def __init__(  # noqa: A002
         self,
@@ -4502,6 +4547,7 @@ class Surv:
             args = named_args
 
         surv_type = _normalize_surv_type(type) if type is not None else None
+        states: tuple[str, ...] = ()
         origin_value = _finite_float(origin, "origin")
         if len(args) == 1:
             if surv_type is not None:
@@ -4523,6 +4569,11 @@ class Surv:
                     for value in _interval_endpoint_vector(args[1], "time2", float("inf"))
                 ]
                 event = _derive_interval2_status(time, time2)
+            elif surv_type == "mstate":
+                time = [value - origin_value for value in _float_vector(args[0], "time")]
+                time2 = None
+                event, states = _mstate_event_vector(args[1], "event")
+                surv_type = "mright"
             else:
                 time = [value - origin_value for value in _float_vector(args[0], "time")]
                 time2 = None
@@ -4538,6 +4589,12 @@ class Surv:
                 time = [value - origin_value for value in _float_vector(args[0], "time")]
                 time2 = [value - origin_value for value in _float_vector(args[1], "time2")]
                 event = _interval_status_vector(args[2], "event")
+            elif surv_type == "mstate":
+                start = [value - origin_value for value in _float_vector(args[0], "start")]
+                time = [value - origin_value for value in _float_vector(args[1], "stop")]
+                time2 = None
+                event, states = _mstate_event_vector(args[2], "event")
+                surv_type = "mcounting"
             else:
                 start = [value - origin_value for value in _float_vector(args[0], "start")]
                 time = [value - origin_value for value in _float_vector(args[1], "stop")]
@@ -4557,9 +4614,10 @@ class Surv:
             raise ValueError("Surv inputs must have the same length")
         if not time:
             raise ValueError("Surv inputs must not be empty")
-        if surv_type not in _SURV_TYPES:
+        if surv_type not in _SURV_RESPONSE_TYPES:
             raise ValueError(
-                "Surv type must be 'right', 'left', 'counting', 'interval', or 'interval2'"
+                "Surv type must be 'right', 'left', 'counting', 'interval', 'interval2', "
+                "or 'mstate'"
             )
         _validate_surv_intervals(time, time2, event, surv_type)
         _validate_surv_time_structure(time, time2, event, start, surv_type)
@@ -4569,13 +4627,34 @@ class Surv:
         object.__setattr__(self, "start", tuple(start) if start is not None else None)
         object.__setattr__(self, "time2", tuple(time2) if time2 is not None else None)
         object.__setattr__(self, "type", surv_type)
+        object.__setattr__(self, "states", states)
 
     def __len__(self) -> int:
         return len(self.time)
 
     @property
-    def status(self) -> tuple[int, ...]:
+    def status(self) -> tuple[int | None, ...]:
         return self.event
+
+    @classmethod
+    def _from_normalized(
+        cls,
+        *,
+        time: Sequence[float],
+        event: Sequence[int | None],
+        start: Sequence[float] | None,
+        time2: Sequence[float] | None,
+        surv_type: str,
+        states: Sequence[str] = (),
+    ) -> Surv:
+        result = object.__new__(cls)
+        object.__setattr__(result, "time", tuple(time))
+        object.__setattr__(result, "event", tuple(event))
+        object.__setattr__(result, "start", None if start is None else tuple(start))
+        object.__setattr__(result, "time2", None if time2 is None else tuple(time2))
+        object.__setattr__(result, "type", surv_type)
+        object.__setattr__(result, "states", tuple(states))
+        return result
 
 
 @dataclass(frozen=True, init=False)
@@ -4987,6 +5066,8 @@ def is_surv(value: Any) -> bool:
 
 
 def _surv_missing_row(response: Surv, idx: int) -> bool:
+    if response.event[idx] is None:
+        return True
     if response.start is not None and math.isnan(response.start[idx]):
         return True
     if math.isnan(response.time[idx]):
@@ -5042,6 +5123,33 @@ def _format_surv_counting(response: Surv) -> list[str]:
     return [value.ljust(width) for value in labels]
 
 
+def _format_surv_mstate(response: Surv) -> list[str]:
+    suffixes = ["+", *(f":{state}" for state in response.states)]
+
+    def suffix(event: int | None) -> str:
+        return "?" if event is None else suffixes[event]
+
+    if response.type == "mright":
+        labels = [
+            f"{_surv_format_number(time)}{suffix(event)}"
+            for time, event in zip(response.time, response.event, strict=True)
+        ]
+    else:
+        if response.start is None:
+            raise ValueError("mcounting Surv response is missing start times")
+        labels = [
+            f"({_surv_format_number(start)},{_surv_format_number(stop)}{suffix(event)}]"
+            for start, stop, event in zip(
+                response.start,
+                response.time,
+                response.event,
+                strict=True,
+            )
+        ]
+    width = max(len(value) for value in labels) if labels else 0
+    return [value.ljust(width) for value in labels]
+
+
 def _format_surv_interval(response: Surv) -> list[str]:
     if response.time2 is None:
         raise ValueError(f"{response.type} Surv response is missing time2")
@@ -5082,6 +5190,8 @@ def format_surv(x: Any) -> list[str]:
         return _format_surv_right_or_left(x)
     if x.type == "counting":
         return _format_surv_counting(x)
+    if x.type in {"mright", "mcounting"}:
+        return _format_surv_mstate(x)
     if x.type in {"interval", "interval2"}:
         return _format_surv_interval(x)
     raise ValueError(f"unsupported Surv type {x.type!r}")
@@ -8523,6 +8633,15 @@ def aeqSurv(x: Any, tolerance: Any | None = None) -> Surv:  # noqa: N802
     if x.start is not None:
         start, stop = _aeq_adjust_time_columns((x.start, x.time), tolerance_value)
         _raise_if_aeq_zero_interval(x.start, x.time, start, stop)
+        if x.type == "mcounting":
+            return Surv._from_normalized(
+                time=stop,
+                event=x.event,
+                start=start,
+                time2=None,
+                surv_type=x.type,
+                states=x.states,
+            )
         return Surv(start, stop, list(x.event), type="counting")
 
     if x.time2 is not None:
@@ -8533,6 +8652,15 @@ def aeqSurv(x: Any, tolerance: Any | None = None) -> Surv:  # noqa: N802
         return Surv(left, right, list(x.event), type=x.type)
 
     (time,) = _aeq_adjust_time_columns((x.time,), tolerance_value)
+    if x.type == "mright":
+        return Surv._from_normalized(
+            time=time,
+            event=x.event,
+            start=None,
+            time2=None,
+            surv_type=x.type,
+            states=x.states,
+        )
     return Surv(time, list(x.event), type=x.type)
 
 
@@ -8628,6 +8756,15 @@ def survSplit(  # noqa: N802
 def _subset_surv(response: Surv, indices: list[int]) -> Surv:
     times = [response.time[idx] for idx in indices]
     events = [response.event[idx] for idx in indices]
+    if response.type in {"mright", "mcounting"}:
+        return Surv._from_normalized(
+            time=times,
+            event=events,
+            start=(None if response.start is None else [response.start[idx] for idx in indices]),
+            time2=None,
+            surv_type=response.type,
+            states=response.states,
+        )
     if response.type in {"right", "left"}:
         return Surv(times, events, type=response.type)
     if response.type == "interval":
@@ -11083,6 +11220,8 @@ def survfit(
 
     if not isinstance(response, Surv):
         raise TypeError("survfit response must be a Surv object, formula, or fitted Cox model")
+    if response.type in {"mright", "mcounting"}:
+        raise NotImplementedError("survfit multi-state Surv responses are not yet supported")
     if subset is not None:
         indices = _subset_indices(subset, len(response))
         response = _subset_surv(response, indices)

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -671,6 +671,7 @@ class SurvfitMultiStateResult:
     n: int
     n_id: int
     std_err: list[list[float]] | None = None
+    std_err0: list[float] | None = None
     std_chaz: list[list[float]] | None = None
     std_auc: list[list[float]] | None = None
     conf_lower: list[list[float]] | None = None
@@ -678,6 +679,8 @@ class SurvfitMultiStateResult:
     n_risk_count: list[list[float]] | None = None
     n_event_count: list[list[float]] | None = None
     n_censor_count: list[list[float]] | None = None
+    n_enter: list[list[float]] | None = None
+    n_enter_count: list[list[float]] | None = None
     n_transition: list[list[float]] = field(default_factory=list)
     n_transition_count: list[list[float]] | None = None
     model: dict[str, Any] | None = None
@@ -933,8 +936,10 @@ def _mstate_levels(values: Any, name: str) -> tuple[list[Any], list[str]]:
 
 
 def _survfit_response_with_etype(response: Surv, etype: Any) -> Surv:
-    if response.type != "right":
-        raise ValueError("etype can only be used with a right-censored Surv response")
+    if response.type not in {"right", "counting"}:
+        raise ValueError(
+            "etype can only be used with a right-censored or counting-process Surv response"
+        )
     raw, levels = _mstate_levels(etype, "etype")
     if len(raw) != len(response):
         raise ValueError("etype must have the same length as the Surv response")
@@ -957,9 +962,9 @@ def _survfit_response_with_etype(response: Surv, etype: Any) -> Surv:
     return Surv._from_normalized(
         time=response.time,
         event=events,
-        start=None,
+        start=response.start,
         time2=None,
-        surv_type="mright",
+        surv_type="mright" if response.start is None else "mcounting",
         states=states,
     )
 
@@ -11211,68 +11216,259 @@ def _survfit_multistate_cluster_codes(
     return codes, len(set(codes))
 
 
-def _survfit_mright_curve(
+def _survfit_multistate_state_data(
+    response: Surv,
+    id_values: list[Any] | None,
+    istate: Any | None,
+    timefix: bool,
+) -> tuple[Surv, list[int], tuple[str, ...], list[Any]]:
+    n = len(response)
+    ids = list(range(n)) if id_values is None else id_values
+    id_codes = _encode_labels(ids, "id")
+    if istate is None:
+        initial_labels = ["(s0)"]
+        provided_states: list[int] | None = None
+    else:
+        raw_initial, initial_levels = _mstate_levels(istate, "istate")
+        if len(raw_initial) != n:
+            raise ValueError("istate must have the same length as the Surv response")
+        observed_initial = {
+            _mstate_event_label(value) for value in raw_initial if not _is_missing_value(value)
+        }
+        initial_labels = [level for level in initial_levels if level in observed_initial]
+        provided_states = []
+
+    states = tuple(
+        [state for state in initial_labels if state not in response.states] + list(response.states)
+    )
+    state_index = {state: idx for idx, state in enumerate(states)}
+    if istate is not None:
+        provided_states = [
+            state_index[_mstate_event_label(value)] for value in _materialize_1d(istate, "istate")
+        ]
+
+    mapped_events = [
+        None if event is None else 0 if event == 0 else state_index[response.states[event - 1]] + 1
+        for event in response.event
+    ]
+    if response.start is None:
+        stop = _survdiff_timefix_values(list(response.time), timefix)
+        start = None
+    else:
+        raw_start = list(response.start)
+        raw_stop = list(response.time)
+        start, stop = _timefix_vectors(raw_start, raw_stop) if timefix else (raw_start, raw_stop)
+        if any(left >= right for left, right in zip(start, stop, strict=True)):
+            raise ValueError("timefix produced an empty multi-state interval")
+
+    current_states = [0] * n
+    if response.start is None:
+        seen_ids: set[int] = set()
+        for idx in sorted(range(n), key=lambda row: (id_codes[row], stop[row], row)):
+            subject = id_codes[idx]
+            if subject in seen_ids:
+                raise ValueError("a subject has overlapping right-censored multi-state rows")
+            seen_ids.add(subject)
+            current_states[idx] = 0 if provided_states is None else provided_states[idx]
+    else:
+        previous_by_id: dict[int, int] = {}
+        for idx in sorted(
+            range(n),
+            key=lambda row: (id_codes[row], stop[row], start[row], row),
+        ):
+            subject = id_codes[idx]
+            previous = previous_by_id.get(subject)
+            if previous is None:
+                current = 0 if provided_states is None else provided_states[idx]
+            else:
+                tolerance = _SURVFIT_TIME_EPSILON if timefix else 0.0
+                if start[idx] < stop[previous] - tolerance:
+                    raise ValueError("a subject has overlapping time intervals")
+                if start[idx] > stop[previous] + tolerance:
+                    raise ValueError("a subject has a gap between time intervals")
+                prior_event = mapped_events[previous]
+                expected = (
+                    current_states[previous] if prior_event in {None, 0} else int(prior_event) - 1
+                )
+                if provided_states is not None and provided_states[idx] != expected:
+                    raise ValueError("istate is inconsistent with the subject transition history")
+                current = expected
+            current_states[idx] = current
+            previous_by_id[subject] = idx
+
+    normalized = Surv._from_normalized(
+        time=stop,
+        event=mapped_events,
+        start=start,
+        time2=None,
+        surv_type=response.type,
+        states=states,
+    )
+    return normalized, current_states, states, ids
+
+
+def _survfit_counting_positions(
+    start: Sequence[float],
+    stop: Sequence[float],
+    ids: Sequence[Any],
+    timefix: bool,
+) -> list[int]:
+    id_codes = _encode_labels(list(ids), "id")
+    order = sorted(range(len(stop)), key=lambda idx: (id_codes[idx], stop[idx], idx))
+    positions = [0] * len(stop)
+    tolerance = _SURVFIT_TIME_EPSILON if timefix else 0.0
+    for order_idx, row_idx in enumerate(order):
+        previous = order[order_idx - 1] if order_idx > 0 else None
+        following = order[order_idx + 1] if order_idx + 1 < len(order) else None
+        first = (
+            previous is None
+            or id_codes[previous] != id_codes[row_idx]
+            or stop[previous] < start[row_idx] - tolerance
+        )
+        last = (
+            following is None
+            or id_codes[following] != id_codes[row_idx]
+            or stop[row_idx] < start[following] - tolerance
+        )
+        positions[row_idx] = int(first) + 2 * int(last)
+    return positions
+
+
+def _survfit_multistate_initial_distribution(
+    current_states: Sequence[int],
+    initial_rows: Sequence[bool],
+    weights: Sequence[float],
+    cluster_codes: Sequence[int],
+    cluster_count: int,
+    state_count: int,
+    p0_override: list[float] | None,
+    include_se: bool,
+) -> tuple[list[float], list[float]]:
+    if p0_override is not None:
+        p0 = list(p0_override)
+        return p0, [0.0] * (cluster_count * state_count) if include_se else []
+
+    total_weight = sum(
+        weight for weight, at_risk in zip(weights, initial_rows, strict=True) if at_risk
+    )
+    if total_weight <= 0.0:
+        raise ValueError("positive total weight is required at the multi-state start time")
+    p0 = [0.0] * state_count
+    for state, weight, at_risk in zip(current_states, weights, initial_rows, strict=True):
+        if at_risk:
+            p0[state] += weight / total_weight
+    if not include_se or any(value == 1.0 for value in p0):
+        return p0, [0.0] * (cluster_count * state_count) if include_se else []
+
+    influence = [[0.0] * state_count for _ in range(cluster_count)]
+    for state, weight, at_risk, cluster_code in zip(
+        current_states,
+        weights,
+        initial_rows,
+        cluster_codes,
+        strict=True,
+    ):
+        if not at_risk:
+            continue
+        for target in range(state_count):
+            influence[cluster_code][target] += (
+                weight * (float(state == target) - p0[target]) / total_weight
+            )
+    return p0, [
+        influence[cluster_code][state]
+        for state in range(state_count)
+        for cluster_code in range(cluster_count)
+    ]
+
+
+def _survfit_multistate_curve(
     response: Surv,
     weights: list[float] | None,
     id_values: list[Any] | None,
     cluster: Any | None,
+    current_states: list[int],
+    positions: list[int],
+    states: tuple[str, ...],
     transitions: tuple[tuple[int, int], ...],
     *,
     t0: float,
-    include_time0: bool,
+    output_times: list[float],
+    initial_rows: list[bool],
+    p0_override: list[float] | None,
+    report_initial_error: bool,
     include_se: bool,
+    include_entry: bool,
     conf_level: float,
     conf_type: str,
-    timefix: bool,
     model_frame: dict[str, Any] | None,
 ) -> SurvfitMultiStateResult:
     n = len(response)
-    stop = _survdiff_timefix_values(list(response.time), timefix)
-    if timefix:
-        stop = [
-            t0 if value < t0 and value >= t0 - _SURVFIT_TIME_EPSILON else value for value in stop
-        ]
+    stop = list(response.time)
+    if response.start is None:
+        initial_time = t0 if t0 < min(stop) else math.nextafter(min(stop), -math.inf)
+        start = [initial_time] * n
+    else:
+        start = list(response.start)
     if any(event is None for event in response.event):
         raise ValueError("missing values in multi-state survfit inputs")
     case_weights = [1.0] * n if weights is None else list(weights)
     if any(weight < 0.0 or not math.isfinite(weight) for weight in case_weights):
         raise ValueError("weights must contain only non-negative finite values")
 
-    output_times = sorted(set(stop))
-    if include_time0 and t0 not in output_times:
-        output_times.insert(0, t0)
-    initial_time = t0 if t0 < min(stop) else math.nextafter(min(stop), -math.inf)
-    state_count = len(response.states) + 1
+    state_count = len(states)
     transition_count = len(transitions)
     hindx = [[transition_count] * state_count for _ in range(state_count)]
     for transition_idx, (source, target) in enumerate(transitions):
         hindx[source][target] = transition_idx
 
     cluster_codes, cluster_count = _survfit_multistate_cluster_codes(n, cluster, id_values)
+    p0, initial_influence = _survfit_multistate_initial_distribution(
+        current_states,
+        initial_rows,
+        case_weights,
+        cluster_codes,
+        cluster_count,
+        state_count,
+        p0_override,
+        include_se,
+    )
+    std_err0 = (
+        [
+            math.sqrt(
+                sum(
+                    initial_influence[cluster_code + state * cluster_count] ** 2
+                    for cluster_code in range(cluster_count)
+                )
+            )
+            for state in range(state_count)
+        ]
+        if include_se and report_initial_error and all(value < 1.0 for value in p0)
+        else None
+    )
     y = [
         value
         for start, end, event in zip(
-            [initial_time] * n,
+            start,
             stop,
             response.event,
             strict=True,
         )
-        for value in (start, end, 0.0 if event == 0 else float(event + 1))
+        for value in (start, end, float(event))
     ]
     raw = _core.survfitaj(
         y=y,
-        sort1=list(range(n)),
+        sort1=sorted(range(n), key=lambda idx: (start[idx], idx)),
         sort2=sorted(range(n), key=lambda idx: (stop[idx], idx)),
         utime=output_times,
-        cstate=[0] * n,
+        cstate=current_states,
         wt=case_weights,
         grp=cluster_codes,
         ngrp=cluster_count,
-        p0=[1.0, *([0.0] * (state_count - 1))],
-        i0=[0.0] * (cluster_count * state_count) if include_se else [],
+        p0=p0,
+        i0=initial_influence,
         sefit=1 if include_se else 0,
-        entry=False,
-        position=[3] * n,
+        entry=include_entry,
+        position=positions,
         hindx=hindx,
         trmat=[list(transition) for transition in transitions],
         t0=t0,
@@ -11295,7 +11491,7 @@ def _survfit_mright_curve(
         ]
         for row in transition_counts
     ]
-    states = ("(s0)", *response.states)
+    n_enter_raw = None if raw.n_enter is None else _survfit_multistate_matrix(raw.n_enter)
     return SurvfitMultiStateResult(
         time=[float(value) for value in output_times],
         n_risk=[row[:state_count] for row in n_risk_raw],
@@ -11305,11 +11501,12 @@ def _survfit_mright_curve(
         cumhaz=_survfit_multistate_matrix(raw.cumhaz),
         states=states,
         transitions=transitions,
-        p0=[1.0, *([0.0] * (state_count - 1))],
+        p0=p0,
         t0=t0,
         n=n,
         n_id=len(_label_levels(id_values, "id")) if id_values is not None else n,
         std_err=std_err,
+        std_err0=std_err0,
         std_chaz=None if raw.std_chaz is None else _survfit_multistate_matrix(raw.std_chaz),
         std_auc=None if raw.std_auc is None else _survfit_multistate_matrix(raw.std_auc),
         conf_lower=conf_lower,
@@ -11317,71 +11514,214 @@ def _survfit_mright_curve(
         n_risk_count=[row[state_count:] for row in n_risk_raw],
         n_event_count=n_event_count,
         n_censor_count=[row[state_count:] for row in n_censor_raw],
+        n_enter=None if n_enter_raw is None else [row[:state_count] for row in n_enter_raw],
+        n_enter_count=(None if n_enter_raw is None else [row[state_count:] for row in n_enter_raw]),
         n_transition=[row[:transition_count] for row in n_transition_raw],
         n_transition_count=transition_counts,
         model=model_frame,
     )
 
 
-def _survfit_mright(
+def _survfit_multistate_output_times(
+    response: Surv,
+    positions: list[int],
+    *,
+    t0: float,
+    include_time0: bool,
+    include_entry: bool,
+) -> list[float]:
+    if response.start is None:
+        times = sorted(set(response.time))
+    elif include_entry:
+        times = sorted(
+            {
+                value
+                for idx, (start, stop, event) in enumerate(
+                    zip(response.start, response.time, response.event, strict=True)
+                )
+                if not (positions[idx] == 0 and event == 0)
+                for value in (start, stop)
+            }
+        )
+    else:
+        times = sorted(
+            {
+                stop
+                for stop, event, position in zip(
+                    response.time, response.event, positions, strict=True
+                )
+                if position >= 2 or event != 0
+            }
+        )
+    if include_time0:
+        return [t0, *[time for time in times if time > t0]]
+    return [time for time in times if time >= t0]
+
+
+def _survfit_multistate(
     response: Surv,
     group: Any | None,
     weights: list[float] | None,
     id_values: list[Any] | None,
     cluster: Any | None,
+    istate: Any | None,
     *,
-    t0: float,
+    start_time: float | None,
     include_time0: bool,
     include_se: bool,
+    include_entry: bool,
     conf_level: float,
     conf_type: str,
     timefix: bool,
     group_levels: Sequence[Any] | None,
     model_frame: dict[str, Any] | None,
 ) -> SurvfitMultiStateResult | dict[Any, SurvfitMultiStateResult]:
-    indices = _survfit_start_time_indices(response, t0, timefix)
-    response = _subset_surv(response, indices)
-    group = _subset_optional_sequence(group, indices, "group")
-    weights = _subset_optional_sequence(weights, indices, "weights")
-    id_values = _subset_optional_sequence(id_values, indices, "id")
-    cluster = _subset_optional_sequence(cluster, indices, "cluster")
-    transitions = tuple(
-        (0, state) for state in sorted({int(event) for event in response.event if event})
+    response, current_states, states, ids = _survfit_multistate_state_data(
+        response, id_values, istate, timefix
     )
 
-    if group is None:
-        return _survfit_mright_curve(
-            response,
-            weights,
-            id_values,
-            cluster,
-            transitions,
+    def initial_curve_indices(
+        curve_response: Surv,
+        curve_groups: Sequence[Any],
+        curve_ids: Sequence[Any],
+    ) -> list[int]:
+        group_codes = _encode_labels(list(curve_groups), "group")
+        id_codes = _encode_labels(list(curve_ids), "id")
+        order = sorted(
+            range(len(curve_response)),
+            key=lambda idx: (
+                group_codes[idx],
+                id_codes[idx],
+                curve_response.start[idx] if curve_response.start is not None else 0.0,
+                idx,
+            ),
+        )
+        first_indices: list[int] = []
+        seen_subjects: set[tuple[int, int]] = set()
+        for idx in order:
+            key = (group_codes[idx], id_codes[idx])
+            if key not in seen_subjects:
+                seen_subjects.add(key)
+                first_indices.append(idx)
+        return first_indices
+
+    group_values = [0] * len(response) if group is None else _materialize_labels(group, "group")
+    initial_indices = initial_curve_indices(response, group_values, ids)
+    initial_states = [current_states[idx] for idx in initial_indices]
+    same_initial_state = len(set(initial_states)) == 1
+    if start_time is not None:
+        t0 = start_time
+    elif response.start is None:
+        t0 = min(0.0, *response.time)
+    elif same_initial_state:
+        t0 = min(response.start)
+    else:
+        initial_starts = [response.start[idx] for idx in initial_indices]
+        if max(initial_starts) == min(initial_starts):
+            t0 = initial_starts[0]
+        else:
+            event_times = [
+                stop for stop, event in zip(response.time, response.event, strict=True) if event
+            ]
+            if not event_times:
+                raise ValueError("start_time is required when initial states have staggered entry")
+            t0 = min(event_times)
+
+    if start_time is not None:
+        for label, indices in _group_indices(group_values, len(response)).items():
+            if max(response.time[idx] for idx in indices) <= t0:
+                raise ValueError(f"start_time has removed all observations from curve {label!r}")
+    keep = _survfit_start_time_indices(response, t0, timefix)
+    transitions = tuple(
+        sorted(
+            {
+                (current_states[idx], int(event) - 1)
+                for idx, event in enumerate(response.event)
+                if event
+            },
+            key=lambda transition: (transition[1], transition[0]),
+        )
+    )
+    response = _subset_surv(response, keep)
+    current_states = [current_states[idx] for idx in keep]
+    group = _subset_optional_sequence(group, keep, "group")
+    weights = _subset_optional_sequence(weights, keep, "weights")
+    ids = [ids[idx] for idx in keep]
+    id_values = _subset_optional_sequence(id_values, keep, "id")
+    cluster = _subset_optional_sequence(cluster, keep, "cluster")
+    if start_time is not None:
+        kept_groups = [0] * len(response) if group is None else _materialize_labels(group, "group")
+        initial_indices = initial_curve_indices(response, kept_groups, ids)
+        initial_states = [current_states[idx] for idx in initial_indices]
+        same_initial_state = len(set(initial_states)) == 1
+    p0_override = None
+    if same_initial_state:
+        p0_override = [float(state == initial_states[0]) for state in range(len(states))]
+
+    def fit_curve(indices: list[int]) -> SurvfitMultiStateResult:
+        curve_response = _subset_surv(response, indices)
+        curve_states = [current_states[idx] for idx in indices]
+        curve_ids = [ids[idx] for idx in indices]
+        curve_positions = (
+            [3] * len(indices)
+            if curve_response.start is None
+            else _survfit_counting_positions(
+                curve_response.start,
+                curve_response.time,
+                curve_ids,
+                timefix,
+            )
+        )
+        output_times = _survfit_multistate_output_times(
+            curve_response,
+            curve_positions,
             t0=t0,
             include_time0=include_time0,
+            include_entry=include_entry,
+        )
+        if curve_response.start is not None and p0_override is None:
+            output_times = [time for time in output_times if time > t0]
+        if not output_times:
+            raise ValueError("multi-state survfit has no output times")
+        initial_rows = (
+            [True] * len(indices)
+            if curve_response.start is None
+            else [
+                start <= t0 <= stop if t0 == min(response.start) else start < t0 <= stop
+                for start, stop in zip(
+                    curve_response.start,
+                    curve_response.time,
+                    strict=True,
+                )
+            ]
+        )
+        return _survfit_multistate_curve(
+            curve_response,
+            _subset_optional_sequence(weights, indices, "weights"),
+            _subset_optional_sequence(id_values, indices, "id"),
+            _subset_optional_sequence(cluster, indices, "cluster"),
+            curve_states,
+            curve_positions,
+            states,
+            transitions,
+            t0=t0,
+            output_times=output_times,
+            initial_rows=initial_rows,
+            p0_override=p0_override,
+            report_initial_error=not include_time0 and p0_override is None,
             include_se=include_se,
+            include_entry=include_entry,
             conf_level=conf_level,
             conf_type=conf_type,
-            timefix=timefix,
             model_frame=model_frame,
         )
 
-    result: dict[Any, SurvfitMultiStateResult] = {}
-    for label, group_indices in _group_indices(group, len(response), levels=group_levels).items():
-        result[label] = _survfit_mright_curve(
-            _subset_surv(response, group_indices),
-            _subset_optional_sequence(weights, group_indices, "weights"),
-            _subset_optional_sequence(id_values, group_indices, "id"),
-            _subset_optional_sequence(cluster, group_indices, "cluster"),
-            transitions,
-            t0=t0,
-            include_time0=include_time0,
-            include_se=include_se,
-            conf_level=conf_level,
-            conf_type=conf_type,
-            timefix=timefix,
-            model_frame=model_frame,
-        )
-    return result
+    if group is None:
+        return fit_curve(list(range(len(response))))
+    return {
+        label: fit_curve(indices)
+        for label, indices in _group_indices(group, len(response), levels=group_levels).items()
+    }
 
 
 def survfit(
@@ -11435,8 +11775,8 @@ def survfit(
     include_se = _normalize_bool_option_with_default(se_fit, "se_fit", True)
     robust_value = _normalize_optional_bool_option(robust, "robust")
     id_arg = id
-    if istate is not None:
-        raise NotImplementedError("survfit multi-state istate inputs are not yet supported")
+    if istate is not None and etype is not None:
+        raise ValueError("survfit cannot use both istate and etype")
     # R's survival keeps `error` for backward compatibility but no longer uses it.
 
     computation = _normalize_survfit_type(type, stype, ctype)
@@ -11454,12 +11794,15 @@ def survfit(
         id_column = id_arg if isinstance(id_arg, str) else None
         cluster_column = cluster if isinstance(cluster, str) else None
         etype_column = etype if isinstance(etype, str) else None
+        istate_column = istate if isinstance(istate, str) else None
         if id_column is not None:
             id_arg = _column(data, id_column)
         if cluster_column is not None:
             cluster = _column(data, cluster_column)
         if etype_column is not None:
             etype = _column(data, etype_column)
+        if istate_column is not None:
+            istate = _column(data, istate_column)
         if subset is not None:
             data, aligned = _subset_formula_inputs(
                 formula,
@@ -11469,11 +11812,13 @@ def survfit(
                 id=id_arg,
                 cluster=cluster,
                 etype=etype,
+                istate=istate,
             )
             weights = aligned["weights"]
             id_arg = aligned["id"]
             cluster = aligned["cluster"]
             etype = aligned["etype"]
+            istate = aligned["istate"]
             subset = None
         data, aligned = _apply_formula_na_action(
             formula,
@@ -11483,11 +11828,13 @@ def survfit(
             id=id_arg,
             cluster=cluster,
             etype=etype,
+            istate=istate,
         )
         weights = aligned["weights"]
         id_arg = aligned["id"]
         cluster = aligned["cluster"]
         etype = aligned["etype"]
+        istate = aligned["istate"]
         na_action = "pass"
         response, terms = _parse_formula(formula, data)
         if terms.clusters:
@@ -11508,13 +11855,17 @@ def survfit(
             model_frame["(etype)"] = _materialize_1d(etype, "etype")
             if etype_column is not None and etype_column not in model_frame:
                 model_frame[etype_column] = _column(data, etype_column)
+        if istate is not None:
+            model_frame["(istate)"] = _materialize_1d(istate, "istate")
+            if istate_column is not None and istate_column not in model_frame:
+                model_frame[istate_column] = _column(data, istate_column)
         if terms.strata or terms.covariates:
             group = _combined_formula_groups(data, terms.strata, terms.covariates, len(response))
             formula_group_levels = _r_formula_ordered_levels(group, "survfit formula groups")
 
     if not isinstance(response, Surv) and hasattr(response, "survival_curve"):
-        if etype is not None:
-            raise ValueError("etype is only supported for Surv or formula inputs")
+        if etype is not None or istate is not None:
+            raise ValueError("etype and istate are only supported for Surv or formula inputs")
         if not computation.is_kaplan_meier:
             raise ValueError(
                 "non-Kaplan-Meier survfit styles are only supported for Surv or formula inputs"
@@ -11571,6 +11922,7 @@ def survfit(
         id_arg = _subset_optional_sequence(id_arg, indices, "id")
         cluster = _subset_optional_sequence(cluster, indices, "cluster")
         etype = _subset_optional_sequence(etype, indices, "etype")
+        istate = _subset_optional_sequence(istate, indices, "istate")
     response, aligned = _apply_surv_na_action(
         response,
         na_action,
@@ -11580,12 +11932,14 @@ def survfit(
         id=id_arg,
         cluster=cluster,
         etype=etype,
+        istate=istate,
     )
     group = aligned["group"]
     weights = aligned["weights"]
     id_arg = aligned["id"]
     cluster = aligned["cluster"]
     etype = aligned["etype"]
+    istate = aligned["istate"]
     if etype is not None:
         response = _survfit_response_with_etype(response, etype)
         if model_frame is not None:
@@ -11598,17 +11952,21 @@ def survfit(
         raise ValueError("id must have the same length as the Surv response")
     if model_frame is None:
         model_frame = _survfit_model_frame(response, group, weights, id_values, cluster)
+        if istate is not None:
+            model_frame["(istate)"] = _materialize_1d(istate, "istate")
     if newdata is not None:
         raise ValueError("newdata is only supported for fitted Cox models")
     if not include_censor:
         raise ValueError("censor is only supported for fitted Cox models")
-    if include_entry and (response.start is None or id_values is None):
+    if (
+        include_entry
+        and response.type != "mcounting"
+        and (response.start is None or id_values is None)
+    ):
         raise ValueError("survfit entry=TRUE requires counting-process Surv input and id")
-    if response.type == "mcounting":
-        raise NotImplementedError(
-            "survfit counting-process multi-state responses are not yet supported"
-        )
-    if response.type == "mright":
+    if istate is not None and response.type not in {"mright", "mcounting"}:
+        raise NotImplementedError("survfit istate requires a multi-state Surv response")
+    if response.type in {"mright", "mcounting"}:
         if robust_value is False:
             raise ValueError("multi-state survfit supports only a robust variance")
         if not computation.is_kaplan_meier:
@@ -11618,15 +11976,17 @@ def survfit(
         wt = _float_vector(weights, "weights") if weights is not None else None
         if wt is not None and len(wt) != len(response):
             raise ValueError("weights must have the same length as the Surv response")
-        return _survfit_mright(
+        return _survfit_multistate(
             response,
             group,
             wt,
             id_values,
             cluster,
-            t0=normalized_start_time if normalized_start_time is not None else 0.0,
+            istate,
+            start_time=normalized_start_time,
             include_time0=include_time0,
             include_se=include_se,
+            include_entry=include_entry and response.type == "mcounting",
             conf_level=normalized_conf_level,
             conf_type=normalized_conf_type,
             timefix=fix_time,

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -11912,8 +11912,6 @@ def survfit(
 
     if not isinstance(response, Surv):
         raise TypeError("survfit response must be a Surv object, formula, or fitted Cox model")
-    if response.type in {"mright", "mcounting"}:
-        raise NotImplementedError("survfit multi-state Surv responses are not yet supported")
     if subset is not None:
         indices = _subset_indices(subset, len(response))
         response = _subset_surv(response, indices)

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -37,6 +37,7 @@ __all__ = [
     "SurvObrienResult",
     "SurvExpResult",
     "SurvfitResult",
+    "SurvfitMultiStateResult",
     "SurvfitConfidenceIntervalResult",
     "TcutResult",
     "aic",
@@ -654,6 +655,65 @@ class SurvfitResult:
 
 
 @dataclass(frozen=True)
+class SurvfitMultiStateResult:
+    """Aalen--Johansen state-probability curves from a multi-state response."""
+
+    time: list[float]
+    n_risk: list[list[float]]
+    n_event: list[list[float]]
+    n_censor: list[list[float]]
+    pstate: list[list[float]]
+    cumhaz: list[list[float]]
+    states: tuple[str, ...]
+    transitions: tuple[tuple[int, int], ...]
+    p0: list[float]
+    t0: float
+    n: int
+    n_id: int
+    std_err: list[list[float]] | None = None
+    std_chaz: list[list[float]] | None = None
+    std_auc: list[list[float]] | None = None
+    conf_lower: list[list[float]] | None = None
+    conf_upper: list[list[float]] | None = None
+    n_risk_count: list[list[float]] | None = None
+    n_event_count: list[list[float]] | None = None
+    n_censor_count: list[list[float]] | None = None
+    n_transition: list[list[float]] = field(default_factory=list)
+    n_transition_count: list[list[float]] | None = None
+    model: dict[str, Any] | None = None
+
+    def __iter__(self):
+        yield self.time
+        yield self.pstate
+
+    @property
+    def surv(self) -> list[list[float]]:
+        return self.pstate
+
+    @property
+    def estimate(self) -> list[list[float]]:
+        return self.pstate
+
+    @property
+    def state_probabilities(self) -> list[list[float]]:
+        return self.pstate
+
+    @property
+    def cumulative_hazard(self) -> list[list[float]]:
+        return self.cumhaz
+
+    @property
+    def cumulative_hazard_std_err(self) -> list[list[float]] | None:
+        return self.std_chaz
+
+    @property
+    def transition_labels(self) -> tuple[tuple[str, str], ...]:
+        return tuple(
+            (self.states[source], self.states[target]) for source, target in self.transitions
+        )
+
+
+@dataclass(frozen=True)
 class SurvfitConfidenceIntervalResult:
     lower: list[float]
     upper: list[float]
@@ -853,6 +913,55 @@ def _mstate_event_vector(values: Any, name: str) -> tuple[list[int | None], tupl
         for value in raw
     ]
     return events, tuple(levels[1:])
+
+
+def _mstate_levels(values: Any, name: str) -> tuple[list[Any], list[str]]:
+    raw = _materialize_1d(values, name)
+    categories = getattr(values, "categories", None)
+    if categories is None:
+        categories = getattr(getattr(values, "dtype", None), "categories", None)
+    levels = (
+        _mstate_inferred_levels(raw)
+        if categories is None
+        else [
+            _mstate_event_label(value)
+            for value in _materialize_1d(categories, f"{name} categories")
+            if not _is_missing_value(value)
+        ]
+    )
+    return raw, levels
+
+
+def _survfit_response_with_etype(response: Surv, etype: Any) -> Surv:
+    if response.type != "right":
+        raise ValueError("etype can only be used with a right-censored Surv response")
+    raw, levels = _mstate_levels(etype, "etype")
+    if len(raw) != len(response):
+        raise ValueError("etype must have the same length as the Surv response")
+
+    event_labels = {
+        _mstate_event_label(value)
+        for value, status in zip(raw, response.event, strict=True)
+        if status == 1 and not _is_missing_value(value)
+    }
+    states = tuple(level for level in levels if level in event_labels)
+    state_index = {state: idx + 1 for idx, state in enumerate(states)}
+    events: list[int | None] = []
+    for value, status in zip(raw, response.event, strict=True):
+        if status is None or _is_missing_value(value):
+            events.append(None)
+        elif status == 0:
+            events.append(0)
+        else:
+            events.append(state_index[_mstate_event_label(value)])
+    return Surv._from_normalized(
+        time=response.time,
+        event=events,
+        start=None,
+        time2=None,
+        surv_type="mright",
+        states=states,
+    )
 
 
 def _interval_status_vector(values: Any, name: str) -> list[int]:
@@ -11056,6 +11165,225 @@ def _cox_flat_basehaz_with_training_times(
     )
 
 
+def _survfit_multistate_matrix(values: Any) -> list[list[float]]:
+    return [[float(value) for value in row] for row in values]
+
+
+def _survfit_multistate_confidence(
+    pstate: list[list[float]],
+    std_err: list[list[float]] | None,
+    conf_level: float,
+    conf_type: str,
+) -> tuple[list[list[float]] | None, list[list[float]] | None]:
+    if std_err is None or conf_type == "none":
+        return None, None
+    if not pstate:
+        return [], []
+    width = len(pstate[0])
+    intervals = survfit_confint(
+        [value for row in pstate for value in row],
+        [value for row in std_err for value in row],
+        logse=False,
+        conf_type=conf_type,
+        conf_int=conf_level,
+    )
+    lower = [
+        intervals.lower[offset : offset + width] for offset in range(0, len(intervals.lower), width)
+    ]
+    upper = [
+        intervals.upper[offset : offset + width] for offset in range(0, len(intervals.upper), width)
+    ]
+    return lower, upper
+
+
+def _survfit_multistate_cluster_codes(
+    n: int,
+    cluster: Any | None,
+    id_values: list[Any] | None,
+) -> tuple[list[int], int]:
+    if cluster is not None:
+        labels = _survfit_cluster_values(cluster, n)
+    elif id_values is not None:
+        labels = id_values
+    else:
+        labels = list(range(n))
+    codes = _encode_labels(labels, "cluster")
+    return codes, len(set(codes))
+
+
+def _survfit_mright_curve(
+    response: Surv,
+    weights: list[float] | None,
+    id_values: list[Any] | None,
+    cluster: Any | None,
+    transitions: tuple[tuple[int, int], ...],
+    *,
+    t0: float,
+    include_time0: bool,
+    include_se: bool,
+    conf_level: float,
+    conf_type: str,
+    timefix: bool,
+    model_frame: dict[str, Any] | None,
+) -> SurvfitMultiStateResult:
+    n = len(response)
+    stop = _survdiff_timefix_values(list(response.time), timefix)
+    if timefix:
+        stop = [
+            t0 if value < t0 and value >= t0 - _SURVFIT_TIME_EPSILON else value for value in stop
+        ]
+    if any(event is None for event in response.event):
+        raise ValueError("missing values in multi-state survfit inputs")
+    case_weights = [1.0] * n if weights is None else list(weights)
+    if any(weight < 0.0 or not math.isfinite(weight) for weight in case_weights):
+        raise ValueError("weights must contain only non-negative finite values")
+
+    output_times = sorted(set(stop))
+    if include_time0 and t0 not in output_times:
+        output_times.insert(0, t0)
+    initial_time = t0 if t0 < min(stop) else math.nextafter(min(stop), -math.inf)
+    state_count = len(response.states) + 1
+    transition_count = len(transitions)
+    hindx = [[transition_count] * state_count for _ in range(state_count)]
+    for transition_idx, (source, target) in enumerate(transitions):
+        hindx[source][target] = transition_idx
+
+    cluster_codes, cluster_count = _survfit_multistate_cluster_codes(n, cluster, id_values)
+    y = [
+        value
+        for start, end, event in zip(
+            [initial_time] * n,
+            stop,
+            response.event,
+            strict=True,
+        )
+        for value in (start, end, 0.0 if event == 0 else float(event + 1))
+    ]
+    raw = _core.survfitaj(
+        y=y,
+        sort1=list(range(n)),
+        sort2=sorted(range(n), key=lambda idx: (stop[idx], idx)),
+        utime=output_times,
+        cstate=[0] * n,
+        wt=case_weights,
+        grp=cluster_codes,
+        ngrp=cluster_count,
+        p0=[1.0, *([0.0] * (state_count - 1))],
+        i0=[0.0] * (cluster_count * state_count) if include_se else [],
+        sefit=1 if include_se else 0,
+        entry=False,
+        position=[3] * n,
+        hindx=hindx,
+        trmat=[list(transition) for transition in transitions],
+        t0=t0,
+    )
+    n_risk_raw = _survfit_multistate_matrix(raw.n_risk)
+    n_censor_raw = _survfit_multistate_matrix(raw.n_censor)
+    n_transition_raw = _survfit_multistate_matrix(raw.n_transition)
+    pstate = _survfit_multistate_matrix(raw.pstate)
+    std_err = None if raw.std_err is None else _survfit_multistate_matrix(raw.std_err)
+    conf_lower, conf_upper = _survfit_multistate_confidence(pstate, std_err, conf_level, conf_type)
+    transition_counts = [row[transition_count:] for row in n_transition_raw]
+    n_event_count = [
+        [
+            sum(
+                row[transition_idx]
+                for transition_idx, (_source, target) in enumerate(transitions)
+                if target == state
+            )
+            for state in range(state_count)
+        ]
+        for row in transition_counts
+    ]
+    states = ("(s0)", *response.states)
+    return SurvfitMultiStateResult(
+        time=[float(value) for value in output_times],
+        n_risk=[row[:state_count] for row in n_risk_raw],
+        n_event=_survfit_multistate_matrix(raw.n_event),
+        n_censor=[row[:state_count] for row in n_censor_raw],
+        pstate=pstate,
+        cumhaz=_survfit_multistate_matrix(raw.cumhaz),
+        states=states,
+        transitions=transitions,
+        p0=[1.0, *([0.0] * (state_count - 1))],
+        t0=t0,
+        n=n,
+        n_id=len(_label_levels(id_values, "id")) if id_values is not None else n,
+        std_err=std_err,
+        std_chaz=None if raw.std_chaz is None else _survfit_multistate_matrix(raw.std_chaz),
+        std_auc=None if raw.std_auc is None else _survfit_multistate_matrix(raw.std_auc),
+        conf_lower=conf_lower,
+        conf_upper=conf_upper,
+        n_risk_count=[row[state_count:] for row in n_risk_raw],
+        n_event_count=n_event_count,
+        n_censor_count=[row[state_count:] for row in n_censor_raw],
+        n_transition=[row[:transition_count] for row in n_transition_raw],
+        n_transition_count=transition_counts,
+        model=model_frame,
+    )
+
+
+def _survfit_mright(
+    response: Surv,
+    group: Any | None,
+    weights: list[float] | None,
+    id_values: list[Any] | None,
+    cluster: Any | None,
+    *,
+    t0: float,
+    include_time0: bool,
+    include_se: bool,
+    conf_level: float,
+    conf_type: str,
+    timefix: bool,
+    group_levels: Sequence[Any] | None,
+    model_frame: dict[str, Any] | None,
+) -> SurvfitMultiStateResult | dict[Any, SurvfitMultiStateResult]:
+    indices = _survfit_start_time_indices(response, t0, timefix)
+    response = _subset_surv(response, indices)
+    group = _subset_optional_sequence(group, indices, "group")
+    weights = _subset_optional_sequence(weights, indices, "weights")
+    id_values = _subset_optional_sequence(id_values, indices, "id")
+    cluster = _subset_optional_sequence(cluster, indices, "cluster")
+    transitions = tuple(
+        (0, state) for state in sorted({int(event) for event in response.event if event})
+    )
+
+    if group is None:
+        return _survfit_mright_curve(
+            response,
+            weights,
+            id_values,
+            cluster,
+            transitions,
+            t0=t0,
+            include_time0=include_time0,
+            include_se=include_se,
+            conf_level=conf_level,
+            conf_type=conf_type,
+            timefix=timefix,
+            model_frame=model_frame,
+        )
+
+    result: dict[Any, SurvfitMultiStateResult] = {}
+    for label, group_indices in _group_indices(group, len(response), levels=group_levels).items():
+        result[label] = _survfit_mright_curve(
+            _subset_surv(response, group_indices),
+            _subset_optional_sequence(weights, group_indices, "weights"),
+            _subset_optional_sequence(id_values, group_indices, "id"),
+            _subset_optional_sequence(cluster, group_indices, "cluster"),
+            transitions,
+            t0=t0,
+            include_time0=include_time0,
+            include_se=include_se,
+            conf_level=conf_level,
+            conf_type=conf_type,
+            timefix=timefix,
+            model_frame=model_frame,
+        )
+    return result
+
+
 def survfit(
     response: Any,
     data: Any | None = None,
@@ -11087,7 +11415,7 @@ def survfit(
     timefix: bool = True,
     **kwargs: Any,
 ):
-    """Fit Kaplan-Meier curves or Cox-model survival curves."""
+    """Fit Kaplan--Meier, Aalen--Johansen, or Cox-model survival curves."""
 
     if _is_clogit_fit(response):
         raise ValueError("predicted survival curves are not defined for a clogit model")
@@ -11107,8 +11435,8 @@ def survfit(
     include_se = _normalize_bool_option_with_default(se_fit, "se_fit", True)
     robust_value = _normalize_optional_bool_option(robust, "robust")
     id_arg = id
-    if istate is not None or etype is not None:
-        raise NotImplementedError("survfit multi-state istate/etype inputs are not supported")
+    if istate is not None:
+        raise NotImplementedError("survfit multi-state istate inputs are not yet supported")
     # R's survival keeps `error` for backward compatibility but no longer uses it.
 
     computation = _normalize_survfit_type(type, stype, ctype)
@@ -11125,10 +11453,13 @@ def survfit(
         formula = response
         id_column = id_arg if isinstance(id_arg, str) else None
         cluster_column = cluster if isinstance(cluster, str) else None
+        etype_column = etype if isinstance(etype, str) else None
         if id_column is not None:
             id_arg = _column(data, id_column)
         if cluster_column is not None:
             cluster = _column(data, cluster_column)
+        if etype_column is not None:
+            etype = _column(data, etype_column)
         if subset is not None:
             data, aligned = _subset_formula_inputs(
                 formula,
@@ -11137,10 +11468,12 @@ def survfit(
                 weights=weights,
                 id=id_arg,
                 cluster=cluster,
+                etype=etype,
             )
             weights = aligned["weights"]
             id_arg = aligned["id"]
             cluster = aligned["cluster"]
+            etype = aligned["etype"]
             subset = None
         data, aligned = _apply_formula_na_action(
             formula,
@@ -11149,10 +11482,12 @@ def survfit(
             weights=weights,
             id=id_arg,
             cluster=cluster,
+            etype=etype,
         )
         weights = aligned["weights"]
         id_arg = aligned["id"]
         cluster = aligned["cluster"]
+        etype = aligned["etype"]
         na_action = "pass"
         response, terms = _parse_formula(formula, data)
         if terms.clusters:
@@ -11169,11 +11504,17 @@ def survfit(
             cluster,
             cluster_column,
         )
+        if etype is not None:
+            model_frame["(etype)"] = _materialize_1d(etype, "etype")
+            if etype_column is not None and etype_column not in model_frame:
+                model_frame[etype_column] = _column(data, etype_column)
         if terms.strata or terms.covariates:
             group = _combined_formula_groups(data, terms.strata, terms.covariates, len(response))
             formula_group_levels = _r_formula_ordered_levels(group, "survfit formula groups")
 
     if not isinstance(response, Surv) and hasattr(response, "survival_curve"):
+        if etype is not None:
+            raise ValueError("etype is only supported for Surv or formula inputs")
         if not computation.is_kaplan_meier:
             raise ValueError(
                 "non-Kaplan-Meier survfit styles are only supported for Surv or formula inputs"
@@ -11220,8 +11561,6 @@ def survfit(
 
     if not isinstance(response, Surv):
         raise TypeError("survfit response must be a Surv object, formula, or fitted Cox model")
-    if response.type in {"mright", "mcounting"}:
-        raise NotImplementedError("survfit multi-state Surv responses are not yet supported")
     if subset is not None:
         indices = _subset_indices(subset, len(response))
         response = _subset_surv(response, indices)
@@ -11229,6 +11568,7 @@ def survfit(
         weights = _subset_optional_sequence(weights, indices, "weights")
         id_arg = _subset_optional_sequence(id_arg, indices, "id")
         cluster = _subset_optional_sequence(cluster, indices, "cluster")
+        etype = _subset_optional_sequence(etype, indices, "etype")
     response, aligned = _apply_surv_na_action(
         response,
         na_action,
@@ -11237,11 +11577,20 @@ def survfit(
         weights=weights,
         id=id_arg,
         cluster=cluster,
+        etype=etype,
     )
     group = aligned["group"]
     weights = aligned["weights"]
     id_arg = aligned["id"]
     cluster = aligned["cluster"]
+    etype = aligned["etype"]
+    if etype is not None:
+        response = _survfit_response_with_etype(response, etype)
+        if model_frame is not None:
+            for name, value in model_frame.items():
+                if isinstance(value, Surv):
+                    model_frame[name] = response
+                    break
     id_values = _materialize_labels(id_arg, "id") if id_arg is not None else None
     if id_values is not None and len(id_values) != len(response):
         raise ValueError("id must have the same length as the Surv response")
@@ -11253,6 +11602,35 @@ def survfit(
         raise ValueError("censor is only supported for fitted Cox models")
     if include_entry and (response.start is None or id_values is None):
         raise ValueError("survfit entry=TRUE requires counting-process Surv input and id")
+    if response.type == "mcounting":
+        raise NotImplementedError(
+            "survfit counting-process multi-state responses are not yet supported"
+        )
+    if response.type == "mright":
+        if robust_value is False:
+            raise ValueError("multi-state survfit supports only a robust variance")
+        if not computation.is_kaplan_meier:
+            raise ValueError("multi-state survfit supports only the Aalen-Johansen estimator")
+        if reverse_curve:
+            raise ValueError("reverse survfit is not supported for multi-state responses")
+        wt = _float_vector(weights, "weights") if weights is not None else None
+        if wt is not None and len(wt) != len(response):
+            raise ValueError("weights must have the same length as the Surv response")
+        return _survfit_mright(
+            response,
+            group,
+            wt,
+            id_values,
+            cluster,
+            t0=normalized_start_time if normalized_start_time is not None else 0.0,
+            include_time0=include_time0,
+            include_se=include_se,
+            conf_level=normalized_conf_level,
+            conf_type=normalized_conf_type,
+            timefix=fix_time,
+            group_levels=formula_group_levels,
+            model_frame=model_frame if keep_model else None,
+        )
     if response.type in {"left", "interval", "interval2"}:
         if (
             include_se

--- a/python/survival/r_api.pyi
+++ b/python/survival/r_api.pyi
@@ -15,10 +15,11 @@ class StrataFactor:
 
 class Surv:
     time: tuple[float, ...]
-    event: tuple[int, ...]
+    event: tuple[int | None, ...]
     start: tuple[float, ...] | None
     time2: tuple[float, ...] | None
     type: str
+    states: tuple[str, ...]
     def __init__(
         self,
         *args: Any,
@@ -34,7 +35,7 @@ class Surv:
     ) -> None: ...
     def __len__(self) -> int: ...
     @property
-    def status(self) -> tuple[int, ...]: ...
+    def status(self) -> tuple[int | None, ...]: ...
 
 class Surv2:
     time: tuple[float, ...]

--- a/python/survival/r_api.pyi
+++ b/python/survival/r_api.pyi
@@ -456,6 +456,7 @@ class SurvfitMultiStateResult:
     n: int
     n_id: int
     std_err: list[list[float]] | None
+    std_err0: list[float] | None
     std_chaz: list[list[float]] | None
     std_auc: list[list[float]] | None
     conf_lower: list[list[float]] | None
@@ -463,6 +464,8 @@ class SurvfitMultiStateResult:
     n_risk_count: list[list[float]] | None
     n_event_count: list[list[float]] | None
     n_censor_count: list[list[float]] | None
+    n_enter: list[list[float]] | None
+    n_enter_count: list[list[float]] | None
     n_transition: list[list[float]]
     n_transition_count: list[list[float]] | None
     model: dict[str, Any] | None

--- a/python/survival/r_api.pyi
+++ b/python/survival/r_api.pyi
@@ -442,6 +442,44 @@ class SurvfitResult:
     @property
     def cumulative_hazard_std_err(self) -> list[float]: ...
 
+class SurvfitMultiStateResult:
+    time: list[float]
+    n_risk: list[list[float]]
+    n_event: list[list[float]]
+    n_censor: list[list[float]]
+    pstate: list[list[float]]
+    cumhaz: list[list[float]]
+    states: tuple[str, ...]
+    transitions: tuple[tuple[int, int], ...]
+    p0: list[float]
+    t0: float
+    n: int
+    n_id: int
+    std_err: list[list[float]] | None
+    std_chaz: list[list[float]] | None
+    std_auc: list[list[float]] | None
+    conf_lower: list[list[float]] | None
+    conf_upper: list[list[float]] | None
+    n_risk_count: list[list[float]] | None
+    n_event_count: list[list[float]] | None
+    n_censor_count: list[list[float]] | None
+    n_transition: list[list[float]]
+    n_transition_count: list[list[float]] | None
+    model: dict[str, Any] | None
+    def __iter__(self): ...
+    @property
+    def surv(self) -> list[list[float]]: ...
+    @property
+    def estimate(self) -> list[list[float]]: ...
+    @property
+    def state_probabilities(self) -> list[list[float]]: ...
+    @property
+    def cumulative_hazard(self) -> list[list[float]]: ...
+    @property
+    def cumulative_hazard_std_err(self) -> list[list[float]] | None: ...
+    @property
+    def transition_labels(self) -> tuple[tuple[str, str], ...]: ...
+
 class SurvfitConfidenceIntervalResult:
     lower: list[float]
     upper: list[float]

--- a/python/tests/test_case_cohort_and_multistate.py
+++ b/python/tests/test_case_cohort_and_multistate.py
@@ -331,6 +331,25 @@ def test_survfitaj_returns_standard_errors_when_requested():
     assert result.std_err[1] == pytest.approx([0.272165526975909] * 2)
 
 
+def test_survfitaj_zero_weights_match_r_case_weight_semantics():
+    kwargs = _competing_survfitaj_kwargs(sefit=1)
+    kwargs["wt"] = [1.0, 0.0, 1.0, 1.0]
+
+    result = survival.survfitaj(**kwargs)
+
+    assert result.n_risk[0] == pytest.approx([3.0, 0.0, 0.0, 4.0, 0.0, 0.0])
+    assert result.n_event[0] == pytest.approx([0.0, 1.0, 0.0])
+    assert result.pstate[0] == pytest.approx([2 / 3, 1 / 3, 0.0])
+    assert result.std_err is not None
+    assert all(math.isfinite(value) for row in result.std_err for value in row)
+
+    kwargs["wt"] = [0.0, 0.0, 0.0, 0.0]
+    all_zero = survival.survfitaj(**kwargs)
+    assert all(row == pytest.approx([1.0, 0.0, 0.0]) for row in all_zero.pstate)
+    assert all_zero.std_err is not None
+    assert all(row == pytest.approx([0.0, 0.0, 0.0]) for row in all_zero.std_err)
+
+
 def test_survfitaj_matches_r_for_simultaneous_competing_transitions():
     result = survival.survfitaj(**_competing_survfitaj_kwargs(sefit=3))
 

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -1636,8 +1636,10 @@ def test_surv_multistate_helpers_preserve_state_metadata():
     assert subset.type == "mright"
     assert subset.states == response.states
     assert subset.status == (1, 0)
-    with pytest.raises(NotImplementedError, match="multi-state Surv"):
-        survival.survfit(response)
+    curve = survival.survfit(response)
+    assert isinstance(curve, survival.SurvfitMultiStateResult)
+    assert curve.states == ("(s0)", *response.states)
+    assert curve.time == pytest.approx([1.0, 2.0])
 
 
 def test_surv_multistate_preserves_categorical_level_order():
@@ -1662,6 +1664,148 @@ def test_surv_multistate_preserves_categorical_level_order():
     assert numeric.status == (0, 2, 1)
     assert numeric_strings.states == ("10", "2")
     assert numeric_strings.status == (0, 1, 2)
+
+
+def test_survfit_multistate_matches_r_aalen_johansen_fixture():
+    response = survival.Surv(
+        [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+        ["censor", "ill", "death", "ill", "censor", "death"],
+        type="mstate",
+    )
+
+    fit = survival.survfit(response)
+
+    assert isinstance(fit, survival.SurvfitMultiStateResult)
+    assert fit.time == pytest.approx([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+    assert fit.states == ("(s0)", "death", "ill")
+    assert fit.transitions == ((0, 1), (0, 2))
+    assert fit.transition_labels == (("(s0)", "death"), ("(s0)", "ill"))
+    assert fit.p0 == pytest.approx([1.0, 0.0, 0.0])
+    assert fit.t0 == 0.0
+    assert fit.n == fit.n_id == 6
+    expected_risk = [[value, 0.0, 0.0] for value in [6, 5, 4, 3, 2, 1]]
+    expected_pstate = [
+        [1.0, 0.0, 0.0],
+        [0.8, 0.0, 0.2],
+        [0.6, 0.2, 0.2],
+        [0.4, 0.2, 0.4],
+        [0.4, 0.2, 0.4],
+        [0.0, 0.6, 0.4],
+    ]
+    expected_cumhaz = [
+        [0.0, 0.0],
+        [0.0, 0.2],
+        [0.25, 0.2],
+        [0.25, 0.5333333333333333],
+        [0.25, 0.5333333333333333],
+        [1.25, 0.5333333333333333],
+    ]
+    for actual, expected in zip(fit.n_risk, expected_risk, strict=True):
+        assert actual == pytest.approx(expected)
+    for actual, expected in zip(fit.pstate, expected_pstate, strict=True):
+        assert actual == pytest.approx(expected)
+    for actual, expected in zip(fit.cumhaz, expected_cumhaz, strict=True):
+        assert actual == pytest.approx(expected)
+    assert fit.n_event == [
+        [0.0, 0.0, 0.0],
+        [0.0, 0.0, 1.0],
+        [0.0, 1.0, 0.0],
+        [0.0, 0.0, 1.0],
+        [0.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+    ]
+    assert fit.std_err is not None
+    assert fit.std_err[1] == pytest.approx([0.1788854382, 0.0, 0.1788854382])
+    assert fit.std_chaz is not None
+    assert fit.std_chaz[-1] == pytest.approx([0.2165063509, 0.3256901504])
+    assert fit.conf_lower is not None
+    assert fit.conf_lower[1] == pytest.approx([0.5161257603, 0.0, 0.0346491185])
+    assert fit.conf_upper is not None
+    assert fit.conf_upper[1] == pytest.approx([1.0, 0.0, 1.0])
+    assert fit.n_risk_count == fit.n_risk
+    assert fit.n_transition_count == fit.n_transition
+
+    time0_fit = survival.survfit(response, time0=True)
+    assert time0_fit.time == pytest.approx([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+    assert time0_fit.n_risk[0] == pytest.approx([0.0, 0.0, 0.0])
+    assert time0_fit.pstate[0] == pytest.approx([1.0, 0.0, 0.0])
+
+    conditional = survival.survfit(response, start_time=3.0)
+    assert conditional.time == pytest.approx([3.0, 4.0, 5.0, 6.0])
+    assert conditional.n_risk[0] == pytest.approx([4.0, 0.0, 0.0])
+    assert conditional.pstate[0] == pytest.approx([0.75, 0.25, 0.0])
+
+    without_se = survival.survfit(response, se_fit=False)
+    assert without_se.std_err is None
+    assert without_se.std_chaz is None
+    assert without_se.conf_lower is None
+    assert without_se.conf_upper is None
+
+    zero_weight = survival.survfit(response, weights=[1.0, 0.0, 1.0, 1.0, 1.0, 1.0])
+    assert zero_weight.n_risk[0] == pytest.approx([5.0, 0.0, 0.0])
+    assert zero_weight.n_event[1] == pytest.approx([0.0, 0.0, 0.0])
+
+
+def test_survfit_multistate_supports_formula_groups_weights_and_etype():
+    data = {
+        "time": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+        "event": ["censor", "ill", "death", "ill", "censor", "death"],
+        "status": [0, 1, 1, 1, 0, 1],
+        "kind": ["none", "ill", "death", "ill", "none", "death"],
+        "arm": ["b", "a", "b", "a", "b", "a"],
+        "weight": [1.0, 2.0, 1.0, 1.0, 1.0, 1.0],
+    }
+
+    grouped = survival.survfit(
+        "Surv(time, event, type='mstate') ~ arm",
+        data=data,
+        weights=data["weight"],
+    )
+
+    assert list(grouped) == ["a", "b"]
+    assert grouped["a"].time == pytest.approx([2.0, 4.0, 6.0])
+    assert grouped["a"].n_risk == [[4.0, 0.0, 0.0], [2.0, 0.0, 0.0], [1.0, 0.0, 0.0]]
+    assert grouped["a"].pstate[0] == pytest.approx([0.5, 0.0, 0.5])
+    assert grouped["a"].pstate[-1] == pytest.approx([0.0, 0.25, 0.75])
+    assert grouped["b"].time == pytest.approx([1.0, 3.0, 5.0])
+    assert grouped["b"].pstate[-1] == pytest.approx([0.5, 0.5, 0.0])
+
+    etype_fit = survival.survfit(
+        "Surv(time, status) ~ 1",
+        data=data,
+        etype="kind",
+    )
+    direct_etype = survival.survfit(
+        survival.Surv(data["time"], data["status"]),
+        etype=data["kind"],
+    )
+    assert etype_fit.states == direct_etype.states == ("(s0)", "death", "ill")
+    for actual, expected in zip(etype_fit.pstate, direct_etype.pstate, strict=True):
+        assert actual == pytest.approx(expected)
+
+
+def test_survfit_multistate_validates_unsupported_options():
+    response = survival.Surv(
+        [1.0, 2.0, 3.0],
+        ["censor", "ill", "death"],
+        type="mstate",
+    )
+    with pytest.raises(ValueError, match="robust variance"):
+        survival.survfit(response, robust=False)
+    with pytest.raises(ValueError, match="Aalen-Johansen"):
+        survival.survfit(response, type="fh")
+    with pytest.raises(ValueError, match="reverse"):
+        survival.survfit(response, reverse=True)
+    with pytest.raises(NotImplementedError, match="counting-process multi-state"):
+        survival.survfit(
+            survival.Surv(
+                [0.0, 0.0],
+                [1.0, 2.0],
+                ["censor", "ill"],
+                type="mstate",
+            ),
+            id=["a", "b"],
+        )
 
 
 def test_surv2_response_matches_r_multistate_shape():
@@ -15712,8 +15856,11 @@ def test_r_api_rejects_unsupported_formula_features():
     with pytest.raises(NotImplementedError, match="istate"):
         survival.survfit(survival.Surv([1.0, 2.0], [1, 0]), istate=[0, 1])
 
-    with pytest.raises(NotImplementedError, match="etype"):
-        survival.survfit(survival.Surv([1.0, 2.0], [1, 0]), etype=[1, 2])
+    etype_fit = survival.survfit(
+        survival.Surv([1.0, 2.0], [1, 0]),
+        etype=[1, 2],
+    )
+    assert etype_fit.states == ("(s0)", "1")
 
     with pytest.raises(TypeError, match="entry"):
         survival.survfit(survival.Surv([1.0, 2.0], [1, 0]), entry=1)

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -1580,6 +1580,90 @@ def test_surv_right_censored_response():
         survival.format_surv([1.0, 2.0])
 
 
+def test_surv_multistate_responses_match_r_shape_and_formatting():
+    right = survival.Surv(
+        [1.0, 2.0, 3.0, 4.0],
+        ["censor", "ill", "death", "ill"],
+        type="mstate",
+    )
+    counting = survival.Surv(
+        [0.0, 0.0, 1.0, 2.0],
+        [1.0, 2.0, 3.0, 4.0],
+        ["ill", "censor", "death", "ill"],
+        type="mstate",
+    )
+    missing = survival.Surv(
+        [1.0, 2.0, 3.0],
+        [None, "censor", "death"],
+        type="m",
+    )
+
+    assert right.type == "mright"
+    assert right.status == (0, 2, 1, 2)
+    assert right.states == ("death", "ill")
+    assert survival.format_surv(right) == ["1+     ", "2:ill  ", "3:death", "4:ill  "]
+
+    assert counting.type == "mcounting"
+    assert counting.status == (2, 0, 1, 2)
+    assert counting.states == ("death", "ill")
+    assert survival.format_surv(counting) == [
+        "(0,1:ill]".ljust(11),
+        "(0,2+]".ljust(11),
+        "(1,3:death]",
+        "(2,4:ill]".ljust(11),
+    ]
+
+    assert missing.status == (None, 0, 1)
+    assert missing.states == ("death",)
+    assert survival.is_na_surv(missing) == [True, False, False]
+    assert survival.format_surv(missing) == ["1?     ", "2+     ", "3:death"]
+
+
+def test_surv_multistate_helpers_preserve_state_metadata():
+    response = survival.Surv(
+        [1.0, 1.0 + 1e-10, 2.0],
+        ["censor", "ill", "death"],
+        type="mstate",
+    )
+
+    adjusted = survival.aeqSurv(response)
+    subset = survival.r_api._subset_surv(response, [2, 0])
+
+    assert adjusted.type == "mright"
+    assert adjusted.states == response.states
+    assert adjusted.status == response.status
+    assert adjusted.time[0] == adjusted.time[1]
+    assert subset.type == "mright"
+    assert subset.states == response.states
+    assert subset.status == (1, 0)
+    with pytest.raises(NotImplementedError, match="multi-state Surv"):
+        survival.survfit(response)
+
+
+def test_surv_multistate_preserves_categorical_level_order():
+    pandas = pytest.importorskip("pandas")
+    events = pandas.Categorical(
+        ["censor", "ill", "censor"],
+        categories=["censor", "ill", "death"],
+    )
+
+    response = survival.Surv([1.0, 2.0, 3.0], events, type="mstate")
+
+    assert response.status == (0, 1, 0)
+    assert response.states == ("ill", "death")
+
+    numeric = survival.Surv([1.0, 2.0, 3.0], [0, 10, 2], type="mstate")
+    numeric_strings = survival.Surv(
+        [1.0, 2.0, 3.0],
+        ["0", "10", "2"],
+        type="mstate",
+    )
+    assert numeric.states == ("2", "10")
+    assert numeric.status == (0, 2, 1)
+    assert numeric_strings.states == ("10", "2")
+    assert numeric_strings.status == (0, 1, 2)
+
+
 def test_surv2_response_matches_r_multistate_shape():
     response = survival.Surv2([1.0, 2.0, 3.0], ["a", "b", "c"])
     missing = survival.Surv2([1.0, math.nan, 3.0], [None, "b", "c"], repeated=True)

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -1796,16 +1796,182 @@ def test_survfit_multistate_validates_unsupported_options():
         survival.survfit(response, type="fh")
     with pytest.raises(ValueError, match="reverse"):
         survival.survfit(response, reverse=True)
-    with pytest.raises(NotImplementedError, match="counting-process multi-state"):
+    with pytest.raises(ValueError, match="both istate and etype"):
         survival.survfit(
-            survival.Surv(
-                [0.0, 0.0],
-                [1.0, 2.0],
-                ["censor", "ill"],
-                type="mstate",
-            ),
-            id=["a", "b"],
+            survival.Surv([1.0, 2.0], [0, 1]),
+            istate=["entry", "entry"],
+            etype=["none", "death"],
         )
+
+
+def test_survfit_counting_multistate_matches_r_subject_history_fixture():
+    class Factor(list):
+        def __init__(self, values, levels):
+            super().__init__(values)
+            self.categories = levels
+
+    subject_id = [1, 1, 2, 3, 3]
+    response = survival.Surv(
+        [0.0, 1.0, 0.0, 0.0, 1.0],
+        [1.0, 3.0, 2.0, 1.0, 3.0],
+        Factor(
+            ["ill", "censor", "death", "censor", "death"],
+            ["censor", "ill", "death"],
+        ),
+        type="mstate",
+    )
+
+    fit = survival.survfit(response, id=subject_id)
+
+    assert fit.time == pytest.approx([1.0, 2.0, 3.0])
+    assert fit.states == ("(s0)", "ill", "death")
+    assert fit.transitions == ((0, 1), (0, 2))
+    assert fit.n == 5
+    assert fit.n_id == 3
+    assert fit.p0 == pytest.approx([1.0, 0.0, 0.0])
+    assert fit.n_risk == [
+        [3.0, 0.0, 0.0],
+        [2.0, 1.0, 0.0],
+        [1.0, 1.0, 0.0],
+    ]
+    assert fit.n_event == [
+        [0.0, 1.0, 0.0],
+        [0.0, 0.0, 1.0],
+        [0.0, 0.0, 1.0],
+    ]
+    assert fit.n_censor == [
+        [0.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+    ]
+    expected_pstate = [
+        [2 / 3, 1 / 3, 0.0],
+        [1 / 3, 1 / 3, 1 / 3],
+        [0.0, 1 / 3, 2 / 3],
+    ]
+    expected_cumhaz = [
+        [1 / 3, 0.0],
+        [1 / 3, 0.5],
+        [1 / 3, 1.5],
+    ]
+    for actual, expected in zip(fit.pstate, expected_pstate, strict=True):
+        assert actual == pytest.approx(expected)
+    for actual, expected in zip(fit.cumhaz, expected_cumhaz, strict=True):
+        assert actual == pytest.approx(expected)
+    assert fit.std_err is not None
+    expected_std_err = [
+        [0.272165527, 0.272165527, 0.0],
+        [0.272165527, 0.272165527, 0.272165527],
+        [0.0, 0.272165527, 0.272165527],
+    ]
+    for actual, expected in zip(fit.std_err, expected_std_err, strict=True):
+        assert actual == pytest.approx(expected)
+
+    with_entry = survival.survfit(response, id=subject_id, entry=True)
+    assert with_entry.time == pytest.approx([0.0, 1.0, 2.0, 3.0])
+    assert with_entry.n_enter is not None
+    assert with_entry.n_enter[0] == pytest.approx([3.0, 0.0, 0.0])
+    assert with_entry.n_enter_count is not None
+    assert with_entry.n_enter_count[0] == pytest.approx([3.0, 0.0, 0.0])
+
+    independent_rows = survival.survfit(response)
+    assert independent_rows.n_id == 5
+    assert independent_rows.n_risk == [
+        [3.0, 0.0, 0.0],
+        [3.0, 0.0, 0.0],
+        [2.0, 0.0, 0.0],
+    ]
+
+
+def test_survfit_counting_multistate_supports_istate_formula_and_etype():
+    class Factor(list):
+        def __init__(self, values, levels):
+            super().__init__(values)
+            self.categories = levels
+
+    data = {
+        "id": [1, 1, 2, 3, 3],
+        "start": [0.0, 1.0, 0.0, 0.0, 1.0],
+        "stop": [1.0, 3.0, 2.0, 1.0, 3.0],
+        "event": Factor(
+            ["ill", "censor", "death", "censor", "death"],
+            ["censor", "ill", "death"],
+        ),
+        "status": [1, 0, 1, 0, 1],
+        "kind": ["ill", "none", "death", "none", "death"],
+        "state": ["entry", "ill", "entry", "entry", "entry"],
+    }
+
+    fit = survival.survfit(
+        "Surv(start, stop, event, type='mstate') ~ 1",
+        data=data,
+        id="id",
+        istate="state",
+    )
+
+    assert fit.states == ("entry", "death", "ill")
+    assert fit.p0 == pytest.approx([1.0, 0.0, 0.0])
+    assert fit.pstate[-1] == pytest.approx([0.0, 2 / 3, 1 / 3])
+
+    etype_fit = survival.survfit(
+        "Surv(start, stop, status) ~ 1",
+        data=data,
+        id="id",
+        etype="kind",
+    )
+    assert etype_fit.states == ("(s0)", "death", "ill")
+    assert etype_fit.pstate[-1] == pytest.approx([0.0, 2 / 3, 1 / 3])
+
+    invalid_state = list(data["state"])
+    invalid_state[1] = "entry"
+    with pytest.raises(ValueError, match="istate is inconsistent"):
+        survival.survfit(
+            survival.Surv(data["start"], data["stop"], data["event"], type="mstate"),
+            id=data["id"],
+            istate=invalid_state,
+        )
+
+    heterogeneous = survival.Surv(
+        [0.0, 0.0],
+        [2.0, 2.0],
+        Factor(["death", "death"], ["censor", "death"]),
+        type="mstate",
+    )
+    heterogeneous_fit = survival.survfit(
+        heterogeneous,
+        id=[1, 2],
+        istate=Factor(["entry", "ill"], ["entry", "ill", "death"]),
+    )
+    assert heterogeneous_fit.time == pytest.approx([2.0])
+    assert heterogeneous_fit.states == ("entry", "ill", "death")
+    assert heterogeneous_fit.p0 == pytest.approx([0.5, 0.5, 0.0])
+    assert heterogeneous_fit.pstate[0] == pytest.approx([0.0, 0.0, 1.0])
+    assert heterogeneous_fit.std_err0 == pytest.approx([0.3535533906, 0.3535533906, 0.0])
+
+    heterogeneous_time0 = survival.survfit(
+        heterogeneous,
+        id=[1, 2],
+        istate=Factor(["entry", "ill"], ["entry", "ill", "death"]),
+        time0=True,
+    )
+    assert heterogeneous_time0.time == pytest.approx([2.0])
+    assert heterogeneous_time0.std_err0 is None
+
+    delayed_start = survival.Surv(
+        [0.0, 1.0, 0.0],
+        [1.0, 3.0, 3.0],
+        Factor(["ill", "censor", "censor"], ["censor", "ill"]),
+        type="mstate",
+    )
+    delayed_fit = survival.survfit(
+        delayed_start,
+        id=[1, 1, 2],
+        start_time=2.0,
+    )
+    assert delayed_fit.time == pytest.approx([3.0])
+    assert delayed_fit.p0 == pytest.approx([0.5, 0.5])
+    assert delayed_fit.pstate[0] == pytest.approx([0.5, 0.5])
+    assert delayed_fit.std_err0 == pytest.approx([0.3535533906, 0.3535533906])
 
 
 def test_surv2_response_matches_r_multistate_shape():

--- a/src/surv_analysis/survfitaj.rs
+++ b/src/surv_analysis/survfitaj.rs
@@ -380,6 +380,9 @@ fn compute_survfitaj_estimates(
             let Some(to) = observation_target(data.y, idx) else {
                 continue;
             };
+            if data.wt[idx] == 0.0 {
+                continue;
+            }
             event_count += 1;
             let from = data.cstate[idx];
             let transition = params.hindx[[from, to]];
@@ -414,6 +417,9 @@ fn compute_survfitaj_estimates(
                 let Some(to) = observation_target(data.y, idx) else {
                     continue;
                 };
+                if data.wt[idx] == 0.0 {
+                    continue;
+                }
                 let from = data.cstate[idx];
                 if from != to {
                     let term = data.wt[idx] * phat[from] / counts.n_risk[[time_idx, from]];
@@ -692,16 +698,6 @@ fn validate_survfitaj_inputs(
     validate_no_nan(i0, "i0")?;
     validate_finite(i0, "i0")?;
 
-    if let Some((idx, weight)) = wt
-        .iter()
-        .copied()
-        .enumerate()
-        .find(|(_, weight)| *weight <= 0.0)
-    {
-        return Err(PyValueError::new_err(format!(
-            "wt must contain only positive values; found {weight} at index {idx}"
-        )));
-    }
     if let Some((idx, times)) = utime
         .windows(2)
         .enumerate()


### PR DESCRIPTION
## Summary
- add a typed high-level multi-state `survfit` result with risk, event, censor, transition, state-probability, cumulative-hazard, variance, and confidence tables
- route right-censored competing-risk responses through the Rust Aalen–Johansen kernel, including grouped formulas, case weights, clusters, `start_time`, `time0`, and R-style confidence transforms
- support R-compatible `etype` conversion for direct and formula inputs while retaining explicit validation for counting-process inputs that are not covered by this slice
- accept zero case weights in the Rust kernel and skip their influence updates, including the all-zero finite-variance edge case

## Stack
- depends on #292, which adds the multi-state `Surv` response representation and metadata preservation

## Testing
- `.venv/bin/python -m pytest -q --import-mode=importlib python/tests/` (800 passed, 18 skipped)
- focused Rust `survfitaj` tests (19 passed)
- Ruff formatting and lint checks
- public stub type checks
- Rust formatting check
- direct comparison with R survival 3.8.6 fixtures for ungrouped, grouped weighted, `etype`, `start_time`, `time0`, confidence intervals, and zero case weights