### PR TITLE
Support stratified survobrien factor formulas

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -7024,7 +7024,7 @@ def _survobrien_formula_terms(
             raise ValueError("This function cannot deal with interaction terms")
         values = _term_values(data, term, n)
         if term.categorical:
-            keepers.append((_survobrien_term_name(term), values))
+            keepers.append((term.column, values))
             continue
         try:
             numeric = [float(value) for value in values]

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -3356,6 +3356,14 @@ def test_r_style_survobrien_uses_direct_vectors():
         "Surv(time, status) ~ x + group",
         data=data,
     )
+    formula_factor_wrapper = survival.survobrien(
+        "Surv(time, status) ~ x + factor(group)",
+        data=data,
+    )
+    formula_as_factor_wrapper = survival.survobrien(
+        "Surv(time, status) ~ x + as.factor(group)",
+        data=data,
+    )
     transformed = survival.survobrien(
         "Surv(time, status) ~ x",
         data=data,
@@ -3387,6 +3395,8 @@ def test_r_style_survobrien_uses_direct_vectors():
     assert formula["status"] == [1, 0, 0, 0, 1, 0, 1]
     assert formula[".id."] == [1, 2, 3, 4, 3, 4, 4]
     assert formula_factor["group"] == ["a", "a", "b", "b", "b", "b", "b"]
+    assert formula_factor_wrapper == formula_factor
+    assert formula_as_factor_wrapper == formula_factor
     assert formula["x"] == pytest.approx(
         [
             -1.9459101490553135,

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -3518,8 +3518,52 @@ finegray <- function(formula, data, weights, subset, na.action = na.pass,
   )
 }
 
+.survobrien_result_frame <- function(result, data) {
+  frame <- as.data.frame(result, check.names = TRUE, stringsAsFactors = FALSE)
+  if (ncol(frame) > 0L || length(result) == 0L) {
+    return(frame)
+  }
+  empty_columns <- lapply(names(result), function(column) {
+    if (column %in% names(data)) {
+      return(data[[column]][integer()])
+    }
+    if (column %in% c("status", ".id.", ".strata.")) {
+      return(integer())
+    }
+    numeric()
+  })
+  names(empty_columns) <- names(result)
+  as.data.frame(empty_columns, check.names = TRUE, stringsAsFactors = FALSE)
+}
+
+.survobrien_restore_row_names <- function(frame, call, formula, data, enclos) {
+  if (nrow(frame) <= 1L || !".id." %in% names(frame) ||
+      anyDuplicated(frame[[".id."]])) {
+    return(frame)
+  }
+  model_args <- match(
+    c("formula", "data", "subset", "na.action"),
+    names(call),
+    nomatch = 0L
+  )
+  model_call <- call[c(1L, model_args[model_args > 0L])]
+  model_call[[1L]] <- quote(stats::model.frame)
+  model_call$formula <- stats::terms(
+    formula,
+    c("strata", "cluster", "tt"),
+    data = data
+  )
+  model_rows <- row.names(eval(model_call, enclos))
+  output_rows <- model_rows[as.integer(frame[[".id."]])]
+  if (!identical(output_rows, as.character(seq_len(nrow(frame))))) {
+    row.names(frame) <- output_rows
+  }
+  frame
+}
+
 survobrien <- function(formula, data, subset, na.action, transform,
                        time, status, covariate, strata = NULL) {
+  call <- match.call()
   direct_time <- NULL
   if (!missing(time)) {
     direct_time <- time
@@ -3536,10 +3580,16 @@ survobrien <- function(formula, data, subset, na.action, transform,
         `na_action` = if (missing(na.action)) NULL else .as_na_action(na.action),
         transform = if (missing(transform)) NULL else transform
       )
-      frame <- as.data.frame(result, check.names = TRUE, stringsAsFactors = FALSE)
+      frame <- .survobrien_result_frame(result, data)
+      frame <- .survobrien_restore_row_names(
+        frame,
+        call,
+        formula,
+        data,
+        parent.frame()
+      )
       return(.restore_r_column_classes(frame, data))
     }
-    call <- match.call()
     call[[1L]] <- quote(survival::survobrien)
     return(eval.parent(call))
   }
@@ -3570,14 +3620,27 @@ survobrien <- function(formula, data, subset, na.action, transform,
     return(is.factor(value) || (is.numeric(value) && !inherits(value, "AsIs")))
   }
   match <- regexec(
-    "^(log|sqrt|exp|identity|as\\.numeric)\\(([[:space:]]*[^()]+[[:space:]]*)\\)$",
+    paste0(
+      "^(log|sqrt|exp|identity|as\\.numeric|factor|as\\.factor)",
+      "\\(([[:space:]]*[^()]+[[:space:]]*)\\)$"
+    ),
     label
   )
   pieces <- regmatches(label, match)[[1L]]
   if (length(pieces) == 0L) {
     return(FALSE)
   }
+  transform <- pieces[[2L]]
   column <- trimws(pieces[[3L]])
+  if (transform %in% c("factor", "as.factor")) {
+    return(
+      column %in% names(data) &&
+        (is.factor(data[[column]]) ||
+          is.character(data[[column]]) ||
+          is.numeric(data[[column]]) ||
+          is.logical(data[[column]]))
+    )
+  }
   column %in% names(data) && is.numeric(data[[column]]) && !is.factor(data[[column]])
 }
 
@@ -3600,10 +3663,14 @@ survobrien <- function(formula, data, subset, na.action, transform,
   }
   factor_terms <- vapply(
     labels,
-    function(label) label %in% names(data) && is.factor(data[[label]]),
+    function(label) {
+      (label %in% names(data) && is.factor(data[[label]])) ||
+        grepl("^(factor|as\\.factor)\\(", label)
+    },
     logical(1)
   )
-  if (any(factor_terms) && length(specials$strata) > 0L) {
+  if (any(factor_terms) && length(specials$strata) > 0L &&
+      length(specials$cluster) > 0L) {
     return(FALSE)
   }
   all(vapply(labels, .survobrien_formula_supported_term, logical(1), data = data))

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -4307,10 +4307,49 @@ test_that("data-prep helpers match R survival shapes", {
   expect_s3_class(bridged_obrien_factor$keeper, "factor")
   expect_equal(levels(bridged_obrien_factor$keeper), c("b", "a"))
   expect_equal(bridged_obrien_factor, reference_obrien_factor)
-  expect_false(.survobrien_formula_python_eligible(
-    survival::Surv(time, status) ~ x + keeper + strata(group),
+  factor_strata_formula <- survival::Surv(time, status) ~ x + keeper + strata(group)
+  expect_true(.survobrien_formula_python_eligible(
+    factor_strata_formula,
     obrien_factor_data
   ))
+  expect_equal(
+    survobrien(factor_strata_formula, data = obrien_factor_data),
+    survival::survobrien(factor_strata_formula, data = obrien_factor_data)
+  )
+  for (wrapper in c("factor", "as.factor")) {
+    wrapper_formula <- stats::as.formula(paste0(
+      "survival::Surv(time, status) ~ x + ", wrapper, "(group) + strata(group)"
+    ))
+    expect_true(.survobrien_formula_python_eligible(wrapper_formula, obrien_factor_data))
+    expect_equal(
+      survobrien(wrapper_formula, data = obrien_factor_data),
+      survival::survobrien(wrapper_formula, data = obrien_factor_data)
+    )
+  }
+  obrien_factor_row_names <- data.frame(
+    time = c(5, 7, 1, 6),
+    status = c(0, 1, 1, 1),
+    x = c(0.1, 0.4, 0.2, 0.8),
+    group = c("a", "b", "b", "b")
+  )
+  obrien_factor_row_names$keeper <- factor(obrien_factor_row_names$group)
+  row_name_formula <- survival::Surv(time, status) ~ x + keeper + strata(group)
+  expect_equal(
+    survobrien(row_name_formula, data = obrien_factor_row_names),
+    survival::survobrien(row_name_formula, data = obrien_factor_row_names)
+  )
+  obrien_empty_risk <- data.frame(
+    time = c(2, 3, 4),
+    status = c(1, 1, 0),
+    x = c(0.1, 0.4, 0.2),
+    group = c("a", "b", "b")
+  )
+  obrien_empty_risk$keeper <- factor(obrien_empty_risk$group)
+  empty_risk_formula <- survival::Surv(time, status) ~ x + keeper + strata(group)
+  expect_equal(
+    survobrien(empty_risk_formula, data = obrien_empty_risk),
+    survival::survobrien(empty_risk_formula, data = obrien_empty_risk)
+  )
 
   obrien_counting_data <- data.frame(
     start = c(0, 0, 1, 2),
@@ -4348,6 +4387,23 @@ test_that("data-prep helpers match R survival shapes", {
     ),
     survival::survobrien(
       survival::Surv(start, stop, status) ~ x + strata(group),
+      data = obrien_counting_strata_data
+    )
+  )
+  obrien_counting_strata_data$keeper <- factor(
+    obrien_counting_strata_data$group,
+    levels = c("b", "a")
+  )
+  counting_factor_strata_formula <-
+    survival::Surv(start, stop, status) ~ x + keeper + strata(group)
+  expect_true(.survobrien_formula_python_eligible(
+    counting_factor_strata_formula,
+    obrien_counting_strata_data
+  ))
+  expect_equal(
+    survobrien(counting_factor_strata_formula, data = obrien_counting_strata_data),
+    survival::survobrien(
+      counting_factor_strata_formula,
       data = obrien_counting_strata_data
     )
   )


### PR DESCRIPTION
## Summary
- run supported `survobrien` formulas with factor keepers and strata through the local implementation
- support `factor(...)` and `as.factor(...)` while preserving R column names and classes
- preserve R-compatible row names and typed empty frames for sparse stratified risk sets
- cover right-censored and counting-process formulas without adding dependencies

## Validation
- 852 Python tests
- full R test suite
- 500 randomized formula comparisons against R survival
- 1,380 core Rust tests
- 1,596 all-feature Rust tests
- strict Rust clippy
- Python formatting, lint, typing, and binding-manifest checks
- built-source `R CMD check`: Status OK