### PR TITLE
Prepare survival 1.3.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1225,7 +1225,7 @@ dependencies = [
 
 [[package]]
 name = "survival"
-version = "2.0.0"
+version = "1.3.0"
 dependencies = [
  "burn",
  "divan",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "survival"
-version = "2.0.0"
+version = "1.3.0"
 edition = "2024"
 rust-version = "1.94"
 authors = ["Cameron Lyons <cameron.lyons2@gmail.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "survival"
-version = "2.0.0"
+version = "1.3.0"
 description = "A high-performance survival analysis library written in Rust with Python bindings"
 readme = "README.md"
 license = { text = "MIT" }

--- a/python/survival/__init__.py
+++ b/python/survival/__init__.py
@@ -2,7 +2,7 @@ from importlib import import_module as _import_module
 
 from ._binding_manifest import MODULE_BINDINGS
 
-__version__ = "2.0.0"
+__version__ = "1.3.0"
 
 _PUBLIC_MODULES = {
     "bayesian": ".bayesian",

--- a/uv.lock
+++ b/uv.lock
@@ -845,7 +845,7 @@ wheels = [
 
 [[package]]
 name = "survival"
-version = "2.0.0"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
Bumps the Python and Rust package versions to 1.3.0 and keeps package metadata and lockfiles aligned.\n\nValidation: cargo test --lib --no-default-features (1,453 passed).\n\nAfter merge, publish the coordinated PyPI and crates.io release from v1.3.0.