### PR TITLE
Accelerate risk stratification cutpoint lookup

### DIFF
--- a/src/validation/calibration.rs
+++ b/src/validation/calibration.rs
@@ -575,16 +575,10 @@ pub(crate) fn stratify_risk(
         let idx = (g * n / n_groups).min(n - 1);
         cutpoints.push(sorted_scores[idx]);
     }
-    let mut risk_groups = Vec::with_capacity(n);
-    for &score in risk_scores {
-        let mut group = 0;
-        for (g, &cut) in cutpoints.iter().enumerate() {
-            if score >= cut {
-                group = g + 1;
-            }
-        }
-        risk_groups.push(group);
-    }
+    let risk_groups: Vec<usize> = risk_scores
+        .iter()
+        .map(|&score| cutpoints.partition_point(|&cut| score >= cut))
+        .collect();
     let mut group_sizes = vec![0usize; n_groups];
     let mut group_events = vec![0usize; n_groups];
     let mut group_scores: Vec<Vec<f64>> = vec![Vec::new(); n_groups];
@@ -1250,6 +1244,19 @@ mod tests {
 
         let explicit_result = risk_stratification(vec![0.2, 0.8], vec![0, 1], Some(5)).unwrap();
         assert_eq!(explicit_result.group_sizes, vec![1, 1]);
+    }
+
+    #[test]
+    fn test_risk_stratification_preserves_duplicate_cutpoint_assignment() {
+        let result = stratify_risk(&[0.1, 0.1, 0.1, 0.2, 0.2, 0.9], &[0, 1, 0, 1, 0, 1], 4);
+
+        assert_eq!(result.cutpoints, vec![0.1, 0.2, 0.2]);
+        assert_eq!(result.risk_groups, vec![1, 1, 1, 3, 3, 3]);
+        assert_eq!(result.group_sizes, vec![0, 3, 0, 3]);
+        assert_eq!(
+            result.group_event_rates,
+            vec![0.0, 1.0 / 3.0, 0.0, 2.0 / 3.0]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- replace the per-score linear scan across every quantile cutpoint with a binary partition lookup
- preserve equal-score and duplicate-cutpoint assignment semantics exactly
- add regression coverage for duplicate cutpoints and empty intermediate groups

## Performance
A local 200,000-score, 1,000-group development-build benchmark produced the same assignment checksum and reduced runtime from 1.442 seconds to 0.157 seconds (9.2x faster).

## Testing
- `.venv/bin/python -m pytest` (851 passed)
- `cargo test` (1,381 passed)
- `cargo test --all-features` (1,597 passed)
- strict Clippy with all targets and all features
- Ruff, mypy, formatting, and generated-manifest checks
- full R bridge compatibility suite
- isolated `R CMD check` (`Status: OK`)

No dependencies added.