### PR TITLE
Avoid duplicate pyears input passes

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -5970,7 +5970,22 @@ def _pyears_group_codes(
     values = _materialize_labels(group, "group")
     if len(values) != n:
         raise ValueError("group must have the same length as the response")
-    group_levels = tuple(levels) if levels is not None else _label_levels(values, "group")
+    if levels is None:
+        group_levels: list[Any] = []
+        labels: dict[Any, int] = {}
+        codes: list[float] = []
+        for value in values:
+            try:
+                code = labels.get(value)
+                if code is None:
+                    code = len(labels) + 1
+                    labels[value] = code
+                    group_levels.append(value)
+            except TypeError as exc:
+                raise TypeError("group contains unhashable labels") from exc
+            codes.append(float(code))
+        return codes, [str(value) for value in group_levels]
+    group_levels = tuple(levels)
     labels = {value: idx + 1 for idx, value in enumerate(group_levels)}
     try:
         codes = [float(labels[value]) for value in values]
@@ -6078,6 +6093,7 @@ def pyears(
 ) -> PyearsResult | dict[str, list[Any]]:
     """Tabulate person-years for direct ``Surv``/formula inputs, like R's ``pyears``."""
 
+    direct_inputs_ready = False
     if isinstance(response, str) and "~" in response:
         response, formula_group, formula_group_levels, formula_weights = _pyears_formula_inputs(
             response,
@@ -6092,7 +6108,7 @@ def pyears(
         weights = formula_weights
     else:
         formula_group_levels = None
-        start_values, stop_values, event_values, _ny, _do_event = _pyears_response_from_direct(
+        start_values, stop_values, event_values, ny, do_event = _pyears_response_from_direct(
             response,
             time=time,
             start=start,
@@ -6119,13 +6135,16 @@ def pyears(
             else:
                 group = _subset_optional_sequence(group, keep, "group")
             weights = _subset_optional_sequence(weights, keep, "weights")
-    start_values, stop_values, event_values, ny, do_event = _pyears_response_from_direct(
-        response,
-        time=time,
-        start=start,
-        stop=stop,
-        event=event,
-    )
+        else:
+            direct_inputs_ready = True
+    if not direct_inputs_ready:
+        start_values, stop_values, event_values, ny, do_event = _pyears_response_from_direct(
+            response,
+            time=time,
+            start=start,
+            stop=stop,
+            event=event,
+        )
     n = len(stop_values)
     event_for_core = [0.0] * n if event_values is None else [float(value) for value in event_values]
     _pyears_validate_time_columns(start_values, stop_values, event_values)

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -2961,6 +2961,28 @@ def test_r_style_pyears_tabulates_surv_inputs():
         survival.pyears([1.0], scale=0)
 
 
+def test_pyears_normalizes_direct_inputs_once_without_subsetting(monkeypatch):
+    original = survival.r_api._pyears_response_from_direct
+    calls = 0
+
+    def tracked(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(survival.r_api, "_pyears_response_from_direct", tracked)
+
+    result = survival.pyears(
+        [10.0, 20.0, 30.0],
+        event=[1, 0, 1],
+        group=["a", "b", "a"],
+        scale=1,
+    )
+
+    assert result.pyears == pytest.approx([40.0, 20.0])
+    assert calls == 1
+
+
 def test_r_style_finegray_matches_right_multistate_fixture():
     data = {
         "id": list(range(1, 9)),


### PR DESCRIPTION
## Summary
- normalize direct `pyears` responses once when no subset is requested
- retain the second normalization only for subsetted inputs that must be rebuilt
- assign first-seen direct group levels and numeric codes in one pass
- preserve formula, subset, counting-process, weight, event, and `tcut` behavior
- add no dependencies

## Performance
Median runtime for direct grouped `pyears` inputs with 20 groups:

| Rows | Before | After | Speedup |
| ---: | ---: | ---: | ---: |
| 100,000 | 23.366 ms | 17.032 ms | 1.37x |
| 250,000 | 58.566 ms | 43.529 ms | 1.35x |
| 500,000 | 119.339 ms | 87.475 ms | 1.36x |
| 1,000,000 | 238.925 ms | 175.943 ms | 1.36x |

## Validation
- 300 randomized right, counting, weighted, grouped, and subsetted equivalence cases matched the previous implementation
- 853 Python tests
- full R bridge suite
- R package check: `Status: OK`
- Python lint, format, binding manifest, and diff checks