### PR TITLE
Support missing dates in neardate

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -4327,6 +4327,19 @@ def _integerish_vector_or_none(values: Any, name: str) -> list[int] | None:
         return None
 
 
+def _neardate_float_vector(values: Any, name: str) -> list[float]:
+    result: list[float] = []
+    for value in _materialize_1d(values, name):
+        if _is_missing_value(value):
+            result.append(math.nan)
+            continue
+        try:
+            result.append(float(value))
+        except (TypeError, ValueError) as exc:
+            raise TypeError(f"{name} must be sortable numeric values") from exc
+    return result
+
+
 def neardate(
     id1: Any,
     id2: Any,
@@ -4343,10 +4356,13 @@ def neardate(
         ("after", "prior", "closest"),
         "best must be 'after', 'prior', or 'closest'",
     )
-    y1_values = _float_vector(y1, "y1")
-    y2_values = _float_vector(y2, "y2")
-    id1_integer = _integerish_vector_or_none(id1, "id1")
-    id2_integer = _integerish_vector_or_none(id2, "id2")
+    y1_values = _neardate_float_vector(y1, "y1")
+    y2_values = _neardate_float_vector(y2, "y2")
+    id1_values = _materialize_1d(id1, "id1")
+    id2_values = _materialize_1d(id2, "id2")
+    id1_missing = [_is_missing_value(value) for value in id1_values]
+    id1_integer = _integerish_vector_or_none(id1_values, "id1")
+    id2_integer = _integerish_vector_or_none(id2_values, "id2")
     nomatch_value = None if nomatch is None else _integer_scalar(nomatch, "nomatch")
 
     if id1_integer is not None and id2_integer is not None:
@@ -4360,15 +4376,24 @@ def neardate(
         )
     else:
         result = _core.neardate_str(
-            [str(value) for value in _materialize_1d(id1, "id1")],
+            [
+                "\0missing" if missing else f"\0value:{value}"
+                for value, missing in zip(id1_values, id1_missing, strict=True)
+            ],
             y1_values,
-            [str(value) for value in _materialize_1d(id2, "id2")],
+            [
+                "\0missing" if _is_missing_value(value) else f"\0value:{value}"
+                for value in id2_values
+            ],
             y2_values,
             best_value,
             None,
         )
 
-    return [nomatch_value if idx is None else int(idx) + 1 for idx in result.indices]
+    return [
+        None if id1_missing[pos] else nomatch_value if idx is None else int(idx) + 1
+        for pos, idx in enumerate(result.indices)
+    ]
 
 
 def _tcut_default_labels(breaks: list[float]) -> list[str]:

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -3418,6 +3418,29 @@ def test_r_style_neardate_and_tcut_use_native_data_prep_helpers():
         [5.0, 10.0],
         nomatch=0,
     ) == [1, 0]
+    missing_and_infinite = [None, 2.0, float("inf"), float("-inf")]
+    reference_dates = [1.0, None, float("inf"), float("-inf")]
+    assert survival.neardate(
+        [1, 1, 1, 1],
+        [1, 1, 1, 1],
+        missing_and_infinite,
+        reference_dates,
+        nomatch=0,
+    ) == [0, 3, 3, 4]
+    assert survival.neardate(
+        [1, 1, 1, 1],
+        [1, 1, 1, 1],
+        missing_and_infinite,
+        reference_dates,
+        best="prior",
+        nomatch=0,
+    ) == [0, 1, 3, 4]
+    assert survival.neardate([None, 1], [None, 1], [1.0, 2.0], [1.0, 2.0], nomatch=0) == [None, 2]
+    assert survival.neardate([None, 1], [None, 2], [1.0, 2.0], [1.0, 2.0], nomatch=0) == [None, 0]
+    with pytest.raises(ValueError, match="No valid entries"):
+        survival.neardate([1], [1], [1.0], [None])
+    with pytest.raises(ValueError, match="No valid entries"):
+        survival.neardate([1], [2], [1.0], [1.0])
 
     cut = survival.tcut([5.0, 15.0, 30.0], [0.0, 10.0, 20.0, 30.0])
     assert isinstance(cut, survival.TcutResult)

--- a/python/tests/test_utilities.py
+++ b/python/tests/test_utilities.py
@@ -299,10 +299,12 @@ def test_aeq_surv_neardate_and_tcut_public_apis():
         survival.aeq_surv([1.0], float("inf"))
     with pytest.raises(ValueError, match="time values must be finite"):
         survival.aeq_surv([1.0, float("nan")])
