### PR TITLE
Reduce Cox zph output traffic

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -14189,11 +14189,15 @@ def cox_zph(
     dense_groups = [columns for _name, columns in groups]
     active_beta = [beta[idx] for idx in active_columns]
 
-    event_indices = _cox_event_indices(fit)
+    all_times = [float(value) for value in model.event_times]
+    all_status = [int(value) for value in model.status]
+    if len(all_times) != len(all_status):
+        raise ValueError("fitted Cox model times and status have inconsistent lengths")
+    row_strata = _cox_training_strata(model, len(all_status))
+    event_indices = _cox_event_indices_from_arrays(all_times, all_status, row_strata)
     if not event_indices:
         raise ValueError("cox_zph requires at least one event")
-    event_times = [float(fit.event_times[idx]) for idx in event_indices]
-    row_strata = _cox_training_strata(fit, len(fit.status))
+    event_times = [all_times[idx] for idx in event_indices]
     event_strata_codes = [row_strata[idx] for idx in event_indices]
     design = _formula_design_for_fit(fit)
     event_strata = None
@@ -14201,8 +14205,14 @@ def cox_zph(
         event_strata = _cox_strata_labels_for_fit(fit, event_strata_codes)
         if event_strata is None:
             event_strata = event_strata_codes
+    raw_entry_times = getattr(model, "entry_times", None)
+    entry_times = (
+        [float(value) for value in raw_entry_times] if raw_entry_times is not None else None
+    )
     transform_name, transformed_time = _cox_zph_transform(
-        fit,
+        all_times,
+        all_status,
+        entry_times,
         event_indices,
         event_times,
         transform,
@@ -14211,7 +14221,7 @@ def cox_zph(
         variance = getattr(fit, "information_matrix", None)
         if variance is None:
             raise TypeError("model does not expose coefficient variance")
-        scaled_result, test = native_method(
+        grouped_result, test = native_method(
             transformed_time,
             active_columns,
             dense_groups,
@@ -14219,7 +14229,11 @@ def cox_zph(
             single_df,
             include_global,
         )
-        scaled = [[float(value) for value in row] for row in scaled_result]
+        grouped_y = [[float(value) for value in row] for row in grouped_result]
+        if len(event_indices) != len(grouped_y):
+            raise ValueError("fitted Cox model event times do not match diagnostic residuals")
+        if any(len(row) != len(groups) for row in grouped_y):
+            raise ValueError("Cox zph diagnostic residuals must be rectangular")
     else:
         if scaled_method is None:
             raise TypeError("cox_zph requires a fitted Cox model")
@@ -14236,15 +14250,15 @@ def cox_zph(
             single_df,
             include_global,
         )
-    if len(event_indices) != len(scaled):
-        raise ValueError("fitted Cox model event times do not match Schoenfeld residuals")
-    if any(len(row) != len(active_columns) for row in scaled):
-        raise ValueError("scaled Schoenfeld residuals must be rectangular")
-    grouped_y = (
-        _cox_zph_term_matrix(scaled, groups, active_beta)
-        if group_terms and groups
-        else _matrix_columns(scaled, [idx for _name, columns in groups for idx in columns])
-    )
+        if len(event_indices) != len(scaled):
+            raise ValueError("fitted Cox model event times do not match Schoenfeld residuals")
+        if any(len(row) != len(active_columns) for row in scaled):
+            raise ValueError("scaled Schoenfeld residuals must be rectangular")
+        grouped_y = (
+            _cox_zph_term_matrix(scaled, groups, active_beta)
+            if group_terms and groups
+            else _matrix_columns(scaled, [idx for _name, columns in groups for idx in columns])
+        )
     return CoxZPHResult(
         variable_names=[name for name, _columns in groups],
         chi2_values=[float(value) for value in test.chi2_values],
@@ -14253,7 +14267,7 @@ def cox_zph(
         x=transformed_time,
         time=event_times,
         y=grouped_y,
-        var=_cox_zph_group_variance(fit, groups, active_beta, active_columns, len(scaled)),
+        var=_cox_zph_group_variance(fit, groups, active_beta, active_columns, len(event_indices)),
         transform=transform_name,
         global_chi2=float(test.global_chi2) if include_global else None,
         global_df=int(test.global_df) if include_global else None,
@@ -14657,12 +14671,19 @@ def _cox_partial_residuals(
     ]
 
 
-def _cox_event_indices(fit: Any) -> list[int]:
-    status = [int(value) for value in fit.status]
-    times = [float(value) for value in fit.event_times]
-    strata_values = fit.strata if hasattr(fit, "strata") else [0] * len(status)
-    strata = [int(value) for value in strata_values]
+def _cox_event_indices_from_arrays(
+    times: list[float], status: list[int], strata: list[int]
+) -> list[int]:
     return [int(idx) for idx in _core.cox_event_indices(times, status, strata)]
+
+
+def _cox_event_indices(fit: Any) -> list[int]:
+    model = _unwrap_formula_fit(fit)
+    status = [int(value) for value in model.status]
+    times = [float(value) for value in model.event_times]
+    raw_strata = getattr(model, "strata", None)
+    strata = [int(value) for value in raw_strata] if raw_strata is not None else [0] * len(status)
+    return _cox_event_indices_from_arrays(times, status, strata)
 
 
 def _cox_scaled_schoenfeld_from_raw(fit: Any, raw: list[list[float]]) -> list[list[float]]:
@@ -14710,14 +14731,16 @@ def _average_ranks(values: list[float]) -> list[float]:
     return ranks
 
 
-def _cox_zph_km_transform(fit: Any, event_times: list[float]) -> list[float]:
-    all_times = [float(value) for value in fit.event_times]
-    status = [int(value) for value in fit.status]
-    entry_times = getattr(fit, "entry_times", None)
+def _cox_zph_km_transform(
+    all_times: list[float],
+    status: list[int],
+    entry_times: list[float] | None,
+    event_times: list[float],
+) -> list[float]:
     km = _core.survfitkm(
         all_times,
         status,
-        entry_times=[float(value) for value in entry_times] if entry_times is not None else None,
+        entry_times=entry_times,
         conf_type="none",
     )
     curve_times = [float(value) for value in km.time]
@@ -14731,12 +14754,13 @@ def _cox_zph_km_transform(fit: Any, event_times: list[float]) -> list[float]:
 
 
 def _cox_zph_transform(
-    fit: Any,
+    all_times: list[float],
+    status: list[int],
+    entry_times: list[float] | None,
     event_indices: list[int],
     event_times: list[float],
     transform: Any,
 ) -> tuple[str, list[float]]:
-    all_times = [float(value) for value in fit.event_times]
     if any(idx < 0 or idx >= len(all_times) for idx in event_indices):
         raise ValueError("event indices do not match fitted model times")
 
@@ -14764,7 +14788,7 @@ def _cox_zph_transform(
     )
 
     if normalized == "km":
-        return "km", _cox_zph_km_transform(fit, event_times)
+        return "km", _cox_zph_km_transform(all_times, status, entry_times, event_times)
     if normalized == "rank":
         return "rank", select_events(_average_ranks(all_times))
     if normalized == "log":

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -1,6 +1,7 @@
 import math
 import random
 from bisect import bisect_right
+from dataclasses import replace
 from itertools import combinations
 from statistics import NormalDist
 
@@ -10801,6 +10802,33 @@ def test_cox_zph_uses_fit_owned_native_diagnostics(monkeypatch):
 
     assert result.variable_names == ["x1", "x2"]
     assert len(result.y) == sum(_toy_data()["status"])
+
+
+def test_cox_zph_materializes_fit_times_once():
+    fit = survival.coxph(
+        "Surv(time, status) ~ x1 + x2",
+        data=_toy_data(),
+        max_iter=10,
+        eps=1e-5,
+    )
+
+    class FitReadCounter:
+        def __init__(self, inner):
+            self.inner = inner
+            self.event_time_reads = 0
+
+        def __getattr__(self, name):
+            if name == "event_times":
+                self.event_time_reads += 1
+            return getattr(self.inner, name)
+
+    counter = FitReadCounter(fit.fit)
+    wrapped = replace(fit, fit=counter)
+
+    result = survival.cox_zph(wrapped, transform="km")
+
+    assert len(result.y) == sum(_toy_data()["status"])
+    assert counter.event_time_reads == 1
 
 
 def test_cox_zph_scales_variance_preserves_strata_and_subsets_variables():

--- a/src/regression/coxph_diagnostics.rs
+++ b/src/regression/coxph_diagnostics.rs
@@ -1462,7 +1462,7 @@ impl CoxPHFit {
         let scaled = scaled_full
             .into_iter()
             .map(|row| active_columns.iter().map(|&column| row[column]).collect())
-            .collect();
+            .collect::<Vec<Vec<f64>>>();
 
         let n = self.event_times.len();
         if self.status.len() != n
@@ -1507,7 +1507,8 @@ impl CoxPHFit {
             center: 0.0,
             include_riskmat: false,
         })?;
-        let active_beta = active_columns.iter().map(|&column| beta[column]).collect();
+        let active_beta: Vec<f64> = active_columns.iter().map(|&column| beta[column]).collect();
+        let grouped = cox_zph_term_matrix(scaled, groups.clone(), active_beta.clone())?;
         let test = cox_zph_tests_from_detail(
             detail,
             &transformed_events,
@@ -1517,7 +1518,7 @@ impl CoxPHFit {
             single_df,
             global_test,
         )?;
-        Ok((scaled, test))
+        Ok((grouped, test))
     }
 
     pub(crate) fn schoenfeld_residuals_internal(&self) -> PyResult<Vec<Vec<f64>>> {
@@ -2225,7 +2226,7 @@ mod tests {
             nocenter: Vec::new(),
         };
 
-        let (scaled, test) = fit
+        let (grouped, test) = fit
             .cox_zph_diagnostics_internal(
                 transformed_events.clone(),
                 vec![1],
@@ -2238,8 +2239,24 @@ mod tests {
         let expected_scaled = fit
             .scaled_schoenfeld_residuals_with_variance_internal(&variance)
             .expect("scaled residuals should compute");
-        for (actual, expected) in scaled.iter().zip(&expected_scaled) {
+        for (actual, expected) in grouped.iter().zip(&expected_scaled) {
             assert_eq!(actual, &vec![expected[1]]);
+        }
+        let (grouped_term, _) = fit
+            .cox_zph_diagnostics_internal(
+                transformed_events.clone(),
+                vec![0, 1],
+                vec![vec![0, 1]],
+                variance.clone(),
+                false,
+                true,
+            )
+            .expect("grouped fit-owned Cox zph diagnostic should compute");
+        for (actual, expected) in grouped_term.iter().zip(&expected_scaled) {
+            assert_eq!(
+                actual,
+                &vec![expected[0] * coefficients[0] + expected[1] * coefficients[1]]
+            );
         }
 
         let selected_rows = covariates


### PR DESCRIPTION
## Summary
- materialize fitted time, status, strata, and entry arrays once during Cox proportional-hazards diagnostics
- remove accidental repeated native-vector conversions from per-event result assembly
- return the final grouped residual matrix from Rust instead of moving a full coefficient matrix through Python and back
- retain the compatibility fallback for fit types without the fused native path

## Performance
On a 400-row, 16-covariate fit with 300 events:
- public `cox_zph`: 1.64 ms to 0.90 ms (about 45% faster for this slice)
- cumulative diagnostic stack: 6.62 ms to 0.90 ms (about 7.4x faster)

## Validation
- Rust all features: 1682 tests passed
- Clippy: all targets and features, warnings denied
- Python: 855 passed, 18 skipped
- Ruff check and format check
- mypy stub check
- R package check: one expected source-directory NOTE