### PR TITLE
Compute robust right-censored variance in Rust

### DIFF
--- a/python/survival/_binding_manifest.py
+++ b/python/survival/_binding_manifest.py
@@ -875,6 +875,7 @@ BINDINGS = (
     "rmst_comparison",
     "rmst_optimal_threshold",
     "robust_counting_survfit_variance",
+    "robust_right_survfit_variance",
     "robust_survfitkm",
     "robustness_analysis",
     "roc_plot_data",

--- a/python/survival/_survival.pyi
+++ b/python/survival/_survival.pyi
@@ -5889,6 +5889,20 @@ def survfitkm_counting_influence(
     conf_type: str | None = None,
     timefix: bool | None = None,
 ) -> SurvFitKMInfluenceOutput: ...
+def robust_right_survfit_variance(
+    time: list[float],
+    status: list[int],
+    curve_time: list[float],
+    curve_estimate: list[float],
+    cluster: list[int],
+    weights: list[float] | None = None,
+    reverse: bool | None = None,
+    conf_level: float | None = None,
+    conf_type: str | None = None,
+    timefix: bool | None = None,
+    stype: int = 1,
+    ctype: int = 1,
+) -> tuple[list[float], list[float], list[float], list[float]]: ...
 def robust_counting_survfit_variance(
     start: list[float],
     stop: list[float],

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -11713,15 +11713,6 @@ def _survfit_robust_km_result(
     )
 
 
-def _matrix_column_norms(matrix: list[list[float]]) -> list[float]:
-    if not matrix:
-        return []
-    width = len(matrix[0])
-    return [
-        math.sqrt(sum(float(row[col]) * float(row[col]) for row in matrix)) for col in range(width)
-    ]
-
-
 def _survfit_robust_right_result(
     result: SurvfitResult,
     response: Surv,
@@ -11742,32 +11733,20 @@ def _survfit_robust_right_result(
     if len(cluster_values) != len(response):
         raise ValueError("cluster must have the same length as the Surv response")
 
-    influence = survfitkm_influence(
+    std_err, std_chaz, conf_lower, conf_upper = _core.robust_right_survfit_variance(
         list(response.time),
         list(response.event),
-        cluster_values,
+        [float(value) for value in result.time],
+        [float(value) for value in result.estimate],
+        _encode_labels(cluster_values, "cluster"),
         weights=weights,
         reverse=reverse,
-        stype=computation.stype,
-        ctype=computation.ctype,
         conf_level=conf_level,
         conf_type=conf_type,
         timefix=timefix,
+        stype=computation.stype,
+        ctype=computation.ctype,
     )
-    std_err = _matrix_column_norms(influence.influence_surv)
-    std_chaz = _matrix_column_norms(influence.influence_chaz)
-    if conf_type == "none":
-        conf_lower: list[float] = []
-        conf_upper: list[float] = []
-    else:
-        alpha = 1.0 - conf_level
-        z = NormalDist().inv_cdf(1.0 - alpha / 2.0)
-        intervals = [
-            _survfit_confidence_interval(estimate, se, z, conf_type)
-            for estimate, se in zip(result.estimate, std_err, strict=True)
-        ]
-        conf_lower = [lower for lower, _upper in intervals]
-        conf_upper = [upper for _lower, upper in intervals]
 
     return SurvfitResult(
         time=result.time,
@@ -11775,11 +11754,11 @@ def _survfit_robust_right_result(
         n_event=result.n_event,
         n_censor=result.n_censor,
         estimate=result.estimate,
-        std_err=std_err,
-        conf_lower=conf_lower,
-        conf_upper=conf_upper,
+        std_err=[float(value) for value in std_err],
+        conf_lower=[float(value) for value in conf_lower],
+        conf_upper=[float(value) for value in conf_upper],
         cumhaz=result.cumhaz,
-        std_chaz=std_chaz,
+        std_chaz=[float(value) for value in std_chaz],
         n_enter=result.n_enter,
         n_risk_count=result.n_risk_count,
         n_event_count=result.n_event_count,

--- a/python/tests/test_binding_contract.py
+++ b/python/tests/test_binding_contract.py
@@ -3722,6 +3722,7 @@ def test_survfitkm_bindings_are_typed():
         "survfitkm_influence",
         "survfitkm_counting_influence",
         "robust_survfitkm",
+        "robust_right_survfit_variance",
         "robust_counting_survfit_variance",
         "survfitkm_with_options",
         "counting_survfit_tables",
@@ -3825,6 +3826,34 @@ def test_survfitkm_bindings_are_typed():
         "conf_level",
         "conf_type",
         "timefix",
+    ]
+    assert list(inspect.signature(core.robust_right_survfit_variance).parameters) == [
+        "time",
+        "status",
+        "curve_time",
+        "curve_estimate",
+        "cluster",
+        "weights",
+        "reverse",
+        "conf_level",
+        "conf_type",
+        "timefix",
+        "stype",
+        "ctype",
+    ]
+    assert _pyi_function_arg_names(stub_path, "robust_right_survfit_variance") == [
+        "time",
+        "status",
+        "curve_time",
+        "curve_estimate",
+        "cluster",
+        "weights",
+        "reverse",
+        "conf_level",
+        "conf_type",
+        "timefix",
+        "stype",
+        "ctype",
     ]
     assert list(inspect.signature(core.robust_counting_survfit_variance).parameters) == [
         "start",
@@ -4049,6 +4078,13 @@ def test_survfitkm_bindings_are_typed():
         [1.0, 1.0, 0.0, 1.0, 0.0, 1.0],
         [0, 0, 1, 1, 2, 2],
     )
+    robust_right = core.robust_right_survfit_variance(
+        [1.0, 2.0, 3.0, 4.0],
+        [1.0, 0.0, 1.0, 0.0],
+        influence.time,
+        [0.75, 0.75, 0.375, 0.375],
+        [0, 1, 2, 3],
+    )
     robust_counting = core.robust_counting_survfit_variance(
         [0.0, 2.0, 0.0, 3.0, 0.0, 4.0],
         [2.0, 5.0, 3.0, 6.0, 4.0, 7.0],
@@ -4131,6 +4167,18 @@ def test_survfitkm_bindings_are_typed():
     assert influence.influence_surv[3] == pytest.approx([0.0625, 0.0625, 0.21875, 0.21875])
     assert robust.std_err == pytest.approx(
         [0.1360828, 0.2721655, 0.2721655, 0.2771598, 0.2771598, 0.0]
+    )
+    assert robust_right[0] == pytest.approx(
+        [
+            sum(row[column] ** 2 for row in influence.influence_surv) ** 0.5
+            for column in range(len(influence.time))
+        ]
+    )
+    assert robust_right[1] == pytest.approx(
+        [
+            sum(row[column] ** 2 for row in influence.influence_chaz) ** 0.5
+            for column in range(len(influence.time))
+        ]
     )
     assert robust_counting[0] == pytest.approx([0.0, 0.2721655, 0.1814437, 0.1814437, 0.0])
     assert robust_counting[1] == pytest.approx([0.0, 0.2721655, 0.2721655, 0.2721655, 0.2721655])

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -4087,6 +4087,15 @@ def test_survfit_non_km_right_censored_curves_support_robust_variance():
 
     fh = survival.survfit(response, cluster=cluster, type="fleming-harrington")
     fh2 = survival.survfit(response, cluster=cluster, type="fh2")
+    reverse_fh2 = survival.survfit(response, cluster=cluster, type="fh2", reverse=True)
+    reverse_influence = survival.survfitkm_influence(
+        time,
+        status,
+        cluster,
+        reverse=True,
+        stype=2,
+        ctype=2,
+    )
     km_survival_fh2_hazard = survival.survfit(response, cluster=cluster, stype=1, ctype=2)
     grouped = survival.survfit(
         response,
@@ -4111,6 +4120,18 @@ def test_survfit_non_km_right_censored_curves_support_robust_variance():
     assert fh2.std_err == pytest.approx([0.1627183900, 0.1508161491, 0.1508161491])
     assert fh2.std_chaz == pytest.approx([0.2347891095, 0.5007272489, 0.5007272489])
     assert fh2.conf_lower == pytest.approx([0.4374272533, 0.1128825508, 0.1128825508])
+    assert reverse_fh2.std_err == pytest.approx(
+        [
+            math.sqrt(sum(row[column] ** 2 for row in reverse_influence.influence_surv))
+            for column in range(len(reverse_influence.time))
+        ]
+    )
+    assert reverse_fh2.std_chaz == pytest.approx(
+        [
+            math.sqrt(sum(row[column] ** 2 for row in reverse_influence.influence_chaz))
+            for column in range(len(reverse_influence.time))
+        ]
+    )
     assert km_survival_fh2_hazard.estimate == pytest.approx([2.0 / 3.0, 2.0 / 9.0, 2.0 / 9.0])
     assert km_survival_fh2_hazard.std_err == pytest.approx(
         [0.1924500897, 0.1924500897, 0.1924500897]

--- a/src/api/python/classical/survival_models.rs
+++ b/src/api/python/classical/survival_models.rs
@@ -10,6 +10,7 @@ pub(super) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(survfitkm_influence, m)?)?;
     m.add_function(wrap_pyfunction!(survfitkm_counting_influence, m)?)?;
     m.add_function(wrap_pyfunction!(robust_counting_survfit_variance, m)?)?;
+    m.add_function(wrap_pyfunction!(robust_right_survfit_variance, m)?)?;
     m.add_function(wrap_pyfunction!(counting_survfit_tables, m)?)?;
     m.add_function(wrap_pyfunction!(survfit_curve_from_tables, m)?)?;
     m.add_function(wrap_pyfunction!(survfitaj, m)?)?;

--- a/src/surv_analysis/mod.rs
+++ b/src/surv_analysis/mod.rs
@@ -76,7 +76,7 @@ pub use survfitaj_module::{SurvFitAJ, survfitaj};
 pub use survfitkm_module::{
     CountingSurvfitTables, KaplanMeierConfig, SurvFitKMInfluenceOutput, SurvFitKMOutput,
     SurvfitCurveResult, SurvfitKMOptions, compute_robust_survfitkm_with_timefix, compute_survfitkm,
-    counting_survfit_tables, robust_counting_survfit_variance, robust_survfitkm,
-    survfit_curve_from_tables, survfitkm, survfitkm_counting_influence, survfitkm_influence,
-    survfitkm_with_options,
+    counting_survfit_tables, robust_counting_survfit_variance, robust_right_survfit_variance,
+    robust_survfitkm, survfit_curve_from_tables, survfitkm, survfitkm_counting_influence,
+    survfitkm_influence, survfitkm_with_options,
 };

--- a/src/surv_analysis/survfitkm.rs
+++ b/src/surv_analysis/survfitkm.rs
@@ -1424,6 +1424,167 @@ pub fn compute_robust_survfitkm_with_timefix(
 }
 
 #[allow(clippy::too_many_arguments)]
+fn compute_right_survfit_influence_curve(
+    time: &[f64],
+    status: &[f64],
+    weights: &[f64],
+    reverse: bool,
+    stype: i32,
+    ctype: i32,
+    conf_level: f64,
+    conf_type: &str,
+    timefix: bool,
+) -> (Vec<f64>, Vec<f64>) {
+    let km_config = KaplanMeierConfig {
+        reverse,
+        computation_type: 0,
+        conf_level,
+        conf_type: conf_type.to_string(),
+    };
+    let position = vec![0; time.len()];
+    let km =
+        compute_survfitkm_with_timefix(time, status, weights, None, &position, &km_config, timefix);
+    if stype == 1 {
+        return (km.time, km.estimate);
+    }
+    let curve = compute_survfit_curve_from_tables(
+        &km.time,
+        &km.n_risk,
+        &km.n_event,
+        &km.n_event_count,
+        &km.n_censor,
+        &km.n_censor_count,
+        None,
+        reverse,
+        stype,
+        ctype,
+        conf_level,
+        conf_type,
+    );
+    (curve.time, curve.estimate)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn compute_robust_right_survfit_variance_with_timefix(
+    time: &[f64],
+    status: &[f64],
+    weights: &[f64],
+    reported_curve_time: &[f64],
+    reported_curve_estimate: &[f64],
+    cluster: &[i32],
+    config: &KaplanMeierConfig,
+    timefix: bool,
+    stype: i32,
+    ctype: i32,
+) -> PyResult<RobustSurvfitVarianceOutput> {
+    let (curve_time, influence_estimate) = compute_right_survfit_influence_curve(
+        time,
+        status,
+        weights,
+        config.reverse,
+        stype,
+        ctype,
+        config.conf_level,
+        &config.conf_type,
+        timefix,
+    );
+    if curve_time.len() != reported_curve_time.len()
+        || curve_time
+            .iter()
+            .zip(reported_curve_time)
+            .any(|(&actual, &reported)| !same_survfit_time(actual, reported, timefix))
+    {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "curve_time does not match the right-censored survival curve",
+        ));
+    }
+    let fixed_time = survfit_timefix_values(time, timefix);
+    let cluster_codes = compact_i32_labels(cluster);
+    let n_clusters = cluster_codes
+        .iter()
+        .copied()
+        .max()
+        .map_or(0, |max_code| max_code + 1);
+    let mut risk_by_cluster = vec![0.0; n_clusters];
+    for (&code, &weight) in cluster_codes.iter().zip(weights.iter()) {
+        risk_by_cluster[code] += weight;
+    }
+    let mut total_risk: f64 = weights.iter().sum();
+    let mut survival_score = vec![0.0; n_clusters];
+    let mut chaz_score = vec![0.0; n_clusters];
+    let mut events_by_cluster = vec![0.0; n_clusters];
+    let order = sorted_indices_by(&fixed_time);
+    let mut cursor = 0;
+    let mut robust_std_err = Vec::with_capacity(curve_time.len());
+    let mut robust_std_chaz = Vec::with_capacity(curve_time.len());
+
+    for (&curve_time, &survival) in curve_time.iter().zip(influence_estimate.iter()) {
+        while cursor < order.len()
+            && survfit_time_before(fixed_time[order[cursor]], curve_time, timefix)
+        {
+            consume_robust_exit_time(
+                &mut cursor,
+                &mut total_risk,
+                &order,
+                &fixed_time,
+                status,
+                weights,
+                &cluster_codes,
+                &mut risk_by_cluster,
+                &mut survival_score,
+                &mut chaz_score,
+                &mut events_by_cluster,
+                config.reverse,
+                timefix,
+                ctype,
+            );
+        }
+        if cursor < order.len() && same_survfit_time(fixed_time[order[cursor]], curve_time, timefix)
+        {
+            consume_robust_exit_time(
+                &mut cursor,
+                &mut total_risk,
+                &order,
+                &fixed_time,
+                status,
+                weights,
+                &cluster_codes,
+                &mut risk_by_cluster,
+                &mut survival_score,
+                &mut chaz_score,
+                &mut events_by_cluster,
+                config.reverse,
+                timefix,
+                ctype,
+            );
+        }
+
+        let survival_variance: f64 = if stype == 1 {
+            survival_score.iter().map(|value| value * value).sum()
+        } else {
+            chaz_score.iter().map(|value| value * value).sum()
+        };
+        let chaz_variance: f64 = chaz_score.iter().map(|value| value * value).sum();
+        robust_std_err.push(survival.abs() * survival_variance.sqrt());
+        robust_std_chaz.push(chaz_variance.sqrt());
+    }
+
+    let alpha = 1.0 - config.conf_level;
+    let z = normal_inverse_cdf(1.0 - alpha / 2.0);
+    let (conf_lower, conf_upper): (Vec<f64>, Vec<f64>) = if config.conf_type == "none" {
+        (vec![], vec![])
+    } else {
+        reported_curve_estimate
+            .iter()
+            .zip(robust_std_err.iter())
+            .map(|(&survival, &se)| compute_confidence_interval(survival, se, z, &config.conf_type))
+            .unzip()
+    };
+
+    Ok((robust_std_err, robust_std_chaz, conf_lower, conf_upper))
+}
+
+#[allow(clippy::too_many_arguments)]
 fn compute_robust_counting_survfit_variance_with_timefix(
     start: &[f64],
     stop: &[f64],
@@ -1609,6 +1770,46 @@ fn validate_robust_counting_survfit_inputs(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
+fn validate_robust_right_survfit_inputs(
+    time: &[f64],
+    status: &[f64],
+    weights: &[f64],
+    curve_time: &[f64],
+    curve_estimate: &[f64],
+    cluster: &[i32],
+    timefix: bool,
+) -> PyResult<()> {
+    validate_non_empty(time, "time")?;
+    validate_length(time.len(), status.len(), "status")?;
+    validate_length(time.len(), weights.len(), "weights")?;
+    validate_length(time.len(), cluster.len(), "cluster")?;
+    validate_length(curve_time.len(), curve_estimate.len(), "curve_estimate")?;
+    validate_no_nan(time, "time")?;
+    validate_finite(time, "time")?;
+    validate_non_negative(time, "time")?;
+    validate_no_nan(status, "status")?;
+    validate_finite(status, "status")?;
+    validate_binary_f64(status, "status")?;
+    validate_no_nan(weights, "weights")?;
+    validate_finite(weights, "weights")?;
+    validate_non_negative(weights, "weights")?;
+    validate_no_nan(curve_time, "curve_time")?;
+    validate_finite(curve_time, "curve_time")?;
+    validate_non_negative(curve_time, "curve_time")?;
+    validate_no_nan(curve_estimate, "curve_estimate")?;
+    validate_finite(curve_estimate, "curve_estimate")?;
+
+    for window in curve_time.windows(2) {
+        if survfit_time_before(window[1], window[0], timefix) {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "curve_time must be sorted in ascending order",
+            ));
+        }
+    }
+    Ok(())
+}
+
 #[pyfunction]
 #[pyo3(signature = (time, status, cluster, weights=None, reverse=None, conf_level=None, conf_type=None, timefix=None))]
 #[allow(clippy::too_many_arguments)]
@@ -1671,48 +1872,9 @@ pub fn compute_survfitkm_influence_with_timefix(
     conf_type: &str,
     timefix: bool,
 ) -> PyResult<SurvFitKMInfluenceOutput> {
-    let km_config = KaplanMeierConfig {
-        reverse,
-        computation_type: 0,
-        conf_level,
-        conf_type: conf_type.to_string(),
-    };
-    let position = vec![0; time.len()];
-    let km =
-        compute_survfitkm_with_timefix(time, status, weights, None, &position, &km_config, timefix);
-    let curve = if stype == 1 {
-        km.clone()
-    } else {
-        let fh_curve = compute_survfit_curve_from_tables(
-            &km.time,
-            &km.n_risk,
-            &km.n_event,
-            &km.n_event_count,
-            &km.n_censor,
-            &km.n_censor_count,
-            None,
-            reverse,
-            stype,
-            ctype,
-            conf_level,
-            conf_type,
-        );
-        SurvFitKMOutput {
-            time: fh_curve.time,
-            n_risk: fh_curve.n_risk,
-            n_risk_count: km.n_risk_count,
-            n_event: fh_curve.n_event,
-            n_event_count: km.n_event_count,
-            n_censor: fh_curve.n_censor,
-            n_censor_count: km.n_censor_count,
-            estimate: fh_curve.estimate,
-            std_err: fh_curve.std_err,
-            cumhaz: fh_curve.cumhaz,
-            std_chaz: fh_curve.std_chaz,
-            conf_lower: fh_curve.conf_lower,
-            conf_upper: fh_curve.conf_upper,
-        }
-    };
+    let (curve_time, curve_estimate) = compute_right_survfit_influence_curve(
+        time, status, weights, reverse, stype, ctype, conf_level, conf_type, timefix,
+    );
 
     let fixed_time = survfit_timefix_values(time, timefix);
     let cluster_codes = compact_i32_labels(cluster);
@@ -1731,10 +1893,10 @@ pub fn compute_survfitkm_influence_with_timefix(
     let mut events_by_cluster = vec![0.0; n_clusters];
     let order = sorted_indices_by(&fixed_time);
     let mut cursor = 0;
-    let mut influence_surv = vec![Vec::with_capacity(curve.time.len()); n_clusters];
-    let mut influence_chaz = vec![Vec::with_capacity(curve.time.len()); n_clusters];
+    let mut influence_surv = vec![Vec::with_capacity(curve_time.len()); n_clusters];
+    let mut influence_chaz = vec![Vec::with_capacity(curve_time.len()); n_clusters];
 
-    for (&curve_time, &survival) in curve.time.iter().zip(curve.estimate.iter()) {
+    for (&curve_time, &survival) in curve_time.iter().zip(curve_estimate.iter()) {
         while cursor < order.len()
             && survfit_time_before(fixed_time[order[cursor]], curve_time, timefix)
         {
@@ -1787,7 +1949,7 @@ pub fn compute_survfitkm_influence_with_timefix(
     }
 
     Ok(SurvFitKMInfluenceOutput {
-        time: curve.time,
+        time: curve_time,
         influence_surv,
         influence_chaz,
     })
@@ -2048,6 +2210,73 @@ pub fn survfitkm_counting_influence(
 }
 
 #[pyfunction]
+#[pyo3(signature = (time, status, curve_time, curve_estimate, cluster, weights=None, reverse=None, conf_level=None, conf_type=None, timefix=None, stype=1, ctype=1))]
+#[allow(clippy::too_many_arguments)]
+pub fn robust_right_survfit_variance(
+    time: &Bound<'_, PyAny>,
+    status: &Bound<'_, PyAny>,
+    curve_time: &Bound<'_, PyAny>,
+    curve_estimate: &Bound<'_, PyAny>,
+    cluster: &Bound<'_, PyAny>,
+    weights: Option<&Bound<'_, PyAny>>,
+    reverse: Option<bool>,
+    conf_level: Option<f64>,
+    conf_type: Option<String>,
+    timefix: Option<bool>,
+    stype: i32,
+    ctype: i32,
+) -> PyResult<RobustSurvfitVarianceOutput> {
+    let time = extract_vec_f64(time)?;
+    let status = extract_vec_f64(status)?;
+    let curve_time = extract_vec_f64(curve_time)?;
+    let curve_estimate = extract_vec_f64(curve_estimate)?;
+    let cluster = extract_vec_i32(cluster)?;
+    let weights = match extract_optional_vec_f64(weights)? {
+        Some(w) => w,
+        None => vec![1.0; time.len()],
+    };
+    let timefix = timefix.unwrap_or(true);
+    let config = KaplanMeierConfig {
+        reverse: reverse.unwrap_or(false),
+        computation_type: 0,
+        conf_level: conf_level.unwrap_or(DEFAULT_CONFIDENCE_LEVEL),
+        conf_type: normalize_conf_type(conf_type.as_deref())?,
+    };
+    validate_conf_level(config.conf_level)?;
+    if stype != 1 && stype != 2 {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "stype must be 1 or 2",
+        ));
+    }
+    if ctype != 1 && ctype != 2 {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "ctype must be 1 or 2",
+        ));
+    }
+    validate_robust_right_survfit_inputs(
+        &time,
+        &status,
+        &weights,
+        &curve_time,
+        &curve_estimate,
+        &cluster,
+        timefix,
+    )?;
+    compute_robust_right_survfit_variance_with_timefix(
+        &time,
+        &status,
+        &weights,
+        &curve_time,
+        &curve_estimate,
+        &cluster,
+        &config,
+        timefix,
+        stype,
+        ctype,
+    )
+}
+
+#[pyfunction]
 #[pyo3(signature = (start, stop, status, curve_time, curve_estimate, cluster, weights=None, reverse=None, conf_level=None, conf_type=None, timefix=None, stype=1, ctype=1))]
 #[allow(clippy::too_many_arguments)]
 pub fn robust_counting_survfit_variance(
@@ -2295,6 +2524,121 @@ mod tests {
             ],
             1e-6,
         );
+    }
+
+    #[test]
+    fn test_robust_right_variance_matches_materialized_influence_norms() {
+        let time = vec![1.0, 2.0, 2.0, 3.0, 4.0, 5.0];
+        let status = vec![1.0, 1.0, 1.0, 0.0, 1.0, 0.0];
+        let weights = vec![1.0, 0.5, 1.5, 1.0, 2.0, 0.75];
+        let cluster = vec![1, 1, 2, 2, 3, 3];
+        let config = KaplanMeierConfig::default();
+        let position = vec![0; time.len()];
+        let km = compute_survfitkm_with_timefix(
+            &time, &status, &weights, None, &position, &config, true,
+        );
+
+        for (stype, ctype) in [(1, 1), (2, 1), (2, 2)] {
+            let (curve_time, curve_estimate) = if stype == 1 {
+                (km.time.clone(), km.estimate.clone())
+            } else {
+                let curve = compute_survfit_curve_from_tables(
+                    &km.time,
+                    &km.n_risk,
+                    &km.n_event,
+                    &km.n_event_count,
+                    &km.n_censor,
+                    &km.n_censor_count,
+                    None,
+                    false,
+                    stype,
+                    ctype,
+                    config.conf_level,
+                    &config.conf_type,
+                );
+                (curve.time, curve.estimate)
+            };
+            let influence = compute_survfitkm_influence_with_timefix(
+                &time,
+                &status,
+                &weights,
+                &cluster,
+                false,
+                stype,
+                ctype,
+                config.conf_level,
+                &config.conf_type,
+                true,
+            )
+            .expect("influence matrices should compute");
+            let column_norms = |matrix: &[Vec<f64>]| {
+                (0..curve_time.len())
+                    .map(|column| {
+                        matrix
+                            .iter()
+                            .map(|row| row[column] * row[column])
+                            .sum::<f64>()
+                            .sqrt()
+                    })
+                    .collect::<Vec<_>>()
+            };
+            let expected_std_err = column_norms(&influence.influence_surv);
+            let expected_std_chaz = column_norms(&influence.influence_chaz);
+            let (std_err, std_chaz, lower, upper) =
+                compute_robust_right_survfit_variance_with_timefix(
+                    &time,
+                    &status,
+                    &weights,
+                    &curve_time,
+                    &curve_estimate,
+                    &cluster,
+                    &config,
+                    true,
+                    stype,
+                    ctype,
+                )
+                .expect("robust variance should compute");
+
+            assert_vec_approx(&std_err, &expected_std_err, 1e-12);
+            assert_vec_approx(&std_chaz, &expected_std_chaz, 1e-12);
+            assert_eq!(lower.len(), curve_time.len());
+            assert_eq!(upper.len(), curve_time.len());
+        }
+
+        let fh2_curve = compute_survfit_curve_from_tables(
+            &km.time,
+            &km.n_risk,
+            &km.n_event,
+            &km.n_event_count,
+            &km.n_censor,
+            &km.n_censor_count,
+            None,
+            false,
+            2,
+            2,
+            config.conf_level,
+            &config.conf_type,
+        );
+        let mut reported_estimate = fh2_curve.estimate.clone();
+        *reported_estimate
+            .last_mut()
+            .expect("curve should not be empty") = -f64::EPSILON;
+        let (_std_err, _std_chaz, lower, upper) =
+            compute_robust_right_survfit_variance_with_timefix(
+                &time,
+                &status,
+                &weights,
+                &fh2_curve.time,
+                &reported_estimate,
+                &cluster,
+                &config,
+                true,
+                2,
+                2,
+            )
+            .expect("tiny negative reported tail should remain supported");
+        assert_eq!(lower.last(), Some(&0.0));
+        assert_eq!(upper.last(), Some(&0.0));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- compute robust survival and cumulative-hazard standard errors during the native right-censored risk-set sweep
- return confidence limits directly from the same native call
- avoid materializing two cluster-by-time influence matrices and scanning their columns in Python
- share internal curve construction with the retained public influence API, preserving KM, Fleming–Harrington, FH2, reverse, tied-time, weighted, clustered, exact-time, and confidence-transform behavior
- preserve tiny negative numerical FH tails and the established reverse-FH2 variance semantics
- add no dependencies

## Performance
Deterministic release benchmark using robust Fleming–Harrington fits with one cluster per observation:

- 250 rows: 6.090 ms -> 0.294 ms (20.7x)
- 500 rows: 25.764 ms -> 0.770 ms (33.5x)
- 1,000 rows: 118.285 ms -> 2.380 ms (49.7x)

At 1,000 rows this also avoids allocating and converting two 1,000-by-1,000 influence matrices.

## Validation
- 200 randomized right-censored cases matched materialized influence norms within 1e-12 across weights, clusters, ties, reverse fits, all three survival styles, all confidence transforms, and both time-fix modes
- 852 Python tests
- 1,381 core Rust tests
- 1,597 all-feature Rust tests
- complete R bridge suite
- isolated built-tarball R check: Status OK
- strict Clippy across no-default, ML, and Python+ML configurations
- Ruff formatting/lint, type stubs, and generated binding manifest checks