### PR TITLE
Preserve missing rows in nsk bases

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -4858,7 +4858,10 @@ def nsk(
     x_values = _float_vector(x, "x")
     if not x_values:
         raise ValueError("x must contain at least one value")
-    if any(not math.isfinite(value) for value in x_values):
+    observed_x = [value for value in x_values if not math.isnan(value)]
+    if not observed_x:
+        raise ValueError("x must contain at least one non-missing value")
+    if any(not math.isfinite(value) for value in observed_x):
         raise ValueError("x must contain only finite values")
 
     intercept_value = _normalize_bool_option(intercept, "intercept")
@@ -4870,13 +4873,13 @@ def nsk(
 
     normalized_knots = _normalize_nsk_knots(knots)
     boundary_knots, core_knots = _normalize_nsk_boundary_knots(
-        x_values,
+        observed_x,
         normalized_knots,
         b,
         boundary_arg,
     )
     if not normalized_knots and core_knots is None:
-        core_knots = _computed_nsk_knots(x_values, boundary_knots, df_value, intercept_value)
+        core_knots = _computed_nsk_knots(observed_x, boundary_knots, df_value, intercept_value)
     spline = _core.NaturalSplineKnot(core_knots, boundary_knots, df_value, intercept_value)
     return spline.basis(x_values)
 

--- a/python/tests/test_binding_contract.py
+++ b/python/tests/test_binding_contract.py
@@ -9311,8 +9311,13 @@ def test_core_nsk_rejects_malformed_inputs():
     setup_survival_import()
     core = importlib.import_module("survival._survival")
 
+    missing = core.nsk([1.0, float("nan"), 2.0, 3.0], 3, None, None)
+    assert missing.n_rows == 4
+    assert all(math.isnan(value) for value in missing.basis[missing.n_cols : 2 * missing.n_cols])
     with pytest.raises(ValueError, match="x contains non-finite"):
-        core.nsk([1.0, float("nan")], 3, None, None)
+        core.nsk([1.0, float("inf")], 3, None, None)
+    with pytest.raises(ValueError, match="at least one non-missing"):
+        core.nsk([float("nan"), float("nan")], 3, None, None)
     with pytest.raises(ValueError, match="non-zero finite range"):
         core.nsk([1.0, 1.0], 3, None, None)
     with pytest.raises(ValueError, match="df must be at least 1"):

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -3288,6 +3288,7 @@ def test_r_style_nsk_wraps_native_spline_basis():
         knots=[2.0, 4.0],
         boundary_knots=[2.5, 3.5],
     )
+    missing = survival.nsk([1.0, math.nan, 2.0, 3.0, 4.0, 5.0], df=3)
 
     assert isinstance(basis, survival._survival.SplineBasisResult)
     assert survival.nsk is survival.r_api.nsk
@@ -3322,10 +3323,20 @@ def test_r_style_nsk_wraps_native_spline_basis():
     assert inside_boundary.boundary_knots == pytest.approx((2.0, 4.0))
     assert inside_boundary.basis[0] == pytest.approx(-0.5)
 
+    assert missing.n_rows == 6
+    assert missing.n_cols == basis.n_cols
+    assert missing.knots == pytest.approx(basis.knots)
+    assert missing.boundary_knots == pytest.approx(basis.boundary_knots)
+    assert all(math.isnan(value) for value in missing.basis[3:6])
+    assert missing.basis[:3] == pytest.approx(basis.basis[:3])
+    assert missing.basis[6:] == pytest.approx(basis.basis[3:])
+
     with pytest.raises(ValueError, match="Boundary.knots"):
         survival.nsk([1.0, 2.0, 3.0], knots=[2.0], Boundary_knots=None)
     with pytest.raises(ValueError, match="x must contain only finite values"):
-        survival.nsk([1.0, math.nan], df=3)
+        survival.nsk([1.0, math.inf], df=3)
+    with pytest.raises(ValueError, match="at least one non-missing"):
+        survival.nsk([math.nan, math.nan], df=3)
 
 
 def test_r_style_pspline_builds_survival_basis_contract():

--- a/src/core/nsk.rs
+++ b/src/core/nsk.rs
@@ -106,7 +106,11 @@ impl NaturalSplineKnot {
     pub fn basis(&self, x: Vec<f64>) -> PyResult<SplineBasisResult> {
         let n = x.len();
         validate_df(self.df, self.intercept)?;
-        validate_finite_slice(&x, "x")?;
+        if let Some((idx, value)) = x.iter().enumerate().find(|(_, value)| value.is_infinite()) {
+            return Err(value_error(format!(
+                "x contains non-finite value {value} at index {idx}"
+            )));
+        }
         validate_finite_slice(&self.knots, "knots")?;
         if !uses_data_boundary(self.boundary_knots) {
             validate_boundary_knots(self.boundary_knots)?;
@@ -122,8 +126,13 @@ impl NaturalSplineKnot {
             });
         }
 
+        let observed_x: Vec<f64> = x.iter().copied().filter(|value| !value.is_nan()).collect();
+        if observed_x.is_empty() {
+            return Err(value_error("x must contain at least one non-missing value"));
+        }
+
         let mut all_knots = resolve_all_knots(
-            &x,
+            &observed_x,
             &self.knots,
             self.boundary_knots,
             self.df,
@@ -141,7 +150,13 @@ impl NaturalSplineKnot {
 
         let basis: Vec<f64> = x
             .par_iter()
-            .flat_map(|&xi| natural_spline_raw_basis_at_point(xi, &all_knots))
+            .flat_map(|&xi| {
+                if xi.is_nan() {
+                    vec![f64::NAN; n_raw_basis]
+                } else {
+                    natural_spline_raw_basis_at_point(xi, &all_knots)
+                }
+            })
             .collect();
 
         let transformed_basis =
@@ -411,14 +426,18 @@ fn transform_to_knot_heights(
         })
         .collect();
 
-    if let Some((idx, value)) = transformed
-        .iter()
-        .enumerate()
-        .find(|(_, value)| !value.is_finite())
-    {
-        return Err(value_error(format!(
-            "knot-height transform produced non-finite value {value} at index {idx}"
-        )));
+    let n_output = n_basis - usize::from(!intercept);
+    for (row_idx, row) in transformed.chunks(n_output).enumerate() {
+        if row.iter().all(|value| value.is_nan()) {
+            continue;
+        }
+        if let Some((col_idx, value)) = row.iter().enumerate().find(|(_, value)| !value.is_finite())
+        {
+            let idx = row_idx * n_output + col_idx;
+            return Err(value_error(format!(
+                "knot-height transform produced non-finite value {value} at index {idx}"
+            )));
+        }
     }
 
     Ok(transformed)
@@ -503,7 +522,8 @@ mod tests {
     fn test_nsk_rejects_malformed_inputs() {
         initialize_python();
 
-        assert!(nsk(vec![1.0, f64::NAN], Some(3), None, None).is_err());
+        assert!(nsk(vec![1.0, f64::INFINITY], Some(3), None, None).is_err());
+        assert!(nsk(vec![f64::NAN, f64::NAN], Some(3), None, None).is_err());
         assert!(nsk(vec![1.0, 1.0], Some(3), None, None).is_err());
         assert!(nsk(vec![1.0, 2.0], Some(0), None, None).is_err());
         assert!(nsk(vec![1.0, 2.0], Some(3), None, Some((2.0, 2.0))).is_err());
@@ -514,6 +534,35 @@ mod tests {
             .expect("duplicate computed quantile knots collapse like R survival::nsk");
         assert_eq!(tied.n_cols, 2);
         assert_eq!(tied.knots, vec![1.0]);
+    }
+
+    #[test]
+    fn test_nsk_preserves_missing_rows_and_uses_observed_values_for_knots() {
+        let result = nsk(vec![1.0, f64::NAN, 2.0, 3.0, 4.0], Some(3), None, None).unwrap();
+        let observed = nsk(vec![1.0, 2.0, 3.0, 4.0], Some(3), None, None).unwrap();
+
+        assert_eq!(result.n_rows, 5);
+        assert_eq!(result.n_cols, observed.n_cols);
+        assert_eq!(result.knots, observed.knots);
+        assert_eq!(result.boundary_knots, observed.boundary_knots);
+        assert!(
+            result.basis[result.n_cols..2 * result.n_cols]
+                .iter()
+                .all(|value| value.is_nan())
+        );
+
+        for (result_row, observed_row) in [0, 2, 3, 4].into_iter().zip(0..4) {
+            let result_start = result_row * result.n_cols;
+            let observed_start = observed_row * observed.n_cols;
+            for col_idx in 0..result.n_cols {
+                assert!(
+                    (result.basis[result_start + col_idx]
+                        - observed.basis[observed_start + col_idx])
+                        .abs()
+                        < 1e-12
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- preserve missing `x` rows as all-missing natural spline basis rows
- compute data-derived boundaries and interior knots from observed values only
- keep infinity and all-missing validation explicit in both Rust and Python paths
- add low-level Rust, direct Python, and binding-contract regression coverage

## Testing
- `.venv/bin/python -m pytest` (827 passed, 18 skipped)
- `cargo test` (1370 passed)
- `cargo test --all-features` (1581 passed)
- `cargo clippy --all-targets --all-features -- -D warnings`
- Ruff format and lint checks
- `mypy python/survival`
- `scripts/generate_binding_manifest.py --check`
- focused R bridge test (153 expectations passed)
- isolated `R CMD check --no-manual --no-build-vignettes` (Status: OK)

No dependencies added.