### PR TITLE
Add multi-state survfit result tables

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -797,6 +797,27 @@ def _coerce_array_like(values: Any, name: str) -> list[Any]:
     return result
 
 
+class _RFactorVector:
+    """Iterable factor values with level metadata preserved across reticulate."""
+
+    def __init__(self, values: Any, levels: Any):
+        self._values = tuple(values)
+        self.categories = tuple(levels)
+
+    def __iter__(self):
+        return iter(self._values)
+
+    def __len__(self) -> int:
+        return len(self._values)
+
+    def __getitem__(self, item: int) -> Any:
+        return self._values[item]
+
+
+def _r_factor(values: Any, levels: Any) -> _RFactorVector:
+    return _RFactorVector(values, levels)
+
+
 def _materialize_1d(values: Any, name: str) -> list[Any]:
     result = _coerce_array_like(values, name)
     if result and isinstance(result[0], list | tuple):
@@ -897,11 +918,16 @@ def _mstate_inferred_levels(values: Sequence[Any]) -> list[str]:
     return sorted(labels)
 
 
+def _mstate_categories(values: Any) -> Any | None:
+    categories = getattr(values, "categories", None)
+    if categories is not None:
+        return categories
+    return getattr(getattr(values, "dtype", None), "categories", None)
+
+
 def _mstate_event_vector(values: Any, name: str) -> tuple[list[int | None], tuple[str, ...]]:
     raw = _materialize_1d(values, name)
-    categories = getattr(values, "categories", None)
-    if categories is None:
-        categories = getattr(getattr(values, "dtype", None), "categories", None)
+    categories = _mstate_categories(values)
     if categories is None:
         levels = _mstate_inferred_levels(raw)
     else:
