### PR TITLE
Add native low-level survreg fitting

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,10 @@ predictors, relative risk scores, term contributions, survival curves, and
 expected event counts.
 For `survreg` fits it supports response-scale predictions, linear predictors,
 term contributions, and quantile predictions via `type="quantile"`.
+The AFT optimizer uses positive-definite observed-information Newton steps when
+available and falls back to the stable outer-product system otherwise. The R
+bridge also routes built-in `survreg.fit` matrix calls through this kernel,
+including fixed or stratified scales and interval-censored responses.
 Model helpers include `model_formula`, `model_weights`, `df_residual`,
 `loglik`, `aic`, `bic`, `extract_aic`, coefficient, variance-covariance,
 confidence-interval, model-matrix/model-frame, and summary accessors for fitted

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -4943,12 +4943,214 @@ survpenal.fit <- function(x, y, weights, offset, init, controlvals, dist,
   eval.parent(call)
 }
 
+.survreg_fit_distribution <- function(dist, parms) {
+  definition <- if (is.character(dist)) {
+    survreg.distributions[[dist]]
+  } else {
+    dist
+  }
+  if (is.null(definition)) {
+    stop("Unrecognized distribution", call. = FALSE)
+  }
+  if (!is.function(definition$density)) {
+    stop("Missing density function in the definition of the distribution", call. = FALSE)
+  }
+
+  distribution <- switch(
+    as.character(definition$name),
+    "Extreme value" = "extreme",
+    "Logistic" = "logistic",
+    "Gaussian" = "gaussian",
+    "Student-t" = "t",
+    NULL
+  )
+  if (is.null(distribution)) {
+    return(NULL)
+  }
+  parameter <- if (identical(distribution, "t")) {
+    values <- if (is.null(parms)) definition$parms else parms
+    if (is.null(values) || length(values) != 1L) {
+      stop("Student-t distribution requires one degrees-of-freedom parameter", call. = FALSE)
+    }
+    as.numeric(values[[1L]])
+  } else {
+    NULL
+  }
+  list(name = distribution, parameter = parameter)
+}
+
+.survreg_fit_start <- function(y, x, weights, offset, strata, nstrat,
+                               fixed_scale, null_scale = NULL) {
+  status <- y[, ncol(y)]
+  proxy <- ifelse(status == 3, rowMeans(y[, 1:2, drop = FALSE]), y[, 1L])
+  target <- proxy - offset
+  location <- if (ncol(x) == 0L) {
+    numeric()
+  } else {
+    fitted <- try(stats::lm.wfit(x, target, weights)$coefficients, silent = TRUE)
+    if (inherits(fitted, "try-error")) rep(0, ncol(x)) else as.numeric(fitted)
+  }
+  location[!is.finite(location)] <- 0
+  if (!is.null(fixed_scale)) {
+    return(location)
+  }
+  if (!is.null(null_scale)) {
+    return(c(location, null_scale))
+  }
+
+  center <- sum(weights * target) / sum(weights)
+  residual <- target - center
+  log_scale <- vapply(seq_len(nstrat), function(group) {
+    keep <- strata == group
+    variance <- sum(weights[keep] * residual[keep]^2) / sum(weights[keep])
+    log(max(sqrt(variance), sqrt(.Machine$double.eps)))
+  }, numeric(1))
+  c(center, log_scale)
+}
+
+.survreg_fit_core <- function(x, y, weights, offset, initial, controlvals,
+                              distribution, distribution_parameter,
+                              fixed_scale, strata) {
+  .call_regression(
+    "survreg",
+    time = .as_python_vector(y[, 1L]),
+    status = .as_python_vector(y[, ncol(y)]),
+    covariates = .coxph_fit_covariates(x, nrow(x)),
+    weights = .as_python_vector(weights),
+    offsets = .as_python_vector(offset),
+    initial_beta = as.list(unname(initial)),
+    strata = .as_python_vector(as.integer(strata) - 1L),
+    distribution = distribution,
+    max_iter = as.integer(controlvals$iter.max),
+    eps = as.numeric(controlvals$rel.tolerance),
+    tol_chol = as.numeric(controlvals$toler.chol),
+    time2 = if (ncol(y) == 3L) .as_python_vector(y[, 2L]) else NULL,
+    fixed_scale = fixed_scale,
+    distribution_parameter = distribution_parameter
+  )
+}
+
 survreg.fit <- function(x, y, weights, offset, init, controlvals, dist,
                         scale = 0, nstrat = 1, strata, parms = NULL,
                         assign) {
-  call <- match.call()
-  call[[1L]] <- quote(survival::survreg.fit)
-  eval.parent(call)
+  if (!is.matrix(x)) {
+    stop("Invalid X matrix ", call. = FALSE)
+  }
+  if (!is.matrix(y) || !ncol(y) %in% c(2L, 3L) || nrow(y) != nrow(x)) {
+    stop("Invalid survival response", call. = FALSE)
+  }
+  n <- nrow(x)
+  nvar <- ncol(x)
+  if (missing(offset) || is.null(offset)) {
+    offset <- rep(0, n)
+  }
+  if (missing(weights) || is.null(weights)) {
+    weights <- rep(1, n)
+  }
+  if (length(weights) != n || any(!is.finite(weights)) || any(weights <= 0)) {
+    stop("Invalid weights, must be >0", call. = FALSE)
+  }
+  if (length(offset) != n || any(!is.finite(offset))) {
+    stop("Invalid offset", call. = FALSE)
+  }
+  if (length(scale) != 1L || !is.finite(scale) || scale < 0) {
+    stop("Invalid scale", call. = FALSE)
+  }
+  nstrat <- .as_integer_scalar(nstrat, "nstrat", positive = TRUE)
+  if (scale > 0 && nstrat > 1L) {
+    stop("Cannot have both a fixed scale and strata", call. = FALSE)
+  }
+  if (nstrat == 1L) {
+    strata <- rep(1L, n)
+  } else {
+    if (missing(strata) || length(strata) != n) {
+      stop("Invalid strata variable", call. = FALSE)
+    }
+    strata <- as.integer(strata)
+    if (anyNA(strata) || any(strata < 1L | strata > nstrat)) {
+      stop("Invalid strata variable", call. = FALSE)
+    }
+  }
+
+  native_distribution <- .survreg_fit_distribution(dist, parms)
+  if (is.null(native_distribution)) {
+    call <- match.call()
+    call[[1L]] <- quote(survival::survreg.fit)
+    return(eval.parent(call))
+  }
+  fixed_scale <- if (scale > 0) as.numeric(scale) else NULL
+  null_x <- matrix(1, nrow = n, ncol = 1L)
+  null_start <- .survreg_fit_start(
+    y, null_x, weights, offset, strata, nstrat, fixed_scale
+  )
+  null_control <- controlvals
+  null_control$iter.max <- 20L
+  null_fit <- .survreg_fit_core(
+    null_x, y, weights, offset, null_start, null_control,
+    native_distribution$name, native_distribution$parameter,
+    fixed_scale, strata
+  )
+  null_coef <- .as_numeric_vector(.result_field(null_fit, "coefficients"))
+  null_scale <- if (is.null(fixed_scale)) null_coef[-1L] else numeric()
+
+  if (missing(init) || is.null(init)) {
+    initial <- .survreg_fit_start(
+      y, x, weights, offset, strata, nstrat, fixed_scale, null_scale
+    )
+  } else {
+    initial <- as.numeric(init)
+    if (is.null(fixed_scale) && length(initial) == nvar) {
+      initial <- c(initial, null_scale)
+    }
+    expected <- nvar + if (is.null(fixed_scale)) nstrat else 0L
+    if (length(initial) != expected) {
+      stop("Wrong length for initial parameters", call. = FALSE)
+    }
+  }
+
+  fit <- .survreg_fit_core(
+    x, y, weights, offset, initial, controlvals,
+    native_distribution$name, native_distribution$parameter,
+    fixed_scale, strata
+  )
+  if (controlvals$iter.max > 1L && .result_field(fit, "convergence_flag") != 0L) {
+    warning("Ran out of iterations and did not converge", call. = FALSE)
+  }
+
+  coefficient_names <- colnames(x)
+  if (is.null(coefficient_names)) {
+    coefficient_names <- paste("x", seq_len(nvar))
+  }
+  if (is.null(fixed_scale)) {
+    coefficient_names <- c(coefficient_names, rep("Log(scale)", nstrat))
+  }
+  coefficients <- .as_numeric_vector(.result_field(fit, "coefficients"))
+  names(coefficients) <- coefficient_names
+  variance <- .as_numeric_matrix(.result_field(fit, "variance_matrix"))
+  dimnames(variance) <- NULL
+  icoef <- if (is.null(fixed_scale)) {
+    null_coef
+  } else {
+    c(null_coef, log(fixed_scale))
+  }
+  names(icoef) <- c("Intercept", rep("Log(scale)", nstrat))
+  full_loglik <- as.numeric(.result_field(fit, "log_likelihood"))
+  null_loglik <- if (nvar == 1L && all(x == 1)) {
+    full_loglik
+  } else {
+    as.numeric(.result_field(null_fit, "log_likelihood"))
+  }
+
+  list(
+    coefficients = coefficients,
+    icoef = icoef,
+    var = variance,
+    loglik = c(null_loglik, full_loglik),
+    iter = as.integer(.result_field(fit, "iterations")),
+    linear.predictors = .as_numeric_vector(.result_field(fit, "linear_predictors")),
+    df = length(coefficients),
+    score = .as_numeric_vector(.result_field(fit, "score_vector"))
+  )
 }
 
 .as_data_frame_model_matrix <- function(x, row.names = NULL, optional = FALSE,

--- a/r/survivalr/README.md
+++ b/r/survivalr/README.md
@@ -26,6 +26,11 @@ model retention options.
 `coxph` formula fits support `tt(...)` terms for right-censored and
 counting-process responses, with either the default O'Brien transform or a
 custom four-argument transform function.
+Low-level `survreg.fit` calls for the built-in extreme-value, logistic,
+Gaussian, and Student-t distributions use the Rust AFT optimizer directly.
+The returned coefficient, null-fit, covariance, likelihood, score, and linear
+predictor components retain the standard R shape for fixed, stratified, and
+interval-censored fits.
 
 Time-dependent data construction is also native: `tmerge` evaluates the
 familiar `tdc`, `cumtdc`, `event`, and `cumevent` expressions locally, uses the

--- a/r/survivalr/man/survivalr.Rd
+++ b/r/survivalr/man/survivalr.Rd
@@ -1044,12 +1044,14 @@ survival when the fitted Cox model used Efron ties.}
 \item{complete}{Logical flag requesting the full variance matrix where the
 Python fit exposes extra parameters such as estimated survreg scale terms.}
 \item{offset, init, control, rownames, resid, nocenter}{Low-level
-\code{coxph.fit}, \code{agexact.fit}, \code{agreg.fit}, and delegated
-\code{survreg.fit}/\code{survpenal.fit} optimizer inputs matching the R
+\code{coxph.fit}, \code{agexact.fit}, \code{agreg.fit}, native built-in
+\code{survreg.fit}, and delegated \code{survpenal.fit} optimizer inputs matching the R
 \pkg{survival} entry points. \code{offset} is also accepted by
 \code{statefig}.}
