### PR TITLE
Use exact risk-score ties in concordance

### DIFF
--- a/python/tests/test_concordance_additional.py
+++ b/python/tests/test_concordance_additional.py
@@ -42,21 +42,34 @@ def test_legacy_concordance_validates_index_inputs():
         survival.core.concordance(y, [0, 1, 2], wt, timewt, [0, 1, 3], [0, 1, 2])
 
 
-def test_concordance_summary_counts_near_tied_risk_scores():
+def test_concordance_summary_keeps_near_equal_risk_scores_distinct():
     summary = survival.core.concordance_summary(
         [1.0, 2.0, 3.0],
         [1, 1, 1],
-        [0.5, 0.5 + 5e-11, 0.1],
+        [0.5, 0.5 + 5e-13, 0.1],
     )
 
     assert summary["comparable"] == pytest.approx(3.0)
-    assert summary["concordant"] == pytest.approx(2.5)
-    assert summary["concordance"] == pytest.approx(2.5 / 3.0)
+    assert summary["concordant"] == pytest.approx(2.0)
+    assert summary["concordance"] == pytest.approx(2.0 / 3.0)
     assert survival.core.concordance_index(
         [1.0, 2.0, 3.0],
         [1, 1, 1],
-        [0.5, 0.5 + 5e-11, 0.1],
-    ) == pytest.approx(2.5 / 3.0)
+        [0.5, 0.5 + 5e-13, 0.1],
+    ) == pytest.approx(2.0 / 3.0)
+
+
+def test_counting_concordance_keeps_near_equal_risk_scores_distinct():
+    summary = survival.core.counting_concordance_summary(
+        [0.0, 0.0, 1.0, 1.0],
+        [1.0, 2.0, 3.0, 4.0],
+        [1, 0, 1, 1],
+        [0.5, 0.5 + 5e-13, 0.1, 0.8],
+    )
+
+    assert summary["comparable"] == pytest.approx(2.0)
+    assert summary["concordant"] == pytest.approx(0.0)
+    assert summary["concordance"] == pytest.approx(0.0)
 
 
 def test_concordance_summary_groups_near_tied_event_times():

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -2570,6 +2570,61 @@ test_that("R formula wrappers delegate to the Python survival package", {
   expect_equal(symbol_concordance_frame$variance, string_column_concordance_frame$variance)
   expect_equal(subset_symbol_concordance_frame$concordance, as.numeric(reference_subset_symbol_concordance$concordance))
   expect_equal(subset_symbol_concordance_frame$variance, as.numeric(reference_subset_symbol_concordance$var))
+  near_risk <- c(0.5, 0.5 + 5e-13, 0.1, 0.8)
+  near_risk_concordance <- concordancefit(
+    response,
+    near_risk,
+    influence = 3,
+    ranks = TRUE
+  )
+  reference_near_risk_concordance <- survival::concordancefit(
+    survival::Surv(data$time, data$status),
+    near_risk,
+    influence = 3,
+    ranks = TRUE
+  )
+  expect_equal(near_risk_concordance$concordance, reference_near_risk_concordance$concordance)
+  expect_equal(near_risk_concordance$count, reference_near_risk_concordance$count)
+  expect_equal(near_risk_concordance$dfbeta, reference_near_risk_concordance$dfbeta)
+  expect_equal(near_risk_concordance$influence, reference_near_risk_concordance$influence)
+  expect_equal(near_risk_concordance$ranks, reference_near_risk_concordance$ranks)
+  counting_near_risk_response <- Surv(
+    c(0, 0, 1, 1),
+    c(1, 2, 3, 4),
+    c(1, 0, 1, 1)
+  )
+  counting_near_risk_concordance <- concordancefit(
+    counting_near_risk_response,
+    near_risk,
+    influence = 3,
+    ranks = TRUE
+  )
+  reference_counting_near_risk_concordance <- survival::concordancefit(
+    survival::Surv(c(0, 0, 1, 1), c(1, 2, 3, 4), c(1, 0, 1, 1)),
+    near_risk,
+    influence = 3,
+    ranks = TRUE
+  )
+  expect_equal(
+    counting_near_risk_concordance$concordance,
+    reference_counting_near_risk_concordance$concordance
+  )
+  expect_equal(
+    counting_near_risk_concordance$count,
+    reference_counting_near_risk_concordance$count
+  )
+  expect_equal(
+    counting_near_risk_concordance$dfbeta,
+    reference_counting_near_risk_concordance$dfbeta
+  )
+  expect_equal(
+    counting_near_risk_concordance$influence,
+    reference_counting_near_risk_concordance$influence
+  )
+  expect_equal(
+    counting_near_risk_concordance$ranks,
+    reference_counting_near_risk_concordance$ranks
+  )
   old_concordance <- suppressWarnings(survConcordance(
     Surv(time, status) ~ x,
     data = data

--- a/src/concordance/basic.rs
+++ b/src/concordance/basic.rs
@@ -16,8 +16,6 @@ use pyo3::types::PyDict;
 use rayon::prelude::*;
 use std::collections::BTreeMap;
 
-const CONCORDANCE_RISK_TIE_FLOOR: f64 = 1e-12;
-
 type ConcordanceRankRows = Vec<(f64, f64, f64, f64)>;
 type ConcordanceInfluenceOutput = (Vec<Vec<f64>>, Vec<f64>, f64);
 
@@ -374,7 +372,7 @@ fn tied_event_risk_pairs(
     let mut window_weight = 0.0;
     let mut left = 0;
     for right in 0..events.len() {
-        while left < right && events[right].0 - events[left].0 >= CONCORDANCE_RISK_TIE_FLOOR {
+        while left < right && events[right].0 != events[left].0 {
             window_weight -= events[left].1;
             left += 1;
         }
@@ -421,12 +419,8 @@ fn right_concordance_tie_counts_for_vectors(
                 .filter(|&idx| status[idx] == 1)
                 .collect();
             for &event_idx in &event_indices {
-                let lower_end = risk_levels.partition_point(|&risk| {
-                    risk <= risk_scores[event_idx] - CONCORDANCE_RISK_TIE_FLOOR
-                });
-                let tied_end = risk_levels.partition_point(|&risk| {
-                    risk < risk_scores[event_idx] + CONCORDANCE_RISK_TIE_FLOOR
-                });
+                let lower_end = risk_levels.partition_point(|&risk| risk < risk_scores[event_idx]);
+                let tied_end = risk_levels.partition_point(|&risk| risk <= risk_scores[event_idx]);
                 let lower = rank_prefix_weight_before(&at_risk, lower_end);
                 let lower_or_tied = rank_prefix_weight_before(&at_risk, tied_end);
                 counts.tied_x += concordance_case_weight(weights, event_idx)
@@ -547,10 +541,8 @@ fn rank_from_active_risk_set(
         return None;
     }
 
-    let lower_end =
-        risk_levels.partition_point(|&risk| risk < event_risk - CONCORDANCE_RISK_TIE_FLOOR);
-    let not_greater_end =
-        risk_levels.partition_point(|&risk| risk <= event_risk + CONCORDANCE_RISK_TIE_FLOOR);
+    let lower_end = risk_levels.partition_point(|&risk| risk < event_risk);
+    let not_greater_end = risk_levels.partition_point(|&risk| risk <= event_risk);
     let lower = rank_prefix_weight_before(at_risk, lower_end);
     let not_greater = rank_prefix_weight_before(at_risk, not_greater_end);
     let greater = risk_weight - not_greater;
@@ -859,9 +851,7 @@ fn right_concordance_influence_rows_for_vectors(
                 if pair_weight <= 0.0 {
                     continue;
                 }
-                let column = if (risk_scores[left] - risk_scores[right]).abs()
-                    < CONCORDANCE_RISK_TIE_FLOOR
-                {
+                let column = if risk_scores[left] == risk_scores[right] {
                     4
                 } else {
                     3
@@ -887,10 +877,10 @@ fn right_concordance_influence_rows_for_vectors(
             }
             comparable += pair_weight;
             let diff = risk_scores[event_idx] - risk_scores[risk_idx];
-            let column = if diff > CONCORDANCE_RISK_TIE_FLOOR {
+            let column = if diff > 0.0 {
                 concordant += pair_weight;
                 0
-            } else if diff < -CONCORDANCE_RISK_TIE_FLOOR {
+            } else if diff < 0.0 {
                 1
             } else {
                 concordant += 0.5 * pair_weight;
@@ -949,9 +939,7 @@ fn counting_concordance_influence_rows_for_vectors(
             }
             if status[risk_idx] == 1 && stop[risk_idx] == event_time {
                 if event_idx < risk_idx {
-                    let column = if (risk_scores[event_idx] - risk_scores[risk_idx]).abs()
-                        < CONCORDANCE_RISK_TIE_FLOOR
-                    {
+                    let column = if risk_scores[event_idx] == risk_scores[risk_idx] {
                         4
                     } else {
                         3
@@ -972,10 +960,10 @@ fn counting_concordance_influence_rows_for_vectors(
 
             comparable += pair_weight;
             let diff = risk_scores[event_idx] - risk_scores[risk_idx];
-            let column = if diff > CONCORDANCE_RISK_TIE_FLOOR {
+            let column = if diff > 0.0 {
                 concordant += pair_weight;
                 0
-            } else if diff < -CONCORDANCE_RISK_TIE_FLOOR {
+            } else if diff < 0.0 {
                 1
             } else {
                 concordant += 0.5 * pair_weight;
@@ -2176,14 +2164,14 @@ mod tests {
             }
         );
 
-        let tolerance_boundary = right_concordance_tie_counts_for_vectors(
+        let distinct_scores = right_concordance_tie_counts_for_vectors(
             &[1.0, 2.0, 3.0],
             &[1, 0, 0],
             &[0.0, 0.5e-12, 1e-12],
             None,
             ConcordanceTimeWeight::N,
         );
-        assert_eq!(tolerance_boundary.tied_x, 1.0);
+        assert_eq!(distinct_scores.tied_x, 0.0);
     }
 
     #[test]

--- a/src/internal/statistical.rs
+++ b/src/internal/statistical.rs
@@ -438,7 +438,7 @@ fn concordance_summary_quadratic(
                 comparable += pair_weight;
                 if risk_scores[i] > risk_scores[j] {
                     concordant += pair_weight;
-                } else if (risk_scores[i] - risk_scores[j]).abs() < DIVISION_FLOOR {
+                } else if risk_scores[i] == risk_scores[j] {
                     concordant += TIED_PAIR_WEIGHT * pair_weight;
                 }
             } else if j_comparable {
@@ -453,7 +453,7 @@ fn concordance_summary_quadratic(
                 comparable += pair_weight;
                 if risk_scores[j] > risk_scores[i] {
                     concordant += pair_weight;
-                } else if (risk_scores[i] - risk_scores[j]).abs() < DIVISION_FLOOR {
+                } else if risk_scores[i] == risk_scores[j] {
                     concordant += TIED_PAIR_WEIGHT * pair_weight;
                 }
             }
@@ -749,13 +749,13 @@ fn concordance_contribution_for_rank(
     risk_score: f64,
 ) -> f64 {
     let less_end = risk_levels.partition_point(|&risk| risk < risk_score);
-    let near_tie_end = risk_levels.partition_point(|&risk| risk - risk_score < DIVISION_FLOOR);
+    let tie_end = risk_levels.partition_point(|&risk| risk <= risk_score);
 
     let lower_risk_count = prefix_count_before(at_risk, less_end);
-    let lower_or_near_tied_count = prefix_count_before(at_risk, near_tie_end);
-    let near_tied_count = lower_or_near_tied_count - lower_risk_count;
+    let lower_or_tied_count = prefix_count_before(at_risk, tie_end);
+    let tied_count = lower_or_tied_count - lower_risk_count;
 
-    lower_risk_count + TIED_PAIR_WEIGHT * near_tied_count
+    lower_risk_count + TIED_PAIR_WEIGHT * tied_count
 }
 
 #[inline]
@@ -1419,12 +1419,16 @@ mod tests {
     }
 
     #[test]
-    fn test_ranked_concordance_preserves_tie_tolerance() {
+    fn test_ranked_concordance_distinguishes_near_equal_risk_scores() {
         let time = [1.0, 2.0, 3.0, 4.0];
         let event = [1, 1, 1, 1];
         let risk = [0.4, 0.4 + DIVISION_FLOOR / 2.0, 0.1, 0.8];
+        let tied_risk = [0.4, 0.4, 0.1, 0.8];
 
         assert_ranked_matches_quadratic(&risk, &time, &event, None);
+        let distinct = concordance_summary_with_horizon(&risk, &time, &event, None);
+        let tied = concordance_summary_with_horizon(&tied_risk, &time, &event, None);
+        assert!((tied.concordant - distinct.concordant - 0.5).abs() < DIVISION_FLOOR);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- treat risk scores as tied only when their floating-point values are exactly equal, matching R survival behavior
- apply the same rule to right-censored and counting-process summaries, tie counts, ranks, influence rows, and variance inputs
- preserve the existing near-time grouping behavior
- add Python and R reference-parity coverage for score differences below `1e-12`

## Dependencies
- no new dependencies
- the raw branch R check exposes the nine empty-confidence failures fixed by #375; applying #375 produces a clean package check

## Testing
- `cargo test --lib` — 1,435 passed
- `python -m pytest -q` — 859 passed
- full R suite reached only the nine known #375 failures
- `R CMD check --no-manual` with #375 applied — `Status: OK`
- Ruff formatting and lint, binding manifest, Rust formatting, and diff checks — passed