### PR TITLE
Honor ordinary istate model frames

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -13323,8 +13323,6 @@ def survfit(
         and (response.start is None or id_values is None)
     ):
         raise ValueError("survfit entry=TRUE requires counting-process Surv input and id")
-    if istate is not None and response.type not in {"mright", "mcounting"}:
-        raise NotImplementedError("survfit istate requires a multi-state Surv response")
     if response.type in {"mright", "mcounting"}:
         if robust_value is False:
             raise ValueError("multi-state survfit supports only a robust variance")
@@ -20226,8 +20224,6 @@ def coxph(
     singular_ok_value = _normalize_bool_option_with_default(singular_ok, "singular_ok", True)
     nocenter_values = _normalize_numeric_sequence_or_none(nocenter, "nocenter")
     id_arg = id
-    if istate is not None or statedata is not None:
-        raise NotImplementedError("coxph multi-state istate/statedata inputs are not supported")
     if init is not None and initial_beta is not None:
         raise ValueError("use only one of init or initial_beta")
     max_iter = _integer_scalar(max_iter, "max_iter")
@@ -20244,11 +20240,15 @@ def coxph(
     time_transform_expanded = False
     time_transform_observed_n: int | None = None
     formula_x = False
+    istate_column: str | None = None
     if isinstance(response, str):
         formula_string = response
         response_spec = _formula_response_spec(response)
         weights = _column_or_values(data, weights, "weights") if weights is not None else None
         id_arg = _column_or_values(data, id_arg, "id") if id_arg is not None else None
+        istate_column = istate if isinstance(istate, str) else None
+        if istate_column is not None:
+            istate = _column(data, istate_column)
         if subset is not None:
             data, aligned = _subset_formula_inputs(
                 response,
@@ -20259,12 +20259,14 @@ def coxph(
                 strata=strata,
                 cluster=cluster,
                 id=id_arg,
+                istate=istate,
             )
             weights = aligned["weights"]
             offset = aligned["offset"]
             strata = aligned["strata"]
             cluster = aligned["cluster"]
             id_arg = aligned["id"]
+            istate = aligned["istate"]
             subset = None
         data, aligned = _apply_formula_na_action(
             response,
@@ -20275,12 +20277,14 @@ def coxph(
             strata=strata,
             cluster=cluster,
             id=id_arg,
+            istate=istate,
         )
         weights = aligned["weights"]
         offset = aligned["offset"]
         strata = aligned["strata"]
         cluster = aligned["cluster"]
         id_arg = aligned["id"]
+        istate = aligned["istate"]
         na_action = "pass"
         if x is not None:
             if not _is_bool_like(x):
@@ -20322,6 +20326,7 @@ def coxph(
         strata = _subset_optional_sequence(strata, indices, "strata")
         cluster = _subset_optional_sequence(cluster, indices, "cluster")
         id_arg = _subset_optional_sequence(id_arg, indices, "id")
+        istate = _subset_optional_sequence(istate, indices, "istate")
     response, aligned = _apply_surv_na_action(
         response,
         na_action,
@@ -20332,6 +20337,7 @@ def coxph(
         strata=strata,
         cluster=cluster,
         id=id_arg,
+        istate=istate,
     )
     x = aligned["x"]
     weights = aligned["weights"]
@@ -20339,6 +20345,7 @@ def coxph(
     strata = aligned["strata"]
     cluster = aligned["cluster"]
     id_arg = aligned["id"]
+    istate = aligned["istate"]
     if response.type not in {"right", "counting"}:
         raise NotImplementedError(
             "coxph currently supports right-censored and counting Surv responses"
@@ -20356,6 +20363,7 @@ def coxph(
         offset = _subset_optional_sequence(offset, source_indices, "offset")
         cluster = _subset_optional_sequence(cluster, source_indices, "cluster")
         id_arg = _subset_optional_sequence(id_arg, source_indices, "id")
+        istate = _subset_optional_sequence(istate, source_indices, "istate")
         transform_weights = _optional_float_vector(weights, "weights", expanded_n)
         transformed = _cox_time_transform_values(
             formula_model_data,
@@ -20384,6 +20392,9 @@ def coxph(
     id_values = _materialize_labels(id_arg, "id") if id_arg is not None else None
     if id_values is not None and len(id_values) != n:
         raise ValueError("id must have the same length as the Surv response")
+    istate_values = _materialize_1d(istate, "istate") if istate is not None else None
+    if istate_values is not None and len(istate_values) != n:
+        raise ValueError("istate must have the same length as the Surv response")
     fit_strata = _encode_groups(strata, n) if strata is not None else None
     fit_weights = _optional_float_vector(weights, "weights", n)
     case_weights = fit_weights if explicit_weights else None
@@ -20413,6 +20424,14 @@ def coxph(
                 id=id_values,
             )
         )
+        if istate_values is not None:
+            model_frame["(istate)"] = istate_values
+            if (
+                istate_column is not None
+                and formula_model_data is not None
+                and istate_column not in model_frame
+            ):
+                model_frame[istate_column] = _column(formula_model_data, istate_column)
 
     fit_times = list(response.time)
     entry_times = list(response.start) if response.start is not None else None

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -16618,12 +16618,6 @@ def test_r_api_rejects_unsupported_formula_features():
     )
     assert nonrobust_id.robust is False
 
-    with pytest.raises(NotImplementedError, match="istate"):
-        survival.coxph("Surv(time, status) ~ x1", data=_toy_data(), istate=_toy_data()["status"])
-
-    with pytest.raises(NotImplementedError, match="statedata"):
-        survival.coxph("Surv(time, status) ~ x1", data=_toy_data(), statedata={"states": [1]})
-
     with pytest.raises(ValueError, match="nocenter"):
         survival.coxph("Surv(time, status) ~ x1", data=_toy_data(), nocenter=[0.0, float("nan")])
 
@@ -17055,9 +17049,6 @@ def test_r_api_rejects_unsupported_formula_features():
     robust_fh = survival.survfit(survival.Surv([1.0, 2.0], [1, 0]), robust=True, type="fh")
     assert robust_fh.std_err == pytest.approx([0.2144409712, 0.2144409712])
 
-    with pytest.raises(NotImplementedError, match="istate"):
-        survival.survfit(survival.Surv([1.0, 2.0], [1, 0]), istate=[0, 1])
-
     etype_fit = survival.survfit(
         survival.Surv([1.0, 2.0], [1, 0]),
         etype=[1, 2],
@@ -17197,6 +17188,49 @@ def test_r_api_rejects_unsupported_formula_features():
             data=_toy_data(),
             offset=[0.0] * 8,
         )
+
+
+def test_ordinary_istate_matches_r_model_frame_semantics():
+    ordinary_curve = survival.survfit(
+        survival.Surv([1.0, 2.0], [1, 0]),
+        istate=["entry", "other"],
+        model=True,
+    )
+    curve_reference = survival.survfit(survival.Surv([1.0, 2.0], [1, 0]))
+    assert ordinary_curve.estimate == pytest.approx(curve_reference.estimate)
+    assert ordinary_curve.model["(istate)"] == ["entry", "other"]
+
+    data = _toy_data()
+    ordinary_fit = survival.coxph(
+        "Surv(time, status) ~ x1",
+        data=data,
+        istate="group",
+        statedata={"states": ["A", "B"]},
+        model=True,
+        max_iter=0,
+    )
+    fit_reference = survival.coxph(
+        "Surv(time, status) ~ x1",
+        data=data,
+        model=True,
+        max_iter=0,
+    )
+    assert ordinary_fit.coefficients[0] == pytest.approx(fit_reference.coefficients[0])
+    assert ordinary_fit.model["(istate)"] == data["group"]
+    assert ordinary_fit.model["group"] == data["group"]
+
+    missing_istate_data = _toy_data()
+    missing_istate_data["group"] = [*missing_istate_data["group"][:-1], None]
+    omitted_fit = survival.coxph(
+        "Surv(time, status) ~ x1",
+        data=missing_istate_data,
+        istate="group",
+        na_action="omit",
+        model=True,
+        max_iter=0,
+    )
+    assert omitted_fit.model["(istate)"] == missing_istate_data["group"][:-1]
+    assert len(omitted_fit.y) == len(missing_istate_data["group"]) - 1
 
 
 def _cch_parity_data() -> dict[str, list[object]]:

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -8162,7 +8162,7 @@ coxph <- function(formula, data = NULL, ..., subset = NULL, na.action = "fail") 
     dots,
     data,
     parent.frame(),
-    vector_args = c("weights", "offset", "strata", "cluster", "id")
+    vector_args = c("weights", "offset", "strata", "cluster", "id", "istate")
   )
   if (!is.null(dots$weights) && is.name(dots$weights)) {
     evaluated_dots[["_weights_column"]] <- as.character(dots$weights)

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -6611,3 +6611,57 @@ test_that("low-level Cox survival curves match individual trajectories", {
     tolerance = 1e-10
   )
 })
+
+test_that("ordinary istate inputs match R model-frame semantics", {
+  skip_if_not_installed("reticulate")
+  skip_if_not_installed("survival")
+  skip_if_not(reticulate::py_module_available("survival"), "Python survival package is unavailable")
+
+  data <- data.frame(
+    time = c(1, 2, 3, 4, 5, 6, 7, 8),
+    status = c(1, 1, 0, 1, 0, 1, 0, 1),
+    x = c(0.2, 0.8, 0.4, 1.1, 0.7, 0.3, 1.3, 0.5),
+    state = factor(c("entry", "other", "entry", "other", "entry", "other", "entry", "other"))
+  )
+  reference_survfit <- getS3method("survfit", "formula", envir = asNamespace("survival"))
+
+  bridged_curve <- survfit(
+    Surv(time, status) ~ 1,
+    data = data,
+    istate = state,
+    model = TRUE
+  )
+  reference_curve <- reference_survfit(
+    survival::Surv(time, status) ~ 1,
+    data = data,
+    istate = state,
+    model = TRUE
+  )
+  expect_equal(bridged_curve$surv, reference_curve$surv, tolerance = 1e-12)
+  bridged_curve_frame <- model.frame(bridged_curve)
+  curve_istate_name <- grep("istate", names(bridged_curve_frame), value = TRUE)
+  expect_length(curve_istate_name, 1L)
+  expect_equal(as.character(bridged_curve_frame[[curve_istate_name]]), as.character(data$state))
+
+  bridged_fit <- coxph(
+    Surv(time, status) ~ x,
+    data = data,
+    istate = state,
+    statedata = data.frame(state = levels(data$state)),
+    model = TRUE,
+    control = coxph.control(iter.max = 50L, eps = 1e-09)
+  )
+  reference_fit <- survival::coxph(
+    survival::Surv(time, status) ~ x,
+    data = data,
+    istate = state,
+    statedata = data.frame(state = levels(data$state)),
+    model = TRUE,
+    control = survival::coxph.control(iter.max = 50L, eps = 1e-09)
+  )
+  expect_equal(coef(bridged_fit), coef(reference_fit), tolerance = 1e-5)
+  bridged_fit_frame <- model.frame(bridged_fit)
+  fit_istate_name <- grep("istate", names(bridged_fit_frame), value = TRUE)
+  expect_length(fit_istate_name, 1L)
+  expect_equal(as.character(bridged_fit_frame[[fit_istate_name]]), as.character(data$state))
+})


### PR DESCRIPTION
## Summary
- accept `istate` for ordinary right-censored and counting-process `survfit` and `coxph` calls, matching R behavior
- align initial-state values through formula subsets, missing-row omission, direct-response subsets, and time-transform expansion
- retain initial-state values in stored model frames while leaving fitted estimates unchanged
- accept `statedata` on ordinary Cox fits, where R treats it as non-operative
- convert R-facing `coxph` initial-state vectors consistently with other row-aligned inputs
- add no dependencies and make no numerical-kernel changes

## Reference behavior
- compared ordinary `survfit` curves and Cox coefficients directly with the installed R survival package
- verified initial-state model-frame retention through both Python and R facades
- verified omission of rows with missing initial states

## Validation
- 857 Python tests passed
- focused R-reference package tests passed
- fresh R source-package check passed with `Status: OK`
- binding manifest, Python formatting/lint/type checks, Rust formatting, and diff checks passed