@@ -920,9 +946,7 @@ def _mstate_event_vector(values: Any, name: str) -> tuple[list[int | None], tupl
 
 def _mstate_levels(values: Any, name: str) -> tuple[list[Any], list[str]]:
     raw = _materialize_1d(values, name)
-    categories = getattr(values, "categories", None)
-    if categories is None:
-        categories = getattr(getattr(values, "dtype", None), "categories", None)
+    categories = _mstate_categories(values)
     levels = (
         _mstate_inferred_levels(raw)
         if categories is None
@@ -1099,11 +1123,15 @@ def _subset_indices(subset: Any, n: int) -> list[int]:
     return indices
 
 
-def _subset_sequence(values: Any, indices: list[int], name: str) -> list[Any]:
+def _subset_sequence(values: Any, indices: list[int], name: str) -> Any:
     materialized = _coerce_array_like(values, name)
     if indices and max(indices) >= len(materialized):
         raise ValueError(f"{name} must have enough rows for subset")
-    return [materialized[idx] for idx in indices]
+    subsetted = [materialized[idx] for idx in indices]
+    categories = _mstate_categories(values)
+    if categories is not None:
+        return _RFactorVector(subsetted, categories)
+    return subsetted
 
 
 def _subset_optional_sequence(
@@ -1593,18 +1621,22 @@ def brier(
     return result
 
 
-def _column(data: Any, name: str) -> list[Any]:
+def _column_source(data: Any, name: str) -> Any:
     if data is None:
         raise ValueError("data is required when using a formula")
     if isinstance(data, Mapping):
         try:
-            return _materialize_1d(data[name], name)
+            return data[name]
         except KeyError as exc:
             raise KeyError(f"column {name!r} not found in data") from exc
     try:
-        return _materialize_1d(data[name], name)
+        return data[name]
     except Exception as exc:
         raise KeyError(f"column {name!r} not found in data") from exc
+
+
+def _column(data: Any, name: str) -> list[Any]:
+    return _materialize_1d(_column_source(data, name), name)
 
 
 def _formula_name(name: str) -> tuple[str, bool]:
@@ -1930,7 +1962,7 @@ def _response_rep_count(count_expression: str, inferred_length: int | None) -> i
     return count
 
 
-def _response_arg_values(data: Any, part: str, inferred_length: int | None = None) -> list[Any]:
+def _response_arg_values(data: Any, part: str, inferred_length: int | None = None) -> Any:
     part = _unwrap_response_identity(part)
     rep_call = _response_rep_call(part)
     if rep_call is not None:
@@ -1942,7 +1974,7 @@ def _response_arg_values(data: Any, part: str, inferred_length: int | None = Non
         operand = _response_operand(part, allow_literal=False)
         if operand.column is None:
             raise ValueError("Surv(...) formula response arguments must be data columns")
-        return _column(data, operand.column)
+        return _column_source(data, operand.column)
 
     left_operand = _response_operand(comparison[0], allow_literal=True)
     right_operand = _response_operand(comparison[2], allow_literal=True)
@@ -1966,7 +1998,7 @@ def _response_arg_values(data: Any, part: str, inferred_length: int | None = Non
     raise ValueError("formula response comparisons require at least one data column")
 
 
-def _formula_response_values(data: Any, spec: _SurvResponseSpec) -> list[list[Any]]:
+def _formula_response_values(data: Any, spec: _SurvResponseSpec) -> list[Any]:
     inferred_length: int | None = None
     if spec.columns:
         inferred_length = len(_column(data, spec.columns[0]))
@@ -4661,6 +4693,12 @@ class Surv:
             args = named_args
 
         surv_type = _normalize_surv_type(type) if type is not None else None
+        categorical_event = len(args) in {2, 3} and _mstate_categories(args[-1]) is not None
+        if categorical_event and (
+            (len(args) == 2 and surv_type in {None, "right", "left", "mstate"})
+            or (len(args) == 3 and surv_type in {None, "counting", "mstate"})
+        ):
+            surv_type = "mstate"
         states: tuple[str, ...] = ()
         origin_value = _finite_float(origin, "origin")
         if len(args) == 1:
@@ -4792,7 +4830,7 @@ class Surv2:
             raise ValueError("invalid value for repeated option")
         repeated_value = bool(repeated)
 
-        levels = _surv2_levels(event_values)
+        levels = _surv2_levels(event)
         states = levels[1:]
         if any(state == "" for state in states):
             raise ValueError("each state must have a non-blank name")
@@ -4831,9 +4869,16 @@ def _surv2_level_sort_key(label: str) -> tuple[int, Any]:
     return (1, label)
 
 
-def _surv2_levels(events: Sequence[Any]) -> list[str]:
+def _surv2_levels(events: Any) -> list[str]:
+    categories = _mstate_categories(events)
+    if categories is not None:
+        return [
+            _surv2_event_label(value)
+            for value in _materialize_1d(categories, "event categories")
+            if not _is_missing_value(value)
+        ]
     levels: dict[str, None] = {}
-    for value in events:
+    for value in _materialize_1d(events, "event"):
         if not _is_missing_value(value):
             levels.setdefault(_surv2_event_label(value), None)
     return sorted(levels, key=_surv2_level_sort_key)
@@ -14499,6 +14544,70 @@ def _survfit_frame(result: SurvfitResult) -> dict[str, list[Any]]:
     return frame
 
 
+def _survfit_multistate_column(
+    values: Sequence[Sequence[Any]],
+    state_index: int,
+    row_count: int,
+    state_count: int,
+    name: str,
+) -> list[Any]:
+    if len(values) != row_count:
+        raise ValueError(f"multi-state survfit column {name!r} must match time length")
+    column: list[Any] = []
+    for row in values:
+        if len(row) != state_count:
+            raise ValueError(f"multi-state survfit column {name!r} must have one value per state")
+        column.append(row[state_index])
+    return column
+
+
+def _survfit_multistate_frame(result: SurvfitMultiStateResult) -> dict[str, list[Any]]:
+    row_count = len(result.time)
+    state_count = len(result.states)
+    required = {
+        "n.risk": result.n_risk,
+        "n.event": result.n_event,
+        "n.censor": result.n_censor,
+        "pstate": result.pstate,
+    }
+    optional = {
+        "std.err": result.std_err,
+        "lower": result.conf_lower,
+        "upper": result.conf_upper,
+    }
+    frame: dict[str, list[Any]] = {
+        "time": [],
+        **{name: [] for name in required},
+        **{name: [] for name, values in optional.items() if values is not None},
+        "state": [],
+    }
+    for state_index, state in enumerate(result.states):
+        frame["time"].extend(float(value) for value in result.time)
+        for name, values in required.items():
+            frame[name].extend(
+                _survfit_multistate_column(
+                    values,
+                    state_index,
+                    row_count,
+                    state_count,
+                    name,
+                )
+            )
+        for name, values in optional.items():
+            if values is not None:
+                frame[name].extend(
+                    _survfit_multistate_column(
+                        values,
+                        state_index,
+                        row_count,
+                        state_count,
+                        name,
+                    )
+                )
+        frame["state"].extend([state] * row_count)
+    return frame
+
+
 def _turnbull_survfit_frame(result: TurnbullSurvfitResult) -> dict[str, list[Any]]:
     return {
         "time": result.time_points,
@@ -14509,6 +14618,31 @@ def _turnbull_survfit_frame(result: TurnbullSurvfitResult) -> dict[str, list[Any
 
 
 def _grouped_survfit_frame(result: Mapping[Any, Any]) -> dict[str, list[Any]]:
+    if result and all(isinstance(curve, SurvfitMultiStateResult) for curve in result.values()):
+        curve_frames = {label: _survfit_multistate_frame(curve) for label, curve in result.items()}
+        columns = list(next(iter(curve_frames.values())))
+        if "state" not in columns:
+            raise ValueError("multi-state survfit frame is missing its state column")
+        frame = {
+            name: [] for name in [*[name for name in columns if name != "state"], "strata", "state"]
+        }
+        states = next(iter(result.values())).states
+        if any(curve.states != states for curve in result.values()):
+            raise ValueError("grouped multi-state results must share state columns")
+        for state in states:
+            for label, curve_frame in curve_frames.items():
+                if list(curve_frame) != columns:
+                    raise ValueError("grouped multi-state results must share tabular columns")
+                indices = [
+                    index for index, value in enumerate(curve_frame["state"]) if value == state
+                ]
+                frame["strata"].extend([str(label)] * len(indices))
+                frame["state"].extend([state] * len(indices))
+                for name in columns:
+                    if name != "state":
+                        frame[name].extend(curve_frame[name][index] for index in indices)
+        return frame
+
     frame: dict[str, list[Any]] = {}
     for label, curve in result.items():
         curve_frame = as_data_frame(curve)
@@ -14784,6 +14918,8 @@ def as_data_frame(result: Any) -> dict[str, list[Any]]:
         return _cox_survfit_frame(result)
     if isinstance(result, CoxBaseHazardResult):
         return _cox_basehaz_frame(result)
+    if isinstance(result, SurvfitMultiStateResult):
+        return _survfit_multistate_frame(result)
     if isinstance(result, SurvfitResult):
         return _survfit_frame(result)
     if isinstance(result, TurnbullSurvfitResult):

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -1649,10 +1649,21 @@ def test_surv_multistate_preserves_categorical_level_order():
         categories=["censor", "ill", "death"],
     )
 
-    response = survival.Surv([1.0, 2.0, 3.0], events, type="mstate")
+    response = survival.Surv([1.0, 2.0, 3.0], events)
+    explicit_right = survival.Surv([1.0, 2.0, 3.0], events, type="right")
+    explicit_counting = survival.Surv(
+        [0.0, 0.0, 1.0],
+        [1.0, 2.0, 3.0],
+        events,
+        type="counting",
+    )
 
     assert response.status == (0, 1, 0)
     assert response.states == ("ill", "death")
+    assert explicit_right.type == "mright"
+    assert explicit_right.states == response.states
+    assert explicit_counting.type == "mcounting"
+    assert explicit_counting.states == response.states
 
     numeric = survival.Surv([1.0, 2.0, 3.0], [0, 10, 2], type="mstate")
     numeric_strings = survival.Surv(
@@ -1841,6 +1852,67 @@ def test_survfit_multistate_supports_p0_and_survfit0():
         assert curve.pstate[0] == pytest.approx(p0)
 
 
+def test_as_data_frame_flattens_multistate_curves_like_r_summary():
+    class Factor(list):
+        def __init__(self, values, levels):
+            super().__init__(values)
+            self.categories = levels
+
+    response = survival.Surv(
+        [1.0, 2.0, 3.0, 4.0],
+        Factor(
+            ["ill", "death", "censor", "death"],
+            ["censor", "ill", "death"],
+        ),
+        type="mstate",
+    )
+    fit = survival.survfit(response, p0=[0.25, 0.5, 0.25])
+
+    frame = survival.as_data_frame(fit)
+
+    assert list(frame) == [
+        "time",
+        "n.risk",
+        "n.event",
+        "n.censor",
+        "pstate",
+        "std.err",
+        "lower",
+        "upper",
+        "state",
+    ]
+    assert frame["time"] == pytest.approx([1.0, 2.0, 3.0, 4.0] * 3)
+    assert frame["state"] == ["(s0)"] * 4 + ["ill"] * 4 + ["death"] * 4
+    assert frame["n.risk"] == pytest.approx([4.0, 3.0, 2.0, 1.0] + [0.0] * 8)
+    assert frame["n.event"] == pytest.approx(
+        [0.0] * 4 + [1.0, 0.0, 0.0, 0.0] + [0.0, 1.0, 0.0, 1.0]
+    )
+    assert frame["n.censor"] == pytest.approx([0.0, 0.0, 1.0, 0.0] + [0.0] * 8)
+    assert frame["pstate"] == pytest.approx(
+        [0.1875, 0.125, 0.125, 0.0] + [0.5625] * 4 + [0.25, 0.3125, 0.3125, 0.4375]
+    )
+
+    grouped = survival.survfit(
+        response,
+        group=["a", "a", "b", "b"],
+        p0=[0.25, 0.5, 0.25],
+    )
+    grouped_frame = survival.as_data_frame(grouped)
+    assert grouped_frame["state"] == ["(s0)"] * 4 + ["ill"] * 4 + ["death"] * 4
+    assert grouped_frame["strata"] == ["a", "a", "b", "b"] * 3
+    assert grouped_frame["time"] == pytest.approx([1.0, 2.0, 3.0, 4.0] * 3)
+
+    without_se = survival.as_data_frame(survival.survfit(response, se_fit=False))
+    assert list(without_se) == [
+        "time",
+        "n.risk",
+        "n.event",
+        "n.censor",
+        "pstate",
+        "state",
+    ]
+
+
 def test_survfit_multistate_validates_p0():
     response = survival.Surv(
         [1.0, 2.0, 3.0],
@@ -1984,15 +2056,15 @@ def test_survfit_counting_multistate_supports_istate_formula_and_etype():
     }
 
     fit = survival.survfit(
-        "Surv(start, stop, event, type='mstate') ~ 1",
+        "Surv(start, stop, event) ~ 1",
         data=data,
         id="id",
         istate="state",
     )
 
-    assert fit.states == ("entry", "death", "ill")
+    assert fit.states == ("entry", "ill", "death")
     assert fit.p0 == pytest.approx([1.0, 0.0, 0.0])
-    assert fit.pstate[-1] == pytest.approx([0.0, 2 / 3, 1 / 3])
+    assert fit.pstate[-1] == pytest.approx([0.0, 1 / 3, 2 / 3])
 
     etype_fit = survival.survfit(
         "Surv(start, stop, status) ~ 1",
@@ -2062,8 +2134,20 @@ def test_survfit_counting_multistate_supports_istate_formula_and_etype():
 
 
 def test_surv2_response_matches_r_multistate_shape():
+    class Factor(list):
+        def __init__(self, values, levels):
+            super().__init__(values)
+            self.categories = levels
+
     response = survival.Surv2([1.0, 2.0, 3.0], ["a", "b", "c"])
     missing = survival.Surv2([1.0, math.nan, 3.0], [None, "b", "c"], repeated=True)
+    categorical = survival.Surv2(
+        [1.0, 2.0, 3.0],
+        Factor(
+            ["entry", "death", "ill"],
+            ["censor", "entry", "ill", "death"],
+        ),
+    )
 
     assert len(response) == 3
     assert response.time == pytest.approx((1.0, 2.0, 3.0))
@@ -2077,6 +2161,8 @@ def test_surv2_response_matches_r_multistate_shape():
     assert missing.repeated is True
     assert survival.is_na_surv(missing) == [True, True, False]
     assert survival.format_surv(missing) == ["1? ", "NA+", "3:c"]
+    assert categorical.status == (1, 3, 2)
+    assert categorical.states == ("entry", "ill", "death")
 
     with pytest.raises(ValueError, match="different lengths"):
         survival.Surv2([1.0, 2.0], ["a"])

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -148,9 +148,19 @@ if (getRversion() >= "2.15.1") {
   frame
 }
 
+.as_python_factor <- function(value) {
+  factor_values <- as.character(value)
+  if (anyNA(factor_values)) {
+    factor_values <- lapply(factor_values, function(item) {
+      if (is.na(item)) reticulate::py_none() else item
+    })
+  }
+  .python_attr("_r_factor")(factor_values, levels(value))
+}
+
 .as_python_vector <- function(value) {
   if (is.factor(value)) {
-    value <- as.character(value)
+    return(.as_python_factor(value))
   } else if (inherits(value, "Date")) {
     value <- as.numeric(value)
   } else {
@@ -347,6 +357,42 @@ attrassign.lm <- function(object, ...) {
   surv_type <- attr(value, "type")
   if (is.null(surv_type)) {
     surv_type <- if (ncol(value) == 3L) "counting" else "right"
+  }
+  if (surv_type %in% c("mright", "mcounting")) {
+    states <- attr(value, "states")
+    if (is.null(states)) {
+      stop("multi-state Surv response is missing its states", call. = FALSE)
+    }
+    status <- as.integer(value[, ncol(value)])
+    event_values <- rep("(censored)", length(status))
+    event_values[is.na(status)] <- NA_character_
+    event_rows <- !is.na(status) & status > 0L
+    event_values[event_rows] <- states[status[event_rows]]
+    event <- factor(
+      event_values,
+      levels = c("(censored)", states)
+    )
+    if (ncol(value) == 2L) {
+      return(.wrap_python(
+        .python_attr("Surv")(
+          as.numeric(value[, 1L]),
+          .as_python_factor(event),
+          type = "mstate"
+        ),
+        c("survival_py_surv", "survival_py_object")
+      ))
+    }
+    if (ncol(value) == 3L) {
+      return(.wrap_python(
+        .python_attr("Surv")(
+          as.numeric(value[, 1L]),
+          as.numeric(value[, 2L]),
+          .as_python_factor(event),
+          type = "mstate"
+        ),
+        c("survival_py_surv", "survival_py_object")
+      ))
+    }
   }
   if (ncol(value) == 2L) {
     return(.wrap_python(
@@ -728,7 +774,8 @@ attrassign.lm <- function(object, ...) {
   diff(c(0, cumulative[indices + 1L]))
 }
 
-.survival_py_summary_curve_at_times <- function(curve, times, extend, dosum) {
+.survival_py_summary_curve_at_times <- function(curve, times, extend, dosum,
+                                                augment = TRUE) {
   if (nrow(curve) == 0L || !("time" %in% names(curve))) {
     return(curve[0L, , drop = FALSE])
   }
@@ -741,7 +788,7 @@ attrassign.lm <- function(object, ...) {
     return(curve[0L, , drop = FALSE])
   }
 
-  augmented <- .survival_py_summary_augmented_curve(curve)
+  augmented <- if (augment) .survival_py_summary_augmented_curve(curve) else curve
   index1 <- findInterval(selected_times, augmented$time)
   step_index <- pmax(1L, index1)
   result <- augmented[step_index, , drop = FALSE]
@@ -765,7 +812,7 @@ attrassign.lm <- function(object, ...) {
 }
 
 .survival_py_summary_split_frame <- function(frame) {
-  group_columns <- intersect(c("strata", "curve"), names(frame))
+  group_columns <- intersect(c("state", "strata", "curve"), names(frame))
   if (length(group_columns) == 0L) {
     return(list(frame))
   }
@@ -774,17 +821,56 @@ attrassign.lm <- function(object, ...) {
   split(frame, factor(keys, levels = unique(keys)), drop = TRUE)
 }
 
+.survival_py_summary_event_rows <- function(frame) {
+  if (!("state" %in% names(frame)) || !("time" %in% names(frame))) {
+    return(frame[["n.event"]] > 0)
+  }
+  key_columns <- c(intersect(c("strata", "curve"), names(frame)), "time")
+  keys <- do.call(paste, c(frame[key_columns], sep = "\r"))
+  groups <- factor(keys, levels = unique(keys))
+  stats::ave(frame[["n.event"]], groups, FUN = sum) > 0
+}
+
+.survival_py_summary_event_frame <- function(frame) {
+  keep <- .survival_py_summary_event_rows(frame)
+  delta_columns <- intersect(c("n.enter", "n.censor"), names(frame))
+  if (any(keep) && length(delta_columns) > 0L) {
+    group_columns <- intersect(c("state", "strata", "curve"), names(frame))
+    if (length(group_columns) == 0L) {
+      groups <- factor(rep.int("curve", nrow(frame)))
+    } else {
+      keys <- do.call(paste, c(frame[group_columns], sep = "\r"))
+      groups <- factor(keys, levels = unique(keys))
+    }
+    for (indices in split(seq_len(nrow(frame)), groups, drop = TRUE)) {
+      selected <- which(keep[indices])
+      if (length(selected) == 0L) {
+        next
+      }
+      for (name in delta_columns) {
+        cumulative <- cumsum(frame[[name]][indices])
+        frame[[name]][indices[selected]] <- diff(c(0, cumulative[selected]))
+      }
+    }
+  }
+  frame[keep, , drop = FALSE]
+}
+
 .survival_py_survfit_summary_frame <- function(object, times, censored, scale,
                                                extend, data.frame, dosum, ...) {
   censored <- .survival_py_summary_logical(censored, "censored")
   extend <- .survival_py_summary_logical(extend, "extend")
   data.frame <- .survival_py_summary_logical(data.frame, "data.frame")
   scale <- .survival_py_summary_scale(scale)
+  has_times <- !missing(times)
+  if (has_times) {
+    object <- survfit0(object)
+  }
   frame <- as.data.frame.survival_py_survfit(object, optional = TRUE)
 
-  if (missing(times)) {
+  if (!has_times) {
     if (!censored && "n.event" %in% names(frame)) {
-      frame <- frame[frame[["n.event"]] > 0, , drop = FALSE]
+      frame <- .survival_py_summary_event_frame(frame)
       row.names(frame) <- NULL
     }
   } else {
@@ -797,8 +883,8 @@ attrassign.lm <- function(object, ...) {
     if (!is.numeric(times)) {
       stop("times must be a numeric vector", call. = FALSE)
     }
-    if (any(is.na(times))) {
-      stop("times contains missing values", call. = FALSE)
+    if (any(!is.finite(times))) {
+      stop("times contains missing or infinite values", call. = FALSE)
     }
     if (missing(dosum)) {
       dosum <- all(diff(times) > 0)
@@ -813,7 +899,8 @@ attrassign.lm <- function(object, ...) {
       .survival_py_summary_curve_at_times,
       times = times,
       extend = extend,
-      dosum = dosum
+      dosum = dosum,
+      augment = FALSE
     )
     frame <- do.call(rbind, pieces)
     row.names(frame) <- NULL
@@ -2263,7 +2350,7 @@ Surv2 <- function(time, event, repeated = FALSE) {
     time_values <- as.list(time_values)
   }
   event_values <- .as_python_vector(event)
-  if (!is.list(event_values)) {
+  if (!is.factor(event) && !is.list(event_values)) {
     event_values <- as.list(event_values)
   }
   result <- .call_r_api(
@@ -5672,7 +5759,7 @@ survfit.formula <- function(formula, data = NULL, ..., subset = NULL, na.action 
     dots,
     data,
     parent.frame(),
-    vector_args = c("weights", "id", "cluster", "group")
+    vector_args = c("weights", "id", "cluster", "group", "istate", "etype")
   )
   do.call(
     .call_r_api,
@@ -5696,7 +5783,7 @@ survfit.character <- function(formula, data = NULL, ..., subset = NULL, na.actio
     dots,
     data,
     parent.frame(),
-    vector_args = c("weights", "id", "cluster", "group")
+    vector_args = c("weights", "id", "cluster", "group", "istate", "etype")
   )
   do.call(
     .call_r_api,
@@ -5725,14 +5812,26 @@ survfit.Surv <- function(formula, ..., group = NULL, subset = NULL, na.action = 
 }
 
 survfit.survival_py_surv <- function(formula, ..., group = NULL, subset = NULL, na.action = "fail") {
-  .call_r_api(
-    "survfit",
-    response = formula,
-    group = if (is.null(group)) NULL else .as_python_vector(group),
-    subset = subset,
-    `na.action` = .as_na_action(na.action),
-    ...,
-    .wrap = c("survival_py_survfit", "survival_py_object")
+  dots <- list(...)
+  vector_args <- intersect(c("weights", "id", "cluster", "istate", "etype"), names(dots))
+  for (name in vector_args) {
+    if (!is.null(dots[[name]])) {
+      dots[[name]] <- .as_python_vector(dots[[name]])
+    }
+  }
+  do.call(
+    .call_r_api,
+    c(
+      list(
+        "survfit",
+        response = formula,
+        group = if (is.null(group)) NULL else .as_python_vector(group),
+        subset = subset,
+        `na.action` = .as_na_action(na.action)
+      ),
+      dots,
+      list(.wrap = c("survival_py_survfit", "survival_py_object"))
+    )
   )
 }
 

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -4416,6 +4416,82 @@ test_that("survreg bridge agrees with R survival distributions", {
   }
 })
 
+test_that("multi-state survfit tables and summaries agree with R survival", {
+  skip_if_not_installed("reticulate")
+  skip_if_not_installed("survival")
+  skip_if_not(reticulate::py_module_available("survival"), "Python survival package is unavailable")
+
+  data <- data.frame(
+    time = c(1, 2, 3, 4, 5, 6),
+    event = factor(
+      c("ill", "death", "censor", "death", "ill", "censor"),
+      levels = c("censor", "ill", "death")
+    ),
+    group = factor(c("a", "a", "a", "b", "b", "b"))
+  )
+  p0 <- c(0.25, 0.5, 0.25)
+  compare_frames <- function(actual, expected) {
+    expect_identical(names(actual), names(expected))
+    expect_identical(actual$state, expected$state)
+    for (name in setdiff(names(expected), c("state", "strata"))) {
+      expect_equal(actual[[name]], expected[[name]], tolerance = 1e-06)
+    }
+    if ("strata" %in% names(expected)) {
+      expect_identical(as.character(actual$strata), as.character(expected$strata))
+    }
+  }
+
+  bridged <- survfit(Surv(time, event) ~ 1, data = data, p0 = p0)
+  reference <- survival::survfit(
+    survival::Surv(time, event) ~ 1,
+    data = data,
+    p0 = p0
+  )
+  compare_frames(
+    as.data.frame(bridged),
+    summary(reference, data.frame = TRUE, censored = TRUE)
+  )
+  compare_frames(
+    as.data.frame(summary(bridged)),
+    summary(reference, data.frame = TRUE)
+  )
+  compare_frames(
+    as.data.frame(summary(bridged, times = c(0, 1.5, 3, 7), extend = TRUE)),
+    summary(
+      reference,
+      times = c(0, 1.5, 3, 7),
+      extend = TRUE,
+      data.frame = TRUE
+    )
+  )
+
+  grouped_bridged <- survfit(Surv(time, event) ~ group, data = data, p0 = p0)
+  grouped_reference <- survival::survfit(
+    survival::Surv(time, event) ~ group,
+    data = data,
+    p0 = p0
+  )
+  grouped_expected <- summary(grouped_reference, data.frame = TRUE, censored = TRUE)
+  grouped_expected$strata <- sub("^group=", "", as.character(grouped_expected$strata))
+  compare_frames(as.data.frame(grouped_bridged), grouped_expected)
+
+  grouped_time_expected <- summary(
+    grouped_reference,
+    times = c(0, 2.5, 7),
+    extend = TRUE,
+    data.frame = TRUE
+  )
+  grouped_time_expected$strata <- sub(
+    "^group=",
+    "",
+    as.character(grouped_time_expected$strata)
+  )
+  compare_frames(
+    as.data.frame(summary(grouped_bridged, times = c(0, 2.5, 7), extend = TRUE)),
+    grouped_time_expected
+  )
+})
+
 test_that("Kaplan-Meier and log-rank bridge results agree with R survival", {
   skip_if_not_installed("reticulate")
   skip_if_not_installed("survival")


### PR DESCRIPTION
## Summary
- export direct and grouped multi-state `survfit` results as reference-compatible long-form tables
- preserve factor level metadata and infer multi-state responses through formula and direct bridge paths
- align event-only and requested-time summaries, including censor accumulation, initial distributions, state ordering, and grouped curves
- add Python and R reference-parity coverage for categorical responses, `Surv2`, direct tables, and summaries

## Testing
- `.venv/bin/pytest -q python/tests` (805 passed, 18 skipped)
- `.venv/bin/ruff format --check python`
- `.venv/bin/ruff check python`
- `uv run --no-sync mypy python/survival/__init__.pyi python/survival/_survival.pyi --ignore-missing-imports`
- `R CMD check --no-manual --no-build-vignettes r/survivalr` (1,279 assertions passed; expected source-directory NOTE)
- `cargo test survfitaj` (19 passed)

Stacked on #295.