### PR TITLE
Aggregate shared-time Cox curves in Rust

### DIFF
--- a/python/survival/_binding_manifest.py
+++ b/python/survival/_binding_manifest.py
@@ -505,6 +505,7 @@ BINDINGS = (
     "adversarial_training_survival",
     "aeq_surv",
     "agexact",
+    "aggregate_shared_survfit",
     "aggregate_survfit",
     "aggregate_survfit_by_group",
     "aggregate_survshap",
@@ -1714,6 +1715,7 @@ MODULE_BINDINGS = {
     ),
     "surv_analysis": (
         "AggregateSurvfitResult",
+        "aggregate_shared_survfit",
         "aggregate_survfit",
         "aggregate_survfit_by_group",
         "agsurv4",

--- a/python/survival/_survival.pyi
+++ b/python/survival/_survival.pyi
@@ -5989,6 +5989,13 @@ def aggregate_survfit_by_group(
     groups: list[int],
     weights: list[float] | None = None,
 ) -> list[AggregateSurvfitResult]: ...
+def aggregate_shared_survfit(
+    time: list[float],
+    survs: list[list[float]],
+    std_errs: list[list[float]] | None = None,
+    weights: list[float] | None = None,
+    groups: list[int] | None = None,
+) -> list[AggregateSurvfitResult]: ...
 def survcheck(
     id: list[int],
     time1: list[float],

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -12465,7 +12465,7 @@ def aggregate_survfit_result(
             model=result.model,
         )
 
-    curve_times = [[float(value) for value in result.time] for _ in range(n_curves)]
+    curve_time = [float(value) for value in result.time]
     curve_survs = [[float(value) for value in curve] for curve in result.surv]
     curve_std_errs = (
         [[float(value) for value in curve] for curve in result.std_err] if result.std_err else None
@@ -12473,15 +12473,15 @@ def aggregate_survfit_result(
     curve_weights = _float_vector(weights, "weights") if weights is not None else None
 
     if groups is None:
-        aggregate = _core.aggregate_survfit(
-            curve_times,
+        aggregates = _core.aggregate_shared_survfit(
+            curve_time,
             curve_survs,
             curve_std_errs,
             curve_weights,
             None,
         )
         linear_predictor = _weighted_average(result.linear_predictors, curve_weights)
-        return _cox_survfit_from_aggregates(result, [aggregate], [linear_predictor])
+        return _cox_survfit_from_aggregates(result, aggregates, [linear_predictor])
 
     group_codes = _integer_code_vector(groups, "groups", "integer group codes")
     if len(group_codes) != n_curves:
@@ -12489,34 +12489,24 @@ def aggregate_survfit_result(
     if any(code < 1 for code in group_codes):
         raise ValueError("groups must use positive integer group codes")
 
-    if len(set(group_codes)) == 1:
-        return aggregate_survfit_result(result, weights=curve_weights)
-
-    indices_by_group: dict[int, list[int]] = {}
+    aggregates = _core.aggregate_shared_survfit(
+        curve_time,
+        curve_survs,
+        curve_std_errs,
+        curve_weights,
+        group_codes,
+    )
+    predictor_sums: dict[int, float] = {}
+    predictor_weights: dict[int, float] = {}
     for idx, code in enumerate(group_codes):
-        indices_by_group.setdefault(code, []).append(idx)
-
-    aggregates = []
-    linear_predictors = []
-    for code in sorted(indices_by_group):
-        indices = indices_by_group[code]
-        group_weights = (
-            [curve_weights[idx] for idx in indices] if curve_weights is not None else None
+        weight = 1.0 if curve_weights is None else curve_weights[idx]
+        predictor_sums[code] = predictor_sums.get(code, 0.0) + (
+            float(result.linear_predictors[idx]) * weight
         )
-        aggregate = _core.aggregate_survfit(
-            [curve_times[idx] for idx in indices],
-            [curve_survs[idx] for idx in indices],
-            [curve_std_errs[idx] for idx in indices] if curve_std_errs is not None else None,
-            group_weights,
-            None,
-        )
-        aggregates.append(aggregate)
-        linear_predictors.append(
-            _weighted_average(
-                [float(result.linear_predictors[idx]) for idx in indices],
-                group_weights,
-            )
-        )
+        predictor_weights[code] = predictor_weights.get(code, 0.0) + weight
+    linear_predictors = [
+        predictor_sums[code] / predictor_weights[code] for code in sorted(predictor_sums)
+    ]
 
     return _cox_survfit_from_aggregates(result, aggregates, linear_predictors)
 

--- a/python/survival/surv_analysis.py
+++ b/python/survival/surv_analysis.py
@@ -4,6 +4,7 @@ __all__ = bind_names(
     globals(),
     [
         "AggregateSurvfitResult",
+        "aggregate_shared_survfit",
         "aggregate_survfit",
         "aggregate_survfit_by_group",
         "agsurv4",

--- a/python/tests/test_binding_contract.py
+++ b/python/tests/test_binding_contract.py
@@ -4669,6 +4669,7 @@ def test_aggregate_survfit_bindings_are_typed():
 
     assert {
         "AggregateSurvfitResult",
+        "aggregate_shared_survfit",
         "aggregate_survfit",
         "aggregate_survfit_by_group",
     } <= stub_names
@@ -4686,6 +4687,13 @@ def test_aggregate_survfit_bindings_are_typed():
         "groups",
         "weights",
     ]
+    assert list(inspect.signature(core.aggregate_shared_survfit).parameters) == [
+        "time",
+        "survs",
+        "std_errs",
+        "weights",
+        "groups",
+    ]
     assert _pyi_function_arg_names(stub_path, "aggregate_survfit") == [
         "times",
         "survs",
@@ -4698,6 +4706,13 @@ def test_aggregate_survfit_bindings_are_typed():
         "survs",
         "groups",
         "weights",
+    ]
+    assert _pyi_function_arg_names(stub_path, "aggregate_shared_survfit") == [
+        "time",
+        "survs",
+        "std_errs",
+        "weights",
+        "groups",
     ]
     assert _pyi_class_property_names(stub_path, "AggregateSurvfitResult") == {
         "time",
@@ -4730,6 +4745,17 @@ def test_aggregate_survfit_bindings_are_typed():
     )
     assert [item.n_curves for item in grouped] == [1, 2]
     assert all(type(item).__name__ == "AggregateSurvfitResult" for item in grouped)
+
+    shared = core.aggregate_shared_survfit(
+        [1.0, 2.0],
+        [[0.9, 0.8], [0.8, 0.6], [0.7, 0.4]],
+        [[0.1, 0.2], [0.3, 0.4], [0.2, 0.1]],
+        [1.0, 2.0, 3.0],
+        [2, 1, 2],
+    )
+    assert [item.n_curves for item in shared] == [1, 2]
+    assert shared[1].surv == pytest.approx([0.75, 0.5])
+    assert shared[1].weights == pytest.approx([0.25, 0.75])
 
 
 def test_survcheck_bindings_are_typed():

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -4870,6 +4870,30 @@ def test_aggregate_survfit_result_averages_cox_prediction_curves():
     assert grouped.surv[0] == pytest.approx(curves.surv[1])
     assert grouped.surv[1] == pytest.approx(expected_group)
 
+    uncertain = survival.r_api.CoxSurvfitResult(
+        time=[1.0, 2.0],
+        surv=[[0.9, 0.8], [0.8, 0.6], [0.7, 0.4]],
+        cumhaz=[[], [], []],
+        linear_predictors=[1.0, 2.0, 3.0],
+        std_err=[[0.1, 0.2], [0.3, 0.4], [0.2, 0.1]],
+        std_chaz=[[0.0], [0.0], [0.0]],
+        conf_lower=[[0.0], [0.0], [0.0]],
+        conf_upper=[[1.0], [1.0], [1.0]],
+    )
+    weighted = survival.r_api.aggregate_survfit_result(
+        uncertain,
+        groups=[2, 1, 2],
+        weights=[1.0, 2.0, 3.0],
+    )
+    assert weighted.surv[0] == pytest.approx([0.8, 0.6])
+    assert weighted.surv[1] == pytest.approx([0.75, 0.5])
+    assert weighted.std_err[0] == pytest.approx([0.3, 0.4])
+    assert weighted.std_err[1] == pytest.approx(
+        [math.hypot(0.25 * 0.1, 0.75 * 0.2), math.hypot(0.25 * 0.2, 0.75 * 0.1)]
+    )
+    assert weighted.linear_predictors == pytest.approx([2.0, 2.5])
+    assert len(weighted.conf_lower) == len(weighted.conf_upper) == 2
+
     with pytest.raises(TypeError, match="data.*margin"):
         survival.r_api.aggregate_survfit_result(object())
     with pytest.raises(ValueError, match="same length"):

--- a/src/api/python/classical/survival_models.rs
+++ b/src/api/python/classical/survival_models.rs
@@ -49,6 +49,7 @@ pub(super) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(pseudo_gee_regression, m)?)?;
     m.add_function(wrap_pyfunction!(aggregate_survfit, m)?)?;
     m.add_function(wrap_pyfunction!(aggregate_survfit_by_group, m)?)?;
+    m.add_function(wrap_pyfunction!(aggregate_shared_survfit, m)?)?;
     m.add_function(wrap_pyfunction!(survcheck, m)?)?;
     m.add_function(wrap_pyfunction!(survcheck_simple, m)?)?;
     m.add_function(wrap_pyfunction!(royston, m)?)?;

--- a/src/surv_analysis/aggregate_survfit.rs
+++ b/src/surv_analysis/aggregate_survfit.rs
@@ -322,6 +322,122 @@ pub fn aggregate_survfit_by_group(
     Ok(results)
 }
 
+#[pyfunction]
+#[pyo3(signature = (time, survs, std_errs=None, weights=None, groups=None))]
+pub fn aggregate_shared_survfit(
+    time: Vec<f64>,
+    survs: Vec<Vec<f64>>,
+    std_errs: Option<Vec<Vec<f64>>>,
+    weights: Option<Vec<f64>>,
+    groups: Option<Vec<i32>>,
+) -> PyResult<Vec<AggregateSurvfitResult>> {
+    let n_curves = survs.len();
+    if let Some(values) = std_errs.as_ref()
+        && values.len() != n_curves
+    {
+        return Err(value_error(
+            "std_errs must have same length as number of curves",
+        ));
+    }
+    if let Some(values) = weights.as_ref()
+        && values.len() != n_curves
+    {
+        return Err(value_error(
+            "weights must have same length as number of curves",
+        ));
+    }
+    if let Some(values) = groups.as_ref()
+        && values.len() != n_curves
+    {
+        return Err(value_error(
+            "groups must have same length as number of curves",
+        ));
+    }
+    validate_time_curve("time", &time)?;
+    for (index, curve) in survs.iter().enumerate() {
+        if curve.len() != time.len() {
+            return Err(value_error(format!(
+                "survs[{index}] must have the same length as time"
+            )));
+        }
+        validate_probability_curve(&format!("survs[{index}]"), curve)?;
+    }
+    if let Some(curves) = std_errs.as_ref() {
+        for (index, curve) in curves.iter().enumerate() {
+            if curve.len() != time.len() {
+                return Err(value_error(format!(
+                    "std_errs[{index}] must have the same length as time"
+                )));
+            }
+            validate_nonnegative_finite_curve(&format!("std_errs[{index}]"), curve)?;
+        }
+    }
+    if let Some(values) = weights.as_ref() {
+        validate_nonnegative_finite_curve("weights", values)?;
+    }
+    if n_curves == 0 {
+        return Ok(Vec::new());
+    }
+
+    let mut aggregate_time = time.clone();
+    aggregate_time.sort_by(|a, b| a.total_cmp(b));
+    aggregate_time.dedup_by(|a, b| (*a - *b).abs() < TIME_EPSILON);
+    let source_indices = aggregate_time
+        .iter()
+        .map(|&eval_time| {
+            time.iter()
+                .position(|&source_time| source_time > eval_time + TIME_EPSILON)
+                .unwrap_or(time.len())
+                .checked_sub(1)
+        })
+        .collect::<Vec<_>>();
+
+    let group_values = groups.unwrap_or_else(|| vec![0; n_curves]);
+    let mut grouped: BTreeMap<i32, Vec<usize>> = BTreeMap::new();
+    for (index, group) in group_values.into_iter().enumerate() {
+        grouped.entry(group).or_default().push(index);
+    }
+
+    let mut results = Vec::with_capacity(grouped.len());
+    for indices in grouped.into_values() {
+        let group_weights = weights
+            .as_ref()
+            .map(|values| indices.iter().map(|&index| values[index]).collect());
+        let normalized = normalized_weights(group_weights, indices.len())?;
+        let mut surv = vec![0.0; aggregate_time.len()];
+        let mut variance = vec![0.0; aggregate_time.len()];
+        for (&curve_index, &weight) in indices.iter().zip(&normalized) {
+            for (aggregate, source_index) in surv.iter_mut().zip(&source_indices) {
+                let value = source_index
+                    .map(|index| survs[curve_index][index])
+                    .unwrap_or(1.0);
+                *aggregate += weight * value;
+            }
+            if let Some(curves) = std_errs.as_ref() {
+                let weight_squared = weight * weight;
+                for (aggregate, source_index) in variance.iter_mut().zip(&source_indices) {
+                    let value = source_index
+                        .map(|index| curves[curve_index][index])
+                        .unwrap_or(0.0);
+                    *aggregate += weight_squared * value * value;
+                }
+            }
+        }
+        let std_err = variance.into_iter().map(f64::sqrt).collect::<Vec<_>>();
+        let (lower, upper) = clamped_normal_ci_bounds(&surv, &std_err, z_score(0.95), 0.0, 1.0);
+        results.push(AggregateSurvfitResult {
+            time: aggregate_time.clone(),
+            surv,
+            std_err,
+            lower,
+            upper,
+            n_curves: indices.len(),
+            weights: normalized,
+        });
+    }
+    Ok(results)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -425,5 +541,61 @@ mod tests {
         assert_eq!(result[1].weights, vec![1.0 / 3.0, 2.0 / 3.0]);
         assert!((result[1].surv[0] - 0.8333333333333333).abs() < 1e-12);
         assert!((result[1].surv[1] - 0.7333333333333333).abs() < 1e-12);
+    }
+
+    #[test]
+    fn aggregate_shared_survfit_groups_weighted_curves_and_errors() {
+        let result = aggregate_shared_survfit(
+            vec![1.0, 2.0],
+            vec![vec![0.9, 0.8], vec![0.8, 0.6], vec![0.7, 0.4]],
+            Some(vec![vec![0.1, 0.2], vec![0.3, 0.4], vec![0.2, 0.1]]),
+            Some(vec![1.0, 2.0, 3.0]),
+            Some(vec![2, 1, 2]),
+        )
+        .unwrap();
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].n_curves, 1);
+        assert_eq!(result[0].surv, vec![0.8, 0.6]);
+        assert_eq!(result[0].std_err, vec![0.3, 0.4]);
+        assert_eq!(result[1].n_curves, 2);
+        assert_eq!(result[1].weights, vec![0.25, 0.75]);
+        assert!((result[1].surv[0] - 0.75).abs() < 1e-12);
+        assert!((result[1].surv[1] - 0.5).abs() < 1e-12);
+        assert!((result[1].std_err[0] - 0.152_069_063_257_455_5).abs() < 1e-12);
+    }
+
+    #[test]
+    fn aggregate_shared_survfit_validates_shared_shapes_and_group_weights() {
+        assert!(
+            aggregate_shared_survfit(vec![1.0], vec![vec![0.9, 0.8]], None, None, None).is_err()
+        );
+        assert!(
+            aggregate_shared_survfit(
+                vec![1.0],
+                vec![vec![0.9], vec![0.8]],
+                None,
+                Some(vec![0.0, 1.0]),
+                Some(vec![1, 2]),
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn aggregate_shared_survfit_preserves_step_deduplication() {
+        let result = aggregate_shared_survfit(
+            vec![1.0, 1.0 + TIME_EPSILON / 2.0, 2.0],
+            vec![vec![0.9, 0.8, 0.7], vec![0.7, 0.6, 0.5]],
+            Some(vec![vec![0.1, 0.2, 0.3], vec![0.3, 0.4, 0.5]]),
+            None,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].time, vec![1.0, 2.0]);
+        assert_eq!(result[0].surv, vec![0.7, 0.6]);
+        assert!((result[0].std_err[0] - 0.223_606_797_749_978_96).abs() < 1e-12);
     }
 }

--- a/src/surv_analysis/mod.rs
+++ b/src/surv_analysis/mod.rs
@@ -27,7 +27,7 @@ pub(crate) mod survfitaj_module;
 pub(crate) mod survfitkm_module;
 
 pub use aggregate_survfit_module::{
-    AggregateSurvfitResult, aggregate_survfit, aggregate_survfit_by_group,
+    AggregateSurvfitResult, aggregate_shared_survfit, aggregate_survfit, aggregate_survfit_by_group,
 };
 pub use agsurv4_module::agsurv4;
 pub use agsurv5_module::agsurv5;


### PR DESCRIPTION
## Summary
- add a native shared-time reducer for grouped Cox prediction curves, including weighted standard errors and confidence intervals
- avoid duplicating and re-sorting the common time axis for every curve and avoid repeated per-group bridge calls
- preserve the existing near-duplicate step-time behavior and publish the typed binding
- add no dependencies

## Performance
Median of 9 runs on 30 time points, 100 groups, and standard errors:

| Curves | Main | This branch | Speedup |
|---:|---:|---:|---:|
| 1,000 | 2.662 ms | 1.442 ms | 1.85x |
| 5,000 | 12.875 ms | 6.601 ms | 1.95x |
| 10,000 | 26.778 ms | 12.875 ms | 2.08x |
| 20,000 | 62.640 ms | 25.777 ms | 2.43x |

Outputs also matched main across 300 deterministic randomized grouping and weighting cases through 12 decimal places.

## Validation
- 852 Python tests
- 1,383 core Rust tests
- 1,599 all-feature Rust tests
- full R-to-Python bridge suite
- built-source `R CMD check`: `Status: OK`
- strict Clippy across all targets and features
- Ruff, strict stub type checking, binding-manifest check, and diff check