-\item{controlvals, dist, nstrat, pcols, pattr, assign}{Low-level delegated
-\code{survreg.fit} and \code{survpenal.fit} inputs.}
+\item{controlvals, dist, nstrat, pcols, pattr, assign}{Low-level
+\code{survreg.fit} and \code{survpenal.fit} inputs. Built-in extreme-value,
+logistic, Gaussian, and Student-t \code{survreg.fit} distributions use the
+Rust optimizer; custom density callbacks retain the upstream fallback.}
 \item{varmat, wt, risk, newrisk, position, oldid, x2, risk2, strata2,
 survtype, vartype, unlist}{Low-level delegated Cox survival-curve inputs.}
 \item{var}{Variance matrix for \code{coxph.wtest}.}
@@ -1091,6 +1093,11 @@ I.Borgan and II.Borgan fits retain stratum sizes, optimal allocation fractions,
 phase-two score matrices, and collapsed scores. The returned \code{cch} object
 carries coefficient, model-based, phase-two, and final variance components with
 R-compatible names and methods.
+
+Built-in \code{survreg.fit} matrix calls use positive-definite
+observed-information steps with an outer-product fallback. Fixed and
+stratified scales, left and interval censoring, null likelihoods, covariance,
+scores, and linear predictors are returned in the usual low-level R shape.
 }
 \seealso{
 \code{\link{survival_python_config}}

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -4541,6 +4541,93 @@ test_that("Cox zph bridge remaps partially aliased terms like R survival", {
   }
 })
 
