### PR TITLE
Support multistate survSplit responses

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -9989,7 +9989,7 @@ def survSplit(
 
     if not isinstance(response, Surv):
         raise TypeError("survSplit response must be a Surv object")
-    if response.type not in {"right", "counting"}:
+    if response.type not in {"right", "mright", "counting", "mcounting"}:
         raise ValueError(f"not valid for {response.type} censored survival data")
 
     cut_values = _float_vector(cut, "cut")

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -244,6 +244,11 @@ def test_aeqSurv_adjusts_surv_response_like_r():
 
 
 def test_survSplit_splits_right_and_counting_surv_responses_like_r():
+    class Factor(list):
+        def __init__(self, values, levels):
+            super().__init__(values)
+            self.categories = levels
+
     right = survival.Surv([5.0, 8.0], [1, 0])
     right_split = survival.survSplit(
         right,
@@ -284,6 +289,54 @@ def test_survSplit_splits_right_and_counting_surv_responses_like_r():
         "stop": [3.0, 5.0, 3.0, 6.0, 8.0],
         "status": [0, 1, 0, 0, 0],
         "episode": [1, 2, 1, 2, 3],
+    }
+
+    multistate_right = survival.Surv(
+        [1.0, 3.0, 4.0],
+        Factor(["a", "censor", "b"], ["censor", "a", "b"]),
+        type="mstate",
+    )
+    multistate_right_split = survival.survSplit(
+        multistate_right,
+        {"x": [11, 12, 13]},
+        cut=[2.0, 3.5],
+        episode="episode",
+        id="subject",
+        end="time",
+        event="state",
+    )
+    assert multistate_right_split == {
+        "x": [11, 12, 12, 13, 13, 13],
+        "subject": [1, 2, 2, 3, 3, 3],
+        "tstart": [0.0, 0.0, 2.0, 0.0, 2.0, 3.5],
+        "time": [1.0, 2.0, 3.0, 2.0, 3.5, 4.0],
+        "state": [1, 0, 0, 0, 0, 2],
+        "episode": [1, 1, 2, 1, 2, 3],
+    }
+
+    multistate_counting = survival.Surv(
+        [0.0, 1.0],
+        [3.0, 4.0],
+        Factor(["a", "b"], ["censor", "a", "b"]),
+        type="mstate",
+    )
+    multistate_counting_split = survival.survSplit(
+        multistate_counting,
+        {"x": [1, 2]},
+        cut=[2.0],
+        start="start",
+        end="stop",
+        event="state",
+        episode="episode",
+        id="subject",
+    )
+    assert multistate_counting_split == {
+        "x": [1, 1, 2, 2],
+        "subject": [1, 1, 2, 2],
+        "start": [0.0, 2.0, 1.0, 2.0],
+        "stop": [2.0, 3.0, 2.0, 4.0],
+        "state": [0, 1, 0, 2],
+        "episode": [1, 2, 1, 2],
     }
 
     with pytest.raises(ValueError, match="not valid for interval2"):

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -424,11 +424,17 @@ attrassign.lm <- function(object, ...) {
 }
 
 .survsplit_response_names <- function(formula, response) {
+  response_expr <- formula[[2L]]
+  if (is.call(response_expr)) {
+    args <- as.list(response_expr[-1L])
+    if (length(args) >= 2L && all(vapply(args, is.name, logical(1)))) {
+      return(vapply(args, as.character, character(1)))
+    }
+  }
   response_names <- colnames(response)
   if (!is.null(response_names) && length(response_names) >= 2L) {
     return(response_names)
   }
-  response_expr <- formula[[2L]]
   if (!is.call(response_expr)) {
     return(character())
   }
@@ -512,6 +518,10 @@ attrassign.lm <- function(object, ...) {
     if (!missing(event)) {
       args <- c(args, list(event))
     }
+  }
+  factor_response <- .surv_factor_response(args, type = type, origin = origin)
+  if (!is.null(factor_response)) {
+    return(factor_response)
   }
   args <- c(args, .compact_null(list(type = type, origin = origin)))
   .survsplit_minimal_surv(args)
@@ -7596,10 +7606,19 @@ survSplit <- function(formula, data, subset, na.action = na.pass, cut,
     id = if (missing(id)) NULL else as.character(id),
     zero = zero
   )
-  .restore_r_column_classes(
+  output <- .restore_r_column_classes(
     as.data.frame(result, stringsAsFactors = FALSE, optional = TRUE),
     covariates
   )
+  states <- attr(response, "states")
+  if (!is.null(states)) {
+    output[[event_name]] <- factor(
+      as.integer(output[[event_name]]),
+      levels = 0:length(states),
+      labels = c("censor", states)
+    )
+  }
+  output
 }
 
 survcondense <- function(formula, data, subset, weights, na.action = na.pass,

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -602,6 +602,59 @@ test_that("R formula wrappers delegate to the Python survival package", {
   expect_equal(as.integer(counting_split$status), c(0L, 1L, 0L, 0L, 0L))
   expect_equal(as.integer(counting_split$episode), c(1L, 2L, 1L, 2L, 3L))
 
+  split_multistate <- data.frame(
+    time = c(1, 3, 4),
+    state = factor(c("a", "censor", "b"), levels = c("censor", "a", "b")),
+    x = 11:13
+  )
+  multistate_split <- survSplit(
+    Surv(time, state) ~ x,
+    data = split_multistate,
+    cut = c(2, 3.5),
+    episode = "episode",
+    id = "subject"
+  )
+  reference_multistate_formula <- Surv(time, state) ~ x
+  environment(reference_multistate_formula) <- list2env(
+    list(Surv = survival::Surv),
+    parent = parent.frame()
+  )
+  reference_multistate_split <- survival::survSplit(
+    reference_multistate_formula,
+    data = split_multistate,
+    cut = c(2, 3.5),
+    episode = "episode",
+    id = "subject"
+  )
+  expect_equal(multistate_split, reference_multistate_split)
+
+  split_multistate_counting <- data.frame(
+    start = c(0, 1),
+    stop = c(3, 4),
+    state = factor(c("a", "b"), levels = c("censor", "a", "b")),
+    x = 1:2
+  )
+  multistate_counting_split <- survSplit(
+    Surv(start, stop, state) ~ x,
+    data = split_multistate_counting,
+    cut = 2,
+    episode = "episode",
+    id = "subject"
+  )
+  reference_multistate_counting_formula <- Surv(start, stop, state) ~ x
+  environment(reference_multistate_counting_formula) <- list2env(
+    list(Surv = survival::Surv),
+    parent = parent.frame()
+  )
+  reference_multistate_counting_split <- survival::survSplit(
+    reference_multistate_counting_formula,
+    data = split_multistate_counting,
+    cut = 2,
+    episode = "episode",
+    id = "subject"
+  )
+  expect_equal(multistate_counting_split, reference_multistate_counting_split)
+
   check_data <- data.frame(
     id = c(1, 1, 2),
     start = c(0, 1, 0),


### PR DESCRIPTION
## Summary
- accept both `mright` and `mcounting` responses in `survSplit`
- reuse the existing Rust split kernel while retaining terminal transition codes and censoring synthetic rows
- preserve multistate response metadata through the R model frame
- restore the split event column as an R factor with reference-compatible names and levels
- add direct Python fixtures and exact R bridge parity tests for both response forms

## Testing
- `.venv/bin/python -m pytest -q python/tests` (827 passed, 18 skipped)
- `cargo test --all-targets` (1,367 passed)
- `cargo fmt --all -- --check`
- strict clippy checks for no-default, `ml`, and `python,ml` feature profiles
- full Ruff format and lint checks
- stub type checks
- `R CMD check --no-manual --no-build-vignettes r/survivalr` (tests pass; source-directory note only)