### PR TITLE
Fix counting-process Cox score inference

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -13922,7 +13922,9 @@ def _cox_dfbeta_from_score_residuals(fit: Any, *, scaled: bool) -> list[list[flo
     score = [[float(value) for value in row] for row in score_method()]
     if nvar == 0:
         return score
-    variance = getattr(fit, "information_matrix", None)
+    variance = getattr(fit, "naive_variance", None)
+    if variance is None:
+        variance = getattr(fit, "information_matrix", None)
     if variance is None:
         raise TypeError("model does not expose coefficient variance")
     matrix = [list(row) for row in variance]

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -7984,7 +7984,10 @@ def test_coxph_formula_cluster_computes_robust_variance():
     score = clustered.score_residuals()
     expected_dfbeta = [
         [
-            sum(expected_robust[col_idx][inner_idx] * row[inner_idx] for inner_idx in range(2))
+            sum(
+                clustered.naive_information_matrix[col_idx][inner_idx] * row[inner_idx]
+                for inner_idx in range(2)
+            )
             for col_idx in range(2)
         ]
         for row in score
@@ -7993,7 +7996,7 @@ def test_coxph_formula_cluster_computes_robust_variance():
         [
             row[col_idx]
             / max(
-                math.sqrt(abs(expected_robust[col_idx][col_idx])),
+                math.sqrt(abs(clustered.naive_information_matrix[col_idx][col_idx])),
                 survival.r_api._COX_DFBETAS_SCALE_FLOOR,
             )
             for col_idx in range(2)
@@ -8016,7 +8019,7 @@ def test_coxph_formula_cluster_computes_robust_variance():
         strict=True,
     ):
         assert actual == pytest.approx(expected)
-    assert clustered.dfbeta()[3] != pytest.approx(clustered.fit.dfbeta()[3])
+    assert clustered.dfbeta()[3] == pytest.approx(clustered.fit.dfbeta()[3])
 
     row = [0.5, 0.8]
     robust_prediction = survival.predict(clustered, [row], reference="zero", se_fit=True)
@@ -10697,6 +10700,59 @@ def test_coxph_counting_process_score_and_dfbeta_residuals_sum_to_score_vector()
             scale = math.sqrt(abs(fit.information_matrix[0][0]))
             assert dfbeta[row_idx][0] == pytest.approx(expected_dfbeta)
             assert dfbetas[row_idx][0] == pytest.approx(expected_dfbeta / scale)
+
+
+@pytest.mark.parametrize(
+    ("method", "expected_coef", "expected_score", "expected_dfbeta", "expected_variance"),
+    [
+        (
+            "breslow",
+            [0.0459536309248242, 0.353370968238964],
+            [-0.477002515097761, 0.0460464768418501],
+            [-0.143794564182129, -0.0193305596279085],
+            [[0.108272854521586, 0.0296127805336108], [0.0296127805336108, 0.227116707749646]],
+        ),
+        (
+            "efron",
+            [-0.0071109501556483, 0.280700887836646],
+            [-0.581824262049244, 0.0154020097871799],
+            [-0.182250992353341, -0.0380955483800846],
+            [[0.149167505896732, 0.0546676978998634], [0.0546676978998634, 0.278398896247739]],
+        ),
+    ],
+)
+def test_coxph_counting_process_score_inference_matches_r(
+    method,
+    expected_coef,
+    expected_score,
+    expected_dfbeta,
+    expected_variance,
+):
+    data = {
+        "start": [0.0, 0.0, 0.0, 1.0, 2.0, 0.0, 1.0, 0.0],
+        "stop": [2.0, 2.0, 3.0, 4.0, 4.0, 3.0, 5.0, 5.0],
+        "status": [1, 1, 0, 1, 0, 1, 1, 0],
+        "x": [-1.2, 0.4, 1.1, -0.3, 0.8, 1.7, -0.9, 0.2],
+        "z": [0.5, -1.0, 0.3, 1.2, -0.7, 0.9, 0.1, -1.3],
+        "group": [0, 0, 0, 0, 0, 1, 1, 1],
+        "id": list(range(8)),
+    }
+    fit = survival.coxph(
+        "Surv(start, stop, status) ~ x + z + strata(group)",
+        data=data,
+        weights=[1.0, 1.5, 0.8, 1.2, 0.7, 1.1, 0.9, 1.3],
+        ties=method,
+        cluster=data["id"],
+        max_iter=50,
+        eps=1e-9,
+        toler=1e-10,
+    )
+
+    assert fit.coefficients[0] == pytest.approx(expected_coef, abs=1e-12)
+    assert fit.score_residuals()[0] == pytest.approx(expected_score, abs=1e-12)
+    assert fit.dfbeta()[0] == pytest.approx(expected_dfbeta, abs=1e-12)
+    for actual, expected in zip(fit.variance_matrix, expected_variance, strict=True):
+        assert actual == pytest.approx(expected, abs=1e-12)
 
 
 def test_coxph_exact_tie_score_and_dfbeta_residuals_sum_to_score_vector():

--- a/src/regression/coxph.rs
+++ b/src/regression/coxph.rs
@@ -846,6 +846,43 @@ mod tests {
         fit
     }
 
+    fn counting_score_reference_fit(method: &str) -> CoxPHFit {
+        let covariates = vec![
+            vec![-1.2, 0.5],
+            vec![0.4, -1.0],
+            vec![1.1, 0.3],
+            vec![-0.3, 1.2],
+            vec![0.8, -0.7],
+            vec![1.7, 0.9],
+            vec![-0.9, 0.1],
+            vec![0.2, -1.3],
+        ];
+        let linear_predictors = covariates
+            .iter()
+            .map(|row| 0.2 * row[0] - 0.1 * row[1])
+            .collect();
+        CoxPHFit {
+            coefficients: vec![vec![0.2, -0.1]],
+            means: vec![0.0, 0.0],
+            score_vector: vec![],
+            information_matrix: vec![],
+            log_likelihood: vec![],
+            score_test: 0.0,
+            convergence_flag: 0,
+            iterations: 0,
+            risk_scores: vec![],
+            event_times: vec![2.0, 2.0, 3.0, 4.0, 4.0, 3.0, 5.0, 5.0],
+            status: vec![1, 1, 0, 1, 0, 1, 1, 0],
+            linear_predictors,
+            entry_times: Some(vec![0.0, 0.0, 0.0, 1.0, 2.0, 0.0, 1.0, 0.0]),
+            weights: vec![1.0, 1.5, 0.8, 1.2, 0.7, 1.1, 0.9, 1.3],
+            covariates,
+            strata: vec![0, 0, 0, 0, 0, 1, 1, 1],
+            method: method.to_string(),
+            nocenter: vec![],
+        }
+    }
+
     fn brute_force_basehaz(fit: &CoxPHFit, centered: bool) -> (Vec<f64>, Vec<f64>, Vec<i32>) {
         let n = fit.event_times.len();
         let row_strata = fit.row_strata_cow().into_owned();
@@ -1260,6 +1297,45 @@ mod tests {
                 entry_times,
             );
 
+            assert_close_matrix(&actual, &expected);
+        }
+    }
+
+    #[test]
+    fn test_coxph_counting_score_residuals_match_r_for_weights_strata_and_ties() {
+        let cases = [
+            (
+                "breslow",
+                vec![
+                    vec![-0.778427039030269, 0.283533537794141],
+                    vec![0.091186357321952, -0.342237690541851],
+                    vec![-0.650093055328823, -0.190343304961445],
+                    vec![-0.0420910220554235, -0.132051648232679],
+                    vec![-0.469472843288164, 0.810907638406828],
+                    vec![0.709746822901141, 0.66611561001089],
+                    vec![-0.143052423889649, 0.568213016404157],
+                    vec![-0.0432781142437781, 0.608556079386341],
+                ],
+            ),
+            (
+                "efron",
+                vec![
+                    vec![-0.890022262887945, 0.233804575353994],
+                    vec![0.0973290025651707, -0.50524720360612],
+                    vec![-0.741057387549249, -0.122553172255785],
+                    vec![0.0221464326595451, -0.166914303193565],
+                    vec![-0.469472843288164, 0.810907638406828],
+                    vec![0.709746822901141, 0.66611561001089],
+                    vec![-0.143052423889649, 0.568213016404157],
+                    vec![-0.0432781142437781, 0.608556079386341],
+                ],
+            ),
+        ];
+
+        for (method, expected) in cases {
+            let actual = counting_score_reference_fit(method)
+                .score_residuals_internal()
+                .expect("counting-process score residuals should compute");
             assert_close_matrix(&actual, &expected);
         }
     }

--- a/src/regression/coxph_diagnostics.rs
+++ b/src/regression/coxph_diagnostics.rs
@@ -1,9 +1,7 @@
 use crate::constants::{EXP_CLAMP_MAX, EXP_CLAMP_MIN, same_time};
 use crate::regression::cox_optimizer::Method as CoxMethod;
 use crate::regression::coxph::CoxPHFit;
-use crate::regression::coxph_support::{
-    ActiveRiskSet, CoxSweepRow, StratifiedBaselineLookup, cumulative_step_at,
-};
+use crate::regression::coxph_support::{ActiveRiskSet, CoxSweepRow, StratifiedBaselineLookup};
 use crate::regression::exact_ties::{exact_inclusion_probabilities, exact_tied_moments};
 use crate::scoring::coxscore2::{CoxScoreData, CoxScoreParams, compute_cox_score_residuals};
 use ndarray::Array2;
@@ -706,6 +704,12 @@ impl CoxPHFit {
     ) -> Vec<Vec<f64>> {
         let n = self.event_times.len();
         let mut residuals = vec![vec![0.0; nvar]; n];
+        let scores = (method != 2).then(|| {
+            self.linear_predictors
+                .iter()
+                .map(|&value| value.clamp(EXP_CLAMP_MIN, EXP_CLAMP_MAX).exp())
+                .collect::<Vec<_>>()
+        });
         let mut stratum_start = 0usize;
         while stratum_start < order.len() {
             let stratum = self.strata[order[stratum_start]];
@@ -763,21 +767,34 @@ impl CoxPHFit {
                     } else {
                         let denom: f64 = risk_indices.iter().map(|&idx| risk[idx]).sum();
                         if denom > 0.0 {
-                            for &idx in &deaths {
-                                for (col_idx, residual) in
-                                    residuals[idx].iter_mut().enumerate().take(nvar)
-                                {
-                                    *residual += self.weights[idx] * self.covariates[idx][col_idx];
-                                }
-                            }
+                            let scores = scores
+                                .as_ref()
+                                .expect("non-exact score residuals have risk scores");
                             if method == 0 || deaths.len() == 1 {
                                 let deadwt: f64 = deaths.iter().map(|&idx| self.weights[idx]).sum();
+                                let hazard = deadwt / denom;
+                                let mut mean = vec![0.0; nvar];
                                 for &idx in &risk_indices {
-                                    let factor = risk[idx] * deadwt / denom;
-                                    for (col_idx, residual) in
-                                        residuals[idx].iter_mut().enumerate().take(nvar)
+                                    for (col_idx, value) in mean.iter_mut().enumerate() {
+                                        *value += risk[idx] * self.covariates[idx][col_idx];
+                                    }
+                                }
+                                for value in &mut mean {
+                                    *value /= denom;
+                                }
+                                for &idx in &risk_indices {
+                                    let score = scores[idx];
+                                    for (col_idx, residual) in residuals[idx].iter_mut().enumerate()
                                     {
-                                        *residual -= factor * self.covariates[idx][col_idx];
+                                        *residual += score
+                                            * hazard
+                                            * (mean[col_idx] - self.covariates[idx][col_idx]);
+                                    }
+                                }
+                                for &idx in &deaths {
+                                    for (col_idx, residual) in residuals[idx].iter_mut().enumerate()
+                                    {
+                                        *residual += self.covariates[idx][col_idx] - mean[col_idx];
                                     }
                                 }
                             } else {
@@ -786,21 +803,52 @@ impl CoxPHFit {
                                 let deadwt: f64 = deaths.iter().map(|&idx| self.weights[idx]).sum();
                                 let weight_average = deadwt / deaths_f;
                                 let death_risk: f64 = deaths.iter().map(|&idx| risk[idx]).sum();
+                                let mut risk_sum = vec![0.0; nvar];
+                                let mut death_risk_sum = vec![0.0; nvar];
+                                for &idx in &risk_indices {
+                                    for (col_idx, value) in risk_sum.iter_mut().enumerate() {
+                                        *value += risk[idx] * self.covariates[idx][col_idx];
+                                    }
+                                }
+                                for &idx in &deaths {
+                                    for (col_idx, value) in death_risk_sum.iter_mut().enumerate() {
+                                        *value += risk[idx] * self.covariates[idx][col_idx];
+                                    }
+                                }
                                 for step in 0..death_count {
                                     let fraction = step as f64 / deaths_f;
                                     let step_denom = denom - fraction * death_risk;
                                     if step_denom <= 0.0 {
                                         continue;
                                     }
+                                    let hazard = weight_average / step_denom;
+                                    let mean: Vec<f64> = risk_sum
+                                        .iter()
+                                        .zip(&death_risk_sum)
+                                        .map(|(&total, &death_total)| {
+                                            (total - fraction * death_total) / step_denom
+                                        })
+                                        .collect();
                                     for &idx in &risk_indices {
+                                        let score = scores[idx];
                                         let multiplier =
                                             if is_death[idx] { 1.0 - fraction } else { 1.0 };
-                                        let factor =
-                                            weight_average * risk[idx] * multiplier / step_denom;
                                         for (col_idx, residual) in
-                                            residuals[idx].iter_mut().enumerate().take(nvar)
+                                            residuals[idx].iter_mut().enumerate()
                                         {
-                                            *residual -= factor * self.covariates[idx][col_idx];
+                                            *residual += score
+                                                * hazard
+                                                * multiplier
+                                                * (mean[col_idx] - self.covariates[idx][col_idx]);
+                                        }
+                                    }
+                                    for &idx in &deaths {
+                                        for (col_idx, residual) in
+                                            residuals[idx].iter_mut().enumerate()
+                                        {
+                                            *residual += (self.covariates[idx][col_idx]
+                                                - mean[col_idx])
+                                                / deaths_f;
                                         }
                                     }
                                 }
@@ -833,6 +881,11 @@ impl CoxPHFit {
     ) -> Vec<Vec<f64>> {
         let n = self.event_times.len();
         let mut residuals = vec![vec![0.0; nvar]; n];
+        let scores: Vec<f64> = self
+            .linear_predictors
+            .iter()
+            .map(|&value| value.clamp(EXP_CLAMP_MIN, EXP_CLAMP_MAX).exp())
+            .collect();
         let mut stratum_start = 0usize;
         while stratum_start < order.len() {
             let stratum = self.strata[order[stratum_start]];
@@ -856,8 +909,11 @@ impl CoxPHFit {
             let event_count = rows.iter().filter(|row| row.status == 1).count();
             let mut event_times = Vec::with_capacity(event_count);
             let mut cumulative_scalars = Vec::with_capacity(event_count);
+            let mut cumulative_xhazards = Vec::with_capacity(event_count);
             let mut deaths: Vec<usize> = Vec::with_capacity(event_count);
             let mut cumulative_scalar = 0.0;
+            let mut cumulative_xhazard = vec![0.0; nvar];
+            let mut active_risk_covariates = vec![0.0; nvar];
             let mut time_start = 0usize;
             while time_start < rows.len() {
                 let event_time = rows[time_start].stop;
@@ -866,78 +922,114 @@ impl CoxPHFit {
                     time_end += 1;
                 }
 
-                active.advance_to(event_time, |_, _| {});
+                active.advance_to(event_time, |row_idx, added| {
+                    let direction = if added { 1.0 } else { -1.0 };
+                    let original_idx = rows[row_idx].original_idx;
+                    for (col_idx, value) in active_risk_covariates.iter_mut().enumerate() {
+                        *value +=
+                            direction * rows[row_idx].risk * self.covariates[original_idx][col_idx];
+                    }
+                });
 
                 deaths.clear();
                 deaths.extend((time_start..=time_end).filter(|&idx| rows[idx].status == 1));
                 if !deaths.is_empty() && active.risk_sum > 0.0 {
-                    for &row_idx in &deaths {
-                        let original_idx = rows[row_idx].original_idx;
-                        for (col_idx, residual) in
-                            residuals[original_idx].iter_mut().enumerate().take(nvar)
-                        {
-                            *residual +=
-                                rows[row_idx].weight * self.covariates[original_idx][col_idx];
-                        }
-                    }
-
                     let deadwt: f64 = deaths.iter().map(|&idx| rows[idx].weight).sum();
-                    let (scalar, death_adjustment) = if method == 1 && deaths.len() > 1 {
+                    if method == 1 && deaths.len() > 1 {
                         let death_count = deaths.len();
                         let deaths_f = death_count as f64;
                         let weight_average = deadwt / deaths_f;
                         let death_risk: f64 = deaths.iter().map(|&idx| rows[idx].risk).sum();
-                        let mut all_active_scalar = 0.0;
-                        let mut death_scalar = 0.0;
+                        let mut death_covariates = vec![0.0; nvar];
+                        for &row_idx in &deaths {
+                            let original_idx = rows[row_idx].original_idx;
+                            for (col_idx, value) in death_covariates.iter_mut().enumerate() {
+                                *value +=
+                                    rows[row_idx].risk * self.covariates[original_idx][col_idx];
+                            }
+                        }
+                        let mut mean = vec![0.0; nvar];
                         for step in 0..death_count {
                             let fraction = step as f64 / deaths_f;
                             let step_denom = active.risk_sum - fraction * death_risk;
                             if step_denom <= 0.0 {
                                 continue;
                             }
-                            let step_scalar = weight_average / step_denom;
-                            all_active_scalar += step_scalar;
-                            death_scalar += step_scalar * (1.0 - fraction);
+                            let hazard = weight_average / step_denom;
+                            for ((value, &active_total), &death_total) in mean
+                                .iter_mut()
+                                .zip(&active_risk_covariates)
+                                .zip(&death_covariates)
+                            {
+                                *value = (active_total - fraction * death_total) / step_denom;
+                            }
+                            cumulative_scalar += hazard;
+                            for (col_idx, value) in cumulative_xhazard.iter_mut().enumerate() {
+                                *value += mean[col_idx] * hazard;
+                            }
+                            for &row_idx in &deaths {
+                                let original_idx = rows[row_idx].original_idx;
+                                let score = scores[original_idx];
+                                for (col_idx, residual) in
+                                    residuals[original_idx].iter_mut().enumerate()
+                                {
+                                    let centered =
+                                        self.covariates[original_idx][col_idx] - mean[col_idx];
+                                    *residual +=
+                                        centered / deaths_f + score * hazard * fraction * centered;
+                                }
+                            }
                         }
-                        (all_active_scalar, all_active_scalar - death_scalar)
                     } else {
-                        (deadwt / active.risk_sum, 0.0)
-                    };
-
-                    cumulative_scalar += scalar;
-                    event_times.push(event_time);
-                    cumulative_scalars.push(cumulative_scalar);
-
-                    if death_adjustment != 0.0 {
+                        let hazard = deadwt / active.risk_sum;
+                        let mean: Vec<f64> = active_risk_covariates
+                            .iter()
+                            .map(|&value| value / active.risk_sum)
+                            .collect();
+                        cumulative_scalar += hazard;
+                        for (col_idx, value) in cumulative_xhazard.iter_mut().enumerate() {
+                            *value += mean[col_idx] * hazard;
+                        }
                         for &row_idx in &deaths {
                             let original_idx = rows[row_idx].original_idx;
                             for (col_idx, residual) in
-                                residuals[original_idx].iter_mut().enumerate().take(nvar)
+                                residuals[original_idx].iter_mut().enumerate()
                             {
-                                *residual += rows[row_idx].risk
-                                    * death_adjustment
-                                    * self.covariates[original_idx][col_idx];
+                                *residual += self.covariates[original_idx][col_idx] - mean[col_idx];
                             }
                         }
                     }
+                    event_times.push(event_time);
+                    cumulative_scalars.push(cumulative_scalar);
+                    cumulative_xhazards.push(cumulative_xhazard.clone());
                 }
 
                 time_start = time_end + 1;
             }
 
             for row in &rows {
-                let start_scalar = cumulative_step_at(&event_times, &cumulative_scalars, row.entry);
-                let stop_scalar = cumulative_step_at(&event_times, &cumulative_scalars, row.stop);
+                let step_index = |time: f64| match event_times
+                    .binary_search_by(|probe| probe.total_cmp(&time))
+                {
+                    Ok(idx) => Some(idx),
+                    Err(0) => None,
+                    Err(idx) => Some(idx - 1),
+                };
+                let start_index = step_index(row.entry);
+                let stop_index = step_index(row.stop);
+                let start_scalar = start_index.map_or(0.0, |idx| cumulative_scalars[idx]);
+                let stop_scalar = stop_index.map_or(0.0, |idx| cumulative_scalars[idx]);
                 let active_scalar = stop_scalar - start_scalar;
-                if active_scalar != 0.0 {
-                    for (col_idx, residual) in residuals[row.original_idx]
-                        .iter_mut()
-                        .enumerate()
-                        .take(nvar)
-                    {
-                        *residual -=
-                            row.risk * active_scalar * self.covariates[row.original_idx][col_idx];
-                    }
+                let score = scores[row.original_idx];
+                for (col_idx, residual) in residuals[row.original_idx].iter_mut().enumerate() {
+                    let start_xhazard =
+                        start_index.map_or(0.0, |idx| cumulative_xhazards[idx][col_idx]);
+                    let stop_xhazard =
+                        stop_index.map_or(0.0, |idx| cumulative_xhazards[idx][col_idx]);
+                    *residual += score
+                        * (stop_xhazard
+                            - start_xhazard
+                            - active_scalar * self.covariates[row.original_idx][col_idx]);
                 }
             }
 


### PR DESCRIPTION
## Summary
- include risk-set mean terms in counting-process Cox score residuals
- match Breslow and Efron behavior for delayed entry, strata, case weights, and tied deaths
- use naive coefficient variance for dfbeta residuals when a fit also has robust variance
- add fixed R parity fixtures through both the Rust kernel and public Python API

## Why
The prior counting-process path accounted for each row’s cumulative hazard contribution but omitted the cumulative risk-set mean contribution. That produced incorrect score residuals and downstream dfbeta and sandwich variance results, especially for case-cohort models.

## Performance
The optimized sweep maintains risk-weighted covariate moments incrementally and retains the existing event-time sweep without rescanning every risk set. No dependency was added.

## Validation
- 1,565 Rust tests passed with all features
- 809 Python tests passed, 18 skipped
- strict Rust lint passed for all targets and features
- Rust and Python formatting/lint checks passed
- all benchmark targets compiled in the optimized profile
- R package check passed with the expected source-tree NOTE only