### PR TITLE
Validate cause-specific predictions

### DIFF
--- a/python/tests/test_binding_contract.py
+++ b/python/tests/test_binding_contract.py
@@ -1599,6 +1599,32 @@ def test_cause_specific_cox_ties_match_reference_fits():
         assert result.n_iter == 4
 
 
+def test_cause_specific_predictions_validate_inputs_and_stay_bounded():
+    setup_survival_import()
+    core = importlib.import_module("survival._survival")
+    time = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+    cause = [1, 0, 1, 2, 1, 0]
+    config = core.CauseSpecificCoxConfig(1, core.CensoringType.Censored, 20, 1e-8, "breslow")
+    result = core.cause_specific_cox([-1.0, -0.5, 0.0, 0.5, 1.0, 1.5], 6, 1, time, cause, config)
+
+    for method_name in ["predict_cumulative_hazard", "predict_survival", "predict_cif"]:
+        method = getattr(result, method_name)
+        with pytest.raises(ValueError, match=r"x length must equal n_obs \* n_vars"):
+            method([0.0], 2)
+        with pytest.raises(ValueError, match="x contains non-finite value"):
+            method([math.inf], 1)
+        with pytest.raises(ValueError, match="x contains NaN"):
+            method([math.nan], 1)
+
+    survival = result.predict_survival([1e300], 1)[0]
+    cif = result.predict_cif([1e300], 1)[0]
+    assert all(math.isfinite(value) and 0.0 <= value <= 1.0 for value in survival + cif)
+    assert survival == sorted(survival, reverse=True)
+    assert cif == sorted(cif)
+    assert cif == pytest.approx([1.0 - value for value in survival])
+    assert result.predict_survival([], 0) == []
+
+
 def test_joint_competing_risk_bindings_are_typed_to_runtime_surface():
     setup_survival_import()
     core = importlib.import_module("survival._survival")

--- a/src/regression/cause_specific_cox.rs
+++ b/src/regression/cause_specific_cox.rs
@@ -1,4 +1,4 @@
-use crate::constants::exp_ci_bounds_95;
+use crate::constants::{exp_ci_bounds_95, exp_clamped};
 use crate::internal::validation::{
     validate_finite, validate_no_nan, validate_non_empty, validate_non_negative,
 };
@@ -133,62 +133,76 @@ impl CauseSpecificCoxResult {
         )
     }
 
