### PR TITLE
Match Aalen-Johansen CIF variance

### DIFF
--- a/python/tests/test_specialized.py
+++ b/python/tests/test_specialized.py
@@ -404,6 +404,49 @@ def test_finegray_regression_matches_reference_expansion_fit():
     assert result.iterations <= 5
 
 
+def test_competing_risks_cif_variance_matches_reference_fit():
+    time = [1.0, 2.0, 2.0, 3.0, 3.0, 4.0, 4.0, 5.0, 5.0, 6.0, 6.0, 7.0, 8.0, 9.0]
+    status = [1, 2, 1, 0, 1, 1, 1, 0, 1, 2, 1, 0, 2, 1]
+    result = survival.competing_risks_cif(time, status, 1)
+
+    assert result.cif == pytest.approx(
+        [
+            0.07142857142857143,
+            0.14285714285714285,
+            0.2142857142857143,
+            0.3730158730158731,
+            0.45238095238095244,
+            0.5476190476190477,
+            0.5476190476190477,
+            0.5476190476190477,
+            0.6904761904761906,
+        ]
+    )
+    assert [value**0.5 for value in result.variance] == pytest.approx(
+        [
+            0.06883029368995938,
+            0.09352195295828245,
+            0.10966421051124832,
+            0.13298562022664268,
+            0.13767692788533334,
+            0.1425323847047763,
+            0.1425323847047763,
+            0.1425323847047763,
+            0.1477037525490764,
+        ],
+        abs=1e-12,
+    )
+    assert result.n_risk == [14, 13, 11, 9, 7, 5, 3, 2, 1]
+    assert result.n_events == [1, 1, 1, 2, 1, 1, 0, 0, 1]
+
+    narrower = survival.competing_risks_cif(time, status, 1, confidence_level=0.8)
+    assert narrower.ci_lower[5] > result.ci_lower[5]
+    assert narrower.ci_upper[5] < result.ci_upper[5]
+
+    sparse_codes = survival.competing_risks_cif([1.0, 2.0], [1, 1_000_000], 1)
+    assert sparse_codes.cif == pytest.approx([0.5, 0.5])
+
+
 def test_finegray_regression_and_cif_validate_public_inputs():
     with pytest.raises(ValueError, match="time must not be empty"):
         survival.finegray_regression([], [], [], 1)

--- a/python/tests/test_specialized.py
+++ b/python/tests/test_specialized.py
@@ -381,6 +381,29 @@ def test_finegray_regression_and_cif_public_api():
     assert len(cif.times) == len(cif.cif)
 
 
+def test_finegray_regression_matches_reference_expansion_fit():
+    x1 = [0.2, -1.0, 0.7, 0.0, -0.6, 1.1, -0.2, 0.5, 1.2, -0.8, 0.3, -1.1, 0.9, -0.4]
+    x2 = [1.0, 0.4, -0.9, 0.2, 0.8, -0.5, 1.1, -0.3, 0.6, 1.3, -0.7, 0.5, -1.2, 0.1]
+    time = [1.0, 2.0, 2.0, 3.0, 3.0, 4.0, 4.0, 5.0, 5.0, 6.0, 6.0, 7.0, 8.0, 9.0]
+    status = [1, 2, 1, 0, 1, 1, 1, 0, 1, 2, 1, 0, 2, 1]
+
+    result = survival.finegray_regression(
+        time,
+        status,
+        [list(row) for row in zip(x1, x2, strict=True)],
+        1,
+        max_iter=100,
+        eps=1e-9,
+    )
+
+    assert result.coefficients == pytest.approx([0.9262513307123474, 0.6708780177415743], abs=1e-9)
+    assert result.std_errors == pytest.approx([0.5333226364854614, 0.5259212543997720], abs=1e-9)
+    assert result.log_likelihood_null == pytest.approx(-17.242724975366503, abs=1e-9)
+    assert result.log_likelihood == pytest.approx(-15.740994444075035, abs=1e-9)
+    assert result.convergence
+    assert result.iterations <= 5
+
+
 def test_finegray_regression_and_cif_validate_public_inputs():
     with pytest.raises(ValueError, match="time must not be empty"):
         survival.finegray_regression([], [], [], 1)

