### PR TITLE
Restore PyPI token authentication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -248,6 +248,8 @@ jobs:
       - name: Publish to PyPI
         if: steps.check.outputs.exists == 'false'
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
 
   publish-crates:
     name: Publish to crates.io


### PR DESCRIPTION
Restores the existing PYPI_API_TOKEN authentication used by prior successful releases. Trusted publishing currently fails because no matching PyPI publisher is configured.