-    with pytest.raises(ValueError, match="date1 values must be finite"):
-        survival.neardate([1], [float("nan")], [1], [1.0])
-    with pytest.raises(ValueError, match="date2 values must be finite"):
-        survival.neardate_str(["a"], [1.0], ["a"], [float("inf")])
+    missing_query = survival.neardate([1], [float("nan")], [1], [1.0])
+    infinite_reference = survival.neardate_str(["a"], [1.0], ["a"], [float("inf")])
+    assert missing_query.indices == [None]
+    assert missing_query.distances == [None]
+    assert infinite_reference.indices == [0]
+    assert infinite_reference.distances == [float("inf")]
     with pytest.raises(ValueError, match="value values must be finite"):
         survival.tcut([float("nan")], [0.0, 1.0])
     with pytest.raises(ValueError, match="breaks must be given in ascending order"):

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -2168,28 +2168,30 @@ neardate <- function(id1, id2, y1, y2, best = c("after", "prior"), nomatch = NA_
   if (length(nomatch) != 1L) {
     stop("nomatch must be a scalar", call. = FALSE)
   }
+  if (is.factor(y1) || is.factor(y2)) {
+    stop("y1 and y2 must be sortable", call. = FALSE)
+  }
   y1 <- as.numeric(y1)
   y2 <- as.numeric(y2)
-  if (any(!is.finite(y1)) || any(!is.finite(y2))) {
-    stop("y1 and y2 must contain only finite values", call. = FALSE)
-  }
+  python_y1 <- lapply(y1, function(value) if (is.na(value)) NaN else value)
+  python_y2 <- lapply(y2, function(value) if (is.na(value)) NaN else value)
 
   if (.is_integerish_vector(id1) && .is_integerish_vector(id2)) {
     result <- .call_data_prep(
       "neardate",
-      as.integer(id1),
-      y1,
-      as.integer(id2),
-      y2,
+      as.list(as.integer(id1)),
+      python_y1,
+      as.list(as.integer(id2)),
+      python_y2,
       best = best
     )
   } else {
     result <- .call_data_prep(
       "neardate_str",
-      as.character(id1),
-      y1,
-      as.character(id2),
-      y2,
+      as.list(as.character(id1)),
+      python_y1,
+      as.list(as.character(id2)),
+      python_y2,
       best = best
     )
   }
@@ -2198,6 +2200,7 @@ neardate <- function(id1, id2, y1, y2, best = c("after", "prior"), nomatch = NA_
   matched <- !vapply(indices, is.null, logical(1))
   values <- rep(nomatch, length(indices))
   values[matched] <- as.integer(unlist(indices[matched], use.names = FALSE)) + 1L
+  values[is.na(id1)] <- NA_integer_
   values
 }
 

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -3208,6 +3208,42 @@ test_that("data-prep helpers match R survival shapes", {
     neardate(c("a", "b"), c("a", "b"), c(4, 12), c(5, 10), nomatch = 0L),
     survival::neardate(c("a", "b"), c("a", "b"), c(4, 12), c(5, 10), nomatch = 0L)
   )
+  neardate_queries <- c(NA, 2, Inf, -Inf)
+  neardate_references <- c(1, NA, Inf, -Inf)
+  expect_equal(
+    neardate(
+      rep(1, 4), rep(1, 4), neardate_queries, neardate_references,
+      nomatch = 0L
+    ),
+    survival::neardate(
+      rep(1, 4), rep(1, 4), neardate_queries, neardate_references,
+      nomatch = 0L
+    )
+  )
+  expect_equal(
+    neardate(
+      rep(1, 4), rep(1, 4), neardate_queries, neardate_references,
+      best = "prior", nomatch = 0L
+    ),
+    survival::neardate(
+      rep(1, 4), rep(1, 4), neardate_queries, neardate_references,
+      best = "prior", nomatch = 0L
+    )
+  )
+  expect_equal(
+    neardate(c(NA, 1), c(NA, 1), c(1, 2), c(1, 2), nomatch = 0L),
+    survival::neardate(c(NA, 1), c(NA, 1), c(1, 2), c(1, 2), nomatch = 0L)
+  )
+  expect_equal(
+    neardate(c(NA, 1), c(NA, 2), c(1, 2), c(1, 2), nomatch = 0L),
+    survival::neardate(c(NA, 1), c(NA, 2), c(1, 2), c(1, 2), nomatch = 0L)
+  )
+  expect_error(neardate(1, 1, 1, NA), "No valid entries")
+  expect_error(survival::neardate(1, 1, 1, NA), "No valid entries")
+  expect_error(neardate(1, 2, 1, 1), "No valid entries")
+  expect_error(survival::neardate(1, 2, 1, 1), "No valid entries")
+  expect_error(neardate(1, 1, factor("2020-01-01"), 1), "sortable")
+  expect_error(survival::neardate(1, 1, factor("2020-01-01"), 1), "sortable")
   reference_lvcf <- get0("lvcf", envir = asNamespace("survival"), inherits = FALSE)
   expect_equal(
     lvcf(c(1, 1, 1, 2, 2), c(10, NA, 12, NA, 20)),

--- a/src/data_prep/neardate.rs
+++ b/src/data_prep/neardate.rs
@@ -1,6 +1,7 @@
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::hash::Hash;
 
 #[derive(Debug, Clone)]
 #[pyclass(from_py_object)]
@@ -11,18 +12,6 @@ pub struct NearDateResult {
     pub distances: Vec<Option<f64>>,
     #[pyo3(get)]
     pub n_matched: usize,
-}
-
-fn validate_dates(name: &str, values: &[f64]) -> PyResult<()> {
-    for (idx, value) in values.iter().enumerate() {
-        if !value.is_finite() {
-            return Err(PyErr::new::<PyValueError, _>(format!(
-                "{} values must be finite, got non-finite value at index {}",
-                name, idx
-            )));
-        }
-    }
-    Ok(())
 }
 
 fn validate_direction(best: Option<&str>) -> PyResult<&'static str> {
@@ -43,6 +32,73 @@ fn validate_direction(best: Option<&str>) -> PyResult<&'static str> {
     Ok(first)
 }
 
+fn neardate_impl<Id>(
+    id1: &[Id],
+    date1: &[f64],
+    id2: &[Id],
+    date2: &[f64],
+    direction: &str,
+    nomatch: Option<usize>,
+) -> PyResult<NearDateResult>
+where
+    Id: Clone + Eq + Hash,
+{
+    if date1.len() != id1.len() {
+        return Err(PyErr::new::<PyValueError, _>(
+            "id1 and date1 must have same length",
+        ));
+    }
+    if date2.len() != id2.len() {
+        return Err(PyErr::new::<PyValueError, _>(
+            "id2 and date2 must have same length",
+        ));
+    }
+
+    let query_ids: HashSet<Id> = id1.iter().cloned().collect();
+    let mut ref_by_id: HashMap<Id, Vec<(usize, f64)>> = HashMap::new();
+    for (idx, (id, &date)) in id2.iter().zip(date2).enumerate() {
+        if date.is_nan() || !query_ids.contains(id) {
+            continue;
+        }
+        ref_by_id.entry(id.clone()).or_default().push((idx, date));
+    }
+    if ref_by_id.is_empty() {
+        return Err(PyErr::new::<PyValueError, _>(
+            "No valid entries in data set 2",
+        ));
+    }
+    for entries in ref_by_id.values_mut() {
+        entries.sort_by(|left, right| left.1.total_cmp(&right.1));
+    }
+
+    let mut indices = Vec::with_capacity(id1.len());
+    let mut distances = Vec::with_capacity(id1.len());
+    let mut n_matched = 0;
+    for (id, &date) in id1.iter().zip(date1) {
+        let matched = if date.is_nan() {
+            None
+        } else {
+            ref_by_id
+                .get(id)
+                .and_then(|references| find_nearest(references, date, direction))
+        };
+        if let Some((idx, distance)) = matched {
+            indices.push(Some(idx));
+            distances.push(Some(distance));
+            n_matched += 1;
+        } else {
+            indices.push(nomatch);
+            distances.push(None);
+        }
+    }
+
+    Ok(NearDateResult {
+        indices,
+        distances,
+        n_matched,
+    })
+}
+
 #[pyfunction]
 #[pyo3(signature = (id1, date1, id2, date2, best=None, nomatch=None))]
 pub fn neardate(
@@ -53,62 +109,8 @@ pub fn neardate(
     best: Option<&str>,
     nomatch: Option<usize>,
 ) -> PyResult<NearDateResult> {
-    let n1 = id1.len();
-    let n2 = id2.len();
-
-    if date1.len() != n1 {
-        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-            "id1 and date1 must have same length",
-        ));
-    }
-    if date2.len() != n2 {
-        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-            "id2 and date2 must have same length",
-        ));
-    }
-    validate_dates("date1", &date1)?;
-    validate_dates("date2", &date2)?;
-
     let direction = validate_direction(best)?;