--- a/src/regression/finegray_regression.rs
+++ b/src/regression/finegray_regression.rs
@@ -1,13 +1,14 @@
 use pyo3::prelude::*;
-use rayon::prelude::*;
 use std::fmt;
 
 use crate::constants::{
-    IPCW_SURVIVAL_FLOOR, PARALLEL_THRESHOLD_LARGE, Z_SCORE_90, Z_SCORE_95, Z_SCORE_99,
-    clamped_normal_ci_bounds, exp_clamped, normal_ci_bounds_95, same_time,
+    IPCW_SURVIVAL_FLOOR, Z_SCORE_90, Z_SCORE_95, Z_SCORE_99, clamped_normal_ci_bounds, exp_clamped,
+    normal_ci_bounds_95, same_time,
 };
 use crate::internal::matrix::invert_matrix;
-use crate::internal::statistical::{compute_censoring_km, km_step_prob_at, normal_cdf};
+#[cfg(test)]
+use crate::internal::statistical::compute_censoring_km;
+use crate::internal::statistical::normal_cdf;
 
 fn value_error(message: impl Into<String>) -> PyErr {
     pyo3::exceptions::PyValueError::new_err(message.into())
@@ -217,44 +218,38 @@ pub(crate) fn finegray_regression_core(
         .count();
     let n_censored = status.iter().filter(|&&s| s == 0).count();
 
-    let (km_times, km_values) = compute_censoring_km(time, status);
-
     let mut indices: Vec<usize> = (0..n).collect();
     indices.sort_by(|&a, &b| time[a].total_cmp(&time[b]));
+    let event_groups = target_event_groups(&indices, time, status, event_type);
+    let censoring_survival = censoring_survival_before(&indices, time, status);
 
     let mut beta = vec![0.0; p];
     let mut converged = false;
     let mut iterations = 0;
 
-    let event_indices: Vec<usize> = indices
-        .iter()
-        .filter(|&&i| status[i] == event_type)
-        .copied()
-        .collect();
-
-    let log_likelihood_null = compute_log_likelihood(
-        &event_indices,
+    let (_, _, log_likelihood_null) = compute_gradient_hessian(
+        &event_groups,
         &vec![0.0; p],
         time,
         status,
         covariates,
         event_type,
-        &km_times,
-        &km_values,
+        &indices,
+        &censoring_survival,
     );
 
     for iter in 0..max_iter {
         iterations = iter + 1;
 
         let (gradient, hessian, _ll) = compute_gradient_hessian(
-            &event_indices,
+            &event_groups,
             &beta,
             time,
             status,
             covariates,
             event_type,
-            &km_times,
-            &km_values,
+            &indices,
+            &censoring_survival,
         );
 
         let neg_hessian: Vec<Vec<f64>> = hessian
@@ -286,26 +281,15 @@ pub(crate) fn finegray_regression_core(
         }
     }
 
-    let log_likelihood = compute_log_likelihood(
-        &event_indices,
+    let (_, hessian, log_likelihood) = compute_gradient_hessian(
+        &event_groups,
         &beta,
         time,
         status,
         covariates,
         event_type,
-        &km_times,
-        &km_values,
-    );
-
-    let (_, hessian, _) = compute_gradient_hessian(
-        &event_indices,
-        &beta,
-        time,
-        status,
-        covariates,
-        event_type,
-        &km_times,
-        &km_values,
+        &indices,
+        &censoring_survival,
     );
 
     let neg_hessian: Vec<Vec<f64>> = hessian
@@ -358,182 +342,184 @@ pub(crate) fn finegray_regression_core(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
-fn compute_log_likelihood(
-    event_indices: &[usize],
-    beta: &[f64],
+fn target_event_groups(
+    sorted_indices: &[usize],
     time: &[f64],
     status: &[i32],
-    covariates: &[Vec<f64>],
     event_type: i32,
-    km_times: &[f64],
-    km_values: &[f64],
-) -> f64 {
-    let n = time.len();
-    let p = beta.len();
+) -> Vec<Vec<usize>> {
+    let event_indices = sorted_indices
+        .iter()
+        .copied()
+        .filter(|&idx| status[idx] == event_type)
+        .collect::<Vec<_>>();
+    let mut groups: Vec<Vec<usize>> = Vec::new();
+    for idx in event_indices {
+        if groups
+            .last()
+            .is_some_and(|group| same_time(time[group[0]], time[idx]))
+        {
+            groups.last_mut().expect("event group exists").push(idx);
+        } else {
+            groups.push(vec![idx]);
+        }
+    }
+    groups
+}
 
-    let mut ll = 0.0;
+fn censoring_survival_before(sorted_indices: &[usize], time: &[f64], status: &[i32]) -> Vec<f64> {
+    let mut survival_before = vec![1.0; time.len()];
+    let mut survival = 1.0;
+    let mut at_risk = time.len();
+    let mut group_start = 0;
 
-    for &i in event_indices {
-        let t_i = time[i];
-
-        let mut eta_i = 0.0;
-        for k in 0..p {
-            eta_i += beta[k] * covariates[i][k];
+    while group_start < sorted_indices.len() {
+        let group_time = time[sorted_indices[group_start]];
+        let mut group_end = group_start + 1;
+        while group_end < sorted_indices.len()
+            && same_time(time[sorted_indices[group_end]], group_time)
+        {
+            group_end += 1;
         }
 
-        let mut sum_exp_eta = 0.0;
-        for j in 0..n {
-            let in_risk_set = if status[j] == 0 || status[j] == event_type {
-                time[j] >= t_i
-            } else {
-                true
-            };
-
-            if in_risk_set {
-                let mut eta_j = 0.0;
-                for k in 0..p {
-                    eta_j += beta[k] * covariates[j][k];
-                }
-
-                let weight = if status[j] != 0 && status[j] != event_type && time[j] < t_i {
-                    let g_ti = km_step_prob_at(t_i, km_times, km_values).max(IPCW_SURVIVAL_FLOOR);
-                    let g_tj =
-                        km_step_prob_at(time[j], km_times, km_values).max(IPCW_SURVIVAL_FLOOR);
-                    g_ti / g_tj
-                } else {
-                    1.0
-                };
-
-                sum_exp_eta += weight * exp_clamped(eta_j);
-            }
+        let group = &sorted_indices[group_start..group_end];
+        for &idx in group {
+            survival_before[idx] = survival;
         }
-
-        ll += eta_i - sum_exp_eta.ln();
+        let censored = group.iter().filter(|&&idx| status[idx] == 0).count();
+        let failures = group.len() - censored;
+        let censoring_risk = at_risk.saturating_sub(failures);
+        if censored > 0 && censoring_risk > 0 {
+            survival *= 1.0 - censored as f64 / censoring_risk as f64;
+        }
+        at_risk -= group.len();
+        group_start = group_end;
     }
 
-    ll
+    survival_before
+}
+
+#[derive(Clone)]
+struct RiskMoments {
+    scalar: f64,
+    first: Vec<f64>,
+    second: Vec<Vec<f64>>,
+}
+
+impl RiskMoments {
+    fn new(n_vars: usize) -> Self {
+        Self {
+            scalar: 0.0,
+            first: vec![0.0; n_vars],
+            second: vec![vec![0.0; n_vars]; n_vars],
+        }
+    }
+
+    fn add(&mut self, covariates: &[f64], weighted_risk: f64) {
+        self.scalar += weighted_risk;
+        for (column, &value) in covariates.iter().enumerate() {
+            self.first[column] += weighted_risk * value;
+            for (other_column, &other_value) in covariates.iter().enumerate() {
+                self.second[column][other_column] += weighted_risk * value * other_value;
+            }
+        }
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
 fn compute_gradient_hessian(
-    event_indices: &[usize],
+    event_groups: &[Vec<usize>],
     beta: &[f64],
     time: &[f64],
     status: &[i32],
     covariates: &[Vec<f64>],
     event_type: i32,
-    km_times: &[f64],
-    km_values: &[f64],
+    sorted_indices: &[usize],
+    censoring_survival: &[f64],
 ) -> (Vec<f64>, Vec<Vec<f64>>, f64) {
-    let n = time.len();
-    let p = beta.len();
+    let n_vars = beta.len();
+    let linear_predictors = covariates
+        .iter()
+        .map(|row| {
+            row.iter()
+                .zip(beta)
+                .map(|(&value, &coefficient)| value * coefficient)
+                .sum::<f64>()
+        })
+        .collect::<Vec<_>>();
+    let risk_scores = linear_predictors
+        .iter()
+        .map(|&value| exp_clamped(value))
+        .collect::<Vec<_>>();
 
-    let mut gradient = vec![0.0; p];
-    let mut hessian = vec![vec![0.0; p]; p];
-    let mut ll = 0.0;
-
-    let compute_event_contribution = |i: usize| -> (Vec<f64>, Vec<Vec<f64>>, f64) {
-        let t_i = time[i];
-        let mut local_grad = vec![0.0; p];
-        let mut local_hess = vec![vec![0.0; p]; p];
-
-        let mut eta_i = 0.0;
-        for k in 0..p {
-            eta_i += beta[k] * covariates[i][k];
-        }
-
-        let mut s0 = 0.0;
-        let mut s1 = vec![0.0; p];
-        let mut s2 = vec![vec![0.0; p]; p];
-
-        for j in 0..n {
-            let in_risk_set = if status[j] == 0 || status[j] == event_type {
-                time[j] >= t_i
-            } else {
-                true
-            };
-
-            if in_risk_set {
-                let mut eta_j = 0.0;
-                for k in 0..p {
-                    eta_j += beta[k] * covariates[j][k];
-                }
-
-                let weight = if status[j] != 0 && status[j] != event_type && time[j] < t_i {
-                    let g_ti = km_step_prob_at(t_i, km_times, km_values).max(IPCW_SURVIVAL_FLOOR);
-                    let g_tj =
-                        km_step_prob_at(time[j], km_times, km_values).max(IPCW_SURVIVAL_FLOOR);
-                    g_ti / g_tj
-                } else {
-                    1.0
-                };
-
-                let exp_eta = exp_clamped(eta_j);
-                let w_exp = weight * exp_eta;
-
-                s0 += w_exp;
-
-                for k in 0..p {
-                    s1[k] += w_exp * covariates[j][k];
-                }
-
-                for k in 0..p {
-                    for l in 0..p {
-                        s2[k][l] += w_exp * covariates[j][k] * covariates[j][l];
-                    }
-                }
+    let mut competing_prefixes = Vec::with_capacity(event_groups.len());
+    let mut competing_prefix = RiskMoments::new(n_vars);
+    let mut row_cursor = 0;
+    for group in event_groups {
+        let event_time = time[group[0]];
+        while row_cursor < sorted_indices.len()
+            && time[sorted_indices[row_cursor]] < event_time
+            && !same_time(time[sorted_indices[row_cursor]], event_time)
+        {
+            let idx = sorted_indices[row_cursor];
+            if status[idx] != 0 && status[idx] != event_type {
+                let normalized_risk =
+                    risk_scores[idx] / censoring_survival[idx].max(IPCW_SURVIVAL_FLOOR);
+                competing_prefix.add(&covariates[idx], normalized_risk);
             }
+            row_cursor += 1;
         }
-
-        let local_ll = eta_i - s0.ln();
-
-        for k in 0..p {
-            local_grad[k] = covariates[i][k] - s1[k] / s0;
-        }
-
-        for k in 0..p {
-            for l in 0..p {
-                local_hess[k][l] = -(s2[k][l] / s0 - (s1[k] / s0) * (s1[l] / s0));
-            }
-        }
-
-        (local_grad, local_hess, local_ll)
-    };
-
-    if event_indices.len() > PARALLEL_THRESHOLD_LARGE {
-        let results: Vec<_> = event_indices
-            .par_iter()
-            .map(|&i| compute_event_contribution(i))
-            .collect();
-
-        for (local_grad, local_hess, local_ll) in results {
-            ll += local_ll;
-            for k in 0..p {
-                gradient[k] += local_grad[k];
-            }
-            for k in 0..p {
-                for l in 0..p {
-                    hessian[k][l] += local_hess[k][l];
-                }
-            }
-        }
-    } else {
-        for &i in event_indices {
-            let (local_grad, local_hess, local_ll) = compute_event_contribution(i);
-            ll += local_ll;
-            for k in 0..p {
-                gradient[k] += local_grad[k];
-            }
-            for k in 0..p {
-                for l in 0..p {
-                    hessian[k][l] += local_hess[k][l];
-                }
-            }
-        }
+        competing_prefixes.push(competing_prefix.clone());
     }
 
-    (gradient, hessian, ll)
+    let mut gradient = vec![0.0; n_vars];
+    let mut hessian = vec![vec![0.0; n_vars]; n_vars];
+    let mut log_likelihood = 0.0;
+    let mut ordinary_risk = RiskMoments::new(n_vars);
+    let mut reverse_cursor = sorted_indices.len();
+
+    for (group_idx, group) in event_groups.iter().enumerate().rev() {
+        let event_time = time[group[0]];
+        while reverse_cursor > 0 {
+            let idx = sorted_indices[reverse_cursor - 1];
+            if time[idx] < event_time && !same_time(time[idx], event_time) {
+                break;
+            }
+            ordinary_risk.add(&covariates[idx], risk_scores[idx]);
+            reverse_cursor -= 1;
+        }
+
+        let censoring_weight = censoring_survival[group[0]].max(IPCW_SURVIVAL_FLOOR);
+        let prefix = &competing_prefixes[group_idx];
+        let risk_sum =
+            (ordinary_risk.scalar + censoring_weight * prefix.scalar).max(IPCW_SURVIVAL_FLOOR);
+        let event_count = group.len() as f64;
+        let mut means = vec![0.0; n_vars];
+
+        for column in 0..n_vars {
+            let first = ordinary_risk.first[column] + censoring_weight * prefix.first[column];
+            means[column] = first / risk_sum;
+            let event_covariate_sum = group
+                .iter()
+                .map(|&idx| covariates[idx][column])
+                .sum::<f64>();
+            gradient[column] += event_covariate_sum - event_count * means[column];
+        }
+
+        for column in 0..n_vars {
+            for other_column in 0..n_vars {
+                let second = ordinary_risk.second[column][other_column]
+                    + censoring_weight * prefix.second[column][other_column];
+                hessian[column][other_column] -=
+                    event_count * (second / risk_sum - means[column] * means[other_column]);
+            }
+        }
+
+        log_likelihood += group.iter().map(|&idx| linear_predictors[idx]).sum::<f64>()
+            - event_count * risk_sum.ln();
+    }
+
+    (gradient, hessian, log_likelihood)
 }
 
 pub(crate) fn competing_risks_cif_core(
@@ -791,6 +777,22 @@ mod tests {
     }
 
     #[test]
+    fn censoring_weights_order_tied_failures_before_censoring() {
+        let time: Vec<f64> = vec![1.0, 2.0, 2.0, 3.0, 4.0];
+        let status = vec![1, 1, 0, 0, 2];
+        let mut indices = (0..time.len()).collect::<Vec<_>>();
+        indices.sort_by(|&left, &right| time[left].total_cmp(&time[right]));
+
+        let survival = censoring_survival_before(&indices, &time, &status);
+
+        assert_eq!(survival[0], 1.0);
+        assert_eq!(survival[1], 1.0);
+        assert_eq!(survival[2], 1.0);
+        assert!((survival[3] - 2.0 / 3.0).abs() < 1e-12);
+        assert!((survival[4] - 1.0 / 3.0).abs() < 1e-12);
+    }
+
+    #[test]
     fn test_finegray_no_competing() {
         let time = vec![1.0, 2.0, 3.0, 4.0, 5.0];
         let status = vec![1, 1, 0, 1, 0];
@@ -858,6 +860,7 @@ mod tests {
 
     #[test]
     fn test_finegray_public_api_rejects_malformed_inputs() {
+        pyo3::Python::initialize();
         assert!(
             finegray_regression(vec![], vec![], vec![], 1, 25, 1e-9)
                 .unwrap_err()
@@ -886,6 +889,7 @@ mod tests {
 
     #[test]
     fn test_competing_risks_cif_public_api_rejects_malformed_inputs() {
+        pyo3::Python::initialize();
         assert!(
             competing_risks_cif(vec![1.0], vec![], 1, 0.95)
                 .unwrap_err()

--- a/src/regression/finegray_regression.rs
+++ b/src/regression/finegray_regression.rs
@@ -2,13 +2,12 @@ use pyo3::prelude::*;
 use std::fmt;
 
 use crate::constants::{
-    IPCW_SURVIVAL_FLOOR, Z_SCORE_90, Z_SCORE_95, Z_SCORE_99, clamped_normal_ci_bounds, exp_clamped,
-    normal_ci_bounds_95, same_time,
+    IPCW_SURVIVAL_FLOOR, clamped_normal_ci_bounds, exp_clamped, normal_ci_bounds_95, same_time,
 };
 use crate::internal::matrix::invert_matrix;
 #[cfg(test)]
 use crate::internal::statistical::compute_censoring_km;
-use crate::internal::statistical::normal_cdf;
+use crate::internal::statistical::{normal_cdf, normal_inverse_cdf};
 
 fn value_error(message: impl Into<String>) -> PyErr {
     pyo3::exceptions::PyValueError::new_err(message.into())
@@ -552,45 +551,62 @@ pub(crate) fn competing_risks_cif_core(
     let mut n_risk_values = Vec::new();
     let mut n_events_values = Vec::new();
 
-    let mut km_surv = 1.0;
-    let mut cum_inc = 0.0;
-    let mut variance = 0.0;
+    let mut cause_codes = status
+        .iter()
+        .copied()
+        .filter(|&value| value > 0)
+        .collect::<Vec<_>>();
+    cause_codes.push(event_type);
+    cause_codes.sort_unstable();
+    cause_codes.dedup();
+    let n_causes = cause_codes.len();
+    let target_cause_idx = cause_codes
+        .binary_search(&event_type)
+        .expect("event type was inserted into cause codes");
+    let mut state_probabilities = vec![0.0; n_causes + 1];
+    state_probabilities[0] = 1.0;
+    let mut state_covariance = vec![vec![0.0; n_causes + 1]; n_causes + 1];
     let mut at_risk = n;
 
     let mut i = 0;
     while i < n {
         let current_time = time[indices[i]];
-        let mut n_event_type = 0;
-        let mut n_other_events = 0;
+        let mut event_counts = vec![0usize; n_causes];
         let mut total_at_time = 0;
 
         while i < n && same_time(time[indices[i]], current_time) {
             let s = status[indices[i]];
-            if s == event_type {
-                n_event_type += 1;
-            } else if s != 0 {
-                n_other_events += 1;
+            if s > 0 {
+                let cause_idx = cause_codes
+                    .binary_search(&s)
+                    .expect("observed event type exists in cause codes");
+                event_counts[cause_idx] += 1;
             }
             total_at_time += 1;
             i += 1;
         }
 
-        if n_event_type > 0 && at_risk > 0 {
-            let hazard = n_event_type as f64 / at_risk as f64;
-            cum_inc += km_surv * hazard;
-
-            let term1 = if at_risk > n_event_type {
-                hazard / (at_risk - n_event_type) as f64
-            } else {
-                0.0
-            };
-            variance += km_surv * km_surv * hazard * (1.0 - hazard) / at_risk as f64 + term1;
+        let hazards = event_counts
+            .iter()
+            .map(|&count| count as f64 / at_risk as f64)
+            .collect::<Vec<_>>();
+        let survival_before = state_probabilities[0];
+        state_covariance = updated_aj_covariance(
+            &state_covariance,
+            survival_before,
+            &hazards,
+            &event_counts,
+            at_risk,
+        );
+        for (cause_idx, &hazard) in hazards.iter().enumerate() {
+            state_probabilities[cause_idx + 1] += survival_before * hazard;
         }
+        state_probabilities[0] *= 1.0 - hazards.iter().sum::<f64>();
 
-        let total_events = n_event_type + n_other_events;
-        if total_events > 0 && at_risk > 0 {
-            km_surv *= 1.0 - total_events as f64 / at_risk as f64;
-        }
+        let n_event_type = event_counts[target_cause_idx];
+        let target_state = target_cause_idx + 1;
+        let cum_inc = state_probabilities[target_state];
+        let variance = state_covariance[target_state][target_state].max(0.0);
 
         unique_times.push(current_time);
         cif_values.push(cum_inc);
@@ -601,12 +617,7 @@ pub(crate) fn competing_risks_cif_core(
         at_risk -= total_at_time;
     }
 
-    let z = match confidence_level {
-        x if (x - 0.90).abs() < 0.01 => Z_SCORE_90,
-        x if (x - 0.95).abs() < 0.01 => Z_SCORE_95,
-        x if (x - 0.99).abs() < 0.01 => Z_SCORE_99,
-        _ => Z_SCORE_95,
-    };
+    let z = normal_inverse_cdf(0.5 + confidence_level / 2.0);
 
     let cif_se: Vec<f64> = variance_values.iter().map(|&v| v.sqrt()).collect();
     let (ci_lower, ci_upper) = clamped_normal_ci_bounds(&cif_values, &cif_se, z, 0.0, 1.0);
@@ -621,6 +632,56 @@ pub(crate) fn competing_risks_cif_core(
         n_events: n_events_values,
         event_type,
     }
+}
+
+fn updated_aj_covariance(
+    covariance: &[Vec<f64>],
+    survival: f64,
+    hazards: &[f64],
+    event_counts: &[usize],
+    at_risk: usize,
+) -> Vec<Vec<f64>> {
+    let n_states = hazards.len() + 1;
+    let survival_scale = 1.0 - hazards.iter().sum::<f64>();
+    let mut left_product = vec![vec![0.0; n_states]; n_states];
+    for state in 0..n_states {
+        for column in 0..n_states {
+            left_product[state][column] = if state == 0 {
+                survival_scale * covariance[0][column]
+            } else {
+                covariance[state][column] + hazards[state - 1] * covariance[0][column]
+            };
+        }
+    }
+
+    let mut updated = vec![vec![0.0; n_states]; n_states];
+    for state in 0..n_states {
+        updated[state][0] = survival_scale * left_product[state][0];
+        for column in 1..n_states {
+            updated[state][column] =
+                left_product[state][column] + hazards[column - 1] * left_product[state][0];
+        }
+    }
+
+    let risk = at_risk as f64;
+    let risk_squared = risk * risk;
+    let risk_cubed = risk_squared * risk;
+    let survival_squared = survival * survival;
+    for (cause, &cause_events) in event_counts.iter().enumerate() {
+        for (other_cause, &other_events) in event_counts.iter().enumerate() {
+            let mut hazard_covariance = -(cause_events as f64) * (other_events as f64) / risk_cubed;
+            if cause == other_cause {
+                hazard_covariance += cause_events as f64 / risk_squared;
+            }
+            let contribution = survival_squared * hazard_covariance;
+            updated[0][0] += contribution;
+            updated[0][other_cause + 1] -= contribution;
+            updated[cause + 1][0] -= contribution;
+            updated[cause + 1][other_cause + 1] += contribution;
+        }
+    }
+
+    updated
 }
 
 #[pyfunction]


### PR DESCRIPTION
## Summary
- replace the ad hoc cumulative-incidence variance sum with the Aalen–Johansen state covariance recursion
- retain cross-cause covariance for tied event times
- calculate arbitrary confidence levels from their actual normal quantile
- compress sparse event labels before allocating state vectors and matrices
- add public reference values for CIFs, standard errors, risk counts, and event counts

## Correctness
The prior point estimates were correct, but uncertainty was substantially inflated. On the reference fixture, the final standard error was 0.404 instead of 0.148. The new recursion matches all nine reference standard errors to numerical tolerance while preserving the CIF estimates.

The public path also accepts sparse labels such as event code 1,000,000 without allocating a matrix indexed by the raw code.

## Validation
- 1,687 Rust tests passed
- 863 Python tests passed; 18 skipped
- strict Clippy, Ruff, formatting, and mypy checks passed
- R package check passed with the standard source-preparation NOTE