+test_that("survreg.fit matches built-in low-level fits", {
+  skip_if_not_installed("reticulate")
+  skip_if_not_installed("survival")
+  skip_if_not(reticulate::py_module_available("survival"), "Python survival package is unavailable")
+
+  x <- cbind(
+    `(Intercept)` = 1,
+    x = c(-1, 0, 1, 2, 3, 4)
+  )
+  y <- unclass(survival::Surv(
+    c(1.2, 2.1, 3.0, 4.5, 6.2, 8.1),
+    c(1, 1, 0, 1, 1, 0)
+  ))
+  weights <- rep(1, nrow(x))
+  offset <- rep(0, nrow(x))
+  control <- survreg.control(maxiter = 150, rel.tolerance = 1e-10)
+  reference_control <- survival::survreg.control(maxiter = 150, rel.tolerance = 1e-10)
+
+  compare_fit <- function(dist, scale = 0, parms = NULL, tolerance = 1e-5) {
+    bridged <- survreg.fit(
+      x, y, weights, offset, NULL, control, dist,
+      scale = scale, nstrat = 1, parms = parms
+    )
+    reference <- survival::survreg.fit(
+      x, y, weights, offset, NULL, reference_control, dist,
+      scale = scale, nstrat = 1, parms = parms
+    )
+    expect_equal(names(bridged), names(reference))
+    expect_equal(bridged$coefficients, reference$coefficients, tolerance = tolerance)
+    expect_equal(bridged$icoef, reference$icoef, tolerance = tolerance)
+    expect_equal(bridged$var, reference$var, tolerance = tolerance)
+    expect_equal(bridged$loglik, reference$loglik, tolerance = tolerance)
+    expect_equal(bridged$linear.predictors, reference$linear.predictors, tolerance = tolerance)
+    expect_equal(bridged$df, reference$df)
+    expect_lt(max(abs(bridged$score)), 1e-5)
+  }
+
+  for (distribution in c("gaussian", "logistic", "extreme")) {
+    compare_fit(distribution)
+  }
+  compare_fit("gaussian", scale = 1.5)
+  compare_fit(survreg.distributions$t, parms = 5, tolerance = 1e-4)
+
+  stratified_x <- cbind(
+    `(Intercept)` = 1,
+    x = c(-2, -1, 0, 1, -2, -1, 0, 1)
+  )
+  stratified_y <- unclass(survival::Surv(
+    c(1, 2, 3, 5, 2, 4, 6, 9),
+    c(1, 1, 0, 1, 1, 0, 1, 1)
+  ))
+  strata <- rep(1:2, each = 4)
+  bridged_stratified <- survreg.fit(
+    stratified_x, stratified_y, rep(1, 8), rep(0, 8), NULL,
+    control, "gaussian", nstrat = 2, strata = strata
+  )
+  reference_stratified <- survival::survreg.fit(
+    stratified_x, stratified_y, rep(1, 8), rep(0, 8), NULL,
+    reference_control, "gaussian", nstrat = 2, strata = strata
+  )
+  expect_equal(
+    bridged_stratified$coefficients,
+    reference_stratified$coefficients,
+    tolerance = 1e-5
+  )
+  expect_equal(bridged_stratified$var, reference_stratified$var, tolerance = 1e-5)
+  expect_equal(bridged_stratified$loglik, reference_stratified$loglik, tolerance = 1e-5)
+
+  interval_x <- cbind(`(Intercept)` = 1, x = c(0.2, 0.4, 0.1, 0.8, 1.0))
+  interval_y <- cbind(
+    time = c(1, 2, 3, 4, 5),
+    time2 = c(1, 2, 3, 4.5, 5),
+    status = c(1, 2, 0, 3, 1)
+  )
+  bridged_interval <- survreg.fit(
+    interval_x, interval_y, rep(1, 5), rep(0, 5), NULL,
+    control, "gaussian"
+  )
+  reference_interval <- survival::survreg.fit(
+    interval_x, interval_y, rep(1, 5), rep(0, 5), NULL,
+    reference_control, "gaussian"
+  )
+  expect_equal(bridged_interval$coefficients, reference_interval$coefficients, tolerance = 1e-5)
+  expect_equal(bridged_interval$var, reference_interval$var, tolerance = 1e-5)
+  expect_equal(bridged_interval$loglik, reference_interval$loglik, tolerance = 1e-5)
+})
+
 test_that("survreg bridge agrees with R survival distributions", {
   skip_if_not_installed("reticulate")
   skip_if_not_installed("survival")

--- a/src/regression/parametric_survival.rs
+++ b/src/regression/parametric_survival.rs
@@ -621,6 +621,39 @@ fn calculate_likelihood(
 fn check_convergence(old: f64, new: f64, eps: f64) -> bool {
     (1.0 - new / old).abs() <= eps || (old - new).abs() <= eps
 }
+
+fn is_positive_definite(matrix: &Array2<f64>, tolerance: f64) -> bool {
+    if matrix.nrows() != matrix.ncols() {
+        return false;
+    }
+    let size = matrix.nrows();
+    let scale = matrix
+        .diag()
+        .iter()
+        .map(|value| value.abs())
+        .fold(1.0_f64, f64::max);
+    let threshold = tolerance * scale;
+    let mut lower = Array2::<f64>::zeros((size, size));
+    for row in 0..size {
+        for column in 0..=row {
+            let product_sum = (0..column)
+                .map(|index| lower[[row, index]] * lower[[column, index]])
+                .sum::<f64>();
+            if row == column {
+                let pivot = matrix[[row, row]] - product_sum;
+                if !pivot.is_finite() || pivot <= threshold {
+                    return false;
+                }
+                lower[[row, column]] = pivot.sqrt();
+            } else {
+                lower[[row, column]] =
+                    (matrix[[row, column]] - product_sum) / lower[[column, column]];
+            }
+        }
+    }
+    true
+}
+
 fn adjust_strata(newbeta: &mut [f64], beta: &[f64], nvar: usize, nstrat: usize) {
     newbeta[nvar..nvar + nstrat]
         .iter_mut()
@@ -1114,57 +1147,71 @@ fn compute_survreg(
     let mut converged = false;
     while iter < max_iter {
         let old_loglik = loglik;
-        let solve_result = regularized_lu_solve(&jj, &u);
-        let delta = match solve_result {
-            Ok(d) => d,
-            Err(_) => regularized_lu_solve(&imat, &u)?,
-        };
-
         let mut accepted = None;
-        let mut step_factor = 1.0;
-        for _ in 0..=MAX_HALVING_ITERATIONS {
-            let mut candidate_beta = beta.clone();
-            candidate_beta
-                .iter_mut()
-                .zip(beta.iter().zip(delta.iter()))
-                .for_each(|(nb, (b, d))| *nb = b + d * step_factor);
-            adjust_strata(&mut candidate_beta, &beta, nvar, estimated_scale_count);
+        let observed_delta = is_positive_definite(&imat, tol_chol)
+            .then(|| regularized_lu_solve(&imat, &u).ok())
+            .flatten();
+        let delta_candidates = [
+            (true, observed_delta),
+            (false, regularized_lu_solve(&jj, &u).ok()),
+        ];
+        for (uses_observed_information, delta) in delta_candidates
+            .iter()
+            .filter_map(|(observed, delta)| delta.as_ref().map(|delta| (*observed, delta)))
+        {
+            let mut step_factor = 1.0;
+            for _ in 0..=MAX_HALVING_ITERATIONS {
+                let mut candidate_beta = beta.clone();
+                candidate_beta
+                    .iter_mut()
+                    .zip(beta.iter().zip(delta.iter()))
+                    .for_each(|(nb, (b, d))| *nb = b + d * step_factor);
+                adjust_strata(&mut candidate_beta, &beta, nvar, estimated_scale_count);
 
-            let mut candidate_imat = Array2::zeros((nvar2, nvar2));
-            let mut candidate_jj = Array2::zeros((nvar2, nvar2));
-            let mut candidate_u = Array1::zeros(nvar2);
-            let candidate_input = LikelihoodInput {
-                n,
-                nvar,
-                nstrat: estimated_scale_count,
-                beta: &candidate_beta,
-                distribution: &distribution,
-                distribution_parameter,
-                strata,
-                offsets,
-                time1: &time1,
-                time2: time2_view.as_ref(),
-                status: &status,
-                weights,
-                covariates,
-            };
-            let mut candidate_output = LikelihoodOutput {
-                imat: &mut candidate_imat,
-                jj: &mut candidate_jj,
-                u: &mut candidate_u,
-            };
-            let candidate_loglik = calculate_likelihood(&candidate_input, &mut candidate_output)?;
-            if candidate_loglik.is_finite() && candidate_loglik >= old_loglik {
-                accepted = Some((
-                    candidate_beta,
-                    candidate_loglik,
-                    candidate_imat,
-                    candidate_jj,
-                    candidate_u,
-                ));
+                let mut candidate_imat = Array2::zeros((nvar2, nvar2));
+                let mut candidate_jj = Array2::zeros((nvar2, nvar2));
+                let mut candidate_u = Array1::zeros(nvar2);
+                let candidate_input = LikelihoodInput {
+                    n,
+                    nvar,
+                    nstrat: estimated_scale_count,
+                    beta: &candidate_beta,
+                    distribution: &distribution,
+                    distribution_parameter,
+                    strata,
+                    offsets,
+                    time1: &time1,
+                    time2: time2_view.as_ref(),
+                    status: &status,
+                    weights,
+                    covariates,
+                };
+                let mut candidate_output = LikelihoodOutput {
+                    imat: &mut candidate_imat,
+                    jj: &mut candidate_jj,
+                    u: &mut candidate_u,
+                };
+                let candidate_loglik =
+                    calculate_likelihood(&candidate_input, &mut candidate_output)?;
+                if candidate_loglik.is_finite()
+                    && candidate_loglik >= old_loglik
+                    && (!uses_observed_information
+                        || is_positive_definite(&candidate_imat, tol_chol))
+                {
+                    accepted = Some((
+                        candidate_beta,
+                        candidate_loglik,
+                        candidate_imat,
+                        candidate_jj,
+                        candidate_u,
+                    ));
+                    break;
+                }
+                step_factor *= STEP_HALVE_FACTOR;
+            }
+            if accepted.is_some() {
                 break;
             }
-            step_factor *= STEP_HALVE_FACTOR;
         }
 
         if let Some((candidate_beta, candidate_loglik, candidate_imat, candidate_jj, candidate_u)) =
@@ -1326,6 +1373,15 @@ mod tests {
         assert!(!check_convergence(-100.0, -99.0, 1e-6));
         assert!(check_convergence(-1e-10, -1e-10, 1e-6));
         assert!(check_convergence(-100.0, -100.0 + 1e-7, 1e-6));
+    }
+
+    #[test]
+    fn positive_definite_check_rejects_saddle_information() {
+        let positive = Array2::from_shape_vec((2, 2), vec![2.0, 0.5, 0.5, 1.0]).unwrap();
+        let indefinite = Array2::from_shape_vec((2, 2), vec![1.0, 2.0, 2.0, 1.0]).unwrap();
+
+        assert!(is_positive_definite(&positive, 1e-10));
+        assert!(!is_positive_definite(&indefinite, 1e-10));
     }
 
     #[test]
@@ -1522,6 +1578,42 @@ mod tests {
         let fit = result.unwrap();
         assert_eq!(fit.coefficients.len(), 2);
         assert!(fit.log_likelihood.is_finite());
+    }
+
+    #[test]
+    fn observed_information_accelerates_well_conditioned_fit() {
+        let y = Array2::from_shape_vec(
+            (6, 2),
+            vec![1.2, 1.0, 2.1, 1.0, 3.0, 0.0, 4.5, 1.0, 6.2, 1.0, 8.1, 0.0],
+        )
+        .unwrap();
+        let covariates = Array2::from_shape_vec(
+            (2, 6),
+            vec![1.0, 1.0, 1.0, 1.0, 1.0, 1.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0],
+        )
+        .unwrap();
+        let result = compute_survreg(ComputeSurvregInput {
+            max_iter: 100,
+            nvar: 2,
+            y: &y,
+            covariates: &covariates,
+            weights: &Array1::from_vec(vec![1.0; 6]),
+            offsets: &Array1::from_vec(vec![0.0; 6]),
+            beta: vec![2.113333, 1.38, 1.103973],
+            nstrat: 1,
+            strata: &[0; 6],
+            eps: 1e-10,
+            tol_chol: 1e-10,
+            distribution: DistributionType::Gaussian,
+            distribution_parameter: None,
+            fixed_scale: None,
+        })
+        .unwrap();
+
+        assert!(result.iterations <= 10);
+        assert!((result.coefficients[0] - 2.244776).abs() < 1e-5);
+        assert!((result.coefficients[1] - 1.392510).abs() < 1e-5);
+        assert!(result.score_vector.iter().all(|score| score.abs() < 1e-5));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- route low-level R `survreg.fit` calls for extreme-value, logistic, Gaussian, and Student-t distributions through the Rust AFT kernel
- use positive-definite observed-information Newton steps with an outer-product fallback, avoiding saddle-point steps while improving convergence
- preserve the standard low-level R coefficient, null-fit, covariance, likelihood, score, and linear-predictor shape
- cover estimated, fixed, and stratified scales plus right-, left-, and interval-censored responses
- retain the existing upstream fallback for user-defined density callbacks

## Performance
- representative censored Gaussian fit converges in 7 iterations instead of 61 with the prior outer-product-only path
- optimizer regression tests require a small final score and reject indefinite observed-information systems

## Validation
- rebased onto current main
- original all-feature Rust run: 1,579 passed
- post-rebase focused Rust run: 19 passed
- strict all-target Rust lint with all features passed
- post-rebase Python suite: 845 passed
- post-rebase complete R bridge suite passed
- `R CMD check --no-manual --no-build-vignettes`: Status OK
- Rust formatting and repository diff checks passed
- no dependency manifest or lockfile changes