-
-    let mut ref_by_id: HashMap<i64, Vec<(usize, f64)>> = HashMap::new();
-    for (idx, (&id, &date)) in id2.iter().zip(date2.iter()).enumerate() {
-        ref_by_id.entry(id).or_default().push((idx, date));
-    }
-
-    for entries in ref_by_id.values_mut() {
-        entries.sort_by(|a, b| a.1.total_cmp(&b.1));
-    }
-
-    let mut indices = Vec::with_capacity(n1);
-    let mut distances = Vec::with_capacity(n1);
-    let mut n_matched = 0;
-
-    for (&id, &date) in id1.iter().zip(date1.iter()) {
-        let match_result = if let Some(refs) = ref_by_id.get(&id) {
-            find_nearest(refs, date, direction)
-        } else {
-            None
-        };
-
-        match match_result {
-            Some((idx, dist)) => {
-                indices.push(Some(idx));
-                distances.push(Some(dist));
-                n_matched += 1;
-            }
-            None => {
-                indices.push(nomatch);
-                distances.push(None);
-            }
-        }
-    }
-
-    Ok(NearDateResult {
-        indices,
-        distances,
-        n_matched,
-    })
+    neardate_impl(&id1, &date1, &id2, &date2, direction, nomatch)
 }
 
 fn find_nearest(refs: &[(usize, f64)], target: f64, direction: &str) -> Option<(usize, f64)> {
@@ -123,28 +125,29 @@ fn find_nearest(refs: &[(usize, f64)], target: f64, direction: &str) -> Option<(
                 None
             } else {
                 let (idx, val) = refs[pos - 1];
-                Some((idx, target - val))
+                Some((idx, ordered_distance(val, target)))
             }
         }
         "after" => {
             let pos = refs.partition_point(|entry| entry.1 < target);
-            refs.get(pos).map(|&(idx, val)| (idx, val - target))
+            refs.get(pos)
+                .map(|&(idx, val)| (idx, ordered_distance(target, val)))
         }
         "closest" => {
             let pos = refs.partition_point(|entry| entry.1 < target);
             if pos == 0 {
                 let (idx, val) = refs[0];
-                return Some((idx, val - target));
+                return Some((idx, ordered_distance(target, val)));
             }
             if pos == refs.len() {
                 let (idx, val) = refs[refs.len() - 1];
-                return Some((idx, target - val));
+                return Some((idx, ordered_distance(val, target)));
             }
 
             let (_, before_val) = refs[pos - 1];
             let (after_idx, after_val) = refs[pos];
-            let before_dist = target - before_val;
-            let after_dist = after_val - target;
+            let before_dist = ordered_distance(before_val, target);
+            let after_dist = ordered_distance(target, after_val);
             if before_dist <= after_dist {
                 let first_before_pos = refs.partition_point(|entry| entry.1 < before_val);
                 Some((refs[first_before_pos].0, before_dist))
@@ -154,6 +157,10 @@ fn find_nearest(refs: &[(usize, f64)], target: f64, direction: &str) -> Option<(
         }
         _ => None,
     }
+}
+
+fn ordered_distance(lower: f64, upper: f64) -> f64 {
+    if lower == upper { 0.0 } else { upper - lower }
 }
 
 #[pyfunction]
