### PR TITLE
Batch step-matrix projection

### DIFF
--- a/python/survival/_binding_manifest.py
+++ b/python/survival/_binding_manifest.py
@@ -904,6 +904,7 @@ BINDINGS = (
     "statefig_matplotlib_code",
     "statefig_transition_matrix",
     "statefig_validate",
+    "step_matrix_values_at",
     "step_values_at",
     "strata",
     "strata_str",

--- a/python/survival/_survival.pyi
+++ b/python/survival/_survival.pyi
@@ -5823,6 +5823,12 @@ def step_values_at(
     requested_times: list[float],
     initial: float,
 ) -> list[float]: ...
+def step_matrix_values_at(
+    times: list[float],
+    values: list[list[float]],
+    requested_times: list[float],
+    initial: float,
+) -> list[list[float]]: ...
 def condition_cox_survfit_curves(
     times: list[float],
     cumhaz: list[list[float]],

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -8784,15 +8784,9 @@ def _pseudo_counting_residual_rows(
     times = [float(value) for value in fit.time]
     requested_times = [float(value) for value in eval_times]
     if pseudo_type == "survival":
-        return [
-            _core.step_values_at(times, [float(value) for value in row], requested_times, 0.0)
-            for row in influence.influence_surv
-        ]
+        return _core.step_matrix_values_at(times, influence.influence_surv, requested_times, 0.0)
     if pseudo_type == "cumhaz":
-        return [
-            _core.step_values_at(times, [float(value) for value in row], requested_times, 0.0)
-            for row in influence.influence_chaz
-        ]
+        return _core.step_matrix_values_at(times, influence.influence_chaz, requested_times, 0.0)
     return [
         _pseudo_integrated_step_values(times, [float(value) for value in row], requested_times)
         for row in influence.influence_surv
@@ -11286,19 +11280,13 @@ def _survfit_residual_rows_at_times(
     curve_times = [float(value) for value in influence.time]
     eval_times = [float(value) for value in times]
     if residual_type == "cumhaz":
-        return [
-            _core.step_values_at(curve_times, [float(value) for value in row], eval_times, 0.0)
-            for row in influence.influence_chaz
-        ]
+        return _core.step_matrix_values_at(curve_times, influence.influence_chaz, eval_times, 0.0)
     if residual_type == "auc":
         return [
             _pseudo_integrated_step_values(curve_times, [float(value) for value in row], eval_times)
             for row in influence.influence_surv
         ]
-    return [
-        _core.step_values_at(curve_times, [float(value) for value in row], eval_times, 0.0)
-        for row in influence.influence_surv
-    ]
+    return _core.step_matrix_values_at(curve_times, influence.influence_surv, eval_times, 0.0)
 
 
 def _survfit_residual_matrix(

--- a/python/tests/test_binding_contract.py
+++ b/python/tests/test_binding_contract.py
@@ -4177,6 +4177,7 @@ def test_survfit_matrix_bindings_are_typed():
         "survfit_from_matrix",
         "survfit_multistate",
         "step_values_at",
+        "step_matrix_values_at",
         "condition_cox_survfit_curves",
         "cox_survfit_from_baseline",
     } <= stub_names
@@ -4238,6 +4239,18 @@ def test_survfit_matrix_bindings_are_typed():
         "requested_times",
         "initial",
     ]
+    assert list(inspect.signature(core.step_matrix_values_at).parameters) == [
+        "times",
+        "values",
+        "requested_times",
+        "initial",
+    ]
+    assert _pyi_function_arg_names(stub_path, "step_matrix_values_at") == [
+        "times",
+        "values",
+        "requested_times",
+        "initial",
+    ]
     assert list(inspect.signature(core.condition_cox_survfit_curves).parameters) == [
         "times",
         "cumhaz",
@@ -4286,6 +4299,14 @@ def test_survfit_matrix_bindings_are_typed():
         [0.5, 1.0, 4.0, 6.0],
         0.0,
     ) == pytest.approx([0.0, 10.0, 30.0, 50.0])
+    projected = core.step_matrix_values_at(
+        [1.0, 3.0, 5.0],
+        [[10.0, 30.0, 50.0], [1.0, 3.0, 5.0]],
+        [6.0, 0.5, 3.0],
+        -1.0,
+    )
+    assert projected[0] == pytest.approx([50.0, -1.0, 30.0])
+    assert projected[1] == pytest.approx([5.0, -1.0, 3.0])
     conditioned_time, conditioned_surv, conditioned_cumhaz = core.condition_cox_survfit_curves(
         [1.0, 3.0, 5.0],
         [[0.2, 0.6, 1.1]],

--- a/src/api/python/classical/survival_models.rs
+++ b/src/api/python/classical/survival_models.rs
@@ -96,6 +96,7 @@ pub(super) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(survfit_multistate, m)?)?;
     m.add_function(wrap_pyfunction!(condition_cox_survfit_curves, m)?)?;
     m.add_function(wrap_pyfunction!(step_values_at, m)?)?;
+    m.add_function(wrap_pyfunction!(step_matrix_values_at, m)?)?;
     m.add_function(wrap_pyfunction!(cox_survfit_from_baseline, m)?)?;
     m.add_function(wrap_pyfunction!(basehaz, m)?)?;
     m.add_function(wrap_pyfunction!(statefig, m)?)?;

--- a/src/surv_analysis/mod.rs
+++ b/src/surv_analysis/mod.rs
@@ -65,8 +65,8 @@ pub use statefig_module::{
 };
 pub use survfit_matrix::{
     SurvfitMatrixResult, basehaz, condition_cox_survfit_curves, cox_survfit_from_baseline,
-    step_values_at, survfit_from_cumhaz, survfit_from_hazard, survfit_from_matrix,
-    survfit_multistate,
+    step_matrix_values_at, step_values_at, survfit_from_cumhaz, survfit_from_hazard,
+    survfit_from_matrix, survfit_multistate,
 };
 pub use survfitaj_extended_module::{
     AalenJohansenExtendedConfig, AalenJohansenExtendedResult, TransitionMatrix, TransitionType,

--- a/src/surv_analysis/survfit_matrix.rs
+++ b/src/surv_analysis/survfit_matrix.rs
@@ -1,5 +1,6 @@
 use pyo3::exceptions::{PyIndexError, PyValueError};
 use pyo3::prelude::*;
+use rayon::prelude::*;
 use std::collections::BTreeMap;
 
 use crate::constants::same_time;
@@ -62,6 +63,47 @@ fn requested_times_are_sorted(values: &[f64]) -> bool {
     values.windows(2).all(|window| window[1] >= window[0])
 }
 
+fn step_positions(times: &[f64], requested_times: &[f64]) -> Vec<Option<usize>> {
+    if requested_times_are_sorted(requested_times) {
+        let mut cursor = 0;
+        return requested_times
+            .iter()
+            .map(|requested_time| {
+                while cursor < times.len() && times[cursor] <= *requested_time {
+                    cursor += 1;
+                }
+                cursor.checked_sub(1)
+            })
+            .collect();
+    }
+    requested_times
+        .iter()
+        .map(|requested_time| {
+            times
+                .partition_point(|time| time <= requested_time)
+                .checked_sub(1)
+        })
+        .collect()
+}
+
+fn validate_step_matrix(times: &[f64], values: &[Vec<f64>]) -> PyResult<()> {
+    for (row_idx, row) in values.iter().enumerate() {
+        if row.len() != times.len() {
+            return Err(value_error(format!(
+                "values row {row_idx} must have the same length as times"
+            )));
+        }
+        for (column_idx, value) in row.iter().enumerate() {
+            if !value.is_finite() {
+                return Err(value_error(format!(
+                    "values contains non-finite value at row {row_idx}, column {column_idx}"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
 fn step_values_at_sorted_requests(
     times: &[f64],
     values: &[f64],
@@ -110,6 +152,31 @@ pub fn step_values_at(
     Ok(requested_times
         .iter()
         .map(|&requested_time| step_value_at_with_initial(&times, &values, requested_time, initial))
+        .collect())
+}
+
+#[pyfunction]
+pub fn step_matrix_values_at(
+    times: Vec<f64>,
+    values: Vec<Vec<f64>>,
+    requested_times: Vec<f64>,
+    initial: f64,
+) -> PyResult<Vec<Vec<f64>>> {
+    validate_step_times("times", &times)?;
+    validate_step_matrix(&times, &values)?;
+    validate_finite_slice("requested_times", &requested_times)?;
+    if !initial.is_finite() {
+        return Err(value_error("initial must be finite"));
+    }
+    let positions = step_positions(&times, &requested_times);
+    Ok(values
+        .par_iter()
+        .map(|row| {
+            positions
+                .iter()
+                .map(|position| position.map_or(initial, |idx| row[idx]))
+                .collect()
+        })
         .collect())
 }
 
@@ -1214,6 +1281,33 @@ mod tests {
         )
         .unwrap();
         assert_eq!(unsorted, vec![50.0, -1.0, 30.0]);
+    }
+
+    #[test]
+    fn test_step_matrix_values_at_reuses_sorted_and_unsorted_positions() {
+        let values = vec![vec![10.0, 30.0, 50.0], vec![1.0, 3.0, 5.0]];
+        let sorted = step_matrix_values_at(
+            vec![1.0, 3.0, 5.0],
+            values.clone(),
+            vec![0.5, 1.0, 4.0, 6.0],
+            0.0,
+        )
+        .unwrap();
+        assert_eq!(
+            sorted,
+            vec![vec![0.0, 10.0, 30.0, 50.0], vec![0.0, 1.0, 3.0, 5.0]]
+        );
+
+        let unsorted =
+            step_matrix_values_at(vec![1.0, 3.0, 5.0], values, vec![6.0, 0.5, 3.0], -1.0).unwrap();
+        assert_eq!(unsorted, vec![vec![50.0, -1.0, 30.0], vec![5.0, -1.0, 3.0]]);
+    }
+
+    #[test]
+    fn test_step_matrix_values_at_validates_rows_and_values() {
+        assert!(step_matrix_values_at(vec![1.0], vec![vec![]], vec![1.0], 0.0).is_err());
+        assert!(step_matrix_values_at(vec![1.0], vec![vec![f64::NAN]], vec![1.0], 0.0,).is_err());
+        assert!(step_matrix_values_at(vec![1.0], vec![vec![1.0]], vec![1.0], f64::NAN).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- compute requested step positions once for a full matrix instead of once per row
- batch pseudo-value and survfit residual projection through one parallel Rust call
- preserve sorted and arbitrary requested-time order, right-continuous boundary semantics, and initial values
- add typed binding and validation coverage

## Performance
A local 500-by-500 development-build microbenchmark produced identical values and reduced projection time from 63.6 ms to 27.5 ms (2.3x faster).

## Testing
- `.venv/bin/python -m pytest` (851 passed)
- `cargo test` (1,381 passed)
- `cargo test --all-features` (1,597 passed)
- strict Clippy with all targets and all features
- Ruff, mypy, formatting, and generated-manifest checks
- full R bridge compatibility suite
- isolated `R CMD check` (`Status: OK`)

No dependencies added.