### PR TITLE
Match aareg cluster special handling

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -2493,13 +2493,16 @@ def _apply_formula_na_action(
     formula: str,
     data: Any,
     na_action: str | None,
+    *,
+    exclude_columns: Sequence[str] = (),
     **row_aligned: Any,
 ) -> tuple[Any, dict[str, Any]]:
     action = _normalize_na_action(na_action)
     if action == "pass":
         return data, row_aligned
 
-    columns = _formula_columns(formula, data)
+    excluded = set(exclude_columns)
+    columns = [column for column in _formula_columns(formula, data) if column not in excluded]
     n = len(_column(data, columns[0]))
     missing = _missing_row_indices(
         [
@@ -20467,6 +20470,20 @@ def aareg(
     if not isinstance(formula, str):
         raise TypeError("aareg formula must be a string or AaregOptions")
 
+    response_spec = _formula_response_spec(formula)
+    _lhs, _separator, rhs = formula.partition("~")
+    formula_terms = _split_terms(rhs, _dot_terms(data, response_spec.columns))
+    if len(formula_terms.clusters) > 1:
+        raise ValueError("a formula cannot have multiple cluster terms")
+    ignored_formula_clusters: tuple[str, ...] = ()
+    if formula_terms.clusters and cluster is not None:
+        ignored_formula_clusters = tuple(formula_terms.clusters)
+        warnings.warn(
+            "cluster appears both in a formula and as an argument, formula term ignored",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
     if subset is not None:
         data, aligned = _subset_formula_inputs(
             formula,
@@ -20481,21 +20498,19 @@ def aareg(
         formula,
         data,
         na_action,
+        exclude_columns=ignored_formula_clusters,
         weights=weights,
         cluster=cluster,
     )
     weights = aligned["weights"]
     cluster = aligned["cluster"]
 
-    response_spec = _formula_response_spec(formula)
     response, terms = _parse_formula(formula, data)
     if response.type not in {"right", "counting"}:
         raise ValueError(f'Aalen model does not support "{response.type}" survival data')
     if terms.strata:
         raise ValueError("strata terms are not allowed in aareg formulas")
-    if terms.clusters:
-        if cluster is not None:
-            raise ValueError("use only one of formula cluster(...) or cluster")
+    if terms.clusters and cluster is None:
         cluster = _combined_columns(data, terms.clusters, len(response))
     if terms.offsets:
         _offset_vector(data, terms.offsets, len(response))
@@ -20548,7 +20563,7 @@ def aareg(
             data,
             response,
             design,
-            extra_columns=terms.clusters,
+            extra_columns=() if ignored_formula_clusters else terms.clusters,
             weights=weights,
             cluster=cluster_values,
         )

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -16991,6 +16991,7 @@ def test_aareg_formula_validates_model_specific_options():
         "status": [1, 1, 1, 1],
         "x": [0.0, 1.0, 0.5, 2.0],
         "group": ["a", "a", "b", "b"],
+        "cluster": ["w", "x", "y", "z"],
     }
 
     with pytest.raises(ValueError, match="strata terms are not allowed"):
@@ -16999,6 +17000,42 @@ def test_aareg_formula_validates_model_specific_options():
         survival.aareg("Surv(time, status) ~ x", data=data, nmin=1, taper=0)
     with pytest.raises(ValueError, match="test must be"):
         survival.aareg("Surv(time, status) ~ x", data=data, nmin=1, test="bogus")
+    with pytest.raises(ValueError, match="multiple cluster terms"):
+        survival.aareg(
+            "Surv(time, status) ~ x + cluster(group) + cluster(cluster)",
+            data=data,
+            nmin=1,
+        )
+    with pytest.raises(ValueError, match="cluster"):
+        survival.aareg("Surv(time, status) ~ x:cluster(group)", data=data, nmin=1)
+
+
+def test_aareg_explicit_cluster_overrides_formula_cluster_like_r():
+    data = {
+        "time": [1.0, 2.0, 2.0, 3.0, 4.0, 4.0],
+        "status": [1, 1, 1, 1, 0, 1],
+        "x": [0.0, 1.0, 2.0, 1.0, 3.0, -1.0],
+        "formula_cluster": ["a", "a", None, "b", "c", "c"],
+        "explicit_cluster": ["left", "right", "left", "right", "left", "right"],
+    }
+
+    with pytest.warns(RuntimeWarning, match="formula term ignored"):
+        fit = survival.aareg(
+            "Surv(time, status) ~ x + cluster(formula_cluster)",
+            data=data,
+            cluster=data["explicit_cluster"],
+            nmin=1,
+            na_action="omit",
+            model=True,
+        )
+
+    assert fit.n[0] == len(data["time"])
+    assert fit.cluster_levels == ["left", "right"]
+    assert fit.dfbeta is not None
+    assert len(fit.dfbeta) == 2
+    assert fit.model is not None
+    assert "formula_cluster" not in fit.model
+    assert fit.model["(cluster)"] == data["explicit_cluster"]
 
 
 def test_r_style_tmerge_matches_mixed_operation_fixture():

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -470,6 +470,43 @@ test_that("R formula wrappers delegate to the Python survival package", {
       y = TRUE
     )
   )
+  bridged_aareg_cluster_override <- NULL
+  expect_warning(
+    bridged_aareg_cluster_override <- aareg(
+      survival::Surv(time, status) ~ x + cluster(cluster),
+      data = aareg_data,
+      cluster = group,
+      nmin = 1
+    ),
+    "formula term ignored"
+  )
+  reference_aareg_cluster_override <- NULL
+  expect_warning(
+    reference_aareg_cluster_override <- survival::aareg(
+      survival::Surv(time, status) ~ x + cluster(cluster),
+      data = aareg_data,
+      cluster = group,
+      nmin = 1
+    ),
+    "formula term ignored"
+  )
+  compare_aareg(bridged_aareg_cluster_override, reference_aareg_cluster_override)
+  expect_error(
+    aareg(
+      survival::Surv(time, status) ~ x + cluster(group) + cluster(cluster),
+      data = aareg_data,
+      nmin = 1
+    ),
+    "multiple cluster terms"
+  )
+  expect_error(
+    aareg(
+      survival::Surv(time, status) ~ x:cluster(group),
+      data = aareg_data,
+      nmin = 1
+    ),
+    "cluster.*interaction"
+  )
   tmerge_data <- data.frame(id = 1:2, tstop = c(5, 6))
   bridged_tmerge <- tmerge(tmerge_data, tmerge_data, id = id, tstop = tstop)
   reference_tmerge <- survival::tmerge(tmerge_data, tmerge_data, id = id, tstop = tstop)


### PR DESCRIPTION
## Summary
- let an explicit `cluster` argument override a formula `cluster()` term with the same warning as R
- reject multiple formula cluster specials and preserve the existing interaction validation
- exclude an ignored formula-cluster column from missing-value filtering and returned model frames
- add direct Python and R bridge regression coverage

## Testing
- `.venv/bin/python -m pytest` (828 passed, 18 skipped)
- `cargo test` (1369 passed)
- Ruff format and lint checks
- `mypy python/survival`
- `scripts/generate_binding_manifest.py --check`
- focused R bridge test (1377 expectations passed)
- isolated `R CMD check --no-manual --no-build-vignettes` (Status: OK)

No dependencies added.