### PR TITLE
Support multistate rttright responses

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -7982,8 +7982,10 @@ def _rttright_validate_id(response: Surv, id: Any | None) -> list[Any] | None:
     id_values = _materialize_labels(id, "id")
     if len(id_values) != len(response):
         raise ValueError("id must have the same length as the Surv response")
-    if response.type not in {"right", "counting"}:
-        raise NotImplementedError("rttright id handling is currently supported only for right data")
+    if response.type not in {"right", "mright", "counting"}:
+        raise NotImplementedError(
+            "rttright id handling is currently supported only for right-censored data"
+        )
 
     seen: set[Any] = set()
     for value in id_values:
@@ -7997,6 +7999,10 @@ def _rttright_validate_id(response: Surv, id: Any | None) -> list[Any] | None:
             raise ValueError("one or more flags are >0 in survcheck")
         seen.add(key)
     return id_values
+
+
+def _rttright_binary_status(response: Surv) -> list[int]:
+    return [1 if int(value) > 0 else 0 for value in response.event]
 
 
 def _rttright_divide(numerator: float, denominator: float) -> float:
@@ -8432,10 +8438,11 @@ def _rttright_core_weights(
     timefix: bool,
     renorm: bool,
 ) -> list[float]:
+    status = _rttright_binary_status(response)
     if group is not None:
         result = _core.rttright_stratified(
             list(response.time),
-            list(response.event),
+            status,
             list(group),
             None if weights is None else _float_vector(weights, "weights"),
             timefix,
@@ -8444,7 +8451,7 @@ def _rttright_core_weights(
         return [float(weight) for weight in result.weights]
     result = _core.rttright(
         list(response.time),
-        list(response.event),
+        status,
         None if weights is None else _float_vector(weights, "weights"),
         timefix,
         renorm,
@@ -9143,6 +9150,8 @@ def rttright(
 
     if not isinstance(response, Surv):
         raise TypeError("rttright response must be a Surv object, formula, or time vector")
+    if response.type == "mcounting":
+        raise NotImplementedError("function not defined for delayed entry or multistate data")
     _rttright_validate_id(response, id_values)
     if response.type == "counting":
         return _rttright_counting_result(
@@ -9154,12 +9163,13 @@ def rttright(
             timefix,
             renorm,
         )
-    if response.type != "right":
+    if response.type not in {"right", "mright"}:
         raise ValueError(f"rttright is not valid for {response.type} censored survival data")
     if times is not None:
+        status_values = _rttright_binary_status(response)
         return _rttright_time_matrix(
             list(response.time),
-            list(response.event),
+            status_values,
             weights,
             times,
             group,

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -557,6 +557,53 @@ def test_rttright_formula_wrapper_preserves_legacy_direct_api():
         )
 
 
+def test_rttright_supports_simple_multistate_right_censoring():
+    class Factor(list):
+        def __init__(self, values, levels):
+            super().__init__(values)
+            self.categories = levels
+
+    data = {
+        "time": [1.0, 2.0, 3.0, 4.0],
+        "state": Factor(
+            ["a", "censor", "b", "a"],
+            ["censor", "a", "b"],
+        ),
+        "id": ["a", "b", "c", "d"],
+    }
+
+    result = survival.rttright("Surv(time, state) ~ 1", data=data, id="id")
+    timed = survival.rttright(
+        "Surv(time, state) ~ 1",
+        data=data,
+        times=[1.0, 2.0, 3.0, 4.0],
+    )
+
+    assert result == pytest.approx([0.25, 0.0, 0.375, 0.375])
+    for actual_row, expected_row in zip(
+        timed,
+        [
+            [0.25, 0.25, 0.25, 0.25],
+            [0.25, 0.25, 0.0, 0.0],
+            [0.25, 0.25, 0.375, 0.375],
+            [0.25, 0.25, 0.375, 0.375],
+        ],
+        strict=True,
+    ):
+        assert actual_row == pytest.approx(expected_row)
+
+    with pytest.raises(NotImplementedError, match="delayed entry or multistate"):
+        survival.rttright(
+            survival.Surv(
+                [0.0, 1.0],
+                [1.0, 2.0],
+                Factor(["a", "censor"], ["censor", "a"]),
+                type="mstate",
+            ),
+            id=["a", "a"],
+        )
+
+
 def test_r_api_statefig_matches_r_coordinate_layouts():
     connect = [[0.0, 1.0], [0.0, 0.0]]
 

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -696,6 +696,37 @@ test_that("R formula wrappers delegate to the Python survival package", {
     )
   )
 
+  multistate_rtt <- data.frame(
+    time = c(1, 2, 3, 4, 5, 6),
+    state = factor(
+      c("a", "censor", "b", "a", "censor", "b"),
+      levels = c("censor", "a", "b")
+    ),
+    group = rep(c("x", "y"), each = 3),
+    wt = c(2, 1, 3, 1, 4, 2),
+    id = letters[1:6]
+  )
+  expect_equal(
+    rttright(Surv(time, state) ~ 1, data = multistate_rtt, id = id),
+    survival::rttright(survival::Surv(time, state) ~ 1, data = multistate_rtt, id = id)
+  )
+  expect_equal(
+    rttright(Surv(time, state) ~ group, data = multistate_rtt, weights = wt),
+    survival::rttright(
+      survival::Surv(time, state) ~ group,
+      data = multistate_rtt,
+      weights = wt
+    )
+  )
+  expect_equal(
+    rttright(Surv(time, state) ~ group, data = multistate_rtt, times = c(2, 4, 6)),
+    survival::rttright(
+      survival::Surv(time, state) ~ group,
+      data = multistate_rtt,
+      times = c(2, 4, 6)
+    )
+  )
+
   counting_rtt <- data.frame(
     id = c("a", "a", "b", "b"),
     start = c(0, 1, 0, 2),


### PR DESCRIPTION
## Summary
- support simple `mright` survival responses in `rttright`
- collapse positive destination-state codes to observed events while reusing the existing optimized redistribution core
- preserve grouping, case weights, explicit IDs, renormalization, and time-grid output
- match R's delayed-entry multistate limitation and add direct Python plus R bridge parity coverage

## Testing
- `.venv/bin/python -m pytest -q python/tests` (828 passed, 18 skipped)
- `cargo test --all-targets` (1,367 passed)
- `cargo fmt --all -- --check`
- strict clippy checks for no-default, `ml`, and `python,ml` feature profiles
- full Ruff format and lint checks
- stub type checks
- `R CMD check --no-manual --no-build-vignettes r/survivalr` (tests pass; source-directory note only)