@@ -166,62 +173,8 @@ pub fn neardate_str(
     best: Option<&str>,
     nomatch: Option<usize>,
 ) -> PyResult<NearDateResult> {
-    let n1 = id1.len();
-    let n2 = id2.len();
-
-    if date1.len() != n1 {
-        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-            "id1 and date1 must have same length",
-        ));
-    }
-    if date2.len() != n2 {
-        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-            "id2 and date2 must have same length",
-        ));
-    }
-    validate_dates("date1", &date1)?;
-    validate_dates("date2", &date2)?;
-
     let direction = validate_direction(best)?;
-
-    let mut ref_by_id: HashMap<String, Vec<(usize, f64)>> = HashMap::new();
-    for (idx, (id, &date)) in id2.iter().zip(date2.iter()).enumerate() {
-        ref_by_id.entry(id.clone()).or_default().push((idx, date));
-    }
-
-    for entries in ref_by_id.values_mut() {
-        entries.sort_by(|a, b| a.1.total_cmp(&b.1));
-    }
-
-    let mut indices = Vec::with_capacity(n1);
-    let mut distances = Vec::with_capacity(n1);
-    let mut n_matched = 0;
-
-    for (id, &date) in id1.iter().zip(date1.iter()) {
-        let match_result = if let Some(refs) = ref_by_id.get(id) {
-            find_nearest(refs, date, direction)
-        } else {
-            None
-        };
-
-        match match_result {
-            Some((idx, dist)) => {
-                indices.push(Some(idx));
-                distances.push(Some(dist));
-                n_matched += 1;
-            }
-            None => {
-                indices.push(nomatch);
-                distances.push(None);
-            }
-        }
-    }
-
-    Ok(NearDateResult {
-        indices,
-        distances,
-        n_matched,
-    })
+    neardate_impl(&id1, &date1, &id2, &date2, direction, nomatch)
 }
 
 #[cfg(test)]