-    fn predict_cumulative_hazard(&self, x: Vec<f64>, n_obs: usize) -> Vec<Vec<f64>> {
-        let n_vars = self.coefficients.len();
+    fn predict_cumulative_hazard(&self, x: Vec<f64>, n_obs: usize) -> PyResult<Vec<Vec<f64>>> {
+        let risk_scores = self.prediction_risk_scores(&x, n_obs)?;
 
-        (0..n_obs)
+        Ok(risk_scores
             .into_par_iter()
-            .map(|i| {
-                let mut linear_pred = 0.0;
-                for j in 0..n_vars {
-                    linear_pred += x[i * n_vars + j] * self.coefficients[j];
-                }
-                let exp_lp = linear_pred.exp();
-
+            .map(|risk_score| {
                 self.cumulative_baseline_hazard
                     .iter()
-                    .map(|&h0| h0 * exp_lp)
+                    .map(|&hazard| hazard * risk_score)
                     .collect()
             })
-            .collect()
+            .collect())
     }
 
-    fn predict_survival(&self, x: Vec<f64>, n_obs: usize) -> Vec<Vec<f64>> {
-        let cum_haz = self.predict_cumulative_hazard(x, n_obs);
-        cum_haz
+    fn predict_survival(&self, x: Vec<f64>, n_obs: usize) -> PyResult<Vec<Vec<f64>>> {
+        let cumulative_hazard = self.predict_cumulative_hazard(x, n_obs)?;
+        Ok(cumulative_hazard
             .into_par_iter()
-            .map(|h| h.iter().map(|&ch| (-ch).exp()).collect())
-            .collect()
-    }
-
-    fn predict_cif(&self, x: Vec<f64>, n_obs: usize) -> Vec<Vec<f64>> {
-        let n_vars = self.coefficients.len();
-        let n_times = self.baseline_hazard_times.len();
-
-        (0..n_obs)
-            .into_par_iter()
-            .map(|i| {
-                let mut linear_pred = 0.0;
-                for j in 0..n_vars {
-                    linear_pred += x[i * n_vars + j] * self.coefficients[j];
-                }
-                let exp_lp = linear_pred.exp();
-
-                let mut cif = Vec::with_capacity(n_times);
-                let mut cum_inc = 0.0;
-                let mut prev_surv = 1.0;
-
-                for t in 0..n_times {
-                    let h0_t = self.baseline_hazard[t];
-                    let h_t = h0_t * exp_lp;
-                    cum_inc += prev_surv * h_t;
-                    prev_surv *= (1.0 - h_t).max(0.0);
-                    cif.push(cum_inc);
-                }
-
-                cif
+            .map(|hazards| {
+                hazards
+                    .into_iter()
+                    .map(|hazard| (-hazard).exp().clamp(0.0, 1.0))
+                    .collect()
             })
-            .collect()
+            .collect())
+    }
+
+    fn predict_cif(&self, x: Vec<f64>, n_obs: usize) -> PyResult<Vec<Vec<f64>>> {
+        let cumulative_hazard = self.predict_cumulative_hazard(x, n_obs)?;
+        Ok(cumulative_hazard
+            .into_par_iter()
+            .map(|hazards| {
+                hazards
+                    .into_iter()
+                    .map(|hazard| (-(-hazard).exp_m1()).clamp(0.0, 1.0))
+                    .collect()
+            })
+            .collect())
+    }
+}
+
+impl CauseSpecificCoxResult {
+    fn prediction_risk_scores(&self, x: &[f64], n_obs: usize) -> PyResult<Vec<f64>> {
+        let n_vars = self.coefficients.len();
+        if n_vars == 0 {
+            return Err(PyValueError::new_err(
+                "cannot predict with a model that has no coefficients",
+            ));
+        }
+
+        let expected_len = n_obs.checked_mul(n_vars).ok_or_else(|| {
+            PyValueError::new_err("n_obs * n_vars overflowed while validating x length")
+        })?;
+        if x.len() != expected_len {
+            return Err(PyValueError::new_err("x length must equal n_obs * n_vars"));
+        }
+        validate_no_nan(x, "x")?;
+        validate_finite(x, "x")?;
+
+        x.par_chunks_exact(n_vars)
+            .map(|row| {
+                let linear_predictor = row
+                    .iter()
+                    .zip(&self.coefficients)
+                    .map(|(&value, &coefficient)| value * coefficient)
+                    .sum::<f64>();
+                (!linear_predictor.is_nan()).then(|| exp_clamped(linear_predictor))
+            })
+            .collect::<Option<Vec<_>>>()
+            .ok_or_else(|| PyValueError::new_err("x produced an undefined linear predictor"))
     }
 }
 
@@ -417,7 +431,10 @@ fn cause_specific_cox_fit(
                 .max(crate::constants::DIVISION_FLOOR)
         })
         .collect::<Vec<_>>();
-    let hazard_ratios = beta.iter().map(|&value| value.exp()).collect::<Vec<_>>();
+    let hazard_ratios = beta
+        .iter()
+        .map(|&value| exp_clamped(value))
+        .collect::<Vec<_>>();
     let (hr_ci_lower, hr_ci_upper) = exp_ci_bounds_95(&beta, &std_errors);
     let (baseline_times, cum_baseline_hazard) = fit.basehaz(false)?;
     let baseline_hazard = hazard_increments(&cum_baseline_hazard);
@@ -712,6 +729,7 @@ mod tests {
 
     #[test]
     fn test_cause_specific_cox_validates_public_inputs() {
+        pyo3::Python::initialize();
         let config =
             CauseSpecificCoxConfig::new(1, CensoringType::Censored, 100, 1e-5, "breslow").unwrap();
 


### PR DESCRIPTION
## Summary
- validate cause-specific prediction matrix shape and finite values before indexing
- build clamped Cox risk scores in one parallel pass
- keep survival and event-probability curves finite, bounded, monotone, and mutually consistent
- clamp fitted hazard-ratio outputs consistently with the shared Cox implementation
- make the focused public-input Rust test initialize Python independently

## Correctness
Malformed flattened matrices now raise `ValueError` instead of risking an out-of-bounds panic. NaN and infinite covariates are rejected, empty prediction batches remain supported, and extreme finite covariates produce bounded survival and event-probability curves.

## Validation
- 1,686 Rust tests passed
- 860 Python tests passed; 18 skipped
- focused Rust and public Python cause-specific tests passed independently
- strict Clippy, Ruff, formatting, and mypy checks passed
- R package check passed with the standard source-preparation NOTE