### PR TITLE
Match R helper call signatures

### DIFF
--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -225,7 +225,14 @@ if (getRversion() >= "2.15.1") {
     return(NULL)
   }
   if (is.data.frame(data)) {
-    return(lapply(data, .as_python_vector))
+    return(lapply(data, function(column) {
+      value <- .as_python_vector(column)
+      if (is.factor(column)) {
+        value
+      } else {
+        as.list(value)
+      }
+    }))
   }
   data
 }
@@ -2455,11 +2462,11 @@ Surv2 <- function(time, event, repeated = FALSE) {
   out
 }
 
-is.Surv <- function(value) {
-  if (inherits(value, "Surv")) {
+is.Surv <- function(x) {
+  if (inherits(x, "Surv")) {
     return(TRUE)
   }
-  .call_r_api("is_surv", value)
+  .call_r_api("is_surv", x)
 }
 
 is.ratetable <- function(x, verbose = FALSE) {
@@ -7893,7 +7900,8 @@ pseudo <- function(fit, times, type, collapse = TRUE, data.frame = FALSE, ...) {
   )
 }
 
-survdiff <- function(formula, data = NULL, ..., group = NULL, subset = NULL, na.action = "fail") {
+survdiff <- function(formula, data = NULL, subset = NULL, na.action = "fail",
+                     rho = 0, timefix = TRUE, ..., group = NULL) {
   env <- parent.frame()
   group_values <- .eval_formula_arg(substitute(group), missing(group), data, env, vector = TRUE)
   subset_values <- .eval_formula_arg(substitute(subset), missing(subset), data, env, vector = TRUE)
@@ -7904,6 +7912,8 @@ survdiff <- function(formula, data = NULL, ..., group = NULL, subset = NULL, na.
     group = group_values,
     subset = subset_values,
     `na.action` = .as_na_action(na.action),
+    rho = rho,
+    timefix = timefix,
     ...,
     .wrap = c("survival_py_survdiff", "survival_py_object")
   )
@@ -8508,10 +8518,11 @@ survreg <- function(formula, data = NULL, ..., subset = NULL, na.action = "fail"
   )
 }
 
-basehaz <- function(fit, ..., centered = TRUE) {
+basehaz <- function(fit, newdata, centered = TRUE, ...) {
   .call_r_api(
     "basehaz",
     fit,
+    newdata = if (missing(newdata)) NULL else .as_python_data(newdata),
     centered = centered,
     ...,
     .wrap = c("survival_py_basehaz", "survival_py_object")
@@ -8992,25 +9003,37 @@ concordancefit <- function(y, x, strata, weights, ymin = NULL, ymax = NULL,
   out
 }
 
-cox.zph <- function(fit, ...) {
-  .call_r_api("cox_zph", fit, ..., .wrap = c("survival_py_cox_zph", "survival_py_object"))
+cox.zph <- function(fit, transform = "km", terms = TRUE, singledf = FALSE,
+                    global = TRUE, ...) {
+  .call_r_api(
+    "cox_zph",
+    fit,
+    transform = transform,
+    terms = terms,
+    singledf = singledf,
+    global = global,
+    ...,
+    .wrap = c("survival_py_cox_zph", "survival_py_object")
+  )
 }
 
 cox_zph <- function(fit, ...) {
   cox.zph(fit, ...)
 }
 
-coxph.detail <- function(fit, ...) {
+coxph.detail <- function(object, riskmat = FALSE, rorder = c("data", "time"), ...) {
   .call_r_api(
     "coxph_detail",
-    fit,
+    object,
+    riskmat = riskmat,
+    rorder = match.arg(rorder),
     ...,
     .wrap = c("survival_py_coxph_detail", "survival_py_object")
   )
 }
 
-coxph_detail <- function(fit, ...) {
-  coxph.detail(fit, ...)
+coxph_detail <- function(object, ...) {
+  coxph.detail(object, ...)
 }
 
 coxph.wtest <- function(var, b, toler.chol = 1e-09) {

--- a/r/survivalr/man/survivalr.Rd
+++ b/r/survivalr/man/survivalr.Rd
@@ -365,7 +365,7 @@ attrassign(object, ...)
 
 \method{attrassign}{lm}(object, ...)
 
-is.Surv(value)
+is.Surv(x)
 
 is.ratetable(x, verbose = FALSE)
 
@@ -552,8 +552,8 @@ survSplit(formula, data, subset, na.action = na.pass, cut,
 survcondense(formula, data, subset, weights, na.action = na.pass,
   id, start = "tstart", end = "tstop", event = "event")
 
-survdiff(formula, data = NULL, ..., group = NULL, subset = NULL,
-  na.action = "fail")
+survdiff(formula, data = NULL, subset = NULL, na.action = "fail",
+  rho = 0, timefix = TRUE, ..., group = NULL)
 
 survexp(formula, data, weights, subset, na.action, rmap, times,
   method = c("ederer", "hakulinen", "conditional", "individual.h",
@@ -640,7 +640,7 @@ survpenal.fit(x, y, weights, offset, init, controlvals, dist,
 
 survregDtest(dlist, verbose = FALSE)
 
-basehaz(fit, ..., centered = TRUE)
+basehaz(fit, newdata, centered = TRUE, ...)
 
 brier(fit, times, newdata, ties = TRUE, detail = FALSE,
   timefix = TRUE, efron = FALSE)
@@ -663,15 +663,16 @@ survConcordance(formula, data, weights, subset, na.action)
 
 survConcordance.fit(y, x, strata, weight)
 
-cox.zph(fit, ...)
+cox.zph(fit, transform = "km", terms = TRUE, singledf = FALSE,
+  global = TRUE, ...)
 
 cox_zph(fit, ...)
 
-coxph.detail(fit, ...)
+coxph.detail(object, riskmat = FALSE, rorder = c("data", "time"), ...)
 
 coxph.wtest(var, b, toler.chol = 1e-09)
 
-coxph_detail(fit, ...)
+coxph_detail(object, ...)
 
 coxsurv.fit(ctype, stype, se.fit, varmat, cluster, y, x, wt,
   risk, position, strata, oldid, y2, x2, risk2, strata2,
@@ -926,7 +927,9 @@ selects the direct or SGTT contrast path.}
 \item{etype, prefix, count}{Formula \code{finegray} endpoint and output-column
 options handled by the native bridge.}
 \item{transform}{Formula \code{survobrien} option delegated to
-\code{survival::survobrien}.}
+\code{survival::survobrien}, or the time-axis transform for \code{cox.zph}.}
+\item{terms, singledf, global}{Logical controls for term grouping,
+single-degree-of-freedom tests, and the global test in \code{cox.zph}.}
 \item{covariate}{Direct numeric covariate vector for Python-backed
 \code{survobrien}.}
 \item{scores, risk.scores}{Optional direct concordance score vectors or
@@ -1015,7 +1018,8 @@ quantiles and Cox summaries.}
 \code{survreg} helper distribution; ignored by the other built-in helper
 distributions to match R.}
 \item{eps, toler.chol, iter.max, toler.inf, outer.max, timefix}{Control
-options passed through \code{coxph.control}. \code{eps} is also the
+options passed through \code{coxph.control}. \code{timefix} also controls
+near-tie correction in \code{survdiff}. \code{eps} is also the
 convergence tolerance used when \code{ridge}, \code{frailty.*}, or
 \code{pspline} searches for a penalty matching \code{df}.}
 \item{maxiter, rel.tolerance, debug}{Control options passed through
@@ -1035,6 +1039,9 @@ quoted.}
 \code{Surv} and \code{Surv2} objects, plus list-field extraction controls for
 Python-backed \code{survfit} objects.}
 \item{centered}{Logical flag for centered baseline hazards.}
+\item{rho}{Fleming--Harrington weight exponent for \code{survdiff}.}
+\item{riskmat, rorder}{Logical risk-matrix request and data/time row-order
+selector for \code{coxph.detail}.}
 \item{detail}{Logical flag requesting detailed \code{brier} output.}
 \item{efron}{Logical flag selecting Efron-compatible \code{brier} baseline
 survival when the fitted Cox model used Efron ties.}

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -4843,6 +4843,99 @@ test_that("Cox bridge agrees with R survival on a small right-censored fixture",
   expect_equal(bridged_concordance$n, reference_concordance$n)
 })
 
+test_that("public helper signatures accept R-style named and positional calls", {
+  skip_if_not_installed("reticulate")
+  skip_if_not_installed("survival")
+  skip_if_not(reticulate::py_module_available("survival"), "Python survival package is unavailable")
+
+  expect_identical(names(formals(is.Surv)), names(formals(survival::is.Surv)))
+  expect_identical(
+    head(names(formals(survdiff)), 6L),
+    names(formals(survival::survdiff))
+  )
+  expect_identical(
+    head(names(formals(basehaz)), 3L),
+    names(formals(survival::basehaz))
+  )
+  expect_identical(
+    head(names(formals(cox.zph)), 5L),
+    names(formals(survival::cox.zph))
+  )
+  expect_identical(
+    head(names(formals(coxph.detail)), 3L),
+    names(formals(survival::coxph.detail))
+  )
+
+  data <- data.frame(
+    time = 1:8,
+    status = c(1, 1, 0, 1, 1, 0, 1, 0),
+    group = rep(c("control", "treated"), 4),
+    x = c(0.1, 0.4, 0.2, 0.8, 1.1, 0.7, 1.5, 1.2),
+    z = c(1, 0, 1, 0, 1, 1, 0, 0)
+  )
+  response <- Surv(data$time, data$status)
+  expect_true(is.Surv(x = response))
+
+  keep <- c(TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, FALSE, FALSE)
+  bridged_diff <- survdiff(
+    Surv(time, status) ~ group,
+    data,
+    keep,
+    stats::na.omit,
+    rho = 0.5,
+    timefix = FALSE
+  )
+  reference_diff <- survival::survdiff(
+    survival::Surv(time, status) ~ group,
+    data,
+    keep,
+    stats::na.omit,
+    rho = 0.5
+  )
+  bridged_diff_frame <- as.data.frame(bridged_diff)
+  expect_equal(bridged_diff_frame$observed, unname(reference_diff$obs), tolerance = 1e-06)
+  expect_equal(bridged_diff_frame$expected, unname(reference_diff$exp), tolerance = 1e-06)
+  expect_equal(
+    bridged_diff_frame$variance,
+    unname(diag(reference_diff$var)),
+    tolerance = 1e-06
+  )
+  expect_equal(as.numeric(bridged_diff$statistic), reference_diff$chisq, tolerance = 1e-06)
+  expect_equal(as.numeric(bridged_diff$p_value), reference_diff$pvalue, tolerance = 1e-06)
+
+  bridged <- coxph(Surv(time, status) ~ x + z, data = data, eps = 1e-10, max_iter = 50)
+  reference <- survival::coxph(
+    survival::Surv(time, status) ~ x + z,
+    data = data,
+    control = survival::coxph.control(eps = 1e-10, iter.max = 50),
+    x = TRUE,
+    y = TRUE
+  )
+  newdata <- data.frame(x = 0.35, z = 1)
+  expect_equal(
+    unname(predict(bridged, newdata, type = "lp")),
+    unname(stats::predict(reference, newdata, type = "lp")),
+    tolerance = 1e-05
+  )
+  bridged_hazard <- as.data.frame(basehaz(bridged, newdata, FALSE))
+  reference_hazard <- survival::basehaz(reference, newdata, FALSE)
+  expect_equal(bridged_hazard$time, reference_hazard$time)
+  expect_equal(bridged_hazard$cumhaz, reference_hazard$hazard, tolerance = 2e-04)
+
+  bridged_zph <- as.data.frame(cox.zph(bridged, "rank", FALSE, FALSE, FALSE))
+  reference_zph <- survival::cox.zph(reference, "rank", FALSE, FALSE, FALSE)
+  expect_equal(bridged_zph$name, rownames(reference_zph$table))
+  expect_equal(bridged_zph$df, as.integer(reference_zph$table[, "df"]))
+
+  bridged_detail <- coxph.detail(object = bridged, TRUE, "time")
+  reference_detail <- survival::coxph.detail(object = reference, TRUE, "time")
+  bridged_riskmat <- do.call(
+    rbind,
+    survivalr:::.result_field(bridged_detail, "riskmat")
+  )
+  expect_equal(unname(bridged_riskmat), unname(reference_detail$riskmat))
+})
+
 test_that("Fitted-model concordance supports joint Cox and survreg comparisons", {
   skip_if_not_installed("reticulate")
   skip_if_not_installed("survival")


### PR DESCRIPTION
## Summary
- align `is.Surv`, `survdiff`, `basehaz`, `cox.zph`, and `coxph.detail` public argument names and positions with R
- preserve optional bridge extensions after the upstream-compatible positional arguments
- keep ordinary data-frame columns sequence-shaped across the R/Python boundary, including one-row numeric and character columns
- fix one-row `predict` and `basehaz` calls that previously converted predictor columns into scalars
- document the corrected helper signatures and options
- add no dependencies and make no Rust-source changes

## Reference behavior
- compare public formals with the installed R survival package
- compare positional `survdiff` subset/NA handling and named weighting controls
- compare one-row Cox predictions and baseline hazards
- compare positional `cox.zph` term controls and named `coxph.detail(object=...)` risk matrices

## Validation
- 856 Python tests passed
- complete R bridge suite passed
- fresh R source-package check passed with `Status: OK`
- binding manifest, Python formatting/lint/type checks, Rust formatting, R parsing, and diff checks passed