### PR TITLE
Accelerate pseudo-value step integration

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -8617,33 +8617,67 @@ def _pseudo_curve_values(
     return _pseudo_rmst_values(times, [float(value) for value in curve.estimate], eval_times)
 
 
+def _integrated_step_values(
+    curve_time: Sequence[float],
+    step_values: Sequence[float],
+    eval_times: Sequence[float],
+    *,
+    start_time: float,
+    initial_value: float,
+) -> list[float]:
+    times = [float(value) for value in curve_time]
+    values = [float(value) for value in step_values]
+    if len(times) != len(values):
+        raise ValueError("curve_time and step_values must have the same length")
+
+    origin = float(start_time)
+    value_at_origin = float(initial_value)
+    active_times: list[float] = []
+    active_values: list[float] = []
+    prefix_areas: list[float] = []
+    previous_time = origin
+    previous_value = value_at_origin
+    area = 0.0
+    for time, value in zip(times, values, strict=True):
+        if time < origin:
+            value_at_origin = value
+            previous_value = value
+            continue
+        area += previous_value * (time - previous_time)
+        active_times.append(time)
+        active_values.append(value)
+        prefix_areas.append(area)
+        previous_time = time
+        previous_value = value
+
+    result: list[float] = []
+    for eval_time in eval_times:
+        target = float(eval_time)
+        if target <= origin:
+            result.append(0.0)
+            continue
+        position = bisect_right(active_times, target) - 1
+        if position < 0:
+            result.append(value_at_origin * (target - origin))
+            continue
+        result.append(
+            prefix_areas[position] + active_values[position] * (target - active_times[position])
+        )
+    return result
+
+
 def _pseudo_integrated_step_values(
     curve_time: Sequence[float],
     step_values: Sequence[float],
     eval_times: Sequence[float],
 ) -> list[float]:
-    result: list[float] = []
-    times = [float(value) for value in curve_time]
-    values = [float(value) for value in step_values]
-    for eval_time in eval_times:
-        target = float(eval_time)
-        area = 0.0
-        previous_time = 0.0
-        previous_value = 0.0
-        for time, value in zip(times, values, strict=True):
-            if target <= previous_time:
-                break
-            upper = min(target, time)
-            if upper > previous_time:
-                area += previous_value * (upper - previous_time)
-                previous_time = upper
-            if time > target:
-                break
-            previous_value = value
-        if target > previous_time:
-            area += previous_value * (target - previous_time)
-        result.append(area)
-    return result
+    return _integrated_step_values(
+        curve_time,
+        step_values,
+        eval_times,
+        start_time=0.0,
+        initial_value=0.0,
+    )
 
 
 def _pseudo_counting_candidate_cumhaz(fit: SurvfitResult, ctype: int) -> list[float]:
@@ -8845,32 +8879,13 @@ def _survfit_multistate_integrated_estimate(
     t0: float,
     eval_times: Sequence[float],
 ) -> list[float]:
-    times = [float(value) for value in curve_time]
-    values = [float(value) for value in estimates]
-    result: list[float] = []
-    for target_value in eval_times:
-        target = float(target_value)
-        if target <= t0:
-            result.append(0.0)
-            continue
-        area = 0.0
-        previous_time = t0
-        previous_value = float(initial)
-        for time, value in zip(times, values, strict=True):
-            if time < t0:
-                previous_value = value
-                continue
-            upper = min(target, time)
-            if upper > previous_time:
-                area += previous_value * (upper - previous_time)
-                previous_time = upper
-            if time > target:
-                break
-            previous_value = value
-        if target > previous_time:
-            area += previous_value * (target - previous_time)
-        result.append(area)
-    return result
+    return _integrated_step_values(
+        curve_time,
+        estimates,
+        eval_times,
+        start_time=t0,
+        initial_value=initial,
+    )
 
 
 def _survfit_multistate_estimates_at_times(

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -770,6 +770,26 @@ def test_coxph_wtest_matches_r_wald_helper_shapes():
         survival.coxph_wtest([[1.0, 0.0], [0.0, float("inf")]], [1.0, 2.0])
 
 
+def test_integrated_step_values_preserve_boundaries_and_preorigin_state():
+    result = survival.r_api._integrated_step_values(
+        [-1.0, 1.0, 1.0, 3.0],
+        [0.25, 0.5, 0.75, 1.0],
+        [4.0, 0.0, 0.5, 1.0, 2.0, -1.0],
+        start_time=0.0,
+        initial_value=0.1,
+    )
+
+    assert result == pytest.approx([2.75, 0.0, 0.125, 0.25, 1.0, 0.0])
+    with pytest.raises(ValueError, match="same length"):
+        survival.r_api._integrated_step_values(
+            [1.0, 2.0],
+            [0.5],
+            [2.0],
+            start_time=0.0,
+            initial_value=0.0,
+        )
+
+
 def test_pseudo_accepts_survfit_results_and_preserves_direct_api():
     response = survival.Surv([1.0, 2.0, 3.0, 4.0], [1, 0, 1, 1])
     fit = survival.survfit(response)


### PR DESCRIPTION
## Summary

- replace repeated full-curve scans in counting-process pseudo-value and multistate restricted-mean integration with one prefix-integral pass
- answer each requested time with binary search while preserving step boundaries, duplicate times, pre-origin state, and arbitrary query order
- share the integration logic between both public paths and add focused boundary coverage

## Performance

For 10,000 curve points and 10,000 requested times:

- counting-process pseudo-value integration fell from 3.216660 seconds on `main` to 0.001892 seconds, about 1,700× faster
- multistate integration fell from 3.271565 seconds to 0.001785 seconds, about 1,830× faster

Both updated paths process 100,000 curve points and 100,000 requested times in about 0.019 seconds.

## Testing

- 2,000 randomized comparisons against the previous step-integration algorithm
- `.venv/bin/python -m pytest -q python/tests` — 828 passed, 18 skipped
- `cargo test --all-targets` — 1,367 passed
- `R CMD check --no-manual --no-build-vignettes r/survivalr` — tests pass; source-directory note only
- focused pseudo-value and multistate residual tests
- Ruff check and format verification
- `git diff --check`

No dependencies added.