### PR TITLE
Preserve explicit multistate Surv responses

### DIFF
--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -476,8 +476,18 @@ attrassign.lm <- function(object, ...) {
   stop("Surv response requires at least two arguments", call. = FALSE)
 }
 
+.warn_deprecated_surv_mstate_type <- function(type) {
+  if (identical(type, "mstate")) {
+    warning(
+      "type= 'mstate' is deprecated, use a factor variable as status",
+      call. = FALSE
+    )
+  }
+}
+
 .survsplit_model_frame_surv <- function(time, time2, event, type = NULL,
                                         origin = 0, time1, start, stop, status) {
+  .warn_deprecated_surv_mstate_type(type)
   use_named_response <- !missing(time1) || !missing(start) ||
     !missing(stop) || !missing(status)
 
@@ -2207,6 +2217,8 @@ neardate <- function(id1, id2, y1, y2, best = c("after", "prior"), nomatch = NA_
   }
   matched_type <- if (is.null(type)) {
     NULL
+  } else if (identical(type, "mstate")) {
+    "mstate"
   } else {
     match.arg(type, c("right", "left", "interval", "counting", "interval2"))
   }
@@ -2243,6 +2255,7 @@ neardate <- function(id1, id2, y1, y2, best = c("after", "prior"), nomatch = NA_
 
 .native_model_frame_surv <- function(time, time2, event, type = NULL,
                                      origin = 0, time1, start, stop, status) {
+  .warn_deprecated_surv_mstate_type(type)
   use_named_response <- !missing(time1) || !missing(start) ||
     !missing(stop) || !missing(status)
 
@@ -2287,6 +2300,7 @@ neardate <- function(id1, id2, y1, y2, best = c("after", "prior"), nomatch = NA_
 }
 
 Surv <- function(time, time2, event, type = NULL, origin = 0, time1, start, stop, status) {
+  .warn_deprecated_surv_mstate_type(type)
   use_named_response <- !missing(time1) || !missing(start) ||
     !missing(stop) || !missing(status)
 
@@ -5887,7 +5901,7 @@ model.frame.formula <- function(formula, ...) {
       stop = time,
       status = status
     )
-    attr(out, "type") <- "counting"
+    attr(out, "type") <- surv_type
   } else if (!is.null(time2)) {
     time2 <- .as_numeric_vector(time2)
     if (identical(surv_type, "interval2")) {
@@ -5911,6 +5925,9 @@ model.frame.formula <- function(formula, ...) {
   } else {
     out <- cbind(time = time, status = status)
     attr(out, "type") <- surv_type
+  }
+  if (surv_type %in% c("mright", "mcounting")) {
+    attr(out, "states") <- as.character(.result_field(x, "states"))
   }
   class(out) <- "Surv"
   out

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -185,6 +185,43 @@ test_that("R formula wrappers delegate to the Python survival package", {
   expect_equal(attr(factor_response, "inputAttributes"), attr(reference_factor_response, "inputAttributes"))
   expect_equal(format(factor_response), format(reference_factor_response))
   expect_equal(is.na(factor_response), is.na(reference_factor_response))
+  expect_warning(
+    explicit_multistate_response <- Surv(
+      c(1, 2, 3),
+      factor(c("censor", "relapse", "death")),
+      type = "mstate"
+    ),
+    "type= 'mstate' is deprecated"
+  )
+  expect_warning(
+    reference_explicit_multistate_response <- survival::Surv(
+      c(1, 2, 3),
+      factor(c("censor", "relapse", "death")),
+      type = "mstate"
+    ),
+    "type= 'mstate' is deprecated"
+  )
+  expect_equal(explicit_multistate_response, reference_explicit_multistate_response)
+  expect_warning(
+    explicit_numeric_multistate_response <- Surv(
+      c(1, 2),
+      c(0, 1),
+      type = "mstate"
+    ),
+    "type= 'mstate' is deprecated"
+  )
+  expect_warning(
+    reference_numeric_multistate_response <- survival::Surv(
+      c(1, 2),
+      c(0, 1),
+      type = "mstate"
+    ),
+    "type= 'mstate' is deprecated"
+  )
+  expect_equal(
+    .as_native_surv(explicit_numeric_multistate_response),
+    reference_numeric_multistate_response
+  )
   factor_counting_response <- Surv(c(0, 0), c(1, 2), factor(c("a", "b")), type = "counting")
   reference_factor_counting_response <- survival::Surv(
     c(0, 0),
@@ -199,6 +236,50 @@ test_that("R formula wrappers delegate to the Python survival package", {
   expect_equal(attr(factor_counting_response, "inputAttributes"), attr(reference_factor_counting_response, "inputAttributes"))
   expect_equal(format(factor_counting_response), format(reference_factor_counting_response))
   expect_equal(is.na(factor_counting_response), is.na(reference_factor_counting_response))
+  expect_warning(
+    explicit_multistate_counting_response <- Surv(
+      c(0, 0),
+      c(1, 2),
+      factor(c("a", "b")),
+      type = "mstate"
+    ),
+    "type= 'mstate' is deprecated"
+  )
+  expect_warning(
+    reference_explicit_multistate_counting_response <- survival::Surv(
+      c(0, 0),
+      c(1, 2),
+      factor(c("a", "b")),
+      type = "mstate"
+    ),
+    "type= 'mstate' is deprecated"
+  )
+  expect_equal(
+    explicit_multistate_counting_response,
+    reference_explicit_multistate_counting_response
+  )
+  expect_warning(
+    explicit_numeric_multistate_counting_response <- Surv(
+      c(0, 0),
+      c(1, 2),
+      c(0, 1),
+      type = "mstate"
+    ),
+    "type= 'mstate' is deprecated"
+  )
+  expect_warning(
+    reference_numeric_multistate_counting_response <- survival::Surv(
+      c(0, 0),
+      c(1, 2),
+      c(0, 1),
+      type = "mstate"
+    ),
+    "type= 'mstate' is deprecated"
+  )
+  expect_equal(
+    .as_native_surv(explicit_numeric_multistate_counting_response),
+    reference_numeric_multistate_counting_response
+  )
   reference_model_frame_formula <- Surv(time, status) ~ group + x
   reference_model_frame_env <- list2env(list(Surv = survival::Surv), parent = parent.frame())
   environment(reference_model_frame_formula) <- reference_model_frame_env

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -193,13 +193,12 @@ test_that("R formula wrappers delegate to the Python survival package", {
     ),
     "type= 'mstate' is deprecated"
   )
-  expect_warning(
-    reference_explicit_multistate_response <- survival::Surv(
+  reference_explicit_multistate_response <- suppressWarnings(
+    survival::Surv(
       c(1, 2, 3),
       factor(c("censor", "relapse", "death")),
       type = "mstate"
-    ),
-    "type= 'mstate' is deprecated"
+    )
   )
   expect_equal(explicit_multistate_response, reference_explicit_multistate_response)
   expect_warning(
@@ -210,13 +209,12 @@ test_that("R formula wrappers delegate to the Python survival package", {
     ),
     "type= 'mstate' is deprecated"
   )
-  expect_warning(
-    reference_numeric_multistate_response <- survival::Surv(
+  reference_numeric_multistate_response <- suppressWarnings(
+    survival::Surv(
       c(1, 2),
       c(0, 1),
       type = "mstate"
-    ),
-    "type= 'mstate' is deprecated"
+    )
   )
   expect_equal(
     .as_native_surv(explicit_numeric_multistate_response),
@@ -245,14 +243,13 @@ test_that("R formula wrappers delegate to the Python survival package", {
     ),
     "type= 'mstate' is deprecated"
   )
-  expect_warning(
-    reference_explicit_multistate_counting_response <- survival::Surv(
+  reference_explicit_multistate_counting_response <- suppressWarnings(
+    survival::Surv(
       c(0, 0),
       c(1, 2),
       factor(c("a", "b")),
       type = "mstate"
-    ),
-    "type= 'mstate' is deprecated"
+    )
   )
   expect_equal(
     explicit_multistate_counting_response,
@@ -267,14 +264,13 @@ test_that("R formula wrappers delegate to the Python survival package", {
     ),
     "type= 'mstate' is deprecated"
   )
-  expect_warning(
-    reference_numeric_multistate_counting_response <- survival::Surv(
+  reference_numeric_multistate_counting_response <- suppressWarnings(
+    survival::Surv(
       c(0, 0),
       c(1, 2),
       c(0, 1),
       type = "mstate"
-    ),
-    "type= 'mstate' is deprecated"
+    )
   )
   expect_equal(
     .as_native_surv(explicit_numeric_multistate_counting_response),


### PR DESCRIPTION
## Summary
- accept R's deprecated explicit `type = "mstate"` spelling and emit the reference warning
- preserve `mright` and `mcounting` types when wrapped responses are converted back to native R matrices
- retain multistate labels during native conversion
- cover factor and numeric event inputs for both right and counting response shapes

## Testing
- `R CMD check --no-manual --no-build-vignettes r/survivalr` (tests pass; source-directory note only)
- `git diff --check`

Python and Rust source are unchanged, and no dependencies are added.