### PR TITLE
Fix crates.io publication ordering

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -275,6 +275,35 @@ jobs:
             echo "Version ${VERSION} not found on crates.io, will publish"
           fi
 
+      - name: Check if shim version exists on crates.io
+        id: check-shim
+        run: |
+          if curl -s "https://crates.io/api/v1/crates/survival-pyo3-macros-shim/0.1.0" | grep -q '"version"'; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Shim version 0.1.0 already exists on crates.io, skipping publish"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "Shim version 0.1.0 not found on crates.io, will publish"
+          fi
+
+      - name: Publish shim to crates.io
+        if: steps.check.outputs.exists == 'false' && steps.check-shim.outputs.exists == 'false'
+        run: cargo publish --manifest-path survival-pyo3-macros-shim/Cargo.toml
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Wait for shim index availability
+        if: steps.check.outputs.exists == 'false' && steps.check-shim.outputs.exists == 'false'
+        run: |
+          for attempt in {1..30}; do
+            if curl -fsS "https://crates.io/api/v1/crates/survival-pyo3-macros-shim/0.1.0" >/dev/null; then
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "Timed out waiting for survival-pyo3-macros-shim 0.1.0 on crates.io" >&2
+          exit 1
+
       - name: Publish to crates.io
         if: steps.check.outputs.exists == 'false'
         run: cargo publish

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ numpy = { version = "0.29.0", optional = true }
 ndarray = "0.17.2"
 rayon = "1.12.0"
 burn = { version = "0.21.0", default-features = false, features = ["autodiff", "ndarray"], optional = true }
-survival-pyo3-macros-shim = { path = "survival-pyo3-macros-shim" }
+survival-pyo3-macros-shim = { version = "0.1.0", path = "survival-pyo3-macros-shim" }
 
 [features]
 default = []

--- a/survival-pyo3-macros-shim/Cargo.toml
+++ b/survival-pyo3-macros-shim/Cargo.toml
@@ -2,7 +2,9 @@
 name = "survival-pyo3-macros-shim"
 version = "0.1.0"
 edition = "2024"
+description = "Internal no-op PyO3 attribute macros for survival's Rust-only builds"
+license = "MIT"
+repository = "https://github.com/Cameron-Lyons/survival"
 
 [lib]
 proc-macro = true
-


### PR DESCRIPTION
Adds the required registry version to the internal proc-macro dependency, publishes that shim before the main crate, and waits for crates.io index availability. This fixes the v1.3.0 crates.io release failure.