### PR TITLE
Keep Cox detail fit-owned

### DIFF
--- a/python/survival/_survival.pyi
+++ b/python/survival/_survival.pyi
@@ -1103,6 +1103,7 @@ class CoxPHFit:
     def scaled_schoenfeld_residuals_with_variance(
         self, information_matrix: list[list[float]]
     ) -> list[list[float]]: ...
+    def coxph_detail(self, riskmat: bool) -> CoxphDetail: ...
     def cox_zph_diagnostics(
         self,
         transformed_events: list[float],

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -19689,6 +19689,7 @@ def coxph_detail(
     rorder_name = _cox_detail_rorder(rorder)
     model = _unwrap_formula_fit(fit)
     method = _cox_detail_method(model)
+    native_detail = getattr(model, "coxph_detail", None)
     beta = _cox_beta(model)
     nvar = len(beta)
     rows = _cox_training_rows(model, nvar)
@@ -19704,25 +19705,27 @@ def coxph_detail(
         raise ValueError("fitted Cox model entry times do not match event rows")
     weights = _model_residual_weights(model, n)
     strata = _cox_training_strata(model, n)
-    linear_predictors = [float(value) for value in model.linear_predictors]
-    if len(linear_predictors) != n:
-        raise ValueError("fitted Cox model linear predictors do not match event rows")
-
-    center = _cox_reference_center(model, "sample")
-    offset = _cox_fit_offset(model, beta)
-    detail = _core.coxph_detail(
-        time,
-        status,
-        rows,
-        beta,
-        weights,
-        entry_times=entry,
-        strata=strata,
-        offset=offset,
-        method=method,
-        center=center,
-        riskmat=include_riskmat,
-    )
+    if native_detail is not None:
+        detail = native_detail(include_riskmat)
+    else:
+        linear_predictors = [float(value) for value in model.linear_predictors]
+        if len(linear_predictors) != n:
+            raise ValueError("fitted Cox model linear predictors do not match event rows")
+        center = _cox_reference_center(model, "sample")
+        offset = _cox_fit_offset(model, beta)
+        detail = _core.coxph_detail(
+            time,
+            status,
+            rows,
+            beta,
+            weights,
+            entry_times=entry,
+            strata=strata,
+            offset=offset,
+            method=method,
+            center=center,
+            riskmat=include_riskmat,
+        )
     detail_rows = list(detail.rows)
 
     row_order = _cox_detail_row_order(time, status, strata, rorder_name)

--- a/python/tests/test_binding_contract.py
+++ b/python/tests/test_binding_contract.py
@@ -849,6 +849,7 @@ def test_coxph_fit_detail_bindings_are_typed_to_runtime_surface():
         "schoenfeld_residuals": ["self"],
         "scaled_schoenfeld_residuals": ["self"],
         "scaled_schoenfeld_residuals_with_variance": ["self", "information_matrix"],
+        "coxph_detail": ["self", "riskmat"],
         "cox_zph_diagnostics": [
             "self",
             "transformed_events",
@@ -1076,6 +1077,12 @@ def test_coxph_fit_detail_bindings_are_typed_to_runtime_surface():
     assert len(detail.variance_hazards()) == sum(status)
     assert len(detail.weighted_risk()) == sum(status)
     assert len(detail.schoenfeld_residuals()) == sum(status)
+
+    fitted_detail = fit.coxph_detail(True)
+    assert type(fitted_detail).__name__ == "CoxphDetail"
+    assert fitted_detail.n_events == detail.n_events
+    assert fitted_detail.n_observations == detail.n_observations
+    assert fitted_detail.riskmat == detail.riskmat
 
     detail_with_riskmat = core.coxph_detail(
         time,

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -9883,6 +9883,79 @@ def test_coxph_detail_exposes_r_style_event_contributions():
     assert all(value > 0.0 for value in detail.varhaz)
 
 
+def test_coxph_detail_uses_fit_owned_native_path(monkeypatch):
+    fit = survival.coxph(
+        "Surv(time, status) ~ x1 + x2",
+        data=_toy_data(),
+        init=[0.0, 0.0],
+        max_iter=0,
+        method="breslow",
+    )
+
+    def reject_exported_arrays(*args, **kwargs):
+        del args, kwargs
+        raise AssertionError("fitted Cox detail should not export arrays to the low-level binding")
+
+    monkeypatch.setattr(survival.r_api._core, "coxph_detail", reject_exported_arrays)
+
+    detail = survival.coxph_detail(fit, riskmat=True)
+
+    assert detail.nevent == [1] * sum(_toy_data()["status"])
+    assert detail.riskmat is not None
+
+
+def test_coxph_detail_fit_owned_path_matches_export_fallback():
+    data = _counting_cox_data() | {
+        "group": ["A", "A", "A", "A", "B", "B"],
+        "binary": [0, 1, 0, 1, 0, 1],
+        "offset": [0.1, -0.2, 0.05, 0.0, 0.2, -0.1],
+    }
+    weights = [1.0, 1.5, 0.75, 2.0, 1.25, 0.5]
+    fit = survival.coxph(
+        "Surv(start, stop, status) ~ x1 + binary + offset(offset) + strata(group)",
+        data=data,
+        weights=weights,
+        init=[0.2, -0.1],
+        max_iter=0,
+        method="efron",
+    )
+
+    class HideNativeDetail:
+        def __init__(self, inner):
+            self.inner = inner
+
+        def __getattr__(self, name):
+            if name == "coxph_detail":
+                raise AttributeError(name)
+            return getattr(self.inner, name)
+
+    fallback_fit = replace(fit, fit=HideNativeDetail(fit.fit))
+    native = survival.coxph_detail(fit, riskmat=True, rorder="time")
+    fallback = survival.coxph_detail(fallback_fit, riskmat=True, rorder="time")
+
+    assert native.time == pytest.approx(fallback.time)
+    assert native.nevent == fallback.nevent
+    assert native.nrisk == fallback.nrisk
+    for actual, expected in zip(native.means, fallback.means, strict=True):
+        assert actual == pytest.approx(expected)
+    for actual, expected in zip(native.score, fallback.score, strict=True):
+        assert actual == pytest.approx(expected)
+    for actual, expected in zip(native.imat, fallback.imat, strict=True):
+        for actual_row, expected_row in zip(actual, expected, strict=True):
+            assert actual_row == pytest.approx(expected_row)
+    assert native.hazard == pytest.approx(fallback.hazard)
+    assert native.varhaz == pytest.approx(fallback.varhaz)
+    assert native.wtrisk == pytest.approx(fallback.wtrisk)
+    assert native.x == fallback.x
+    assert native.y == fallback.y
+    assert native.strata == fallback.strata
+    assert native.riskmat == fallback.riskmat
+    assert native.weights == pytest.approx(fallback.weights)
+    assert native.nevent_wt == pytest.approx(fallback.nevent_wt)
+    assert native.nrisk_wt == pytest.approx(fallback.nrisk_wt)
+    assert native.sortorder == fallback.sortorder
+
+
 def test_coxph_detail_efron_tie_averages_step_risk_means():
     data = {
         "time": [1.0, 1.0, 2.0],

--- a/src/regression/coxph.rs
+++ b/src/regression/coxph.rs
@@ -4,6 +4,7 @@ use crate::constants::{
 };
 use crate::internal::validation::validate_binary_i32;
 use crate::regression::cox_optimizer::{CoxFit, Method as CoxMethod};
+use crate::regression::coxph_detail_module::{CoxphDetail, fitted_coxph_detail};
 pub use crate::regression::coxph_model::{CoxPHModel, Subject};
 use crate::regression::coxph_support::{ActiveRiskSet, CoxSweepRow, StratifiedBaselineLookup};
 use ndarray::{Array1, Array2};
@@ -502,6 +503,10 @@ impl CoxPHFit {
         information_matrix: Vec<Vec<f64>>,
     ) -> PyResult<Vec<Vec<f64>>> {
         self.scaled_schoenfeld_residuals_with_variance_internal(&information_matrix)
+    }
+
+    pub fn coxph_detail(&self, riskmat: bool) -> PyResult<CoxphDetail> {
+        fitted_coxph_detail(self, riskmat)
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/src/regression/coxph_detail.rs
+++ b/src/regression/coxph_detail.rs
@@ -1,6 +1,7 @@
 use crate::constants::TIME_EPSILON;
 use crate::internal::cox_risk::{cox_risk_shift, shifted_weighted_exp_eta_with_shift};
 use crate::internal::validation::validate_binary_i32;
+use crate::regression::coxph::CoxPHFit;
 use crate::regression::coxph_support::{ActiveRiskSet, CoxSweepRow};
 use pyo3::prelude::*;
 use std::borrow::Cow;
@@ -73,6 +74,7 @@ pub(crate) struct CoxphDetailOptions<'a> {
     pub entry_times: Option<&'a [f64]>,
     pub strata: Option<&'a [i32]>,
     pub offset: Option<&'a [f64]>,
+    pub linear_predictors: Option<&'a [f64]>,
     pub method: &'a str,
     pub center: f64,
     pub include_riskmat: bool,
@@ -340,12 +342,19 @@ pub(crate) fn compute_coxph_detail_with_options(
         entry_times,
         strata,
         offset,
+        linear_predictors,
         method,
         center,
         include_riskmat,
     } = options;
     let n = time.len();
     let nvar = coefficients.len();
+
+    if linear_predictors.is_some_and(|values| values.len() != n) {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "linear_predictors must have the same length as time",
+        ));
+    }
 
     if n == 0 {
         return Ok(CoxphDetail {
@@ -368,21 +377,22 @@ pub(crate) fn compute_coxph_detail_with_options(
     let strata_values = strata
         .map(Cow::Borrowed)
         .unwrap_or_else(|| Cow::Owned(vec![0; n]));
-    let offsets = offset
-        .map(Cow::Borrowed)
-        .unwrap_or_else(|| Cow::Owned(vec![0.0; n]));
 
-    let linear_predictors: Vec<f64> = covariates
-        .iter()
-        .enumerate()
-        .map(|(idx, cov)| {
-            let mut lp = offsets[idx];
-            for j in 0..nvar {
-                lp += cov[j] * coefficients[j];
-            }
-            lp
-        })
-        .collect();
+    let linear_predictors = linear_predictors.map(Cow::Borrowed).unwrap_or_else(|| {
+        Cow::Owned(
+            covariates
+                .iter()
+                .enumerate()
+                .map(|(idx, cov)| {
+                    let mut lp = offset.map_or(0.0, |values| values[idx]);
+                    for j in 0..nvar {
+                        lp += cov[j] * coefficients[j];
+                    }
+                    lp
+                })
+                .collect(),
+        )
+    });
     let risk_shift = cox_risk_shift_optional(&linear_predictors, weights);
     let risk_weights = shifted_weighted_exp_eta_optional(&linear_predictors, weights, risk_shift);
 
@@ -577,6 +587,80 @@ pub(crate) fn compute_coxph_detail_with_options(
     })
 }
 
+pub(crate) fn fitted_coxph_detail(fit: &CoxPHFit, include_riskmat: bool) -> PyResult<CoxphDetail> {
+    let beta = fit.coefficients.first().ok_or_else(|| {
+        PyErr::new::<pyo3::exceptions::PyValueError, _>("model has no fitted coefficients")
+    })?;
+    let n = fit.event_times.len();
+    let nvar = beta.len();
+    if fit.status.len() != n
+        || fit.covariates.len() != n
+        || fit.linear_predictors.len() != n
+        || fit.weights.len() != n
+        || fit.strata.len() != n
+    {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "fitted Cox model detail arrays have inconsistent lengths",
+        ));
+    }
+    if fit.covariates.iter().any(|row| row.len() != nvar) {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "fitted Cox model covariates do not match coefficient width",
+        ));
+    }
+    if fit.means.len() != nvar {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "fitted Cox model means do not match coefficient width",
+        ));
+    }
+    if fit
+        .entry_times
+        .as_ref()
+        .is_some_and(|values| values.len() != n)
+    {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "fitted Cox model entry times do not match event rows",
+        ));
+    }
+
+    let offset_sum = fit
+        .covariates
+        .iter()
+        .zip(&fit.linear_predictors)
+        .map(|(row, &linear_predictor)| {
+            linear_predictor
+                - row
+                    .iter()
+                    .zip(beta)
+                    .map(|(&value, &coefficient)| value * coefficient)
+                    .sum::<f64>()
+        })
+        .sum::<f64>();
+    let offset_center = if n == 0 { 0.0 } else { offset_sum / n as f64 };
+    let center = fit
+        .means
+        .iter()
+        .zip(beta)
+        .map(|(&value, &coefficient)| value * coefficient)
+        .sum::<f64>()
+        + offset_center;
+
+    compute_coxph_detail_with_options(CoxphDetailOptions {
+        time: &fit.event_times,
+        status: &fit.status,
+        covariates: &fit.covariates,
+        coefficients: beta,
+        weights: Some(&fit.weights),
+        entry_times: fit.entry_times.as_deref(),
+        strata: Some(&fit.strata),
+        offset: None,
+        linear_predictors: Some(&fit.linear_predictors),
+        method: &fit.method,
+        center,
+        include_riskmat,
+    })
+}
+
 #[pyfunction]
 #[pyo3(signature = (
     time,
