### PR TITLE
Keep zero-tail Fine-Gray expansion in Rust

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -6213,15 +6213,6 @@ class _FineGrayInputs:
     strata_levels: tuple[Any, ...] | None
 
 
-@dataclass(frozen=True)
-class _FineGraySplit:
-    row: list[int]
-    start: list[float]
-    end: list[float]
-    wt: list[float]
-    add: list[int]
-
-
 def _finegray_raw_column(data: Any, name: str) -> Any:
     if isinstance(data, Mapping):
         try:
@@ -6755,44 +6746,8 @@ def _finegray_split_intervals(
     cut_probability: list[float],
     extend: list[bool],
     keep: list[bool],
-) -> FineGrayOutput | _FineGraySplit:
-    if all(probability > 0.0 for probability in cut_probability):
-        return _core.finegray(start, stop, cut_time, cut_probability, extend, keep)
-
-    rows: list[int] = []
-    output_start: list[float] = []
-    output_end: list[float] = []
-    output_weight: list[float] = []
-    output_add: list[int] = []
-    kept_indices = [idx for idx, value in enumerate(keep) if value]
-    for row_idx, (left, right, should_extend) in enumerate(zip(start, stop, extend, strict=True)):
-        cut_idx = bisect_left(cut_time, right) if should_extend else len(cut_time)
-        current_end = cut_time[cut_idx] if cut_idx < len(cut_time) else right
-        rows.append(row_idx + 1)
-        output_start.append(left)
-        output_end.append(current_end)
-        output_weight.append(1.0)
-        output_add.append(0)
-        if not should_extend or cut_idx >= len(cut_time):
-            continue
-
-        later_kept = kept_indices[bisect_right(kept_indices, cut_idx) :]
-        denominator = cut_probability[cut_idx]
-        if later_kept and denominator == 0.0:
-            raise ValueError("censoring probability is zero before a selected event")
-        for add, next_idx in enumerate(later_kept, start=1):
-            rows.append(row_idx + 1)
-            output_start.append(cut_time[next_idx - 1])
-            output_end.append(cut_time[next_idx])
-            output_weight.append(cut_probability[next_idx] / denominator)
-            output_add.append(add)
-    return _FineGraySplit(
-        row=rows,
-        start=output_start,
-        end=output_end,
-        wt=output_weight,
-        add=output_add,
-    )
+) -> FineGrayOutput:
+    return _core.finegray(start, stop, cut_time, cut_probability, extend, keep)
 
 
 _R_RESERVED_NAMES = {

--- a/python/tests/test_specialized.py
+++ b/python/tests/test_specialized.py
@@ -325,7 +325,28 @@ def test_finegray_validates_public_inputs():
         survival.regression.finegray([0.0], [1.0], [2.0, 1.0], [1.0, 1.0], [True], [True, True])
 
     with pytest.raises(ValueError, match="cprob must contain values"):
-        survival.regression.finegray([0.0], [1.0], [1.0], [0.0], [True], [True])
+        survival.regression.finegray([0.0], [1.0], [1.0], [-0.1], [True], [True])
+
+    harmless_zero = survival.regression.finegray(
+        [0.0, 0.0],
+        [1.0, 3.0],
+        [1.0, 2.0, 3.0],
+        [1.0, 0.5, 0.0],
+        [True, True],
+        [True, True, True],
+    )
+    assert harmless_zero.row == [1, 1, 1, 2]
+    assert harmless_zero.wt == pytest.approx([1.0, 0.5, 0.0, 1.0])
+
+    with pytest.raises(ValueError, match="probability is zero"):
+        survival.regression.finegray(
+            [0.0],
+            [2.0],
+            [1.0, 2.0, 3.0],
+            [1.0, 0.0, 0.0],
+            [True],
+            [True, False, True],
+        )
 
 
 def test_finegray_regression_and_cif_public_api():

--- a/src/regression/finegray_data.rs
+++ b/src/regression/finegray_data.rs
@@ -112,11 +112,34 @@ fn validate_finegray_inputs(
                 idx
             )));
         }
