### PR TITLE
Build coxph detail risk matrices in Rust

### DIFF
--- a/python/survival/_survival.pyi
+++ b/python/survival/_survival.pyi
@@ -1106,6 +1106,8 @@ class CoxphDetail:
     @property
     def rows(self) -> list[CoxphDetailRow]: ...
     @property
+    def riskmat(self) -> list[list[int]] | None: ...
+    @property
     def n_events(self) -> int: ...
     @property
     def n_observations(self) -> int: ...
@@ -6800,6 +6802,7 @@ def coxph_detail(
     offset: list[float] | None = None,
     method: str = "breslow",
     center: float = 0.0,
+    riskmat: bool = False,
 ) -> CoxphDetail: ...
 def clustered_crossprod(
     rows: list[list[float]],

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -16754,38 +16754,6 @@ def _cox_detail_rorder(rorder: Any) -> str:
     )
 
 
-def _cox_detail_event_times(
-    time: list[float],
-    status: list[int],
-    strata: list[int],
-) -> list[tuple[int, float]]:
-    event_times: dict[int, set[float]] = {}
-    for event_time, event, stratum in zip(time, status, strata, strict=True):
-        if event == 1:
-            event_times.setdefault(stratum, set()).add(event_time)
-    return [
-        (stratum, event_time)
-        for stratum in sorted(event_times)
-        for event_time in sorted(event_times[stratum])
-    ]
-
-
-def _cox_detail_at_risk(
-    time: list[float],
-    entry: list[float] | None,
-    strata: list[int],
-    stratum: int,
-    event_time: float,
-) -> list[int]:
-    return [
-        idx
-        for idx, stop in enumerate(time)
-        if strata[idx] == stratum
-        and stop >= event_time
-        and (entry is None or entry[idx] < event_time)
-    ]
-
-
 def _cox_detail_y(
     time: list[float],
     status: list[int],
@@ -20022,6 +19990,7 @@ def coxph_detail(
             rows,
             _float_vector(coefficients, "coefficients"),
             _optional_float_vector(weights, "weights", len(rows)) if weights is not None else None,
+            riskmat=include_riskmat,
         )
 
     if fit is None:
@@ -20052,7 +20021,6 @@ def coxph_detail(
 
     center = _cox_reference_center(model, "sample")
     offset = _cox_fit_offset(model, beta)
-    event_groups = _cox_detail_event_times(time, status, strata)
     detail = _core.coxph_detail(
         time,
         status,
@@ -20064,15 +20032,10 @@ def coxph_detail(
         offset=offset,
         method=method,
         center=center,
+        riskmat=include_riskmat,
     )
     detail_rows = list(detail.rows)
-    risk_matrix_columns: list[list[int]] = []
-
-    for stratum, event_time in event_groups:
-        at_risk = _cox_detail_at_risk(time, entry, strata, stratum, event_time)
-        if include_riskmat:
-            at_risk_set = set(at_risk)
-            risk_matrix_columns.append([1 if idx in at_risk_set else 0 for idx in range(n)])
+    event_groups = [(int(row.stratum), float(row.time)) for row in detail_rows]
 
     row_order = _cox_detail_row_order(time, status, strata, rorder_name)
     x_rows = [rows[idx] for idx in row_order]
@@ -20082,7 +20045,14 @@ def coxph_detail(
     risk_matrix = None
     sortorder = row_order if rorder_name == "time" else None
     if include_riskmat:
-        risk_matrix = [[column[idx] for column in risk_matrix_columns] for idx in row_order]
+        native_risk_matrix = detail.riskmat
+        if native_risk_matrix is None:
+            raise RuntimeError("native Cox detail omitted the requested risk matrix")
+        risk_matrix = (
+            native_risk_matrix
+            if rorder_name == "data"
+            else [native_risk_matrix[idx] for idx in row_order]
+        )
 
     has_case_weights = any(abs(weight - 1.0) > 1e-12 for weight in weights)
     return CoxPHDetailResult(

--- a/python/tests/test_binding_contract.py
+++ b/python/tests/test_binding_contract.py
@@ -823,6 +823,7 @@ def test_coxph_fit_detail_bindings_are_typed_to_runtime_surface():
             "offset",
             "method",
             "center",
+            "riskmat",
         ],
     }
     for name, args in expected_args.items():
@@ -907,6 +908,7 @@ def test_coxph_fit_detail_bindings_are_typed_to_runtime_surface():
     }
     assert _pyi_class_property_names(stub_path, "CoxphDetail") == {
         "rows",
+        "riskmat",
         "n_events",
         "n_observations",
         "n_covariates",
@@ -1001,6 +1003,7 @@ def test_coxph_fit_detail_bindings_are_typed_to_runtime_surface():
     assert detail.n_events == sum(status)
     assert detail.n_observations == len(time)
     assert detail.n_covariates == 1
+    assert detail.riskmat is None
     assert len(detail.rows) == sum(status)
     assert detail.times() == pytest.approx([1.0, 3.0, 4.0, 6.0, 8.0])
     assert len(detail.hazards()) == sum(status)
@@ -1012,6 +1015,17 @@ def test_coxph_fit_detail_bindings_are_typed_to_runtime_surface():
     assert len(detail.variance_hazards()) == sum(status)
     assert len(detail.weighted_risk()) == sum(status)
     assert len(detail.schoenfeld_residuals()) == sum(status)
+
+    detail_with_riskmat = core.coxph_detail(
+        time,
+        status,
+        covariates,
+        fit.coefficients[-1],
+        riskmat=True,
+    )
+    assert detail_with_riskmat.riskmat is not None
+    assert detail_with_riskmat.riskmat[0] == [1, 0, 0, 0, 0]
+    assert detail_with_riskmat.riskmat[-1] == [1, 1, 1, 1, 1]
 
     first_row = detail.rows[0]
     assert type(first_row).__name__ == "CoxphDetailRow"

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -4793,8 +4793,17 @@ test_that("Cox detail weighted tied-event moments agree with R survival", {
       ties = method,
       control = survival::coxph.control(iter.max = 0)
     )
-    bridged_detail <- coxph.detail(bridged)
-    reference_detail <- survival::coxph.detail(reference)
+    bridged_detail <- coxph.detail(bridged, riskmat = TRUE)
+    reference_detail <- survival::coxph.detail(reference, riskmat = TRUE)
+
+    bridged_riskmat <- do.call(
+      rbind,
+      survivalr:::.result_field(bridged_detail, "riskmat")
+    )
+    expect_equal(
+      unname(bridged_riskmat),
+      unname(reference_detail$riskmat)
+    )
 
     for (field in c("means", "score", "imat", "hazard", "varhaz", "wtrisk")) {
       actual <- as.numeric(unlist(survivalr:::.result_field(bridged_detail, field)))

--- a/src/regression/coxph_detail.rs
+++ b/src/regression/coxph_detail.rs
@@ -54,6 +54,8 @@ pub struct CoxphDetail {
     #[pyo3(get)]
     pub rows: Vec<CoxphDetailRow>,
     #[pyo3(get)]
+    pub riskmat: Option<Vec<Vec<i32>>>,
+    #[pyo3(get)]
     pub n_events: usize,
     #[pyo3(get)]
     pub n_observations: usize,
@@ -72,6 +74,7 @@ pub(crate) struct CoxphDetailOptions<'a> {
     pub offset: Option<&'a [f64]>,
     pub method: &'a str,
     pub center: f64,
+    pub include_riskmat: bool,
 }
 
 #[pymethods]
@@ -332,6 +335,7 @@ pub(crate) fn compute_coxph_detail_with_options(
         offset,
         method,
         center,
+        include_riskmat,
     } = options;
     let n = time.len();
     let nvar = coefficients.len();
@@ -339,6 +343,7 @@ pub(crate) fn compute_coxph_detail_with_options(
     if n == 0 {
         return Ok(CoxphDetail {
             rows: vec![],
+            riskmat: include_riskmat.then(Vec::new),
             n_events: 0,
             n_observations: 0,
             n_covariates: nvar,
@@ -376,6 +381,7 @@ pub(crate) fn compute_coxph_detail_with_options(
 
     let groups = event_groups(time, status, strata_values.as_ref());
     let mut rows = Vec::with_capacity(groups.len());
+    let mut riskmat = include_riskmat.then(|| vec![vec![0; groups.len()]; n]);
     let mut total_events = 0;
     let mut current_stratum = None;
     let mut cumhaz = 0.0_f64;
@@ -395,7 +401,7 @@ pub(crate) fn compute_coxph_detail_with_options(
     let mut step_means = vec![0.0; nvar];
     let mut step_covariance = vec![0.0; nvar * nvar];
 
-    for (stratum, event_time) in groups {
+    for (group_index, (stratum, event_time)) in groups.into_iter().enumerate() {
         if current_stratum != Some(stratum) {
             current_stratum = Some(stratum);
             cumhaz = 0.0;
@@ -408,6 +414,11 @@ pub(crate) fn compute_coxph_detail_with_options(
             stratum,
             event_time,
         );
+        if let Some(matrix) = riskmat.as_mut() {
+            for &row_index in &at_risk {
+                matrix[row_index][group_index] = 1;
+            }
+        }
         fill_event_indices(
             &mut deaths,
             time,
@@ -518,6 +529,7 @@ pub(crate) fn compute_coxph_detail_with_options(
 
     Ok(CoxphDetail {
         rows,
+        riskmat,
         n_events: total_events,
         n_observations: n,
         n_covariates: nvar,
@@ -535,7 +547,8 @@ pub(crate) fn compute_coxph_detail_with_options(
     strata=None,
     offset=None,
     method="breslow".to_string(),
-    center=0.0
+    center=0.0,
+    riskmat=false
 ))]
 #[allow(clippy::too_many_arguments)]
 pub fn coxph_detail(
@@ -549,6 +562,7 @@ pub fn coxph_detail(
     offset: Option<Vec<f64>>,
     method: String,
     center: f64,
+    riskmat: bool,
 ) -> PyResult<CoxphDetail> {
     let n = time.len();
     if status.len() != n || covariates.len() != n {
@@ -672,6 +686,7 @@ pub fn coxph_detail(
         offset: offset.as_deref(),
         method: &method,
         center,
+        include_riskmat: riskmat,
     })
 }
 
@@ -713,6 +728,7 @@ mod tests {
     }
 
     fn assert_detail_close(left: &CoxphDetail, right: &CoxphDetail) {
+        assert_eq!(left.riskmat, right.riskmat);
         assert_eq!(left.n_events, right.n_events);
         assert_eq!(left.n_observations, right.n_observations);
         assert_eq!(left.n_covariates, right.n_covariates);
@@ -754,6 +770,7 @@ mod tests {
             offset: None,
             method: "breslow",
             center: 0.0,
+            include_riskmat: false,
         })
         .unwrap();
 
@@ -791,6 +808,7 @@ mod tests {
             offset: None,
             method: "efron",
             center: 0.0,
+            include_riskmat: false,
         })
         .unwrap();
         let unit_weights = vec![1.0; time.len()];
@@ -805,6 +823,7 @@ mod tests {
             offset: None,
             method: "efron",
             center: 0.0,
+            include_riskmat: false,
         })
         .unwrap();
 
@@ -829,6 +848,7 @@ mod tests {
             offset: None,
             method: "efron",
             center: 0.0,
+            include_riskmat: false,
         })
         .unwrap();
 
@@ -862,6 +882,7 @@ mod tests {
             offset: None,
             method: "breslow",
             center: 0.0,
+            include_riskmat: false,
         })
         .unwrap();
         let efron = compute_coxph_detail_with_options(CoxphDetailOptions {
@@ -875,6 +896,7 @@ mod tests {
             offset: None,
             method: "efron",
             center: 0.0,
+            include_riskmat: false,
         })
         .unwrap();
 
@@ -903,6 +925,7 @@ mod tests {
             offset: None,
             method: "breslow",
             center: 0.0,
+            include_riskmat: false,
         })
         .unwrap();
 
@@ -935,6 +958,7 @@ mod tests {
             offset: None,
             method: "breslow",
             center: 0.0,
+            include_riskmat: false,
         })
         .unwrap();
 
@@ -963,6 +987,7 @@ mod tests {
             offset: None,
             method: "breslow",
             center: 0.0,
+            include_riskmat: false,
         })
         .unwrap();
 
@@ -972,5 +997,39 @@ mod tests {
         assert_eq!(detail.rows[0].n_event, 2);
         assert_eq!(detail.rows[1].stratum, 2);
         assert_eq!(detail.rows[1].time, 2.0);
+    }
+
+    #[test]
+    fn test_coxph_detail_materializes_counting_process_risk_matrix() {
+        let time = vec![2.0, 4.0, 5.0, 5.0];
+        let status = vec![1, 1, 1, 0];
+        let entry = vec![0.0, 2.0, 0.0, 4.0];
+        let strata = vec![0, 0, 1, 1];
+        let covariates = vec![vec![0.0]; time.len()];
+
+        let detail = compute_coxph_detail_with_options(CoxphDetailOptions {
+            time: &time,
+            status: &status,
+            covariates: &covariates,
+            coefficients: &[0.0],
+            weights: None,
+            entry_times: Some(&entry),
+            strata: Some(&strata),
+            offset: None,
+            method: "breslow",
+            center: 0.0,
+            include_riskmat: true,
+        })
+        .unwrap();
+
+        assert_eq!(
+            detail.riskmat,
+            Some(vec![
+                vec![1, 0, 0],
+                vec![0, 1, 0],
+                vec![0, 0, 1],
+                vec![0, 0, 1]
+            ])
+        );
     }
 }


### PR DESCRIPTION
## Summary
- materialize optional `coxph.detail` risk matrices during the existing Rust risk-set sweep
- remove duplicate Python event grouping, repeated risk-set scans, set construction, and matrix transposition
- keep the default path free of matrix allocation while preserving right-censored, counting-process, stratified, weighted, tied-event, and `rorder` behavior
- add low-level typing plus Rust, Python, and R parity coverage
- add no dependencies

## Performance
Release build, 1,000 observations and 1,000 event columns (1,000,000 output cells), median of 11 runs:

- plain detail: 26.748 ms -> 5.115 ms (5.2x faster)
- `riskmat=TRUE`: 62.966 ms -> 8.752 ms (7.2x faster)
- matrix-specific overhead: 36.219 ms -> 3.637 ms (10.0x faster)

## Validation
- 852 Python tests
- 1,381 core Rust tests
- 1,597 all-feature Rust tests
- full R bridge test suite, including equality with `survival::coxph.detail(..., riskmat=TRUE)`
- strict Clippy
- Ruff format and lint
- type-stub checking
- binding manifest check
- built-tarball `R CMD check`: Status OK