### PR TITLE
Move P-spline basis construction to Rust

### DIFF
--- a/python/survival/_binding_manifest.py
+++ b/python/survival/_binding_manifest.py
@@ -843,6 +843,7 @@ BINDINGS = (
     "pseudo",
     "pseudo_fast",
     "pseudo_gee_regression",
+    "pspline_basis",
     "publication_bias_tests",
     "pwp_gap_time",
     "pwp_model",

--- a/python/survival/_survival.pyi
+++ b/python/survival/_survival.pyi
@@ -7043,6 +7043,12 @@ def nsk(
     knots: list[float] | None = None,
     boundary_knots: tuple[float, float] | None = None,
 ) -> SplineBasisResult: ...
+def pspline_basis(
+    x: list[float],
+    nterm: int,
+    degree: int,
+    boundary_knots: tuple[float, float],
+) -> tuple[list[list[float]], list[float]]: ...
 def cox_score_residuals(
     y: list[float],
     strata: list[int],

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -4544,56 +4544,6 @@ def _computed_nsk_knots(
     return [_quantile_type7(inside, idx / (n_interior + 1)) for idx in range(1, n_interior + 1)]
 
 
-def _pspline_basis_row(knots: Sequence[float], x: float, order: int) -> list[float]:
-    n_basis = len(knots) - order
-    values = [0.0] * (len(knots) - 1)
-    for idx in range(len(knots) - 1):
-        if knots[idx] <= x < knots[idx + 1] or (
-            x == knots[-1] and knots[idx] <= x <= knots[idx + 1]
-        ):
-            values[idx] = 1.0
-
-    for current_order in range(2, order + 1):
-        next_values = [0.0] * (len(knots) - current_order)
-        for idx in range(len(next_values)):
-            left_denominator = knots[idx + current_order - 1] - knots[idx]
-            right_denominator = knots[idx + current_order] - knots[idx + 1]
-            left = (
-                0.0
-                if left_denominator == 0.0
-                else (x - knots[idx]) / left_denominator * values[idx]
-            )
-            right = (
-                0.0
-                if right_denominator == 0.0
-                else (knots[idx + current_order] - x) / right_denominator * values[idx + 1]
-            )
-            next_values[idx] = left + right
-        values = next_values
-    return values[:n_basis]
-
-
-def _pspline_basis_derivative_row(
-    knots: Sequence[float],
-    x: float,
-    order: int,
-) -> list[float]:
-    lower_order = _pspline_basis_row(knots, x, order - 1)
-    n_basis = len(knots) - order
-    result: list[float] = []
-    for idx in range(n_basis):
-        left_denominator = knots[idx + order - 1] - knots[idx]
-        right_denominator = knots[idx + order] - knots[idx + 1]
-        left = 0.0 if left_denominator == 0.0 else (order - 1) / left_denominator * lower_order[idx]
-        right = (
-            0.0
-            if right_denominator == 0.0
-            else (order - 1) / right_denominator * lower_order[idx + 1]
-        )
-        result.append(left - right)
-    return result
-
-
 def _pspline_difference_penalty(n_cols: int) -> list[list[float]]:
     if n_cols == 0:
         return []
@@ -4752,7 +4702,6 @@ def pspline(
     degree_value = _integer_scalar(degree, "degree")
     if degree_value < 1:
         raise ValueError("degree must be positive")
-    order = degree_value + 1
     intercept_value = _normalize_bool_option(intercept, "intercept")
     penalty_value = _normalize_bool_option(penalty, "penalty")
 
@@ -4773,43 +4722,17 @@ def pspline(
         if len(boundary_values) != 2:
             raise ValueError("Invalid values for Boundary.knots")
         boundary = (boundary_values[0], boundary_values[1])
-    if (
-        not math.isfinite(boundary[0])
-        or not math.isfinite(boundary[1])
-        or boundary[0] >= boundary[1]
-    ):
+    if not math.isfinite(boundary[0]) or not math.isfinite(boundary[1]):
+        raise ValueError("Invalid values for Boundary.knots")
+    if boundary[0] > boundary[1] or (boundary_arg is not None and boundary[0] == boundary[1]):
         raise ValueError("Invalid values for Boundary.knots")
 
-    dx = (boundary[1] - boundary[0]) / nterm_value
-    knots = [boundary[0] + dx * idx for idx in range(-degree_value, nterm_value)] + [
-        boundary[1] + dx * idx for idx in range(0, degree_value + 1)
-    ]
-
-    left_basis = _pspline_basis_row(knots, boundary[0], order)
-    left_derivative = _pspline_basis_derivative_row(knots, boundary[0], order)
-    right_basis = _pspline_basis_row(knots, boundary[1], order)
-    right_derivative = _pspline_basis_derivative_row(knots, boundary[1], order)
-
-    full_matrix: list[list[float]] = []
-    for value in x_values:
-        if math.isnan(value):
-            full_matrix.append([math.nan] * (nterm_value + degree_value))
-        elif value < boundary[0]:
-            full_matrix.append(
-                [
-                    basis + (value - boundary[0]) * derivative
-                    for basis, derivative in zip(left_basis, left_derivative, strict=True)
-                ]
-            )
-        elif value > boundary[1]:
-            full_matrix.append(
-                [
-                    basis + (value - boundary[1]) * derivative
-                    for basis, derivative in zip(right_basis, right_derivative, strict=True)
-                ]
-            )
-        else:
-            full_matrix.append(_pspline_basis_row(knots, value, order))
+    full_matrix, knots = _core.pspline_basis(
+        x_values,
+        nterm_value,
+        degree_value,
+        boundary,
+    )
 
     full_matrix, combine_values = _pspline_combine_matrix(
         full_matrix,

--- a/python/tests/test_binding_contract.py
+++ b/python/tests/test_binding_contract.py
@@ -9125,6 +9125,7 @@ def test_core_utility_bindings_are_typed():
         "SplineBasisResult",
         "PSpline",
         "nsk",
+        "pspline_basis",
         "cox_score_residuals",
         "schoenfeld_residuals",
         "concordance",
@@ -9161,6 +9162,7 @@ def test_core_utility_bindings_are_typed():
 
     expected_args = {
         "nsk": ["x", "df", "knots", "boundary_knots"],
+        "pspline_basis": ["x", "nterm", "degree", "boundary_knots"],
         "cox_score_residuals": ["y", "strata", "covar", "score", "weights", "nvar", "method"],
         "schoenfeld_residuals": ["y", "score", "strata", "covar", "nvar", "method"],
         "concordance": ["y", "x", "wt", "timewt", "sortstart", "sortstop"],
@@ -9168,6 +9170,17 @@ def test_core_utility_bindings_are_typed():
     for name, args in expected_args.items():
         assert list(inspect.signature(getattr(core, name)).parameters) == args
         assert _pyi_function_arg_names(stub_path, name) == args
+
+    constant_basis, constant_knots = core.pspline_basis(
+        [2.0, float("nan"), 2.0],
+        5,
+        3,
+        (2.0, 2.0),
+    )
+    assert constant_basis[0] == pytest.approx([0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0])
+    assert all(math.isnan(value) for value in constant_basis[1])
+    assert constant_basis[2] == pytest.approx(constant_basis[0])
+    assert constant_knots == pytest.approx([2.0] * 12)
 
     assert _pyi_class_annotation_names(stub_path, "CovariateMatrix") == {
         "values",

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -3420,6 +3420,8 @@ def test_r_style_pspline_builds_survival_basis_contract():
         df=3,
         combine=[1] * 10,
     )
+    constant = survival.pspline([2.0, 2.0, 2.0], df=2)
+    missing = survival.pspline([1.0, float("nan"), 2.0], df=2)
 
     assert survival.pspline is survival.r_api.pspline
     assert basis["method"] == "df"
@@ -3444,6 +3446,10 @@ def test_r_style_pspline_builds_survival_basis_contract():
     assert aic["n_cols"] == 17
     assert combined["combine"] == [1] * 10
     assert combined["n_cols"] == 1
+    assert constant["boundary_knots"] == [2.0, 2.0]
+    assert constant["basis"][0] == pytest.approx([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0])
+    assert constant["basis"] == [constant["basis"][0]] * 3
+    assert all(math.isnan(value) for value in missing["basis"][1])
 
     with pytest.raises(ValueError, match="Invalid value for theta"):
         survival.pspline([1.0, 2.0, 3.0], theta=1.0)

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -2005,14 +2005,14 @@ pspline <- function(x, df = 4, theta, nterm = 2.5 * df, degree = 3,
 
   result <- .call_r_api(
     "pspline",
-    x = .as_python_vector(x),
+    x = if (anyNA(x)) as.list(x) else .as_python_vector(x),
     df = df,
     theta = if (missing(theta)) NULL else theta,
     nterm = nterm,
     degree = degree,
     eps = if (missing(eps)) NULL else eps,
     method = if (missing(method)) NULL else method,
-    boundary_knots = Boundary.knots,
+    boundary_knots = if (missing(Boundary.knots)) NULL else Boundary.knots,
     intercept = intercept,
     penalty = penalty,
     combine = if (missing(combine)) NULL else combine

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -1003,6 +1003,14 @@ test_that("R formula wrappers delegate to the Python survival package", {
     pspline(1:5, df = 3, intercept = TRUE, penalty = FALSE),
     survival::pspline(1:5, df = 3, intercept = TRUE, penalty = FALSE)
   )
+  expect_pspline_equal(
+    pspline(rep(2, 3), df = 2, penalty = FALSE),
+    survival::pspline(rep(2, 3), df = 2, penalty = FALSE)
+  )
+  expect_pspline_equal(
+    pspline(c(1, NA, 2), df = 2, penalty = FALSE),
+    survival::pspline(c(1, NA, 2), df = 2, penalty = FALSE)
+  )
 
   strata_factor <- strata(c("b", "a", "b", NA), c(2, 1, 1, 1), shortlabel = TRUE)
   expect_s3_class(strata_factor, "factor")

--- a/src/api/python/classical/core.rs
+++ b/src/api/python/classical/core.rs
@@ -79,6 +79,7 @@ pub(super) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(cipoisson, m)?)?;
     m.add_function(wrap_pyfunction!(cipoisson_exact, m)?)?;
     m.add_function(wrap_pyfunction!(cipoisson_anscombe, m)?)?;
+    m.add_function(wrap_pyfunction!(pspline_basis, m)?)?;
     m.add_function(wrap_pyfunction!(crate::concordance::basic::concordance, m)?)?;
     m.add_function(wrap_pyfunction!(agexact, m)?)?;
     m.add_function(wrap_pyfunction!(compute_baseline_survival_steps, m)?)?;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -8,4 +8,4 @@ pub(crate) mod pspline;
 pub use coxcount1_module::{CoxCountOutput, coxcount1, coxcount2};
 pub use coxscho::schoenfeld_residuals;
 pub use nsk_module::{NaturalSplineKnot, SplineBasisResult, nsk};
-pub use pspline::PSpline;
+pub use pspline::{PSpline, pspline_basis};

--- a/src/core/pspline.rs
+++ b/src/core/pspline.rs
@@ -3,6 +3,7 @@ use crate::internal::matrix::lu_solve;
 use ndarray::{Array1, Array2};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
+use rayon::prelude::*;
 use std::fmt;
 
 #[derive(Debug)]
@@ -86,6 +87,174 @@ fn validate_positive_scalar(value: f64, field: &str) -> PyResult<()> {
         return Err(value_error(format!("{field} must be positive")));
     }
     Ok(())
+}
+
+fn r_pspline_basis_row(knots: &[f64], x: f64, order: usize) -> Vec<f64> {
+    let n_basis = knots.len() - order;
+    let mut values = vec![0.0; knots.len() - 1];
+    for idx in 0..knots.len() - 1 {
+        if (knots[idx] <= x && x < knots[idx + 1])
+            || (x == knots[knots.len() - 1] && knots[idx] <= x && x <= knots[idx + 1])
+        {
+            values[idx] = 1.0;
+        }
+    }
+
+    for current_order in 2..=order {
+        let mut next_values = vec![0.0; knots.len() - current_order];
+        for idx in 0..next_values.len() {
+            let left_denominator = knots[idx + current_order - 1] - knots[idx];
+            let right_denominator = knots[idx + current_order] - knots[idx + 1];
+            let left = if left_denominator == 0.0 {
+                0.0
+            } else {
+                (x - knots[idx]) / left_denominator * values[idx]
+            };
+            let right = if right_denominator == 0.0 {
+                0.0
+            } else {
+                (knots[idx + current_order] - x) / right_denominator * values[idx + 1]
+            };
+            next_values[idx] = left + right;
+        }
+        values = next_values;
+    }
+    values.truncate(n_basis);
+    values
+}
+
+fn r_pspline_basis_derivative_row(knots: &[f64], x: f64, order: usize) -> Vec<f64> {
+    let lower_order = r_pspline_basis_row(knots, x, order - 1);
+    let n_basis = knots.len() - order;
+    (0..n_basis)
+        .map(|idx| {
+            let left_denominator = knots[idx + order - 1] - knots[idx];
+            let right_denominator = knots[idx + order] - knots[idx + 1];
+            let left = if left_denominator == 0.0 {
+                0.0
+            } else {
+                (order - 1) as f64 / left_denominator * lower_order[idx]
+            };
+            let right = if right_denominator == 0.0 {
+                0.0
+            } else {
+                (order - 1) as f64 / right_denominator * lower_order[idx + 1]
+            };
+            left - right
+        })
+        .collect()
+}
+
+fn r_pspline_knots(boundary_knots: (f64, f64), nterm: usize, degree: usize) -> PyResult<Vec<f64>> {
+    let knot_count = nterm
+        .checked_add(
+            degree
+                .checked_mul(2)
+                .and_then(|value| value.checked_add(1))
+                .ok_or_else(|| value_error("degree is too large"))?,
+        )
+        .ok_or_else(|| value_error("nterm and degree are too large"))?;
+    let (lower, upper) = boundary_knots;
+    let dx = (upper - lower) / nterm as f64;
+    let mut knots = Vec::with_capacity(knot_count);
+    for idx in 0..nterm + degree {
+        knots.push(lower + dx * (idx as f64 - degree as f64));
+    }
+    for idx in 0..=degree {
+        knots.push(upper + dx * idx as f64);
+    }
+    Ok(knots)
+}
+
+pub(crate) fn pspline_basis_core(
+    x: &[f64],
+    nterm: usize,
+    degree: usize,
+    boundary_knots: (f64, f64),
+) -> PyResult<(Vec<Vec<f64>>, Vec<f64>)> {
+    if nterm < 3 {
+        return Err(value_error("nterm must be at least 3"));
+    }
+    if degree == 0 {
+        return Err(value_error("degree must be positive"));
+    }
+    let (lower, upper) = boundary_knots;
+    if !lower.is_finite() || !upper.is_finite() || lower > upper {
+        return Err(value_error(
+            "boundary_knots must be finite and non-decreasing",
+        ));
+    }
+    for (idx, value) in x.iter().copied().enumerate() {
+        if value.is_infinite() {
+            return Err(value_error(format!(
+                "x contains infinite value {value} at index {idx}"
+            )));
+        }
+    }
+
+    let n_basis = nterm
+        .checked_add(degree)
+        .ok_or_else(|| value_error("nterm and degree are too large"))?;
+    let knots = r_pspline_knots(boundary_knots, nterm, degree)?;
+    if lower == upper {
+        if x.iter().any(|value| !value.is_nan() && *value != lower) {
+            return Err(value_error(
+                "zero-width boundary_knots require all observed x values to match the boundary",
+            ));
+        }
+        let basis = x
+            .iter()
+            .map(|value| {
+                if value.is_nan() {
+                    vec![f64::NAN; n_basis]
+                } else {
+                    let mut row = vec![0.0; n_basis];
+                    row[nterm - 1] = 1.0;
+                    row
+                }
+            })
+            .collect();
+        return Ok((basis, knots));
+    }
+
+    let order = degree + 1;
+    let left_basis = r_pspline_basis_row(&knots, lower, order);
+    let left_derivative = r_pspline_basis_derivative_row(&knots, lower, order);
+    let right_basis = r_pspline_basis_row(&knots, upper, order);
+    let right_derivative = r_pspline_basis_derivative_row(&knots, upper, order);
+    let basis = x
+        .par_iter()
+        .map(|value| {
+            if value.is_nan() {
+                vec![f64::NAN; n_basis]
+            } else if *value < lower {
+                left_basis
+                    .iter()
+                    .zip(&left_derivative)
+                    .map(|(basis, derivative)| basis + (value - lower) * derivative)
+                    .collect()
+            } else if *value > upper {
+                right_basis
+                    .iter()
+                    .zip(&right_derivative)
+                    .map(|(basis, derivative)| basis + (value - upper) * derivative)
+                    .collect()
+            } else {
+                r_pspline_basis_row(&knots, *value, order)
+            }
+        })
+        .collect();
+    Ok((basis, knots))
+}
+
+#[pyfunction]
+pub fn pspline_basis(
+    x: Vec<f64>,
+    nterm: usize,
+    degree: usize,
+    boundary_knots: (f64, f64),
+) -> PyResult<(Vec<Vec<f64>>, Vec<f64>)> {
+    pspline_basis_core(&x, nterm, degree, boundary_knots)
 }
 
 #[pyclass]
@@ -642,5 +811,41 @@ mod tests {
             .expect_err("non-finite prediction input should be rejected");
 
         assert!(err.to_string().contains("new_x contains non-finite"));
+    }
+
+    #[test]
+    fn r_pspline_basis_matches_boundary_and_extrapolation_rows() {
+        let (basis, knots) = pspline_basis_core(&[0.0, 1.0, 5.0, 6.0], 8, 3, (1.0, 5.0)).unwrap();
+
+        assert_eq!(basis.len(), 4);
+        assert_eq!(basis[0].len(), 11);
+        assert_eq!(knots.len(), 15);
+        let expected_left = [7.0 / 6.0, 2.0 / 3.0, -5.0 / 6.0];
+        for (actual, expected) in basis[0][..3].iter().zip(expected_left) {
+            assert!((actual - expected).abs() < 1e-12);
+        }
+        let expected_right = [-5.0 / 6.0, 2.0 / 3.0, 7.0 / 6.0];
+        for (actual, expected) in basis[3][8..].iter().zip(expected_right) {
+            assert!((actual - expected).abs() < 1e-12);
+        }
+    }
+
+    #[test]
+    fn r_pspline_basis_preserves_missing_and_constant_rows() {
+        let (basis, knots) = pspline_basis_core(&[2.0, f64::NAN, 2.0], 5, 3, (2.0, 2.0)).unwrap();
+
+        assert_eq!(knots, vec![2.0; 12]);
+        assert_eq!(basis[0], vec![0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]);
+        assert!(basis[1].iter().all(|value| value.is_nan()));
+        assert_eq!(basis[2], basis[0]);
+    }
+
+    #[test]
+    fn r_pspline_basis_rejects_invalid_inputs() {
+        assert!(pspline_basis_core(&[1.0], 2, 3, (0.0, 1.0)).is_err());
+        assert!(pspline_basis_core(&[1.0], 3, 0, (0.0, 1.0)).is_err());
+        assert!(pspline_basis_core(&[f64::INFINITY], 3, 1, (0.0, 1.0)).is_err());
+        assert!(pspline_basis_core(&[1.0], 3, 1, (1.0, 0.0)).is_err());
+        assert!(pspline_basis_core(&[2.0], 3, 1, (1.0, 1.0)).is_err());
     }
 }


### PR DESCRIPTION
## Summary
- move P-spline knot generation, basis evaluation, and boundary extrapolation from Python into a parallel Rust kernel
- preserve missing rows and match R for constant-valued inputs with data-derived zero-width boundaries
- keep explicit zero-width boundary arguments invalid while preserving the R wrapper's omitted-argument semantics
- expose the native helper through the typed binding surface and add Rust, Python, and R bridge regressions

## Performance
A local 20,000-row microbenchmark with 15 terms and cubic splines produced identical values and reduced basis construction from 0.1459s to 0.0066s (22.2x faster).

## Testing
- `.venv/bin/python -m pytest` (850 passed)
- `cargo test` (1377 passed)
- `cargo test --all-features` (1588 passed)
- `cargo clippy --all-targets --all-features -- -D warnings`
- Ruff format and lint checks
- `mypy python/survival`
- `scripts/generate_binding_manifest.py --check`
- full R bridge parity suite
- isolated `R CMD check --no-manual --no-build-vignettes` (Status: OK)

No dependencies added.