-        if !(0.0..=1.0).contains(&probability) || probability == 0.0 {
+        if !(0.0..=1.0).contains(&probability) {
             return Err(value_error(format!(
-                "cprob must contain values in (0, 1]; found {} at index {}",
+                "cprob must contain values in [0, 1]; found {} at index {}",
                 probability, idx
             )));
+        }
+    }
+
+    if cprob.contains(&0.0) {
+        let kept_indices: Vec<usize> = keep
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, &is_kept)| is_kept.then_some(idx))
+            .collect();
+        for (&stop, &should_extend) in tstop.iter().zip(extend) {
+            if !should_extend {
+                continue;
+            }
+            let initial_cut = ctime.partition_point(|&cut_time| cut_time < stop);
+            let first_later_kept = kept_indices.partition_point(|&idx| idx <= initial_cut);
+            if initial_cut < ncut
+                && first_later_kept < kept_indices.len()
+                && cprob[initial_cut] == 0.0
+            {
+                return Err(value_error(
+                    "censoring probability is zero before a selected event",
+                ));
+            }
         }
     }
 
@@ -436,11 +459,45 @@ mod tests {
                 vec![0.0],
                 vec![1.0],
                 vec![1.0],
-                vec![0.0],
+                vec![-0.1],
                 vec![true],
                 vec![true]
             )
             .is_err()
         );
+    }
+
+    #[test]
+    fn test_finegray_allows_harmless_zero_probability_tails() {
+        let result = finegray(
+            vec![0.0, 0.0],
+            vec![1.0, 3.0],
+            vec![1.0, 2.0, 3.0],
+            vec![1.0, 0.5, 0.0],
+            vec![true, true],
+            vec![true, true, true],
+        )
+        .unwrap();
+
+        assert_eq!(result.row, vec![1, 1, 1, 2]);
+        assert_eq!(result.start, vec![0.0, 1.0, 2.0, 0.0]);
+        assert_eq!(result.end, vec![1.0, 2.0, 3.0, 3.0]);
+        assert_eq!(result.wt, vec![1.0, 0.5, 0.0, 1.0]);
+        assert_eq!(result.add, vec![0, 1, 2, 0]);
+    }
+
+    #[test]
+    fn test_finegray_rejects_zero_probability_before_later_kept_cut() {
+        let error = finegray(
+            vec![0.0],
+            vec![2.0],
+            vec![1.0, 2.0, 3.0],
+            vec![1.0, 0.0, 0.0],
+            vec![true],
+            vec![true, false, true],
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("probability is zero"));
     }
 }


### PR DESCRIPTION
## Summary
- allow zero censoring probabilities in native Fine-Gray input when no later selected cut divides by them
- preserve the existing error when a zero probability occurs before a later selected event
- route formula-level zero-tail expansion through the native kernel and remove the duplicate Python fallback
- add no dependencies and make no public interface changes

## Performance
Warm median time for `_finegray_split_intervals` on a fixture producing about 6.5 output rows per input row:

| Input rows | Before | After | Speedup |
| ---: | ---: | ---: | ---: |
| 10,000 | 5.769 ms | 0.376 ms | 15.34x |
| 50,000 | 30.541 ms | 1.870 ms | 16.33x |
| 100,000 | 62.171 ms | 3.939 ms | 15.78x |

## Accuracy
- 1,000 randomized differential cases against the prior Python path
- 547 expected early-zero errors matched
- zero numeric drift on every accepted case
- direct low-level coverage for harmless zero tails and invalid earlier zero probabilities

## Validation
- 852 Python tests passed
- 1,382 Rust tests passed without default features
- 1,598 Rust tests passed with all features
- strict all-feature, all-target Rust linting passed with warnings denied
- binding manifest, Python formatting/lint/type checks, Rust formatting, and diff checks passed
- fresh R source-package check passed with `Status: OK`