### PR TITLE
Move coxph Wald factorization into Rust

### DIFF
--- a/python/survival/_binding_manifest.py
+++ b/python/survival/_binding_manifest.py
@@ -624,6 +624,7 @@ BINDINGS = (
     "coxmart",
     "coxph_detail",
     "coxph_fit",
+    "coxph_wtest",
     "cqr_conformal_survival",
     "create_model_card",
     "create_simple_ratetable",

--- a/python/survival/_survival.pyi
+++ b/python/survival/_survival.pyi
@@ -6801,6 +6801,11 @@ def coxph_detail(
     method: str = "breslow",
     center: float = 0.0,
 ) -> CoxphDetail: ...
+def coxph_wtest(
+    matrix: list[list[float]],
+    rhs_columns: list[list[float]],
+    toler_chol: float = 1e-9,
+) -> tuple[list[float], int, list[list[float]]]: ...
 def clustered_crossprod(
     rows: list[list[float]],
     weights: list[float],

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -14236,79 +14236,6 @@ def _coxph_wtest_var_matrix(var: Any) -> tuple[list[list[float]], int]:
     return [], len(values)
 
 
-def _coxph_solve_linear_system(matrix: list[list[float]], rhs: Sequence[float]) -> list[float]:
-    n = len(matrix)
-    if n == 0:
-        return []
-    augmented = [list(row) + [float(rhs[idx])] for idx, row in enumerate(matrix)]
-    for col in range(n):
-        pivot = max(range(col, n), key=lambda row: abs(augmented[row][col]))
-        if abs(augmented[pivot][col]) <= 1e-14:
-            raise ValueError("First argument must be a square matrix")
-        if pivot != col:
-            augmented[col], augmented[pivot] = augmented[pivot], augmented[col]
-        pivot_value = augmented[col][col]
-        for row in range(col + 1, n):
-            factor = augmented[row][col] / pivot_value
-            if factor == 0.0:
-                continue
-            for idx in range(col, n + 1):
-                augmented[row][idx] -= factor * augmented[col][idx]
-    solution = [0.0] * n
-    for row in range(n - 1, -1, -1):
-        total = augmented[row][n] - sum(
-            augmented[row][col] * solution[col] for col in range(row + 1, n)
-        )
-        solution[row] = total / augmented[row][row]
-    return solution
-
-
-def _coxph_wtest_active_indices(matrix: list[list[float]], toler_chol: float) -> list[int]:
-    n = len(matrix)
-    max_diag = max((abs(matrix[idx][idx]) for idx in range(n)), default=0.0)
-    threshold = toler_chol * max_diag
-    active: list[int] = []
-    for idx in range(n):
-        variance = matrix[idx][idx]
-        if active:
-            submatrix = [[matrix[row][col] for col in active] for row in active]
-            covariance = [matrix[idx][col] for col in active]
-            projected = _coxph_solve_linear_system(submatrix, covariance)
-            variance -= sum(value * coef for value, coef in zip(covariance, projected, strict=True))
-        if variance > threshold and variance > 0.0:
-            active.append(idx)
-    return active
-
-
-def _coxph_wtest_solve(
-    matrix: list[list[float]],
-    b_columns: list[list[float]],
-    toler_chol: float,
-) -> tuple[list[float], int, list[list[float]]]:
-    n = len(matrix)
-    active = _coxph_wtest_active_indices(matrix, toler_chol)
-    if not active:
-        return [0.0 for _ in b_columns], 0, [[0.0 for _ in b_columns] for _ in range(n)]
-
-    submatrix = [[matrix[row][col] for col in active] for row in active]
-    solve_columns: list[list[float]] = []
-    tests: list[float] = []
-    for column in b_columns:
-        rhs = [column[idx] for idx in active]
-        active_solution = _coxph_solve_linear_system(submatrix, rhs)
-        solution = [0.0] * n
-        for idx, value in zip(active, active_solution, strict=True):
-            solution[idx] = value
-        solve_columns.append(solution)
-        tests.append(sum(value * coef for value, coef in zip(column, solution, strict=True)))
-
-    solve_rows = [
-        [solve_columns[col_idx][row_idx] for col_idx in range(len(solve_columns))]
-        for row_idx in range(n)
-    ]
-    return tests, len(active), solve_rows
-
-
 def coxph_wtest(var: Any, b: Any, toler_chol: Any = 1e-9) -> CoxPHWTestResult:
     """Compute the Wald test helper exported as R's ``coxph.wtest``."""
 
@@ -14356,7 +14283,7 @@ def coxph_wtest(var: Any, b: Any, toler_chol: Any = 1e-9) -> CoxPHWTestResult:
     b_columns = [
         [b_numeric[row_idx][col_idx] for row_idx in range(nvar)] for col_idx in range(ntest)
     ]
-    tests, df, solve_rows = _coxph_wtest_solve(matrix, b_columns, toler_value)
+    tests, df, solve_rows = _core.coxph_wtest(matrix, b_columns, toler_value)
     solve: list[float] | list[list[float]] = (
         solve_rows if b_is_matrix and ntest > 1 else [row[0] for row in solve_rows]
     )

--- a/python/tests/test_binding_contract.py
+++ b/python/tests/test_binding_contract.py
@@ -794,6 +794,7 @@ def test_coxph_fit_detail_bindings_are_typed_to_runtime_surface():
         "CoxphDetailRow",
         "coxph_fit",
         "coxph_detail",
+        "coxph_wtest",
     } <= stub_names
 
     expected_args = {
@@ -824,6 +825,7 @@ def test_coxph_fit_detail_bindings_are_typed_to_runtime_surface():
             "method",
             "center",
         ],
+        "coxph_wtest": ["matrix", "rhs_columns", "toler_chol"],
     }
     for name, args in expected_args.items():
         assert list(inspect.signature(getattr(core, name)).parameters) == args

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -840,6 +840,8 @@ def test_coxph_wtest_matches_r_wald_helper_shapes():
     correlated = survival.coxph_wtest([[2.0, 0.5], [0.5, 1.0]], [1.0, 2.0])
     singular = survival.coxph_wtest([[1.0, 2.0], [2.0, 4.0]], [1.0, 2.0])
     trailing = survival.coxph_wtest([[0.0, 0.0], [0.0, 2.0]], [1.0, 2.0])
