### PR TITLE
Reuse Gaussian weights in Schoenfeld smoothing

### DIFF
--- a/benches/survival_benchmarks.rs
+++ b/benches/survival_benchmarks.rs
@@ -2,6 +2,7 @@ use std::hint::black_box;
 use survival::regression::{
     CoxPHModel, aareg_fit, agexact, cch_borgan_fit, cch_fit, coxph_fit, finegray, survreg,
 };
+use survival::residuals::smooth_schoenfeld;
 use survival::{
     KaplanMeierConfig, WeightType, compute_brier, compute_rmst, compute_survfitkm, concordance1,
     nelson_aalen, pseudo, uno_c_index, weighted_logrank_test,
@@ -769,6 +770,38 @@ mod cox_regression {
         bencher.bench_local(|| {
             let variance = black_box(&model).vcov();
             black_box(variance);
+        });
+    }
+}
+
+mod schoenfeld_smoothing {
+    use super::*;
+
+    #[divan::bench(args = [100, 500, 1000])]
+    fn gaussian_smoothing(bencher: divan::Bencher, n_events: usize) {
+        const N_COVARIATES: usize = 8;
+        let event_times: Vec<f64> = (0..n_events)
+            .map(|idx| idx as f64 * 0.25 + (idx % 7) as f64 * 0.01)
+            .collect();
+        let residuals: Vec<f64> = (0..n_events)
+            .flat_map(|event| {
+                (0..N_COVARIATES)
+                    .map(move |covariate| ((event * (covariate + 3)) % 17) as f64 * 0.02 - 0.16)
+            })
+            .collect();
+        let coefficients = vec![0.1; N_COVARIATES];
+
+        bencher.bench_local(|| {
+            let result = smooth_schoenfeld(
+                event_times.clone(),
+                residuals.clone(),
+                N_COVARIATES,
+                coefficients.clone(),
+                None,
+                "identity",
+            )
+            .expect("benchmark Schoenfeld smoothing should succeed");
+            black_box(result);
         });
     }
 }

