### PR TITLE
Carry Surv2data covariates forward

### DIFF
--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -3959,6 +3959,44 @@ totimeline <- function(formula, data, id, istate) {
   factor(codes, levels = seq_along(states), labels = states)
 }
 
+.surv2data_fill_vector <- function(value, id, time) {
+  missing <- is.na(value)
+  if (!any(missing)) {
+    return(value)
+  }
+  source <- .call_data_prep(
+    "lvcf_indices",
+    as.list(as.integer(id)),
+    as.list(as.logical(missing)),
+    as.list(as.numeric(time))
+  )
+  source <- as.integer(.as_numeric_vector(source)) + 1L
+  update <- missing & source != seq_along(source)
+  value[update] <- value[source[update]]
+  value
+}
+
+.surv2data_fill_model_frame <- function(frame, id, time) {
+  if (nrow(frame) == 0L) {
+    return(frame)
+  }
+  id_codes <- match(id, unique(id))
+  excluded <- match(c("(id)", "(cluster)"), names(frame), nomatch = 0L)
+  fill_columns <- setdiff(seq_along(frame)[-1L], excluded)
+  for (index in fill_columns) {
+    value <- frame[[index]]
+    if (is.matrix(value)) {
+      for (column in seq_len(ncol(value))) {
+        value[, column] <- .surv2data_fill_vector(value[, column], id_codes, time)
+      }
+      frame[[index]] <- value
+    } else {
+      frame[[index]] <- .surv2data_fill_vector(value, id_codes, time)
+    }
+  }
+  frame
+}
+
 Surv2data <- function(formula, data, subset, id) {
   call <- match.call()
   indx <- match(
@@ -3988,6 +4026,11 @@ Surv2data <- function(formula, data, subset, id) {
   )
   rows <- as.integer(.as_numeric_vector(.result_field(result, "row"))) + 1L
   mf2 <- mf[rows, , drop = FALSE]
+  mf2 <- .surv2data_fill_model_frame(
+    mf2,
+    id_values[rows],
+    .as_numeric_vector(.result_field(result, "start"))
+  )
   mf2[["Surv2.y"]] <- .as_surv2data_response(result)
 
   id_result <- .result_field(result, "id")

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -378,6 +378,30 @@ test_that("R formula wrappers delegate to the Python survival package", {
     Surv2data(survival::Surv2(time, state) ~ z + x, data = timeline_data, id = id),
     survival::Surv2data(survival::Surv2(time, state) ~ z + x, data = timeline_data, id = id)
   )
+  timeline_missing_data <- data.frame(
+    id = c(1, 2, 1, 2, 1, 2),
+    time = c(0, 0, 2, 3, 5, 6),
+    state = factor(
+      c("entry", "entry", "ill", "ill", "death", "death"),
+      levels = c("censor", "entry", "ill", "death")
+    ),
+    x = c(10, 20, NA, NA, 12, 22),
+    z = factor(c("A", "B", NA, NA, "C", "D")),
+    observed = c(TRUE, FALSE, NA, NA, TRUE, TRUE),
+    visit = as.Date("2026-01-01") + c(0, 1, NA, NA, 4, 5)
+  )
+  expect_equal(
+    Surv2data(
+      survival::Surv2(time, state) ~ x + z + observed + visit,
+      data = timeline_missing_data,
+      id = id
+    ),
+    survival::Surv2data(
+      survival::Surv2(time, state) ~ x + z + observed + visit,
+      data = timeline_missing_data,
+      id = id
+    )
+  )
 
   counting_data <- data.frame(
     id = c(1, 1, 2),


### PR DESCRIPTION
## Summary
- carry missing `Surv2data` model-frame covariates forward from the most recent row within each subject timeline before constructing interval rows
- preserve numeric, factor, logical, Date, and matrix-valued columns while keeping initial missing values missing
- handle interleaved subject rows by ordering the fill plan by subject and interval start time
- reuse the existing Rust last-value index routine instead of duplicating the scan in R
- add no dependencies or public API changes

## Reference behavior
- fixes interval rows that previously retained missing covariates where R carries the prior observation forward
- 250 randomized interleaved timelines matched the installed R survival package exactly across mixed column types and missingness patterns

## Validation
- 856 Python tests passed
- complete R bridge suite passed
- fresh R source-package check passed with `Status: OK`
- binding manifest, Python formatting/lint/type checks, Rust formatting, R parsing, and diff checks passed