+    zero = survival.coxph_wtest([[0.0, 0.0], [0.0, 0.0]], [1.0, 2.0])
+    indefinite = survival.coxph_wtest([[1.0, 2.0], [2.0, 1.0]], [1.0, 2.0])
     matrix_rhs = survival.coxph_wtest(
         [[1.0, 0.0], [0.0, 1.0]],
         [[1.0, 3.0], [2.0, 4.0]],
@@ -858,6 +860,12 @@ def test_coxph_wtest_matches_r_wald_helper_shapes():
     assert trailing.df == 1
     assert trailing.test == pytest.approx([2.0])
     assert trailing.solve == pytest.approx([0.0, 1.0])
+    assert zero.test == pytest.approx([0.0])
+    assert zero.df == 0
+    assert zero.solve == pytest.approx([0.0, 0.0])
+    assert indefinite.test == pytest.approx([1.0])
+    assert indefinite.df == 1
+    assert indefinite.solve == pytest.approx([1.0, 0.0])
     assert matrix_rhs.test == pytest.approx([5.0, 25.0])
     assert len(matrix_rhs.solve) == 2
     for actual_row, expected_row in zip(

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -1268,6 +1268,19 @@ test_that("R formula wrappers delegate to the Python survival package", {
     coxph.wtest(diag(2), matrix(c(1, 2, 3, 4), nrow = 2)),
     survival::coxph.wtest(diag(2), matrix(c(1, 2, 3, 4), nrow = 2))
   )
+  expect_equal(
+    coxph.wtest(matrix(0, 2, 2), c(1, 2)),
+    survival::coxph.wtest(matrix(0, 2, 2), c(1, 2))
+  )
+  expect_equal(
+    coxph.wtest(matrix(c(1, 2, 2, 1), 2), c(1, 2)),
+    survival::coxph.wtest(matrix(c(1, 2, 2, 1), 2), c(1, 2))
+  )
+  asymmetric_wtest <- matrix(c(2, 0.25, 7, 1), 2, byrow = TRUE)
+  expect_equal(
+    coxph.wtest(asymmetric_wtest, c(1, 2)),
+    survival::coxph.wtest(asymmetric_wtest, c(1, 2))
+  )
   expect_equal(coxph.wtest(diag(2), c(NA, 2)), survival::coxph.wtest(diag(2), c(NA, 2)))
 
   survreg_control <- survreg.control(maxiter = 1, rel.tolerance = 1e-05, toler.chol = 1e-08)

--- a/src/api/python/classical/diagnostics.rs
+++ b/src/api/python/classical/diagnostics.rs
@@ -9,6 +9,7 @@ pub(super) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(cox_interval_cumulative_hazard_se, m)?)?;
     m.add_function(wrap_pyfunction!(cox_zph_group_variance, m)?)?;
     m.add_function(wrap_pyfunction!(cox_zph_term_matrix, m)?)?;
+    m.add_function(wrap_pyfunction!(coxph_wtest, m)?)?;
     m.add_function(wrap_pyfunction!(leverage_cox, m)?)?;
     m.add_function(wrap_pyfunction!(prediction_se_from_variance, m)?)?;
     m.add_function(wrap_pyfunction!(scale_schoenfeld_residuals, m)?)?;

--- a/src/regression/coxph_wtest.rs
+++ b/src/regression/coxph_wtest.rs
@@ -1,0 +1,222 @@
+use pyo3::prelude::*;
+
+fn value_error(message: impl Into<String>) -> PyErr {
+    PyErr::new::<pyo3::exceptions::PyValueError, _>(message.into())
+}
+
+#[derive(Debug)]
+struct CoxphWtestFactorization {
+    factors: Vec<f64>,
+    n: usize,
+    rank: usize,
+}
+
+impl CoxphWtestFactorization {
+    fn decompose(matrix: &[Vec<f64>], toler_chol: f64) -> PyResult<Self> {
+        let n = matrix.len();
+        if matrix.iter().any(|row| row.len() != n) {
+            return Err(value_error("First argument must be a square matrix"));
+        }
+        if matrix.iter().flatten().any(|value| !value.is_finite()) {
+            return Err(value_error("infinite argument in coxph.wtest"));
+        }
+        if !toler_chol.is_finite() || toler_chol < 0.0 {
+            return Err(value_error("toler_chol must be non-negative"));
+        }
+
+        let mut factors = vec![0.0; n * n];
+        let mut epsilon = 0.0_f64;
+        for row in 0..n {
+            epsilon = epsilon.max(matrix[row][row]);
+            for col in 0..=row {
+                factors[row * n + col] = matrix[row][col];
+            }
+        }
+        epsilon = if epsilon == 0.0 {
+            toler_chol
+        } else {
+            epsilon * toler_chol
+        };
+
+        let mut rank = 0;
+        for pivot_col in 0..n {
+            let pivot_index = pivot_col * n + pivot_col;
+            let pivot = factors[pivot_index];
+            if !pivot.is_finite() || pivot < epsilon || pivot == 0.0 {
+                factors[pivot_index] = 0.0;
+                continue;
+            }
+
+            rank += 1;
+            for row in (pivot_col + 1)..n {
+                let row_pivot_index = row * n + pivot_col;
+                let multiplier = factors[row_pivot_index] / pivot;
+                factors[row_pivot_index] = multiplier;
+                factors[row * n + row] -= multiplier * multiplier * pivot;
+                for target_row in (row + 1)..n {
+                    let target_index = target_row * n + row;
+                    factors[target_index] -= multiplier * factors[target_row * n + pivot_col];
+                }
+            }
+        }
+
+        Ok(Self { factors, n, rank })
+    }
+
+    fn solve(&self, rhs: &[f64]) -> PyResult<Vec<f64>> {
+        if rhs.len() != self.n {
+            return Err(value_error("Argument lengths do not match"));
+        }
+        if rhs.iter().any(|value| !value.is_finite()) {
+            return Err(value_error("infinite argument in coxph.wtest"));
+        }
+
+        let mut solution = rhs.to_vec();
+        for row in 0..self.n {
+            let mut value = solution[row];
+            for (col, &known) in solution.iter().take(row).enumerate() {
+                value -= known * self.factors[row * self.n + col];
+            }
+            solution[row] = value;
+        }
+        for row in (0..self.n).rev() {
+            let diagonal = self.factors[row * self.n + row];
+            if diagonal == 0.0 {
+                solution[row] = 0.0;
+                continue;
+            }
+            let mut value = solution[row] / diagonal;
+            for (col, &known) in solution.iter().enumerate().skip(row + 1) {
+                value -= known * self.factors[col * self.n + row];
+            }
+            solution[row] = value;
+        }
+        Ok(solution)
+    }
+}
+
+pub(crate) fn coxph_wtest_core(
+    matrix: &[Vec<f64>],
+    rhs_columns: &[Vec<f64>],
+    toler_chol: f64,
+) -> PyResult<(Vec<f64>, usize, Vec<Vec<f64>>)> {
+    let factorization = CoxphWtestFactorization::decompose(matrix, toler_chol)?;
+    let mut tests = Vec::with_capacity(rhs_columns.len());
+    let mut solve_rows = vec![vec![0.0; rhs_columns.len()]; matrix.len()];
+
+    for (column_index, rhs) in rhs_columns.iter().enumerate() {
+        let solution = factorization.solve(rhs)?;
+        tests.push(
+            rhs.iter()
+                .zip(solution.iter())
+                .map(|(&value, &coefficient)| value * coefficient)
+                .sum(),
+        );
+        for (row, &value) in solution.iter().enumerate() {
+            solve_rows[row][column_index] = value;
+        }
+    }
+
+    Ok((tests, factorization.rank, solve_rows))
+}
+
+#[pyfunction]
+#[pyo3(signature = (matrix, rhs_columns, toler_chol=1e-9))]
+pub fn coxph_wtest(
+    matrix: Vec<Vec<f64>>,
+    rhs_columns: Vec<Vec<f64>>,
+    toler_chol: f64,
+) -> PyResult<(Vec<f64>, usize, Vec<Vec<f64>>)> {
+    coxph_wtest_core(&matrix, &rhs_columns, toler_chol)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_close(actual: &[f64], expected: &[f64]) {
+        assert_eq!(actual.len(), expected.len());
+        for (&actual, &expected) in actual.iter().zip(expected.iter()) {
+            assert!((actual - expected).abs() < 1e-12, "{actual} != {expected}");
+        }
+    }
+
+    #[test]
+    fn matches_reference_full_rank_and_multiple_rhs() {
+        let (tests, rank, solve) = coxph_wtest_core(
+            &[vec![2.0, 0.5], vec![0.5, 1.0]],
+            &[vec![1.0, 2.0], vec![3.0, 4.0]],
+            1e-9,
+        )
+        .expect("factorization should succeed");
+
+        assert_eq!(rank, 2);
+        assert_close(&tests, &[4.0, 16.571428571428573]);
+        assert_close(&solve[0], &[0.0, 0.5714285714285714]);
+        assert_close(&solve[1], &[2.0, 3.7142857142857144]);
+    }
+
+    #[test]
+    fn matches_reference_singular_and_indefinite_semantics() {
+        let cases = [
+            (
+                vec![
+                    vec![1.0, 2.0, 3.0],
+                    vec![2.0, 4.0, 6.0],
+                    vec![3.0, 6.0, 9.0],
+                ],
+                vec![1.0, 2.0, 3.0],
+                1,
+                vec![1.0, 0.0, 0.0],
+            ),
+            (
+                vec![
+                    vec![0.0, 0.0, 0.0],
+                    vec![0.0, 2.0, 0.0],
+                    vec![0.0, 0.0, 3.0],
+                ],
+                vec![1.0, 2.0, 3.0],
+                2,
+                vec![0.0, 1.0, 1.0],
+            ),
+            (
+                vec![vec![1.0, 2.0], vec![2.0, 1.0]],
+                vec![1.0, 2.0],
+                1,
+                vec![1.0, 0.0],
+            ),
+        ];
+
+        for (matrix, rhs, expected_rank, expected_solve) in cases {
+            let (_, rank, solve) =
+                coxph_wtest_core(&matrix, &[rhs], 1e-9).expect("factorization should succeed");
+            assert_eq!(rank, expected_rank);
+            assert_close(
+                &solve.iter().map(|row| row[0]).collect::<Vec<_>>(),
+                &expected_solve,
+            );
+        }
+    }
+
+    #[test]
+    fn matches_r_column_major_lower_triangle_semantics() {
+        let (tests, rank, solve) =
+            coxph_wtest_core(&[vec![2.0, 0.25], vec![7.0, 1.0]], &[vec![1.0, 2.0]], 1e-9)
+                .expect("factorization should succeed");
+
+        assert_eq!(rank, 1);
+        assert_close(&tests, &[0.5]);
+        assert_close(
+            &solve.iter().map(|row| row[0]).collect::<Vec<_>>(),
+            &[0.5, 0.0],
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_inputs() {
+        assert!(coxph_wtest_core(&[vec![1.0, 2.0]], &[vec![1.0]], 1e-9).is_err());
+        assert!(coxph_wtest_core(&[vec![1.0]], &[vec![1.0, 2.0]], 1e-9).is_err());
+        assert!(coxph_wtest_core(&[vec![f64::INFINITY]], &[vec![1.0]], 1e-9).is_err());
+        assert!(coxph_wtest_core(&[vec![1.0]], &[vec![1.0]], -1.0).is_err());
+    }
+}

--- a/src/regression/mod.rs
+++ b/src/regression/mod.rs
@@ -17,6 +17,8 @@ pub(crate) mod coxph_detail_module;
 pub(crate) mod coxph_diagnostics;
 pub(crate) mod coxph_model;
 pub(crate) mod coxph_support;
+#[path = "coxph_wtest.rs"]
+pub(crate) mod coxph_wtest_module;
 pub(crate) mod cure_models;
 pub(crate) mod elastic_net;
 pub(crate) mod exact_ties;
@@ -57,6 +59,7 @@ pub use coxph_diagnostics::{
     cox_zph_term_matrix, prediction_se_from_variance, scale_schoenfeld_residuals,
     term_prediction_se_from_variance,
 };
+pub use coxph_wtest_module::coxph_wtest;
 pub use cure_models::{
     BoundedCumulativeHazardConfig, BoundedCumulativeHazardResult, CureDistribution,
     CureModelComparisonResult, LinkFunction, MixtureCureConfig, MixtureCureResult,


### PR DESCRIPTION
## Summary

- replace repeated Python Gaussian elimination with one native rank-revealing LDLT factorization
- reuse the factorization across every right-hand side, reducing the main path from quartic to cubic complexity
- preserve tolerance-based rank detection, zero and indefinite pivots, singular-column solutions, and R's lower-triangle matrix orientation
- keep the existing Python and R result shapes and scalar edge handling
- remove 74 lines of Python numerical code with no dependency changes

## Performance

Optimized build, 80-variable correlated covariance matrix:

| Before | After | Speedup |
|---:|---:|---:|
| 102.052 ms | 0.284 ms | 359x |

## R parity

80 deterministic randomized comparisons covered dimensions 2, 5, 10, and 25, three simultaneous right-hand sides, full-rank and deliberately rank-deficient covariance matrices, plus asymmetric orientation cases.

- maximum test-statistic absolute error: 1.99e-13
- maximum solution absolute error: 8.08e-14
- ranks matched exactly in every case

## Validation

- 852 Python tests
- 1,384 core Rust tests
- 1,600 all-feature Rust tests
- strict Clippy
- Ruff
- mypy
- generated binding manifest check
- full R bridge suite
- isolated R package build and check: Status OK
- post-rebase focused Rust, Python, binding, and R bridge checks