@@ -725,6 +809,7 @@ pub fn coxph_detail(
         entry_times: entry_times.as_deref(),
         strata: strata.as_deref(),
         offset: offset.as_deref(),
+        linear_predictors: None,
         method: &method,
         center,
         include_riskmat: riskmat,
@@ -809,6 +894,7 @@ mod tests {
             entry_times: None,
             strata: None,
             offset: None,
+            linear_predictors: None,
             method: "breslow",
             center: 0.0,
             include_riskmat: false,
@@ -847,6 +933,7 @@ mod tests {
             entry_times: None,
             strata: None,
             offset: None,
+            linear_predictors: None,
             method: "efron",
             center: 0.0,
             include_riskmat: false,
@@ -862,6 +949,7 @@ mod tests {
             entry_times: None,
             strata: None,
             offset: None,
+            linear_predictors: None,
             method: "efron",
             center: 0.0,
             include_riskmat: false,
@@ -887,6 +975,7 @@ mod tests {
             entry_times: None,
             strata: None,
             offset: None,
+            linear_predictors: None,
             method: "efron",
             center: 0.0,
             include_riskmat: false,
@@ -921,6 +1010,7 @@ mod tests {
             entry_times: None,
             strata: None,
             offset: None,
+            linear_predictors: None,
             method: "breslow",
             center: 0.0,
             include_riskmat: false,
@@ -935,6 +1025,7 @@ mod tests {
             entry_times: None,
             strata: None,
             offset: None,
+            linear_predictors: None,
             method: "efron",
             center: 0.0,
             include_riskmat: false,
@@ -964,6 +1055,7 @@ mod tests {
             entry_times: None,
             strata: None,
             offset: None,
+            linear_predictors: None,
             method: "breslow",
             center: 0.0,
             include_riskmat: false,
@@ -997,6 +1089,7 @@ mod tests {
             entry_times: None,
             strata: None,
             offset: None,
+            linear_predictors: None,
             method: "breslow",
             center: 0.0,
             include_riskmat: false,
@@ -1026,6 +1119,7 @@ mod tests {
             entry_times: None,
             strata: Some(&strata),
             offset: None,
+            linear_predictors: None,
             method: "breslow",
             center: 0.0,
             include_riskmat: true,
@@ -1061,6 +1155,7 @@ mod tests {
             entry_times: Some(&entry),
             strata: Some(&strata),
             offset: None,
+            linear_predictors: None,
             method: "breslow",
             center: 0.0,
             include_riskmat: true,
@@ -1109,6 +1204,7 @@ mod tests {
             entry_times: Some(&entry),
             strata: Some(&strata),
             offset: Some(&offsets),
+            linear_predictors: None,
             method: "breslow",
             center: 0.0,
             include_riskmat: true,

--- a/src/regression/coxph_diagnostics.rs
+++ b/src/regression/coxph_diagnostics.rs
@@ -1476,19 +1476,6 @@ impl CoxPHFit {
             ));
         }
         validate_matrix_width(&self.covariates, nvar, "covariates")?;
-        let offset: Vec<f64> = self
-            .covariates
-            .iter()
-            .zip(&self.linear_predictors)
-            .map(|(row, &linear_predictor)| {
-                linear_predictor
-                    - row
-                        .iter()
-                        .zip(beta)
-                        .map(|(&value, &coefficient)| value * coefficient)
-                        .sum::<f64>()
-            })
-            .collect();
         let method = if matches!(self.tie_method(), CoxMethod::Efron) {
             "efron"
         } else {
@@ -1502,7 +1489,8 @@ impl CoxPHFit {
             weights: Some(&self.weights),
             entry_times: self.entry_times.as_deref(),
             strata: Some(&self.strata),
-            offset: Some(&offset),
+            offset: None,
+            linear_predictors: Some(&self.linear_predictors),
             method,
             center: 0.0,
             include_riskmat: false,


### PR DESCRIPTION
## Summary
- compute `coxph_detail` directly from arrays already owned by a fitted Rust model
- reuse stored linear predictors instead of exporting training arrays and recomputing offsets and risk scores through Python
- retain the low-level raw-array API and compatibility fallback
- cover weighted Efron ties, strata, delayed entry, offsets, uncentered binary covariates, risk matrices, and row ordering

## Performance
On a 400-row, 16-covariate fit:
- exported-array `coxph_detail`: 2.79 ms median
- fit-owned `coxph_detail`: 1.91 ms median (about 32% faster)
- public `cox_zph`: about 0.73 ms after reusing stored linear predictors, roughly 9x faster than the original 6.62 ms path

## Validation
- Rust all features: 1682 tests passed
- Clippy: all targets and features, warnings denied
- Python: 857 passed, 18 skipped
- Ruff check and format check
- mypy stub check
- R package check: one expected source-directory NOTE