### PR TITLE
Honor Brier newdata weights and IDs

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -265,10 +265,12 @@ class _FormulaFit:
     formula: str | None = None
     coefficient_names: tuple[str, ...] | None = None
     case_weights: list[float] | None = None
+    case_weight_column: str | None = None
     robust_variance: list[list[float]] | None = None
     naive_variance: list[list[float]] | None = None
     cluster: list[Any] | None = None
     id_values: list[Any] | None = None
+    id_column: str | None = None
     x_matrix: list[list[float]] | None = None
     y_response: Surv | None = None
     model_frame: dict[str, Any] | None = None
@@ -1503,8 +1505,26 @@ def _brier_fit_response_and_data(fit: Any, newdata: Any | None) -> tuple[Surv, A
     return Surv(list(model.event_times), list(model.status)), None
 
 
-def _brier_case_weights(fit: Any, n: int) -> list[float]:
-    weights = _model_residual_weights(fit, n)
+def _brier_case_weights(
+    fit: Any,
+    model_data: Any | None,
+    n: int,
+    *,
+    use_newdata: bool,
+) -> list[float]:
+    weight_column = getattr(fit, "case_weight_column", None)
+    if use_newdata and weight_column is not None:
+        if model_data is None:
+            raise ValueError("newdata is required to evaluate case weights")
+        try:
+            source = _column(model_data, weight_column)
+        except KeyError as exc:
+            raise ValueError(f"newdata is missing weights column {weight_column!r}") from exc
+        weights = _float_vector(source, "weights")
+        if len(weights) != n:
+            raise ValueError("weights must have the same length as the Surv response")
+    else:
+        weights = _model_residual_weights(fit, n)
     if any(not math.isfinite(weight) for weight in weights):
         raise ValueError("weights must be finite")
     if any(weight < 0.0 for weight in weights):
@@ -1526,7 +1546,25 @@ def _brier_id_column(data: Any | None, name: str) -> list[Any] | None:
         return None
 
 
-def _brier_id_values(fit: Any, model_data: Any | None, n: int) -> list[Any] | None:
+def _brier_id_values(
+    fit: Any,
+    model_data: Any | None,
+    n: int,
+    *,
+    use_newdata: bool,
+) -> list[Any] | None:
+    id_column = getattr(fit, "id_column", None)
+    if use_newdata and id_column is not None:
+        if model_data is None:
+            raise ValueError("newdata is required to evaluate id")
+        try:
+            values = _materialize_labels(_column(model_data, id_column), "id")
+        except KeyError as exc:
+            raise ValueError(f"newdata is missing id column {id_column!r}") from exc
+        if len(values) != n:
+            raise ValueError("id must have the same length as the Surv response")
+        return values
+
     for name in ("(id)", "id"):
         values = _brier_id_column(model_data, name)
         if values is not None:
@@ -1687,10 +1725,21 @@ def brier(
     timefix_value = _normalize_bool_option(timefix, "timefix")
     efron_value = _normalize_bool_option(efron, "efron")
     response, prediction_data = _brier_fit_response_and_data(fit, newdata)
-    id_values = _brier_id_values(fit, prediction_data, len(response))
+    using_newdata = newdata is not None
+    id_values = _brier_id_values(
+        fit,
+        prediction_data,
+        len(response),
+        use_newdata=using_newdata,
+    )
     dtime, dstat = _brier_event_times(response, timefix_value, id_values)
     n = len(dtime)
-    weights = _brier_case_weights(fit, n)
+    weights = _brier_case_weights(
+        fit,
+        prediction_data,
+        n,
+        use_newdata=using_newdata,
+    )
     eval_times = (
         _float_vector(times, "times")
         if times is not None
@@ -20621,6 +20670,8 @@ def coxph(
 ):
     """Fit a Cox proportional hazards model from Surv plus covariates."""
 
+    case_weight_column = kwargs.pop("_weights_column", None)
+    id_column = kwargs.pop("_id_column", None)
     na_action = _pop_dotted_keyword(kwargs, "na.action", "na_action", na_action, "fail")
     singular_ok = _pop_dotted_keyword(
         kwargs,
@@ -20636,6 +20687,16 @@ def coxph(
     method_name = _cox_tie_method(method, ties)
     robust_value = _normalize_optional_bool_option(robust, "robust")
     explicit_weights = weights is not None
+    if case_weight_column is None and isinstance(weights, str):
+        case_weight_column = weights
+    if id_column is None and isinstance(id, str):
+        id_column = id
+    for column, name in (
+        (case_weight_column, "_weights_column"),
+        (id_column, "_id_column"),
+    ):
+        if column is not None and (not isinstance(column, str) or not column):
+            raise TypeError(f"{name} must be a non-empty string")
     keep_model = _normalize_bool_option_with_default(model, "model", False)
     keep_y = _normalize_bool_option_with_default(y, "y", True)
     singular_ok_value = _normalize_bool_option_with_default(singular_ok, "singular_ok", True)
@@ -20662,6 +20723,8 @@ def coxph(
     if isinstance(response, str):
         formula_string = response
         response_spec = _formula_response_spec(response)
+        weights = _column_or_values(data, weights, "weights") if weights is not None else None
+        id_arg = _column_or_values(data, id_arg, "id") if id_arg is not None else None
         if subset is not None:
             data, aligned = _subset_formula_inputs(
                 response,
@@ -20904,10 +20967,12 @@ def coxph(
             formula=formula_string,
             coefficient_names=direct_coefficient_names,
             case_weights=case_weights,
+            case_weight_column=case_weight_column,
             robust_variance=robust_variance,
             naive_variance=naive_variance,
             cluster=cluster_values,
             id_values=id_values,
+            id_column=id_column,
             x_matrix=formula_x_matrix,
             y_response=response if formula_design is not None and keep_y else None,
             model_frame=model_frame,

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -603,6 +603,7 @@ def test_r_api_brier_returns_r_style_cox_model_fields():
         "time": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
         "status": [1, 1, 0, 1, 0, 1, 1, 0],
         "x": [0.2, 0.4, 0.1, 0.8, 1.0, 1.2, 0.6, 1.4],
+        "wt": [1.0] * 8,
     }
     fit = survival.coxph("Surv(time, status) ~ x", data=data, model=True, max_iter=50)
     assert fit.coefficients[0] == pytest.approx([-2.1132119551866904], abs=3e-5)
@@ -619,6 +620,30 @@ def test_r_api_brier_returns_r_style_cox_model_fields():
     )
     assert len(result["phat"]) == 3
     assert all(len(row) == len(data["time"]) for row in result["phat"])
+
+    weighted_fit = survival.coxph(
+        "Surv(time, status) ~ x",
+        data=data,
+        weights="wt",
+        model=True,
+        max_iter=50,
+    )
+    weighted_newdata = {**data, "wt": [8.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]}
+    weighted_result = survival.r_api.brier(
+        weighted_fit,
+        times=[2.0, 4.0, 6.0],
+        newdata=weighted_newdata,
+        detail=True,
+    )
+    assert weighted_result["eff.n"] == pytest.approx([3.1690140845, 3.1163434903, 3.0356177407])
+    assert weighted_result["brier"] == pytest.approx(
+        [0.21987334, 0.09626662, 0.12947811],
+        abs=1e-6,
+    )
+    assert weighted_result["rsquared"] == pytest.approx(
+        [0.0838611, 0.5575983, 0.2284805],
+        abs=1e-6,
+    )
 
     counting_data = {
         "start": [0.0] * len(data["time"]),
@@ -680,6 +705,25 @@ def test_r_api_brier_returns_r_style_cox_model_fields():
     )
     with pytest.raises(ValueError, match="survcheck"):
         survival.r_api.brier(gap_fit, times=[3.0, 5.0, 7.0])
+
+    custom_id_data = {
+        **{name: values for name, values in common_start_data.items() if name != "id"},
+        "subject": common_start_data["id"],
+    }
+    custom_id_fit = survival.coxph(
+        "Surv(start, stop, status) ~ x",
+        data=custom_id_data,
+        id="subject",
+        model=True,
+        max_iter=0,
+    )
+    bad_id_newdata = {**custom_id_data, "subject": [1, 2, 2, 1, 3, 3]}
+    with pytest.raises(ValueError, match="survcheck"):
+        survival.r_api.brier(
+            custom_id_fit,
+            times=[3.0, 5.0, 7.0],
+            newdata=bad_id_newdata,
+        )
 
     staggered_data = {**counting_data, "start": [0.0, 0.0, 1.0, 1.0, 2.0, 2.0, 3.0, 3.0]}
     staggered_fit = survival.coxph(

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -7849,6 +7849,12 @@ coxph <- function(formula, data = NULL, ..., subset = NULL, na.action = "fail") 
     parent.frame(),
     vector_args = c("weights", "offset", "strata", "cluster", "id")
   )
+  if (!is.null(dots$weights) && is.name(dots$weights)) {
+    evaluated_dots[["_weights_column"]] <- as.character(dots$weights)
+  }
+  if (!is.null(dots$id) && is.name(dots$id)) {
+    evaluated_dots[["_id_column"]] <- as.character(dots$id)
+  }
   do.call(
     .call_r_api,
     c(

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -2035,6 +2035,52 @@ test_that("R formula wrappers delegate to the Python survival package", {
   expect_lt(max(abs(bridged_brier$rsquared - reference_brier$rsquared)), 3e-3)
   expect_lt(max(abs(bridged_brier$phat - reference_brier$phat)), 3e-3)
 
+  brier_weighted_data <- transform(brier_data, wt = 1)
+  brier_weighted_newdata <- transform(
+    brier_weighted_data,
+    wt = c(8, 1, 1, 1, 1, 1, 1, 1)
+  )
+  brier_weighted_fit <- coxph(
+    Surv(time, status) ~ x,
+    data = brier_weighted_data,
+    weights = wt,
+    max_iter = 50,
+    model = TRUE
+  )
+  reference_brier_weighted_fit <- survival::coxph(
+    survival::Surv(time, status) ~ x,
+    data = brier_weighted_data,
+    weights = wt,
+    iter.max = 50,
+    model = TRUE,
+    y = TRUE
+  )
+  bridged_brier_weighted <- brier(
+    brier_weighted_fit,
+    times = c(2, 4, 6),
+    newdata = brier_weighted_newdata,
+    detail = TRUE
+  )
+  reference_brier_weighted <- survival::brier(
+    reference_brier_weighted_fit,
+    times = c(2, 4, 6),
+    newdata = brier_weighted_newdata,
+    detail = TRUE
+  )
+  expect_equal(
+    bridged_brier_weighted$eff.n,
+    reference_brier_weighted$eff.n,
+    tolerance = 1e-12
+  )
+  expect_lt(
+    max(abs(bridged_brier_weighted$brier - reference_brier_weighted$brier)),
+    3e-3
+  )
+  expect_lt(
+    max(abs(bridged_brier_weighted$rsquared - reference_brier_weighted$rsquared)),
+    3e-3
+  )
+
   brier_counting_data <- data.frame(
     start = rep(0, nrow(brier_data)),
     stop = brier_data$time,
@@ -2114,6 +2160,46 @@ test_that("R formula wrappers delegate to the Python survival package", {
   expect_lt(max(abs(bridged_brier_common_start$brier - reference_brier_common_start$brier)), 3e-3)
   expect_equal(bridged_brier_common_start$rsquared, reference_brier_common_start$rsquared, tolerance = 3e-3)
   expect_lt(max(abs(bridged_brier_common_start$phat - reference_brier_common_start$phat)), 3e-3)
+
+  brier_custom_id_data <- transform(
+    brier_common_start_data[names(brier_common_start_data) != "id"],
+    subject = brier_common_start_data$id
+  )
+  brier_custom_id_fit <- coxph(
+    Surv(start, stop, status) ~ x,
+    data = brier_custom_id_data,
+    id = subject,
+    max_iter = 0,
+    model = TRUE
+  )
+  reference_brier_custom_id_fit <- survival::coxph(
+    survival::Surv(start, stop, status) ~ x,
+    data = brier_custom_id_data,
+    id = subject,
+    iter.max = 0,
+    model = TRUE,
+    y = TRUE
+  )
+  brier_bad_id_newdata <- transform(
+    brier_custom_id_data,
+    subject = c(1, 2, 2, 1, 3, 3)
+  )
+  expect_error(
+    brier(
+      brier_custom_id_fit,
+      times = c(3, 5, 7),
+      newdata = brier_bad_id_newdata
+    ),
+    "survcheck"
+  )
+  expect_error(
+    survival::brier(
+      reference_brier_custom_id_fit,
+      times = c(3, 5, 7),
+      newdata = brier_bad_id_newdata
+    ),
+    "survcheck"
+  )
 
   brier_gap_data <- transform(brier_common_start_data, start = c(0, 3, 0, 3, 0, 4))
   brier_gap_fit <- coxph(


### PR DESCRIPTION
## Summary
- retain simple weight and subject-ID column names on formula Cox fits
- resolve named weight and ID inputs directly in the Python formula interface
- evaluate case weights and subject histories from `newdata` during Brier scoring
- preserve those source names through the R bridge
- add weighted scoring and custom start/stop ID parity coverage
- add no dependencies

## Testing
- 827 Python tests passed, 18 skipped
- 1,369 Rust tests passed, including benchmark smoke targets
- full R package check passed with the standard source-directory note only
- Ruff formatting and lint checks passed
- mypy passed
- Rust formatting passed
- strict Rust lint checks passed for no-default, `ml`, and `python,ml` feature profiles