### PR TITLE
Linearize Python group indexing

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -4302,7 +4302,10 @@ def strata(
             pieces.append(level_label if short else f"{term_labels[term_idx]}={level_label}")
         levels.append(sep.join(pieces))
     row_labels = [None if code is None else levels[code - 1] for code in codes]
-    counts = [sum(1 for code in codes if code == idx + 1) for idx in range(len(levels))]
+    counts = [0] * len(levels)
+    for code in codes:
+        if code is not None:
+            counts[code - 1] += 1
     return StrataFactor(codes=codes, levels=levels, labels=row_labels, counts=counts)
 
 
@@ -12430,10 +12433,14 @@ def aggregate_survfit_result(
     if len(set(group_codes)) == 1:
         return aggregate_survfit_result(result, weights=curve_weights)
 
+    indices_by_group: dict[int, list[int]] = {}
+    for idx, code in enumerate(group_codes):
+        indices_by_group.setdefault(code, []).append(idx)
+
     aggregates = []
     linear_predictors = []
-    for code in sorted(set(group_codes)):
-        indices = [idx for idx, group_code in enumerate(group_codes) if group_code == code]
+    for code in sorted(indices_by_group):
+        indices = indices_by_group[code]
         group_weights = (
             [curve_weights[idx] for idx in indices] if curve_weights is not None else None
         )
@@ -16693,13 +16700,15 @@ def _cox_detail_event_times(
     status: list[int],
     strata: list[int],
 ) -> list[tuple[int, float]]:
-    groups: list[tuple[int, float]] = []
-    for stratum in sorted(set(strata)):
-        values = sorted(
-            {time[idx] for idx, event in enumerate(status) if event == 1 and strata[idx] == stratum}
-        )
-        groups.extend((stratum, value) for value in values)
-    return groups
+    event_times: dict[int, set[float]] = {}
+    for event_time, event, stratum in zip(time, status, strata, strict=True):
+        if event == 1:
+            event_times.setdefault(stratum, set()).add(event_time)
+    return [
+        (stratum, event_time)
+        for stratum in sorted(event_times)
+        for event_time in sorted(event_times[stratum])
+    ]
 
 
 def _cox_detail_at_risk(

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -187,6 +187,16 @@ def test_strata_matches_r_factor_codes_and_preserves_low_level_call():
         survival.strata(["a", "b"], [1])
 
 
+def test_strata_counts_high_cardinality_levels_once():
+    values = [f"group-{idx:04d}" for idx in range(2_000)]
+
+    result = survival.strata(values)
+
+    assert result.codes == list(range(1, len(values) + 1))
+    assert result.levels == values
+    assert result.counts == [1] * len(values)
+
+
 def test_aeqSurv_adjusts_surv_response_like_r():
     right = survival.Surv([1.0, 1.0 + 1e-8, 2.0], [1, 0, 1])
     adjusted_right = survival.aeqSurv(right, tolerance=1e-7)


### PR DESCRIPTION
## Summary

- count R-style strata levels in a single pass instead of rescanning all rows for every level
- pre-index grouped Cox survival curves and detailed Cox event times once while preserving sorted output
- add a high-cardinality strata regression test

## Performance

For 10,000 distinct string strata, median runtime fell from 1.173308 seconds on `main` to 0.009940 seconds on this branch, about 118× faster. The updated path processes 100,000 distinct strata in about 0.108 seconds.

## Testing

- `.venv/bin/python -m pytest -q python/tests` — 828 passed, 18 skipped
- `cargo test --all-targets` — 1,367 passed
- `R CMD check --no-manual --no-build-vignettes r/survivalr` — tests pass; source-directory note only
- `.venv/bin/ruff check python/survival/r_api.py python/tests/test_r_api.py`
- `.venv/bin/ruff format --check python/survival/r_api.py python/tests/test_r_api.py`
- `git diff --check`

No dependencies added.