### PR TITLE
Implement native Ederer cohort survival

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -5768,7 +5768,7 @@ def _normalize_survexp_method(
         raise TypeError("method must be a string")
     value = method.strip().lower().replace("_", ".")
     aliases = {
-        "ederer": "hakulinen",
+        "ederer": "ederer",
         "hakulinen": "hakulinen",
         "conditional": "conditional",
         "individual": "individual",

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -2571,10 +2571,11 @@ def test_r_style_ratetable_helpers_delegate_to_population_core():
 
     assert isinstance(scaled, survival.SurvExpResult)
     assert scaled.time == pytest.approx([1.0, 2.0])
-    assert scaled.method == "hakulinen"
+    assert scaled.method == "ederer"
     assert conditional.method == "conditional"
     assert individual_surv == pytest.approx(direct_individual)
     assert individual_hazard == pytest.approx([-math.log(value) for value in direct_individual])
+
     with pytest.warns(RuntimeWarning, match="se_fit value ignored"):
         survival.survexp(
             time=[365.25],
@@ -2597,6 +2598,49 @@ def test_r_style_ratetable_helpers_delegate_to_population_core():
         survival.ratetableDate(2001, 2, 29)
     with pytest.raises(TypeError, match="month and day"):
         survival.ratetableDate(2000, month=2)
+
+
+def test_survexp_ederer_keeps_the_full_reference_cohort():
+    ages = [14610.0, 25567.5]
+    years = [2000.0, 2000.0]
+    sexes = [0, 1]
+    eval_times = [365.25, 730.5]
+    follow_up = [180.0, 1095.0]
+
+    ederer = survival.survexp(
+        follow_up,
+        ages,
+        years,
+        sex=sexes,
+        times=eval_times,
+        method="ederer",
+    )
+    hakulinen = survival.survexp(
+        follow_up,
+        ages,
+        years,
+        sex=sexes,
+        times=eval_times,
+        method="hakulinen",
+    )
+
+    assert isinstance(ederer, survival.SurvExpResult)
+    assert isinstance(hakulinen, survival.SurvExpResult)
+    assert ederer.n_risk == pytest.approx([2.0, 2.0])
+    assert hakulinen.n_risk == pytest.approx([1.0, 1.0])
+    expected_ederer = [
+        sum(
+            survival.survexp_individual(
+                time=[eval_time, eval_time],
+                age=ages,
+                year=years,
+                sex=sexes,
+            )
+        )
+        / 2.0
+        for eval_time in eval_times
+    ]
+    assert ederer.surv == pytest.approx(expected_ederer)
 
 
 def test_r_style_cipoisson_uses_rust_scalar_kernel_with_r_recycling():

--- a/src/population/survexp.rs
+++ b/src/population/survexp.rs
@@ -97,9 +97,9 @@ pub fn survexp(
     validate_optional_sex(sex, n)?;
 
     let calc_method = method.unwrap_or("hakulinen");
-    if !["hakulinen", "conditional", "individual"].contains(&calc_method) {
+    if !["ederer", "hakulinen", "conditional", "individual"].contains(&calc_method) {
         return Err(value_error(
-            "method must be 'hakulinen', 'conditional', or 'individual'",
+            "method must be 'ederer', 'hakulinen', 'conditional', or 'individual'",
         ));
     }
 
@@ -126,10 +126,30 @@ pub fn survexp(
     validate_eval_times(&eval_times)?;
 
     match calc_method {
+        "ederer" => compute_ederer(&time, &age, &year, sex, ratetable, &eval_times),
         "hakulinen" => compute_hakulinen(&time, &age, &year, sex, ratetable, &eval_times),
         "conditional" => compute_conditional(&time, &age, &year, sex, ratetable, &eval_times),
         "individual" => compute_individual(&time, &age, &year, sex, ratetable, &eval_times),
         _ => compute_hakulinen(&time, &age, &year, sex, ratetable, &eval_times),
+    }
+}
+
+#[derive(Clone, Copy)]
+enum CohortMethod {
+    Ederer,
+    Hakulinen,
+}
+
+impl CohortMethod {
+    fn uses_observed_risk_set(self) -> bool {
+        matches!(self, Self::Hakulinen)
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Ederer => "ederer",
+            Self::Hakulinen => "hakulinen",
+        }
     }
 }
 
@@ -141,22 +161,58 @@ fn compute_hakulinen(
     ratetable: &RateTable,
     eval_times: &[f64],
 ) -> PyResult<SurvExpResult> {
+    compute_cohort_average(
+        time,
+        age,
+        year,
+        sex,
+        ratetable,
+        eval_times,
+        CohortMethod::Hakulinen,
+    )
+}
+
+fn compute_ederer(
+    time: &[f64],
+    age: &[f64],
+    year: &[f64],
+    sex: Option<&[i32]>,
+    ratetable: &RateTable,
+    eval_times: &[f64],
+) -> PyResult<SurvExpResult> {
+    compute_cohort_average(
+        time,
+        age,
+        year,
+        sex,
+        ratetable,
+        eval_times,
+        CohortMethod::Ederer,
+    )
+}
+
+fn compute_cohort_average(
+    time: &[f64],
+    age: &[f64],
+    year: &[f64],
+    sex: Option<&[i32]>,
+    ratetable: &RateTable,
+    eval_times: &[f64],
+    method: CohortMethod,
+) -> PyResult<SurvExpResult> {
     let n = time.len();
 
     let results: Vec<(f64, f64, f64)> = eval_times
         .par_iter()
         .map(|&eval_t| {
             let (total_surv, total_cumhaz, count) = (0..n)
-                .filter(|&i| time[i] >= eval_t)
+                .filter(|&i| !method.uses_observed_risk_set() || time[i] >= eval_t)
                 .map(|i| {
                     let age_at_eval = age[i] + eval_t;
-                    let exp_surv = ratetable
-                        .expected_survival(age[i], age_at_eval, year[i], Some(sex_at(sex, i)))
-                        .unwrap_or(1.0);
                     let exp_cumhaz = ratetable
                         .cumulative_hazard(age[i], age_at_eval, year[i], Some(sex_at(sex, i)))
                         .unwrap_or(0.0);
-                    (exp_surv, exp_cumhaz, 1.0)
+                    ((-exp_cumhaz).exp(), exp_cumhaz, 1.0)
                 })
                 .fold((0.0, 0.0, 0.0), |acc, x| {
                     (acc.0 + x.0, acc.1 + x.1, acc.2 + x.2)
@@ -181,7 +237,7 @@ fn compute_hakulinen(
         surv,
         n_risk,
         cumhaz,
-        method: "hakulinen".to_string(),
+        method: method.as_str().to_string(),
         n,
     })
 }
@@ -392,6 +448,53 @@ mod tests {
     }
 
     #[test]
+    fn ederer_keeps_the_full_reference_cohort() {
+        let rt = create_test_ratetable();
+        let time = vec![180.0, 1095.0];
+        let age = vec![14610.0, 25567.5];
+        let year = vec![2000.0, 2000.0];
+        let sex = vec![0, 1];
+        let times = vec![365.25, 730.5];
+
+        let ederer = survexp(
+            time.clone(),
+            age.clone(),
+            year.clone(),
+            &rt,
+            Some(sex.clone()),
+            Some(times.clone()),
+            Some("ederer"),
+        )
+        .unwrap();
+        let hakulinen = survexp(
+            time,
+            age.clone(),
+            year.clone(),
+            &rt,
+            Some(sex.clone()),
+            Some(times.clone()),
+            Some("hakulinen"),
+        )
+        .unwrap();
+
+        assert_eq!(ederer.method, "ederer");
+        assert_eq!(ederer.n_risk, vec![2.0, 2.0]);
+        assert_eq!(hakulinen.n_risk, vec![1.0, 1.0]);
+        for (index, eval_time) in times.into_iter().enumerate() {
+            let individual = survexp_individual(
+                vec![eval_time, eval_time],
+                age.clone(),
+                year.clone(),
+                &rt,
+                Some(sex.clone()),
+            )
+            .unwrap();
+            let expected = individual.iter().sum::<f64>() / individual.len() as f64;
+            assert!((ederer.surv[index] - expected).abs() < 1e-12);
+        }
+    }
+
+    #[test]
     fn survexp_default_sex_matches_explicit_zero_sex() {
         let rt = create_test_ratetable();
 
@@ -400,7 +503,7 @@ mod tests {
         let year = vec![2000.0, 2000.0, 2000.0];
         let times = vec![365.0, 730.0, 1095.0];
 
-        for method in ["hakulinen", "conditional", "individual"] {
+        for method in ["ederer", "hakulinen", "conditional", "individual"] {
             let default_result = survexp(
                 time.clone(),
                 age.clone(),


### PR DESCRIPTION
## Summary
- implement a distinct Rust Ederer cohort estimator that retains the full reference cohort at every evaluation time
- route Python `method="ederer"` through the native estimator instead of aliasing it to Hakulinen
- share the cohort kernel and compute each cumulative hazard once, with no new dependencies

## Compatibility
- matches the upstream Ederer risk-set behavior on a two-person fixture: Ederer `n.risk = c(2, 2)` while Hakulinen uses the observed risk set `c(1, 1)`
- verifies Ederer survival as the mean of subject-level expected survival values

## Performance
- 2,000 records across five evaluation times in a local debug build: median 5.63 s before and 2.74 s after (about 51% faster)

## Testing
- `cargo test --no-default-features` (1,368 passed)
- `cargo clippy --all-targets --no-default-features -- -D warnings`
- `cargo clippy --all-targets --features python,ml -- -D warnings`
- `cargo fmt --check`
- `pytest -q python/tests` (828 passed, 18 skipped)
- full `testthat` bridge suite with the project Python environment
- `ruff check` and `ruff format --check`
- direct upstream Ederer risk-set comparison