### PR TITLE
Preserve lvcf input attributes

### DIFF
--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -2824,15 +2824,16 @@ lvcf <- function(id, x, time) {
     return(factor(.as_nullable_character_vector(result), levels = levels(x)))
   }
   if (is.integer(x)) {
-    return(as.integer(.as_nullable_numeric_vector(result)))
+    output <- as.integer(.as_nullable_numeric_vector(result))
+  } else if (is.numeric(x)) {
+    output <- .as_nullable_numeric_vector(result)
+  } else if (is.logical(x)) {
+    output <- .as_nullable_logical_vector(result)
+  } else {
+    output <- .as_nullable_character_vector(result)
   }
-  if (is.numeric(x)) {
-    return(.as_nullable_numeric_vector(result))
-  }
-  if (is.logical(x)) {
-    return(.as_nullable_logical_vector(result))
-  }
-  .as_nullable_character_vector(result)
+  attributes(output) <- attributes(x)
+  output
 }
 
 nostutter <- function(id, x, censor = 0, single = FALSE) {

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -3584,6 +3584,29 @@ test_that("data-prep helpers match R survival shapes", {
       lvcf(lvcf_factor_id, c(NA, 1, 2, NA)),
       reference_lvcf(lvcf_factor_id, c(NA, 1, 2, NA))
     )
+    for (structured in list(
+      structure(c(1, NA, 3), names = c("a", "b", "c")),
+      structure(c(1L, NA, 3L), names = c("a", "b", "c")),
+      structure(c(TRUE, NA, FALSE), names = c("a", "b", "c")),
+      structure(c("x", NA, "z"), names = c("a", "b", "c")),
+      structure(c(1, NA, 3), names = c("a", "b", "c"), source = "probe")
+    )) {
+      expect_equal(lvcf(c(1, 1, 1), structured), reference_lvcf(c(1, 1, 1), structured))
+    }
+    lvcf_matrix <- matrix(
+      c(1, NA, 3, 4, NA, 6),
+      nrow = 3,
+      dimnames = list(c("a", "b", "c"), c("u", "v"))
+    )
+    expect_equal(lvcf(rep(1, 6), lvcf_matrix), reference_lvcf(rep(1, 6), lvcf_matrix))
+    named_lvcf_factor <- structure(
+      factor(c("a", NA, "b"), levels = c("a", "b")),
+      names = c("a", "b", "c")
+    )
+    expect_equal(
+      lvcf(c(1, 1, 1), named_lvcf_factor),
+      reference_lvcf(c(1, 1, 1), named_lvcf_factor)
+    )
   }
   lvcf_factor <- factor(c("a", NA, "b", NA), levels = c("a", "b"))
   expect_equal(


### PR DESCRIPTION
## Summary
- restore names and other input attributes on non-factor `lvcf` results after the Python round trip
- preserve matrix dimensions/dimnames and custom attributes while keeping factor behavior unchanged
- add no dependencies or native changes

## Reference behavior
- match installed R survival for named numeric, integer, logical, and character vectors
- match matrices with dimnames and custom numeric attributes
- retain the reference behavior where factor reconstruction drops input names

## Validation
- 856 Python tests passed
- complete R bridge suite passed
- fresh R source-package check passed with `Status: OK`
- binding manifest, Python formatting/lint/type checks, Rust formatting, R parsing, and diff checks passed