### PR TITLE
Support multistate survcondense responses

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -7693,7 +7693,7 @@ def _survcondense_from_formula(
     weights = aligned["weights"]
     response, terms = _parse_formula(formula, data)
     _reject_formula_clusters("survcondense", terms)
-    if response.type != "counting":
+    if response.type not in {"counting", "mcounting"}:
         raise ValueError("survcondense requires a counting-process Surv response")
     if response.start is None:
         raise ValueError("counting Surv response is missing start times")
@@ -7743,7 +7743,13 @@ def _survcondense_from_formula(
     }
     output[start] = [starts[idx] for idx in keep_indices]
     output[end] = [response.time[idx] for idx in keep_indices]
-    output[event] = [response.event[idx] for idx in keep_indices]
+    if response.type == "mcounting":
+        output[event] = [
+            "censor" if response.event[idx] == 0 else response.states[int(response.event[idx]) - 1]
+            for idx in keep_indices
+        ]
+    else:
+        output[event] = [response.event[idx] for idx in keep_indices]
     return output
 
 

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -979,6 +979,11 @@ def test_pseudo_supports_counting_process_survfit_results():
 
 
 def test_survcondense_accepts_formula_and_preserves_direct_api():
+    class Factor(list):
+        def __init__(self, values, levels):
+            super().__init__(values)
+            self.categories = levels
+
     data = {
         "id": [2, 1, 1, 2],
         "tstart": [0.0, 0.0, 5.0, 3.0],
@@ -1055,6 +1060,22 @@ def test_survcondense_accepts_formula_and_preserves_direct_api():
         data=special_data,
         id="id",
     )
+    multistate_data = {
+        "id": [1, 1, 2, 2, 3, 3],
+        "tstart": [0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
+        "tstop": [1.0, 2.0, 1.0, 2.0, 1.0, 2.0],
+        "state": Factor(
+            ["a", "censor", "b", "a", "a", "b"],
+            ["censor", "a", "b"],
+        ),
+        "x": [1, 1, 2, 2, 3, 3],
+    }
+    multistate = survival.survcondense(
+        "Surv(tstart, tstop, state) ~ x",
+        data=multistate_data,
+        id="id",
+        event="state",
+    )
 
     assert result == {
         "x": ["b", "a"],
@@ -1096,6 +1117,13 @@ def test_survcondense_accepts_formula_and_preserves_direct_api():
     assert list(offset_first)[:2] == ["offset(off)", "x"]
     assert offset_first["offset(off)"] == pytest.approx([2.0, 1.0])
     assert offset_first["x"] == ["b", "a"]
+    assert multistate == {
+        "x": [1, 2, 3],
+        "id": [1, 2, 3],
+        "tstart": [0.0, 0.0, 0.0],
+        "tstop": [2.0, 2.0, 2.0],
+        "state": ["censor", "a", "b"],
+    }
 
     with pytest.raises(ValueError, match="counting-process"):
         survival.survcondense(

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -7608,6 +7608,30 @@ survcondense <- function(formula, data, subset, weights, na.action = na.pass,
     stop("id is required", call. = FALSE)
   }
   env <- parent.frame()
+  start_missing <- missing(start)
+  end_missing <- missing(end)
+  event_missing <- missing(event)
+  event_source <- NULL
+  response_call <- formula[[2L]]
+  if (
+    is.call(response_call) &&
+      is.name(response_call[[1L]]) &&
+      identical(response_call[[1L]], quote(Surv))
+  ) {
+    matched_response <- match.call(Surv, response_call)
+    if (start_missing && !is.null(matched_response$time) && is.name(matched_response$time)) {
+      start <- as.character(matched_response$time)
+    }
+    if (end_missing && !is.null(matched_response$time2) && is.name(matched_response$time2)) {
+      end <- as.character(matched_response$time2)
+    }
+    if (event_missing && !is.null(matched_response$event) && is.name(matched_response$event)) {
+      event <- as.character(matched_response$event)
+    }
+    if (!is.null(matched_response$event)) {
+      event_source <- eval(matched_response$event, data, env)
+    }
+  }
   id_name <- paste(deparse(substitute(id), width.cutoff = 500L), collapse = " ")
   weight_name <- if (missing(weights)) {
     NULL
@@ -7636,7 +7660,15 @@ survcondense <- function(formula, data, subset, weights, na.action = na.pass,
   for (column in strata_columns) {
     frame[[column]] <- factor(frame[[column]])
   }
-  .restore_r_column_classes(frame, data)
+  event_values <- frame[[event]]
+  frame <- .restore_r_column_classes(frame, data)
+  if (is.factor(event_source)) {
+    frame[[event]] <- factor(
+      as.character(event_values),
+      levels = c("censor", levels(event_source)[-1L])
+    )
+  }
+  frame
 }
 
 coxph <- function(formula, data = NULL, ..., subset = NULL, na.action = "fail") {

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -4124,6 +4124,48 @@ test_that("data-prep helpers match R survival shapes", {
     survcondense(condense_offset_formula, data = condense_special_data, id = id),
     survival::survcondense(condense_offset_formula, data = condense_special_data, id = id)
   )
+  condense_multistate_data <- data.frame(
+    id = rep(1:3, each = 2),
+    tstart = rep(c(0, 1), 3),
+    tstop = rep(c(1, 2), 3),
+    state = factor(
+      c("a", "censor", "b", "a", "a", "b"),
+      levels = c("censor", "a", "b")
+    ),
+    x = rep(1:3, each = 2)
+  )
+  condense_multistate_formula <- Surv(tstart, tstop, state) ~ x
+  environment(condense_multistate_formula) <- environment(reference_formula)
+  expect_equal(
+    survcondense(
+      condense_multistate_formula,
+      data = condense_multistate_data,
+      id = id
+    ),
+    survival::survcondense(
+      condense_multistate_formula,
+      data = condense_multistate_data,
+      id = id
+    )
+  )
+  expect_equal(
+    survcondense(
+      condense_multistate_formula,
+      data = condense_multistate_data,
+      id = id,
+      start = "begin",
+      end = "finish",
+      event = "transition"
+    ),
+    survival::survcondense(
+      condense_multistate_formula,
+      data = condense_multistate_data,
+      id = id,
+      start = "begin",
+      end = "finish",
+      event = "transition"
+    )
+  )
 })
 
 test_that("Cox bridge agrees with R survival on a small right-censored fixture", {


### PR DESCRIPTION
## Summary
- accept multistate counting-process `Surv` responses in `survcondense`
- map transition codes back to state labels in the Python interface
- infer response output names and restore factor levels in the R bridge, including custom output names
- add exact reference-parity coverage for inferred and custom names
- add no dependencies

## Testing
- 827 Python tests passed, 18 skipped
- 1,367 Rust tests passed, including benchmark smoke targets
- full R package check passed with the standard source-directory note only
- Ruff formatting and lint checks passed
- mypy passed
- Rust formatting passed
- strict Rust lint checks passed for no-default, `ml`, and `python,ml` feature profiles