--- a/src/residuals/diagnostics/schoenfeld.rs
+++ b/src/residuals/diagnostics/schoenfeld.rs
@@ -105,35 +105,37 @@ pub fn smooth_schoenfeld(
     let mut smoothed: Vec<Vec<f64>> = vec![vec![0.0; n_covariates]; n_events];
     let mut coefficient_path: Vec<Vec<f64>> = vec![vec![0.0; n_covariates]; n_events];
 
-    for i in 0..n_events {
+    for (i, (smoothed_row, coefficient_row)) in smoothed
+        .iter_mut()
+        .zip(coefficient_path.iter_mut())
+        .enumerate()
+    {
         let t_i = transformed_times[i];
+        let mut sum_w = 0.0;
+        let mut sum_wy = vec![0.0; n_covariates];
 
-        for j in 0..n_covariates {
-            let mut sum_w = 0.0;
-            let mut sum_wy = 0.0;
-            let mut _sum_wty = 0.0;
-            let mut _sum_wt = 0.0;
-            let mut _sum_wtt = 0.0;
-
-            for k in 0..n_events {
-                let t_k = transformed_times[k];
-                let diff = (t_i - t_k) / h;
-                let w = (-0.5 * diff * diff).exp();
-
-                let y = schoenfeld_residuals[k * n_covariates + j];
-
-                sum_w += w;
-                sum_wy += w * y;
-                _sum_wty += w * t_k * y;
-                _sum_wt += w * t_k;
-                _sum_wtt += w * t_k * t_k;
+        for (k, &t_k) in transformed_times.iter().enumerate() {
+            let diff = (t_i - t_k) / h;
+            let weight = (-0.5 * diff * diff).exp();
+            sum_w += weight;
+            let residual_row = &schoenfeld_residuals
+                [k * n_covariates..(k + 1) * n_covariates];
+            for (weighted_sum, &residual) in sum_wy.iter_mut().zip(residual_row) {
+                *weighted_sum += weight * residual;
             }
+        }
 
-            if sum_w > 1e-10 {
-                let y_mean = sum_wy / sum_w;
-                smoothed[i][j] = y_mean;
-
-                coefficient_path[i][j] = coefficients[j] + y_mean;
+        if sum_w > 1e-10 {
+            for (((smoothed_value, coefficient_value), &weighted_sum), &coefficient) in
+                smoothed_row
+                    .iter_mut()
+                    .zip(coefficient_row.iter_mut())
+                    .zip(&sum_wy)
+                    .zip(&coefficients)
+            {
+                let mean = weighted_sum / sum_w;
+                *smoothed_value = mean;
+                *coefficient_value = coefficient + mean;
             }
         }
     }

--- a/src/residuals/diagnostics/tests.rs
+++ b/src/residuals/diagnostics/tests.rs
@@ -33,15 +33,50 @@ mod tests {
     #[test]
     fn test_schoenfeld_smooth() {
         let event_times = vec![1.0, 2.0, 3.0, 4.0, 5.0];
-        let schoenfeld = vec![0.1, -0.1, 0.2, -0.2, 0.1];
-        let coefficients = vec![0.5];
+        let schoenfeld = vec![0.1, 1.0, -0.1, 0.5, 0.2, 0.0, -0.2, -0.5, 0.1, -1.0];
+        let coefficients = vec![0.5, -0.25];
+        let bandwidth = 1.25;
 
-        let result =
-            smooth_schoenfeld(event_times, schoenfeld, 1, coefficients, None, "identity").unwrap();
+        let result = smooth_schoenfeld(
+            event_times.clone(),
+            schoenfeld.clone(),
+            2,
+            coefficients.clone(),
+            Some(bandwidth),
+            "identity",
+        )
+        .unwrap();
 
         assert_eq!(result.n_events, 5);
-        assert_eq!(result.n_vars, 1);
+        assert_eq!(result.n_vars, 2);
         assert_eq!(result.smoothed_residuals.len(), 5);
+        for (event_idx, (&time, actual_row)) in event_times
+            .iter()
+            .zip(&result.smoothed_residuals)
+            .enumerate()
+        {
+            for covariate in 0..2 {
+                let mut weight_sum = 0.0;
+                let mut weighted_residual_sum = 0.0;
+                for (row, &other_time) in event_times.iter().enumerate() {
+                    let difference = (time - other_time) / bandwidth;
+                    let weight = (-0.5_f64 * difference * difference).exp();
+                    weight_sum += weight;
+                    weighted_residual_sum += weight * schoenfeld[row * 2 + covariate];
+                }
+                let expected = weighted_residual_sum / weight_sum;
+                assert!(
+                    (actual_row[covariate] - expected).abs() <= 1e-15,
+                    "event={event_idx}, covariate={covariate}"
+                );
+                assert!(
+                    (result.coefficient_path[event_idx][covariate]
+                        - (coefficients[covariate] + expected))
+                        .abs()
+                        <= 1e-15
+                );
+            }
+        }
     }
 
     #[test]
@@ -127,6 +162,9 @@ mod tests {
 
     #[test]
     fn test_schoenfeld_smooth_validates_inputs() {
+        #[cfg(feature = "python")]
+        pyo3::Python::initialize();
+
         let bad_bandwidth =
             smooth_schoenfeld(vec![1.0, 2.0], vec![0.1, 0.2], 1, vec![0.5], Some(0.0), "identity")
                 .unwrap_err()


### PR DESCRIPTION
## Summary
- compute each Gaussian kernel weight once per event pair and reuse it across covariates
- remove unused weighted-moment accumulation from the smoothing loop
- strengthen multi-covariate reference coverage and make validation tests independent of test order
- add a dedicated Gaussian smoothing benchmark

## Performance
Median time for eight covariates:
- 100 events: 180.7 us to 43.66 us (4.14x faster)
- 500 events: 4.014 ms to 0.9482 ms (4.23x faster)
- 1,000 events: 15.99 ms to 3.756 ms (4.26x faster)

## Validation
- cargo test --all-features (1,687 passed)
- cargo clippy --all-targets --all-features -- -D warnings
- pytest -q (863 passed, 18 skipped)
- ruff check and format check
- mypy python/survival
- R CMD check --no-manual --no-build-vignettes r/survivalr (1 source-preparation NOTE)