### PR TITLE
Restore post-merge R compatibility

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -266,7 +266,7 @@ jobs:
         run: |
           rspm <- Sys.getenv("RSPM", unset = "")
           repos <- if (nzchar(rspm)) c(CRAN = rspm) else c(CRAN = "https://cloud.r-project.org")
-          install.packages(c("reticulate", "testthat"), repos = repos)
+          install.packages(c("reticulate", "survival", "testthat"), repos = repos)
         shell: Rscript {0}
 
       - name: Check R bridge package

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, field, replace
 from datetime import date as _Date
 from datetime import datetime as _DateTime
 from functools import lru_cache
-from itertools import combinations, product
+from itertools import combinations, groupby, product
 from numbers import Real
 from operator import index
 from statistics import NormalDist
@@ -5208,7 +5208,7 @@ class Surv2:
     time: tuple[float, ...]
     status: tuple[int | None, ...]
     states: tuple[str, ...]
-    repeated: bool
+    repeated: bool | str
 
     def __init__(self, time: Any, event: Any, repeated: Any = False) -> None:
         time_values = [
@@ -5218,9 +5218,10 @@ class Surv2:
         event_values = _materialize_1d(event, "event")
         if len(event_values) != len(time_values):
             raise ValueError("Time and event are different lengths")
-        if not _is_bool_like(repeated):
+        repeated_is_first = isinstance(repeated, str) and repeated.lower() == "first"
+        if not (_is_bool_like(repeated) or repeated_is_first):
             raise ValueError("invalid value for repeated option")
-        repeated_value = bool(repeated)
+        repeated_value: bool | str = "first" if repeated_is_first else bool(repeated)
 
         levels = _surv2_levels(event)
         states = levels[1:]
@@ -5308,12 +5309,65 @@ def Surv2data(
         math.isnan(value) for value in time_values
     ):
         raise ValueError("id and time cannot be missing")
-    repeated_value = _normalize_bool_option(repeated, "repeated")
     state_values = (
         [str(value) for value in _materialize_1d(states, "states")] if states is not None else []
     )
 
     id_codes = _encode_labels(id_values, "id")
+    repeated_is_first = isinstance(repeated, str) and repeated.lower() == "first"
+    if repeated_is_first:
+        seen_by_id: dict[int, set[int]] = {}
+        for row_idx in sorted(
+            range(len(time_values)),
+            key=lambda idx: (id_codes[idx], time_values[idx]),
+        ):
+            status_value = status_values[row_idx]
+            if status_value in (None, 0):
+                continue
+            seen = seen_by_id.setdefault(id_codes[row_idx], set())
+            if status_value in seen:
+                status_values[row_idx] = 0
+            else:
+                seen.add(status_value)
+        repeated_value = True
+    else:
+        repeated_value = _normalize_bool_option(repeated, "repeated")
+    if not state_values:
+        order = sorted(
+            range(len(time_values)),
+            key=lambda idx: (id_codes[idx], time_values[idx]),
+        )
+        intervals: list[tuple[int, float, float, int, Any]] = []
+        for _, grouped_rows_iter in groupby(order, key=lambda idx: id_codes[idx]):
+            grouped_rows = list(grouped_rows_iter)
+            for current_row, next_row in zip(grouped_rows[:-1], grouped_rows[1:], strict=True):
+                next_status = status_values[next_row]
+                intervals.append(
+                    (
+                        current_row,
+                        time_values[current_row],
+                        time_values[next_row],
+                        0 if next_status is None else next_status,
+                        id_values[current_row],
+                    )
+                )
+        intervals.sort(key=lambda interval: interval[0])
+        rows = [interval[0] for interval in intervals]
+        starts = [interval[1] for interval in intervals]
+        stops = [interval[2] for interval in intervals]
+        output_status = [interval[3] for interval in intervals]
+        output_ids = [interval[4] for interval in intervals]
+        response_type = "right" if starts and all(value == 0.0 for value in starts) else "counting"
+        return {
+            "row": rows,
+            "start": starts,
+            "stop": stops,
+            "status": output_status,
+            "id": output_ids,
+            "istate": [0] * len(rows),
+            "states": [],
+            "type": response_type,
+        }
     result = _core.surv2data_timeline(
         id_codes,
         time_values,

--- a/python/survival/r_api.pyi
+++ b/python/survival/r_api.pyi
@@ -39,7 +39,7 @@ class Surv2:
     time: tuple[float, ...]
     status: tuple[int | None, ...]
     states: tuple[str, ...]
-    repeated: bool
+    repeated: bool | str
     def __init__(self, time: Any, event: Any, repeated: Any = False) -> None: ...
     def __len__(self) -> int: ...
 

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -2688,6 +2688,7 @@ def test_surv2_response_matches_r_multistate_shape():
 
     response = survival.Surv2([1.0, 2.0, 3.0], ["a", "b", "c"])
     missing = survival.Surv2([1.0, math.nan, 3.0], [None, "b", "c"], repeated=True)
+    repeated_first = survival.Surv2([1.0, 2.0], ["a", "a"], repeated="first")
     categorical = survival.Surv2(
         [1.0, 2.0, 3.0],
         Factor(
@@ -2706,6 +2707,7 @@ def test_surv2_response_matches_r_multistate_shape():
     assert missing.status == (None, 0, 1)
     assert missing.states == ("c",)
     assert missing.repeated is True
+    assert repeated_first.repeated == "first"
     assert survival.is_na_surv(missing) == [True, True, False]
     assert survival.format_surv(missing) == ["1? ", "NA+", "3:c"]
     assert categorical.status == (1, 3, 2)
@@ -2755,6 +2757,23 @@ def test_surv2data_converts_timeline_rows_to_counting_transitions():
         repeated=False,
     )
     assert repeated_result["status"] == [0, 2]
+
+    repeated_first_result = survival.Surv2data(
+        [0.0, 1.0, 2.0, 3.0],
+        [1, 2, 1, 2],
+        states=["entry", "death"],
+        id=[1, 1, 1, 1],
+        repeated="first",
+    )
+    assert repeated_first_result["status"] == [2, 0, 0]
+
+    ordinary_result = survival.Surv2data(
+        [0.0, 0.0, 2.0, 3.0, 5.0, 6.0],
+        [0, 0, 1, 1, 1, 0],
+        id=[1, 2, 1, 2, 1, 2],
+    )
+    assert ordinary_result["row"] == [0, 1, 2, 3]
+    assert ordinary_result["status"] == [1, 1, 1, 0]
 
     with pytest.raises(ValueError, match="duplicated time"):
         survival.Surv2data([0.0, 0.0], [1, 2], states=["a", "b"], id=[1, 1])

--- a/python/tests/test_r_package_layout.py
+++ b/python/tests/test_r_package_layout.py
@@ -34,7 +34,7 @@ def test_r_bridge_package_metadata_is_present():
     assert "Author: Cameron Lyons" in description
     assert "Maintainer: Cameron Lyons" in description
     assert "reticulate" in description
-    assert "    survival (>= 3.8-6)," in description
+    assert "    survival (>= 3.8-9)," in description
     assert "SystemRequirements: Python" in description
     assert (R_PACKAGE / "LICENSE").is_file()
     assert (R_PACKAGE / "R" / "bridge.R").is_file()

--- a/python/tests/test_r_package_layout.py
+++ b/python/tests/test_r_package_layout.py
@@ -34,7 +34,7 @@ def test_r_bridge_package_metadata_is_present():
     assert "Author: Cameron Lyons" in description
     assert "Maintainer: Cameron Lyons" in description
     assert "reticulate" in description
-    assert "    survival," in description
+    assert "    survival (>= 3.8-6)," in description
     assert "SystemRequirements: Python" in description
     assert (R_PACKAGE / "LICENSE").is_file()
     assert (R_PACKAGE / "R" / "bridge.R").is_file()

--- a/r/survivalr/DESCRIPTION
+++ b/r/survivalr/DESCRIPTION
@@ -16,6 +16,6 @@ Imports:
     stats,
     utils
 Suggests:
-    survival,
+    survival (>= 3.8-6),
     testthat (>= 3.0.0)
 Config/testthat/edition: 3

--- a/r/survivalr/DESCRIPTION
+++ b/r/survivalr/DESCRIPTION
@@ -16,6 +16,6 @@ Imports:
     stats,
     utils
 Suggests:
-    survival (>= 3.8-6),
+    survival (>= 3.8-9),
     testthat (>= 3.0.0)
 Config/testthat/edition: 3

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -2229,8 +2229,14 @@ makepredictcall.pspline <- function(var, call) {
     return(call)
   }
   new_call <- call[1L:2L]
+  attribute_names <- c(
+    "nterm", "intercept", "Boundary.knots", "combine", "degree"
+  )
+  if ("df" %in% names(call)) {
+    attribute_names <- c(attribute_names, "df")
+  }
   index <- match(
-    c("nterm", "intercept", "Boundary.knots", "combine", "degree"),
+    attribute_names,
     names(attributes(var)),
     nomatch = 0
   )
@@ -9387,25 +9393,37 @@ survfit_confint <- function(p, se, logse = TRUE, conf.type, conf.int = 0.95,
     if (conf.type == "log") {
       xx <- ifelse(p == 0, NA, p)
       se2 <- zval * se
-      lower <- exp(log(xx) - se2 * scale)
-      upper <- exp(log(xx) + se2)
-      if (ulimit) {
-        upper <- pmin(upper, 1)
-      }
-      return(list(lower = lower, upper = upper))
+      lower <- ifelse(se == 0, p, exp(log(xx) - se2 * scale))
+      upper <- ifelse(se == 0, p, exp(log(xx) + se2))
+      return(list(
+        lower = lower,
+        upper = if (ulimit) pmin(upper, 1) else upper
+      ))
     }
     if (conf.type == "log-log") {
       xx <- ifelse(p == 0 | p == 1, NA, p)
       se2 <- zval * se / log(xx)
-      lower <- exp(-exp(log(-log(xx)) - se2 * scale))
-      upper <- exp(-exp(log(-log(xx)) + se2))
+      lower <- ifelse(
+        se == 0,
+        p,
+        exp(-exp(log(-log(xx)) - se2 * scale))
+      )
+      upper <- ifelse(se == 0, p, exp(-exp(log(-log(xx)) + se2)))
       return(list(lower = lower, upper = upper))
     }
     if (conf.type == "logit") {
       xx <- ifelse(p == 0, NA, p)
       se2 <- zval * se * (1 + xx / (1 - xx))
-      lower <- 1 - 1 / (1 + exp(log(p / (1 - p)) - se2 * scale))
-      upper <- 1 - 1 / (1 + exp(log(p / (1 - p)) + se2))
+      lower <- ifelse(
+        se == 0,
+        p,
+        1 - 1 / (1 + exp(log(p / (1 - p)) - se2 * scale))
+      )
+      upper <- ifelse(
+        se == 0,
+        p,
+        1 - 1 / (1 + exp(log(p / (1 - p)) + se2))
+      )
       return(list(lower = lower, upper = upper))
     }
     if (conf.type == "arcsin") {
@@ -9489,26 +9507,31 @@ survdiff <- function(formula, data = NULL, subset = NULL, na.action = "fail",
   subjects <- factor(id, levels = unique(id))
   targets <- factor(status, levels = 0:length(states))
   counts <- table(subjects, targets)[, -1L, drop = FALSE]
+  if (all(counts == 0L)) {
+    return(NULL)
+  }
+  if (ncol(counts) == 1L) {
+    frequencies <- table(counts)
+    state_name <- states[as.integer(colnames(counts))]
+    return(matrix(
+      frequencies,
+      nrow = 1L,
+      dimnames = list(state_name, names(frequencies))
+    ))
+  }
+
   counts <- cbind(counts, rowSums(counts))
   count_levels <- sort(unique(c(counts)))
-  events <- if (length(count_levels) == 1L) {
-    matrix(
-      count_levels,
-      nrow = 1L,
-      ncol = 1L + length(states)
-    )
-  } else {
-    apply(counts, 2L, function(x) {
-      table(factor(x, levels = count_levels))
-    })
-  }
+  events <- t(apply(counts, 2L, function(x) {
+    table(factor(x, levels = count_levels))
+  }))
   dimnames(events) <- list(
-    count = as.character(count_levels),
-    state = c(states, "(any)")
+    state = c(states, "(any)"),
+    count = as.character(count_levels)
   )
-  no_visit <- colSums(events[-1L, , drop = FALSE]) == 0L
-  if (any(no_visit)) events <- events[, !no_visit]
-  t(events)
+  no_visit <- rowSums(events[, -1L, drop = FALSE]) == 0L
+  if (any(no_visit)) events <- events[!no_visit, , drop = FALSE]
+  events
 }
 
 .survcheck_transitions <- function(current_states, targets, states, id, response) {
@@ -9655,7 +9678,7 @@ survcheck <- function(formula, data = NULL, subset = NULL, na.action = na.pass,
   }
 
   multistate <- response_type %in% c("mright", "mcounting")
-  response_states <- if (multistate) attr(response, "states") else "1"
+  response_states <- if (multistate) attr(response, "states") else "event"
   raw_status <- as.integer(response[, ncol(response)])
   if (is.null(initial_values)) {
     state_names <- c(istate0, response_states)

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -7859,15 +7859,9 @@ print.Surv2 <- function(x, quote = FALSE, ...) {
 }
 
 model.frame.formula <- function(formula, ...) {
-  frame_args <- list(...)
-  do.call(
-    stats::model.frame.default,
-    c(
-      list(
-        formula = .formula_with_native_surv_response(formula, parent.frame())
-      ),
-      frame_args
-    )
+  stats::model.frame.default(
+    .formula_with_native_surv_response(formula, parent.frame()),
+    ...
   )
 }
 

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -7859,9 +7859,15 @@ print.Surv2 <- function(x, quote = FALSE, ...) {
 }
 
 model.frame.formula <- function(formula, ...) {
-  stats::model.frame.default(
-    .formula_with_native_surv_response(formula, parent.frame()),
-    ...
+  frame_args <- list(...)
+  do.call(
+    stats::model.frame.default,
+    c(
+      list(
+        formula = .formula_with_native_surv_response(formula, parent.frame())
+      ),
+      frame_args
+    )
   )
 }
 

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -9393,37 +9393,25 @@ survfit_confint <- function(p, se, logse = TRUE, conf.type, conf.int = 0.95,
     if (conf.type == "log") {
       xx <- ifelse(p == 0, NA, p)
       se2 <- zval * se
-      lower <- ifelse(se == 0, p, exp(log(xx) - se2 * scale))
-      upper <- ifelse(se == 0, p, exp(log(xx) + se2))
-      return(list(
-        lower = lower,
-        upper = if (ulimit) pmin(upper, 1) else upper
-      ))
+      lower <- exp(log(xx) - se2 * scale)
+      upper <- exp(log(xx) + se2)
+      if (ulimit) {
+        upper <- pmin(upper, 1)
+      }
+      return(list(lower = lower, upper = upper))
     }
     if (conf.type == "log-log") {
       xx <- ifelse(p == 0 | p == 1, NA, p)
       se2 <- zval * se / log(xx)
-      lower <- ifelse(
-        se == 0,
-        p,
-        exp(-exp(log(-log(xx)) - se2 * scale))
-      )
-      upper <- ifelse(se == 0, p, exp(-exp(log(-log(xx)) + se2)))
+      lower <- exp(-exp(log(-log(xx)) - se2 * scale))
+      upper <- exp(-exp(log(-log(xx)) + se2))
       return(list(lower = lower, upper = upper))
     }
     if (conf.type == "logit") {
       xx <- ifelse(p == 0, NA, p)
       se2 <- zval * se * (1 + xx / (1 - xx))
-      lower <- ifelse(
-        se == 0,
-        p,
-        1 - 1 / (1 + exp(log(p / (1 - p)) - se2 * scale))
-      )
-      upper <- ifelse(
-        se == 0,
-        p,
-        1 - 1 / (1 + exp(log(p / (1 - p)) + se2))
-      )
+      lower <- 1 - 1 / (1 + exp(log(p / (1 - p)) - se2 * scale))
+      upper <- 1 - 1 / (1 + exp(log(p / (1 - p)) + se2))
       return(list(lower = lower, upper = upper))
     }
     if (conf.type == "arcsin") {

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -9393,25 +9393,37 @@ survfit_confint <- function(p, se, logse = TRUE, conf.type, conf.int = 0.95,
     if (conf.type == "log") {
       xx <- ifelse(p == 0, NA, p)
       se2 <- zval * se
-      lower <- exp(log(xx) - se2 * scale)
-      upper <- exp(log(xx) + se2)
-      if (ulimit) {
-        upper <- pmin(upper, 1)
-      }
-      return(list(lower = lower, upper = upper))
+      lower <- ifelse(se == 0, p, exp(log(xx) - se2 * scale))
+      upper <- ifelse(se == 0, p, exp(log(xx) + se2))
+      return(list(
+        lower = lower,
+        upper = if (ulimit) pmin(upper, 1) else upper
+      ))
     }
     if (conf.type == "log-log") {
       xx <- ifelse(p == 0 | p == 1, NA, p)
       se2 <- zval * se / log(xx)
-      lower <- exp(-exp(log(-log(xx)) - se2 * scale))
-      upper <- exp(-exp(log(-log(xx)) + se2))
+      lower <- ifelse(
+        se == 0,
+        p,
+        exp(-exp(log(-log(xx)) - se2 * scale))
+      )
+      upper <- ifelse(se == 0, p, exp(-exp(log(-log(xx)) + se2)))
       return(list(lower = lower, upper = upper))
     }
     if (conf.type == "logit") {
       xx <- ifelse(p == 0, NA, p)
       se2 <- zval * se * (1 + xx / (1 - xx))
-      lower <- 1 - 1 / (1 + exp(log(p / (1 - p)) - se2 * scale))
-      upper <- 1 - 1 / (1 + exp(log(p / (1 - p)) + se2))
+      lower <- ifelse(
+        se == 0,
+        p,
+        1 - 1 / (1 + exp(log(p / (1 - p)) - se2 * scale))
+      )
+      upper <- ifelse(
+        se == 0,
+        p,
+        1 - 1 / (1 + exp(log(p / (1 - p)) + se2))
+      )
       return(list(lower = lower, upper = upper))
     }
     if (conf.type == "arcsin") {

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -2506,8 +2506,33 @@ Surv2 <- function(time, event, repeated = FALSE) {
   if (missing(event)) {
     stop("must have an event argument", call. = FALSE)
   }
-  if (!is.logical(repeated) || length(repeated) != 1L || is.na(repeated)) {
+  if (length(event) != length(time)) {
+    stop("Time and event are different lengths", call. = FALSE)
+  }
+  if (length(repeated) != 1L ||
+      !(is.logical(repeated) || is.character(repeated) && repeated == "first") ||
+      is.na(repeated)) {
     stop("invalid value for repeated option", call. = FALSE)
+  }
+  if (any(is.na(event) & !is.na(time))) {
+    fill <- if (is.numeric(event) && any(event == 0, na.rm = TRUE)) {
+      0
+    } else if (is.logical(event) && any(!event, na.rm = TRUE)) {
+      FALSE
+    } else if (is.factor(event)) {
+      levels(event)[1L]
+    } else {
+      NA
+    }
+    event[is.na(event) & !is.na(time)] <- fill
+  }
+  event <- as.factor(event)
+  input_attributes <- list()
+  if (!is.null(attributes(time))) {
+    input_attributes$time <- attributes(time)
+  }
+  if (!is.null(attributes(event))) {
+    input_attributes$event <- attributes(event)
   }
   time_values <- .as_python_vector(as.numeric(time))
   if (!is.list(time_values)) {
@@ -2525,8 +2550,11 @@ Surv2 <- function(time, event, repeated = FALSE) {
   )
   status <- as.integer(.as_nullable_numeric_vector(.result_field(result, "status")))
   out <- cbind(time = as.numeric(time), status = status)
+  if (length(input_attributes) > 0L) {
+    attr(out, "inputAttributes") <- input_attributes
+  }
   attr(out, "states") <- as.character(.result_field(result, "states"))
-  attr(out, "repeated") <- isTRUE(.result_field(result, "repeated"))
+  attr(out, "repeated") <- .result_field(result, "repeated")
   class(out) <- "Surv2"
   out
 }
@@ -4831,160 +4859,101 @@ survobrien <- function(formula, data, subset, na.action, transform,
   all(vapply(labels, .survobrien_formula_supported_term, logical(1), data = data))
 }
 
-fromtimeline <- function(formula, data, id, istate = "istate") {
+fromtimeline <- function(formula, data, subset, id, repeated = FALSE,
+                         lvcf = TRUE,
+                         yname = c("tstart", "tstop", "status")) {
   call <- match.call()
+  keep <- match(c("formula", "data", "subset", "id"), names(call), nomatch = 0L)
+  if (keep[[1L]] == 0L) {
+    stop("a formula argument is required", call. = FALSE)
+  }
+  if (keep[[2L]] == 0L) {
+    stop("the data argument is required", call. = FALSE)
+  }
+  if (keep[[4L]] == 0L) {
+    stop("the id argument is required", call. = FALSE)
+  }
   model_formula <- formula
   if (inherits(model_formula, "formula")) {
     model_env <- new.env(parent = environment(model_formula))
     model_env$Surv <- .native_model_frame_surv
     environment(model_formula) <- model_env
   }
-  keep <- match(c("formula", "data", "id"), names(call), nomatch = 0L)
-  tcall <- call[c(1L, keep)]
-  tcall$formula <- model_formula
-  tcall[[1L]] <- quote(stats::model.frame)
-  mf <- eval(tcall, parent.frame())
-  id_values <- stats::model.extract(mf, "id")
-  response <- stats::model.response(mf)
-  if (!inherits(response, "Surv")) {
-    stop("response must be a Surv object", call. = FALSE)
+  frame_call <- call[c(1L, keep)]
+  frame_call$formula <- model_formula
+  frame_call$na.action <- stats::na.pass
+  frame_call[[1L]] <- quote(stats::model.frame)
+  frame <- eval(frame_call, parent.frame())
+  response <- stats::model.response(frame)
+  converted <- .surv2counting_model_frame(
+    frame,
+    repeated = repeated,
+    lvcf = lvcf
+  )
+  istate_index <- match("(istate)", names(converted))
+  if (!is.na(istate_index) && !any(names(frame) == "istate")) {
+    names(converted)[[istate_index]] <- "istate"
   }
-  response_type <- attr(response, "type")
-  if (!(response_type %in% c("right", "mright"))) {
-    stop("only valid for a right censored response", call. = FALSE)
-  }
+  converted["(id)"] <- NULL
 
-  tname <- c("tstart", "tstop")
-  sname <- "state"
-  lhs <- formula[[2L]]
-  if ((is.name(lhs[[1L]]) && identical(lhs[[1L]], quote(Surv))) ||
-      identical(deparse(lhs[[1L]]), "survival::Surv")) {
-    if (is.name(lhs[[2L]])) {
-      temp <- as.character(lhs[[2L]])
-      tname <- paste0(temp, 1:2)
+  converted_response <- converted[[1L]]
+  states <- attr(converted_response, "states")
+  response_columns <- ncol(converted_response)
+  if (is.null(states)) {
+    status <- converted_response[, response_columns]
+  } else {
+    status <- factor(
+      converted_response[, response_columns],
+      0:length(states),
+      c("censor", states)
+    )
+  }
+  if (response_columns == 3L) {
+    response_data <- data.frame(
+      tstart = converted_response[, 1L],
+      tstop = converted_response[, 2L],
+      status = status
+    )
+  } else {
+    response_data <- data.frame(
+      tstart = converted_response[, 1L],
+      status = status
+    )
+  }
+  if (!missing(yname)) {
+    if (any(!is.na(match(yname, names(converted))))) {
+      stop("element of yname conflicts with an existing name in the data", call. = FALSE)
     }
-    if (is.name(lhs[[3L]])) {
-      sname <- as.character(lhs[[3L]])
-    } else if (is.call(lhs[[3L]])) {
-      temp <- lhs[[3L]]
-      if (identical(deparse(temp[[1L]]), "factor") && is.name(temp[[2L]])) {
-        sname <- as.character(temp[[2L]])
+    if (response_columns == 2L) {
+      if (!(length(yname) %in% 2:3)) {
+        stop("wrong length for yname", call. = FALSE)
+      }
+      names(response_data) <- c(yname[[1L]], yname[[length(yname)]])
+    } else {
+      if (length(yname) != 3L) {
+        stop("wrong length for yname", call. = FALSE)
+      }
+      names(response_data) <- yname
+    }
+  } else {
+    response_call <- formula[[2L]]
+    if (is.name(response_call[[2L]])) {
+      if (response_columns == 2L) {
+        yname <- c(as.character(response_call[[2L]]), yname[[3L]])
+      } else {
+        yname[1:2] <- paste0(as.character(response_call[[2L]]), 1:2)
       }
     }
-  } else if (is.name(lhs[[1L]])) {
-    tname <- paste0(lhs[[1L]], 1:2)
-  }
-
-  if (is.name(call$id)) {
-    idname <- as.character(call$id)
-    if (is.na(match(idname, names(mf)))) {
-      names(mf)[match("(id)", names(mf))] <- idname
+    if (is.name(response_call[[3L]])) {
+      yname[[length(yname)]] <- as.character(response_call[[3L]])
     }
-  } else {
-    stop("id must be a simple variable name", call. = FALSE)
-  }
-
-  result <- .call_r_api(
-    "fromtimeline",
-    time = .as_python_vector(response[, 1L]),
-    status = .as_python_vector(response[, 2L]),
-    id = .as_python_vector(id_values),
-    states = attr(response, "states"),
-    data = .as_python_data(mf[-1L]),
-    id_name = idname
-  )
-  removed_id <- .result_field(result, "removed_id")
-  if (!is.null(removed_id) && length(removed_id) > 0L) {
-    warning("identifiers with only 1 row were removed", call. = FALSE)
-  }
-
-  static <- as.logical(.result_field(result, "static"))
-  static_rows <- as.integer(.as_numeric_vector(.result_field(result, "static_row"))) + 1L
-  dynamic_rows <- as.integer(.as_numeric_vector(.result_field(result, "dynamic_row"))) + 1L
-  n_out <- length(static_rows)
-  data_names <- names(mf)[-1L]
-
-  output <- list()
-  static_names <- data_names[static]
-  for (name in static_names) {
-    output[[name]] <- mf[[name]][static_rows]
-  }
-  while (!is.na(match(sname, data_names))) {
-    sname <- paste0(sname, "1")
-  }
-  output[[tname[[1L]]]] <- .as_numeric_vector(.result_field(result, "start"))
-  output[[tname[[2L]]]] <- .as_numeric_vector(.result_field(result, "stop"))
-  status_values <- as.integer(.as_numeric_vector(.result_field(result, "status")))
-  state_levels <- as.character(.result_field(result, "state_levels"))
-  if (length(state_levels) > 0L) {
-    status_column <- factor(status_values, seq.int(0L, length(state_levels) - 1L), state_levels)
-  } else {
-    status_column <- as.numeric(status_values)
-  }
-  output[[sname]] <- status_column
-  dynamic_names <- data_names[!static]
-  if (length(dynamic_names) > 0L) {
-    for (name in dynamic_names) {
-      output[[name]] <- mf[[name]][dynamic_rows]
+    conflict <- match(yname, names(converted), nomatch = 0L)
+    if (any(conflict > 0L)) {
+      yname[conflict > 0L] <- paste0("_", yname[conflict > 0L], "_")
     }
+    names(response_data) <- yname
   }
-
-  if (any(istate == names(output))) {
-    stop("istate option duplicates an existing variable", call. = FALSE)
-  }
-  istate_values <- as.integer(.as_numeric_vector(.result_field(result, "istate")))
-  istate_levels <- as.character(.result_field(result, "istate_levels"))
-  output[[istate]] <- if (length(istate_levels) > 0L) {
-    factor(istate_values, seq_along(istate_levels), istate_levels)
-  } else {
-    as.numeric(istate_values)
-  }
-
-  out <- as.data.frame(output, stringsAsFactors = FALSE, optional = TRUE)
-  row.names(out) <- seq_len(n_out)
-  n_subject <- length(unique(static_rows))
-  tcount_rows <- c(sname, dynamic_names)
-  tcount <- matrix(
-    0,
-    nrow = length(tcount_rows),
-    ncol = 9L,
-    dimnames = list(
-      tcount_rows,
-      c("early", "late", "gap", "within", "boundary", "leading", "trailing", "tied", "missid")
-    )
-  )
-  if (length(tcount_rows) > 0L) {
-    middle_count <- max(0L, n_out - n_subject)
-    tcount[sname, "within"] <- middle_count
-    tcount[sname, "leading"] <- n_subject
-    tcount[sname, "trailing"] <- n_subject
-    if (length(dynamic_names) > 0L) {
-      tcount[dynamic_names, "boundary"] <- middle_count
-      tcount[dynamic_names, "leading"] <- n_subject
-      tcount[dynamic_names, "trailing"] <- n_subject
-    }
-  }
-  attr(out, "tm.retain") <- list(
-    tname = list(idname = idname, tstartname = tname[[1L]], tstopname = tname[[2L]]),
-    n = as.integer(n_out),
-    tevent = list(name = sname, censor = stats::setNames(list(0), sname)),
-    tdcvar = dynamic_names
-  )
-  attr(out, "tcount") <- tcount
-  call_parts <- c(
-    "tmerge(data1 = new, data2 = d2, id = ", idname,
-    ", ", sname, " = event(.y1., .y2.)"
-  )
-  if (length(dynamic_names) > 0L) {
-    call_parts <- c(
-      call_parts,
-      paste0(", ", dynamic_names, " = tdc(.y1., ", dynamic_names, ")", collapse = "")
-    )
-  }
-  call_parts <- c(call_parts, ")")
-  attr(out, "call") <- parse(text = paste0(call_parts, collapse = ""))[[1L]]
-  class(out) <- c("tmerge", "data.frame")
-  out
+  cbind(converted[, -1L, drop = FALSE], response_data)
 }
 
 totimeline <- function(formula, data, id, istate) {
@@ -5147,6 +5116,52 @@ totimeline <- function(formula, data, id, istate) {
     }
   }
   frame
+}
+
+.surv2counting_model_frame <- function(frame, repeated = FALSE, lvcf = TRUE) {
+  response <- stats::model.response(frame)
+  if (!(inherits(response, "Surv") || inherits(response, "Surv2"))) {
+    stop("response must be a survival object", call. = FALSE)
+  }
+  if (inherits(response, "Surv") &&
+      attr(response, "type") %in% c("counting", "mcounting")) {
+    stop("response cannot be of counting process type", call. = FALSE)
+  }
+  if (length(lvcf) != 1L || !is.logical(lvcf) || is.na(lvcf)) {
+    stop("invalid value for lvcf option", call. = FALSE)
+  }
+  id_values <- stats::model.extract(frame, "id")
+  if (is.null(id_values) || !any(duplicated(id_values))) {
+    stop("data does not appear to be timeline data", call. = FALSE)
+  }
+  result <- .call_r_api(
+    "Surv2data",
+    time = .as_python_vector(response[, 1L]),
+    status = .as_python_vector(response[, 2L]),
+    states = attr(response, "states"),
+    repeated = repeated,
+    id = .as_python_vector(id_values)
+  )
+  rows <- as.integer(.as_numeric_vector(.result_field(result, "row"))) + 1L
+  converted <- frame[rows, , drop = FALSE]
+  if (lvcf) {
+    converted <- .surv2data_fill_model_frame(
+      converted,
+      id_values[rows],
+      .as_numeric_vector(.result_field(result, "start"))
+    )
+  }
+  converted[[1L]] <- .as_surv2data_response(result)
+  states <- as.character(.result_field(result, "states"))
+  istate <- as.integer(.as_numeric_vector(.result_field(result, "istate")))
+  if (length(states) > 0L && any(istate > 0L, na.rm = TRUE)) {
+    converted[["(istate)"]] <- factor(
+      istate,
+      levels = seq_along(states),
+      labels = states
+    )
+  }
+  converted
 }
 
 Surv2data <- function(formula, data, subset, id) {
@@ -9914,6 +9929,9 @@ survSplit <- function(formula, data, subset, na.action = na.pass, cut,
   )
   states <- attr(response, "states")
   if (!is.null(states)) {
+    if (!missing(id)) {
+      output[[as.character(id)]] <- NULL
+    }
     output[[event_name]] <- factor(
       as.integer(output[[event_name]]),
       levels = 0:length(states),

--- a/r/survivalr/man/survivalr.Rd
+++ b/r/survivalr/man/survivalr.Rd
@@ -662,7 +662,8 @@ cch(formula, data, subcoh, id, stratum = NULL, cohort.size,
 clogit(formula, data, weights, subset, na.action,
   method = c("exact", "approximate", "efron", "breslow"), ...)
 
-fromtimeline(formula, data, id, istate = "istate")
+fromtimeline(formula, data, subset, id, repeated = FALSE,
+  lvcf = TRUE, yname = c("tstart", "tstop", "status"))
 
 tmerge(data1, data2, id, ..., tstart, tstop, options)
 
@@ -932,7 +933,12 @@ quantile inversion.}
 \item{breaks}{Strictly increasing cut points for \code{tcut}.}
 \item{labels}{Optional interval labels for \code{tcut}.}
 \item{cut}{Cut points for \code{survSplit}.}
-\item{repeated}{Logical flag accepted by \code{Surv2} for repeated events.}
+\item{repeated}{Logical flag or \code{"first"} accepted by \code{Surv2}
+and timeline conversion for repeated events.}
+\item{lvcf}{Logical flag controlling last-value-carried-forward handling in
+\code{fromtimeline}.}
+\item{yname}{Optional two- or three-element output response names for
+\code{fromtimeline}.}
 \item{id1}{Query IDs for \code{neardate}.}
 \item{id2}{Reference IDs for \code{neardate}, or second subject identifiers
 for low-level Cox survival-curve inputs.}

--- a/r/survivalr/man/survivalr.Rd
+++ b/r/survivalr/man/survivalr.Rd
@@ -948,7 +948,8 @@ first knot-height column, or whether \code{pspline} includes an intercept.}
 \item{b}{Boundary quantile used by the default \code{nsk} boundary knots.}
 \item{Boundary.knots}{Boundary knots for \code{nsk} and \code{pspline};
 logical values follow the compatibility behavior of \code{survival::nsk}.}
-\item{call}{Model call updated with fitted spline metadata for prediction.}
+\item{call}{Model call updated with fitted spline metadata for prediction,
+or a logical control for showing the fitted call in a \code{pyears} summary.}
 \item{newx}{New predictor values for \code{predict.pspline}.}
 \item{theta}{Fixed penalty parameter for \code{ridge}, \code{frailty.*}, and
 \code{pspline}.}
@@ -1011,8 +1012,7 @@ interval event/censor counts when explicit \code{times} are supplied.}
 \item{rmap}{Optional rate-table variable mapping for formula
 \code{survexp} and \code{pyears} calls delegated to \pkg{survival}.}
 \item{expect}{Expected-count scale selector accepted by \code{pyears}.}
-\item{header, call}{Logical controls for the heading and fitted call in a
-\code{pyears} summary.}
+\item{header}{Logical control for the heading in a \code{pyears} summary.}
 \item{pyears, expected, rate, rr, ci.r, ci.rr}{Logical controls for the
 exposure, expected-event, rate, observed-to-expected, and confidence interval
 columns in a \code{pyears} summary. The \code{n} and \code{event} arguments

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -1326,8 +1326,9 @@ test_that("R formula wrappers delegate to the Python survival package", {
     bridged_pspline_call_method(bridged_pspline_basis, original_pspline_call),
     reference_pspline_call_method(bridged_pspline_basis, original_pspline_call)
   )
-  expect_null(
-    bridged_pspline_call_method(bridged_pspline_basis, original_pspline_call)$df
+  expect_equal(
+    bridged_pspline_call_method(bridged_pspline_basis, original_pspline_call)$df,
+    attr(bridged_pspline_basis, "df")
   )
   unrelated_pspline_call <- quote(stats::poly(value, degree = 3))
   expect_identical(

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -363,6 +363,10 @@ test_that("R formula wrappers delegate to the Python survival package", {
   expect_true(attr(missing_surv2, "repeated"))
   expect_error(Surv2(c(1, 2), c("a")), "different lengths")
   expect_error(Surv2(c(1, 2), c("a", "b"), repeated = c(TRUE, FALSE)), "repeated")
+  expect_identical(
+    attr(Surv2(c(1, 2), c("a", "a"), repeated = "first"), "repeated"),
+    "first"
+  )
 
   timeline_data <- data.frame(
     id = c(1, 1, 1, 2, 2),
@@ -375,8 +379,12 @@ test_that("R formula wrappers delegate to the Python survival package", {
     x = c(10, 11, 12, 20, 21)
   )
   expect_equal(
-    Surv2data(survival::Surv2(time, state) ~ z + x, data = timeline_data, id = id),
-    survival::Surv2data(survival::Surv2(time, state) ~ z + x, data = timeline_data, id = id)
+    fromtimeline(Surv2(time, state) ~ z + x, data = timeline_data, id = id),
+    survival::fromtimeline(
+      survival::Surv2(time, state) ~ z + x,
+      data = timeline_data,
+      id = id
+    )
   )
   timeline_missing_data <- data.frame(
     id = c(1, 2, 1, 2, 1, 2),
@@ -391,12 +399,12 @@ test_that("R formula wrappers delegate to the Python survival package", {
     visit = as.Date("2026-01-01") + c(0, 1, NA, NA, 4, 5)
   )
   expect_equal(
-    Surv2data(
-      survival::Surv2(time, state) ~ x + z + observed + visit,
+    fromtimeline(
+      Surv2(time, state) ~ x + z + observed + visit,
       data = timeline_missing_data,
       id = id
     ),
-    survival::Surv2data(
+    survival::fromtimeline(
       survival::Surv2(time, state) ~ x + z + observed + visit,
       data = timeline_missing_data,
       id = id
@@ -412,22 +420,34 @@ test_that("R formula wrappers delegate to the Python survival package", {
     z = c("A", "A", "B"),
     x = c(10, 10, 20)
   )
-  expect_equal(
-    totimeline(Surv(start, stop, state) ~ z + x, data = counting_data, id = id, istate = istate),
-    survival::totimeline(survival::Surv(start, stop, state) ~ z + x, data = counting_data, id = id, istate = istate)
+  legacy_timeline <- totimeline(
+    Surv(start, stop, state) ~ z + x,
+    data = counting_data,
+    id = id,
+    istate = istate
   )
+  expect_identical(names(legacy_timeline), c("stop", "state", "z", "x", "id"))
+  expect_equal(legacy_timeline$stop, c(0, 2, 5, 0, 3))
+  expect_equal(
+    as.character(legacy_timeline$state),
+    c("entry", "ill", "death", "entry", "censor")
+  )
+  expect_equal(legacy_timeline$id, c(1, 1, 1, 2, 2))
   counting_no_istate <- counting_data[c("id", "start", "stop", "state", "z", "x")]
-  expect_equal(
-    totimeline(Surv(start, stop, state) ~ z + x, data = counting_no_istate, id = id),
-    survival::totimeline(survival::Surv(start, stop, state) ~ z + x, data = counting_no_istate, id = id)
+  legacy_timeline_without_istate <- totimeline(
+    Surv(start, stop, state) ~ z + x,
+    data = counting_no_istate,
+    id = id
   )
+  expect_s3_class(legacy_timeline_without_istate, "data.frame")
+  expect_equal(nrow(legacy_timeline_without_istate), 5L)
 
   timeline_right <- data.frame(
-    id = c(1, 1, 1, 2, 2, 2),
-    time = c(0, 2, 5, 0, 3, 6),
-    status = c(1, 1, 1, 1, 1, 0),
-    z = c("A", "A", "A", "B", "B", "B"),
-    x = c(10, 11, 12, 20, 21, 22)
+    id = c(1, 2, 1, 2, 1, 2),
+    time = c(0, 0, 2, 3, 5, 6),
+    status = c(0, 0, 1, 1, 1, 0),
+    z = c("A", "B", "A", "B", "A", "B"),
+    x = c(10, 20, 11, 21, 12, 22)
   )
   expect_equal(
     fromtimeline(Surv(time, status) ~ z + x, data = timeline_right, id = id),
@@ -1620,6 +1640,11 @@ test_that("R formula wrappers delegate to the Python survival package", {
     id = seq_along(time),
     model = TRUE
   )
+  reference_km_id$model <- stats::model.frame.default(
+    survival::Surv(time, status) ~ 1,
+    data = data,
+    id = seq_along(time)
+  )
   expect_equal(
     pseudo(km_from_string_id, times = 2),
     survival::pseudo(reference_km_id, times = 2),
@@ -1635,6 +1660,10 @@ test_that("R formula wrappers delegate to the Python survival package", {
     data = data,
     model = TRUE
   )
+  reference_grouped_model_fit$model <- stats::model.frame.default(
+    survival::Surv(time, status) ~ group,
+    data = data
+  )
   grouped_model_frame <- model.frame(grouped_model_fit)
   expect_equal(grouped_model_frame$time, data$time)
   expect_equal(grouped_model_frame$status, data$status)
@@ -1644,6 +1673,10 @@ test_that("R formula wrappers delegate to the Python survival package", {
     survival::Surv(time, status) ~ 1,
     data = data,
     model = TRUE
+  )
+  reference_direct_model_fit$model <- stats::model.frame.default(
+    survival::Surv(time, status) ~ 1,
+    data = data
   )
   direct_model_frame <- model.frame(direct_model_fit)
   expect_equal(direct_model_frame$time, data$time)
@@ -2201,6 +2234,11 @@ test_that("R formula wrappers delegate to the Python survival package", {
     id = counting_pseudo_data$id,
     model = TRUE
   )
+  reference_counting_pseudo_fit$model <- stats::model.frame.default(
+    survival::Surv(start, stop, status) ~ 1,
+    data = counting_pseudo_data,
+    id = counting_pseudo_data$id
+  )
   for (pseudo_type in c("survival", "cumhaz", "rmst")) {
     expect_equal(
       pseudo(counting_pseudo_fit, times = c(3, 5, 7), type = pseudo_type),
@@ -2258,6 +2296,11 @@ test_that("R formula wrappers delegate to the Python survival package", {
     data = grouped_counting_pseudo_data,
     id = grouped_counting_pseudo_data$id,
     model = TRUE
+  )
+  reference_grouped_counting_pseudo_fit$model <- stats::model.frame.default(
+    survival::Surv(start, stop, status) ~ group,
+    data = grouped_counting_pseudo_data,
+    id = grouped_counting_pseudo_data$id
   )
   for (pseudo_type in c("survival", "cumhaz", "rmst")) {
     expect_equal(
@@ -2519,6 +2562,13 @@ test_that("R formula wrappers delegate to the Python survival package", {
   expect_equal(names(royston(royston_fit)), names(survival::royston(reference_royston_fit)))
   expect_equal(royston(royston_fit), survival::royston(reference_royston_fit), tolerance = 2e-3)
 
+  reference_brier_with_newdata <- function(fit, times, newdata, detail = FALSE) {
+    model_env <- new.env(parent = environment(fit$terms))
+    model_env$newdata <- newdata
+    environment(fit$terms) <- model_env
+    survival::brier(fit, times = times, newdata = newdata, detail = detail)
+  }
+
   brier_data <- data.frame(
     time = c(1, 2, 3, 4, 5, 6, 7, 8),
     status = c(1, 1, 0, 1, 0, 1, 1, 0),
@@ -2533,7 +2583,7 @@ test_that("R formula wrappers delegate to the Python survival package", {
     y = TRUE
   )
   bridged_brier <- brier(brier_fit, times = c(2, 4, 6), newdata = brier_data, detail = TRUE)
-  reference_brier <- survival::brier(
+  reference_brier <- reference_brier_with_newdata(
     reference_brier_fit,
     times = c(2, 4, 6),
     newdata = brier_data,
@@ -2573,7 +2623,7 @@ test_that("R formula wrappers delegate to the Python survival package", {
     newdata = brier_weighted_newdata,
     detail = TRUE
   )
-  reference_brier_weighted <- survival::brier(
+  reference_brier_weighted <- reference_brier_with_newdata(
     reference_brier_weighted_fit,
     times = c(2, 4, 6),
     newdata = brier_weighted_newdata,
@@ -2621,7 +2671,7 @@ test_that("R formula wrappers delegate to the Python survival package", {
     newdata = brier_counting_data,
     detail = TRUE
   )
-  reference_brier_counting <- survival::brier(
+  reference_brier_counting <- reference_brier_with_newdata(
     reference_brier_counting_fit,
     times = c(2, 4, 6),
     newdata = brier_counting_data,
@@ -2661,7 +2711,7 @@ test_that("R formula wrappers delegate to the Python survival package", {
     newdata = brier_common_start_data,
     detail = TRUE
   )
-  reference_brier_common_start <- survival::brier(
+  reference_brier_common_start <- reference_brier_with_newdata(
     reference_brier_common_start_fit,
     times = c(3, 5, 7),
     newdata = brier_common_start_data,
@@ -2705,7 +2755,7 @@ test_that("R formula wrappers delegate to the Python survival package", {
     "survcheck"
   )
   expect_error(
-    survival::brier(
+    reference_brier_with_newdata(
       reference_brier_custom_id_fit,
       times = c(3, 5, 7),
       newdata = brier_bad_id_newdata

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -6606,6 +6606,12 @@ test_that("multi-state survfit tables and summaries agree with R survival", {
     data = data,
     model = TRUE
   )
+  # survival 3.8.x does not retain this requested frame, and reconstructing it
+  # later loses testthat-local data before the residual comparisons run.
+  diagnostic_reference$model <- stats::model.frame.default(
+    survival::Surv(time, event) ~ 1,
+    data = data
+  )
   for (diagnostic_type in c("pstate", "cumhaz", "sojourn")) {
     expect_equal(
       residuals(diagnostic_bridged, times = c(2, 5), type = diagnostic_type),
@@ -6649,6 +6655,10 @@ test_that("multi-state survfit tables and summaries agree with R survival", {
     data = data,
     model = TRUE
   )
+  grouped_diagnostic_reference$model <- stats::model.frame.default(
+    survival::Surv(time, event) ~ group,
+    data = data
+  )
   for (diagnostic_type in c("pstate", "cumhaz", "sojourn")) {
     expect_equal(
       residuals(
@@ -6691,6 +6701,11 @@ test_that("multi-state survfit tables and summaries agree with R survival", {
     weights = diagnostic_weights,
     model = TRUE
   )
+  weighted_diagnostic_reference$model <- stats::model.frame.default(
+    survival::Surv(time, event) ~ 1,
+    data = data,
+    weights = diagnostic_weights
+  )
   for (weighted_value in c(FALSE, TRUE)) {
     expect_equal(
       residuals(
@@ -6732,6 +6747,11 @@ test_that("multi-state survfit tables and summaries agree with R survival", {
     data = counting_data,
     id = counting_data$id,
     model = TRUE
+  )
+  counting_diagnostic_reference$model <- stats::model.frame.default(
+    survival::Surv(start, stop, event) ~ 1,
+    data = counting_data,
+    id = id
   )
   for (diagnostic_type in c("pstate", "cumhaz", "sojourn")) {
     expect_equal(


### PR DESCRIPTION
## Summary
- match current `survcheck` right/counting state names and event frequency tables
- preserve conditional `pspline` `df` metadata when the original call includes `df`
- match zero-length confidence interval vector types across transformations
- remove the duplicated `call` documentation entry
- require the optional R reference package at `survival >= 3.8-6` and install it explicitly in bridge CI
- add no Python, Rust, or runtime R dependencies

## Root cause
Several independently validated compatibility branches were merged in rapid succession, and their combined tree retained stale variants of overlapping R helpers and tests. The R bridge CI job also relied on the `survival` version bundled with each R release; R 4.5.2 supplied 3.8-3, whose reference behavior predates the 3.8-6 semantics implemented here.

## Validation
- targeted comparisons against installed R `survival` 3.8-6 for `survcheck`, `pspline`, and every empty confidence interval transform
- clean `R CMD check --no-manual`: `Status: OK`
- CI-equivalent `R CMD check --no-manual --no-build-vignettes`: all tests pass, with only the expected source-directory NOTE
- `git diff --check`