@@ -301,14 +254,15 @@ mod tests {
 
     #[test]
     fn test_neardate_no_match() {
-        let id1 = vec![1];
-        let date1 = vec![10.0];
+        let id1 = vec![1, 2];
+        let date1 = vec![10.0, 10.0];
         let id2 = vec![2];
         let date2 = vec![10.0];
 
         let result = neardate(id1, date1, id2, date2, None, None).unwrap();
-        assert_eq!(result.n_matched, 0);
+        assert_eq!(result.n_matched, 1);
         assert_eq!(result.indices[0], None);
+        assert_eq!(result.indices[1], Some(0));
     }
 
     #[test]
@@ -350,18 +304,60 @@ mod tests {
     }
 
     #[test]
-    fn test_neardate_rejects_nonfinite_dates() {
-        assert!(neardate(vec![1], vec![f64::NAN], vec![1], vec![1.0], None, None).is_err());
+    fn test_neardate_skips_missing_dates_and_accepts_infinite_endpoints() {
+        let after = neardate(
+            vec![1, 1, 1, 1],
+            vec![f64::NAN, 2.0, f64::INFINITY, f64::NEG_INFINITY],
+            vec![1, 1, 1, 1],
+            vec![1.0, f64::NAN, f64::INFINITY, f64::NEG_INFINITY],
+            Some("after"),
+            None,
+        )
+        .unwrap();
+        let prior = neardate(
+            vec![1, 1, 1, 1],
+            vec![f64::NAN, 2.0, f64::INFINITY, f64::NEG_INFINITY],
+            vec![1, 1, 1, 1],
+            vec![1.0, f64::NAN, f64::INFINITY, f64::NEG_INFINITY],
+            Some("prior"),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(after.indices, vec![None, Some(2), Some(2), Some(3)]);
+        assert_eq!(prior.indices, vec![None, Some(0), Some(2), Some(3)]);
+        assert_eq!(
+            after.distances,
+            vec![None, Some(f64::INFINITY), Some(0.0), Some(0.0)]
+        );
+        assert_eq!(prior.distances, vec![None, Some(1.0), Some(0.0), Some(0.0)]);
+        assert_eq!(after.n_matched, 3);
+        assert_eq!(prior.n_matched, 3);
+    }
+
+    #[test]
+    fn test_neardate_requires_a_valid_reference_for_a_query_id() {
+        let missing =
+            neardate(vec![1], vec![1.0], vec![1], vec![f64::NAN], None, None).unwrap_err();
+        let unmatched = neardate_str(
+            vec!["a".to_string()],
+            vec![1.0],
+            vec!["b".to_string()],
+            vec![1.0],
+            None,
+            None,
+        )
+        .unwrap_err();
+
         assert!(
-            neardate_str(
-                vec!["a".to_string()],
-                vec![1.0],
-                vec!["a".to_string()],
-                vec![f64::INFINITY],
-                None,
-                None,
-            )
-            .is_err()
+            missing
+                .to_string()
+                .contains("No valid entries in data set 2")
+        );
+        assert!(
+            unmatched
+                .to_string()
+                .contains("No valid entries in data set 2")
         );
         assert!(neardate(vec![1], vec![1.0], vec![1], vec![1.0], Some(""), None).is_err());
     }


### PR DESCRIPTION
## Summary
- accept missing query dates and discard missing reference dates while preserving original reference-row indices
- support infinite endpoints and report zero distance for equal infinities
- share one Rust matcher between integer and string IDs, with missing-ID parity through the Python and R interfaces
- match the reference error when the second data set has no usable rows for any query ID
- add low-level and cross-language regression coverage

No dependencies added.

## Testing
- `.venv/bin/python -m pytest -q` — 827 passed, 18 skipped
- `cargo test --all-targets` — 1,370 passed
- `R CMD check r/survivalr --no-manual` — passed with the expected source-directory NOTE
- strict Clippy checks for no-default, `ml`, and `python,ml` feature profiles
- Ruff formatting/lint and mypy