### PR TITLE
Reuse counting Cox kernel for Andersen-Gill

### DIFF
--- a/benches/survival_benchmarks.rs
+++ b/benches/survival_benchmarks.rs
@@ -1,8 +1,8 @@
 use std::hint::black_box;
 use survival::regression::{
     ClogitDataSet, ConditionalLogisticRegression, CoxPHModel, SplineConfig, aareg_fit, agexact,
-    cch_borgan_fit, cch_fit, coxph_fit, finegray, flexible_parametric_model, landmark_cox_analysis,
-    survreg, time_varying_cox,
+    anderson_gill_model, cch_borgan_fit, cch_fit, coxph_fit, finegray, flexible_parametric_model,
+    landmark_cox_analysis, survreg, time_varying_cox,
 };
 use survival::residuals::smooth_schoenfeld;
 use survival::{
@@ -920,6 +920,50 @@ mod conditional_logistic_bench {
                 .fit()
                 .expect("benchmark conditional logistic fit should succeed");
             black_box(model);
+        });
+    }
+}
+
+mod anderson_gill_bench {
+    use super::*;
+
+    type RecurrentData = (Vec<i32>, Vec<f64>, Vec<f64>, Vec<i32>, Vec<f64>);
+
+    fn recurrent_data(n_subjects: usize) -> RecurrentData {
+        let mut id = Vec::with_capacity(n_subjects * 3);
+        let mut start = Vec::with_capacity(n_subjects * 3);
+        let mut stop = Vec::with_capacity(n_subjects * 3);
+        let mut event = Vec::with_capacity(n_subjects * 3);
+        let mut covariates = Vec::with_capacity(n_subjects * 6);
+        for subject in 1..=n_subjects {
+            for interval in 0..3 {
+                let row = id.len();
+                id.push(subject as i32);
+                start.push(interval as f64);
+                stop.push((interval + 1) as f64);
+                event.push(i32::from(row % 4 != 0));
+                covariates.push(((row * 3 + subject * 2) % 17) as f64 * 0.1);
+                covariates.push(((row * 7 + subject) % 13) as f64 * 0.1);
+            }
+        }
+        (id, start, stop, event, covariates)
+    }
+
+    #[divan::bench(args = [20, 100, 200])]
+    fn fit(bencher: divan::Bencher, n_subjects: usize) {
+        let (id, start, stop, event, covariates) = recurrent_data(n_subjects);
+        bencher.bench_local(|| {
+            let result = anderson_gill_model(
+                id.clone(),
+                start.clone(),
+                stop.clone(),
+                event.clone(),
+                covariates.clone(),
+                50,
+                1e-9,
+            )
+            .expect("benchmark Andersen-Gill fit should succeed");
+            black_box(result);
         });
     }
 }

--- a/python/tests/test_regression.py
+++ b/python/tests/test_regression.py
@@ -1115,6 +1115,39 @@ def test_survreg_residual_apis_validate_numeric_inputs():
         )
 
 
+def test_anderson_gill_matches_tied_cluster_reference():
+    n_subjects = 20
+    subject_id = []
+    start = []
+    stop = []
+    event = []
+    covariates = []
+    for subject in range(1, n_subjects + 1):
+        for interval in range(3):
+            row = len(subject_id)
+            subject_id.append(subject)
+            start.append(float(interval))
+            stop.append(float(interval + 1))
+            event.append(int(row % 4 != 0))
+            covariates.extend(
+                [
+                    ((row * 3 + subject * 2) % 17) * 0.1,
+                    ((row * 7 + subject) % 13) * 0.1,
+                ]
+            )
+
+    result = survival.anderson_gill_model(subject_id, start, stop, event, covariates, 50, 1e-9)
+
+    assert result.coef == pytest.approx([-0.176545463952229, 0.0386815494247862], abs=1e-10)
+    assert result.std_errors == pytest.approx([0.309771133238645, 0.4072363513213], abs=1e-10)
+    assert result.robust_std_errors == pytest.approx(
+        [0.272213095533931, 0.34197721951329], abs=1e-10
+    )
+    assert result.log_likelihood == pytest.approx(-112.465975135154, abs=1e-10)
+    assert result.n_iter == 3
+    assert result.converged is True
+
+
 def test_recurrent_event_regression_validates_public_inputs():
     with pytest.raises(ValueError, match="x length"):
         survival.gap_time_model([0, 1], [0.0, 0.0], [1.0, 1.0], [1, 0], [0.5], 2, 1, 10, 1e-6)

--- a/src/regression/recurrent_events/anderson_gill.rs
+++ b/src/regression/recurrent_events/anderson_gill.rs
@@ -19,177 +19,73 @@ pub fn anderson_gill_model(
 
     let unique_ids = sorted_unique_i32(&id);
     let n_subjects = unique_ids.len();
-
-    let n_events_total = event.iter().filter(|&&e| e == 1).count();
-
-    let total_time: f64 = stop.iter().zip(start.iter()).map(|(&s, &st)| s - st).sum();
+    let n_events_total = event.iter().filter(|&&value| value == 1).count();
+    let total_time: f64 = stop
+        .iter()
+        .zip(&start)
+        .map(|(&end, &begin)| end - begin)
+        .sum();
     let mean_event_rate = n_events_total as f64 / total_time;
+    let covariate_rows = x_mat
+        .chunks_exact(p)
+        .map(<[f64]>::to_vec)
+        .collect::<Vec<_>>();
+    let fit = coxph_fit(
+        stop,
+        event,
+        covariate_rows,
+        None,
+        None,
+        None,
+        None,
+        Some(max_iter),
+        Some(tol),
+        None,
+        Some("efron"),
+        Some(start),
+        None,
+    )?;
+    let beta = fit.coefficients.first().cloned().unwrap_or_default();
+    let covariance = fit.information_matrix.clone();
 
     let id_to_idx = index_by_i32(&unique_ids);
+    let clusters = id
+        .iter()
+        .map(|value| id_to_idx[value])
+        .collect::<Vec<_>>();
+    let score_residuals = fit.score_residuals()?;
 
-    let mut beta = vec![0.0; p];
-    let mut converged = false;
-    let mut n_iter = 0;
-    let mut prev_loglik = f64::NEG_INFINITY;
-
-    let mut sorted_indices: Vec<usize> = (0..n).collect();
-    sorted_indices.sort_by(|&a, &b| stop[b].total_cmp(&stop[a]));
-
-    for iter in 0..max_iter {
-        n_iter = iter + 1;
-
-        let mut loglik = 0.0;
-        let mut gradient = vec![0.0; p];
-        let mut hessian = vec![vec![0.0; p]; p];
-
-        for &i in &sorted_indices {
-            if event[i] != 1 {
-                continue;
-            }
-
-            let t_event = stop[i];
-            let mut eta_i = 0.0;
-            for j in 0..p {
-                eta_i += x_mat[i * p + j] * beta[j];
-            }
-
-            let mut risk_sum = 0.0;
-            let mut risk_x_sum = vec![0.0; p];
-            let mut risk_xx_sum = vec![vec![0.0; p]; p];
-
-            for &k in &sorted_indices {
-                if start[k] < t_event && stop[k] >= t_event {
-                    let mut eta_k = 0.0;
-                    for j in 0..p {
-                        eta_k += x_mat[k * p + j] * beta[j];
-                    }
-                    let exp_eta_k = eta_k.exp();
-
-                    risk_sum += exp_eta_k;
-                    for j in 0..p {
-                        risk_x_sum[j] += x_mat[k * p + j] * exp_eta_k;
-                    }
-                    for j1 in 0..p {
-                        for j2 in 0..p {
-                            risk_xx_sum[j1][j2] +=
-                                x_mat[k * p + j1] * x_mat[k * p + j2] * exp_eta_k;
-                        }
-                    }
-                }
-            }
-
-            if risk_sum > DIVISION_FLOOR {
-                loglik += eta_i - risk_sum.ln();
-
-                for j in 0..p {
-                    let x_bar = risk_x_sum[j] / risk_sum;
-                    gradient[j] += x_mat[i * p + j] - x_bar;
-                }
-
-                for j1 in 0..p {
-                    let x_bar1 = risk_x_sum[j1] / risk_sum;
-                    for j2 in 0..p {
-                        let x_bar2 = risk_x_sum[j2] / risk_sum;
-                        hessian[j1][j2] += risk_xx_sum[j1][j2] / risk_sum - x_bar1 * x_bar2;
-                    }
-                }
-            }
-        }
-
-        for j in 0..p {
-            if hessian[j][j].abs() > DIVISION_FLOOR {
-                beta[j] += gradient[j] / hessian[j][j];
-                beta[j] = beta[j].clamp(-10.0, 10.0);
-            }
-        }
-
-        if (loglik - prev_loglik).abs() < tol {
-            converged = true;
-            break;
-        }
-        prev_loglik = loglik;
-    }
-
-    let mut info_matrix = vec![vec![0.0; p]; p];
-    let mut score_residuals: Vec<Vec<f64>> = unique_ids.iter().map(|_| vec![0.0; p]).collect();
-
-    for &i in &sorted_indices {
-        if event[i] != 1 {
-            continue;
-        }
-
-        let t_event = stop[i];
-        let mut risk_sum = 0.0;
-        let mut risk_x_sum = vec![0.0; p];
-        let mut risk_xx_sum = vec![vec![0.0; p]; p];
-
-        for &k in &sorted_indices {
-            if start[k] < t_event && stop[k] >= t_event {
-                let mut eta_k = 0.0;
-                for j in 0..p {
-                    eta_k += x_mat[k * p + j] * beta[j];
-                }
-                let exp_eta_k = eta_k.exp();
-
-                risk_sum += exp_eta_k;
-                for j in 0..p {
-                    risk_x_sum[j] += x_mat[k * p + j] * exp_eta_k;
-                }
-                for j1 in 0..p {
-                    for j2 in 0..p {
-                        risk_xx_sum[j1][j2] += x_mat[k * p + j1] * x_mat[k * p + j2] * exp_eta_k;
-                    }
-                }
-            }
-        }
-
-        if risk_sum > DIVISION_FLOOR {
-            for j1 in 0..p {
-                let x_bar1 = risk_x_sum[j1] / risk_sum;
-                for j2 in 0..p {
-                    let x_bar2 = risk_x_sum[j2] / risk_sum;
-                    info_matrix[j1][j2] += risk_xx_sum[j1][j2] / risk_sum - x_bar1 * x_bar2;
-                }
-            }
-
-            if let Some(&subj_idx) = id_to_idx.get(&id[i]) {
-                for j in 0..p {
-                    let x_bar = risk_x_sum[j] / risk_sum;
-                    score_residuals[subj_idx][j] += x_mat[i * p + j] - x_bar;
-                }
-            }
-        }
-    }
-
-    let std_errors: Vec<f64> = (0..p)
-        .map(|j| {
-            if info_matrix[j][j] > DIVISION_FLOOR {
-                (1.0 / info_matrix[j][j]).sqrt()
+    let std_errors = (0..p)
+        .map(|idx| {
+            let variance = covariance
+                .get(idx)
+                .and_then(|row| row.get(idx))
+                .copied()
+                .unwrap_or(0.0);
+            if variance > 0.0 {
+                variance.sqrt()
             } else {
                 f64::INFINITY
             }
         })
-        .collect();
-
-    let mut robust_var = vec![vec![0.0; p]; p];
-    for subj_scores in &score_residuals {
-        for j1 in 0..p {
-            for j2 in 0..p {
-                robust_var[j1][j2] += subj_scores[j1] * subj_scores[j2];
-            }
-        }
-    }
-
-    let robust_std_errors: Vec<f64> = (0..p)
-        .map(|j| {
-            let inv_info = if info_matrix[j][j] > DIVISION_FLOOR {
-                1.0 / info_matrix[j][j]
-            } else {
-                0.0
-            };
-            (inv_info * robust_var[j][j] * inv_info).sqrt()
+        .collect::<Vec<_>>();
+    let robust_covariance = clustered_sandwich_variance(
+        score_residuals,
+        vec![1.0; n],
+        clusters,
+        covariance,
+    )?;
+    let robust_std_errors = (0..p)
+        .map(|idx| {
+            robust_covariance
+                .get(idx)
+                .and_then(|row| row.get(idx))
+                .copied()
+                .unwrap_or(0.0)
+                .max(0.0)
+                .sqrt()
         })
-        .collect();
+        .collect::<Vec<_>>();
 
     let z_scores: Vec<f64> = beta
         .iter()
@@ -221,11 +117,11 @@ pub fn anderson_gill_model(
         hazard_ratios,
         hr_lower,
         hr_upper,
-        log_likelihood: prev_loglik,
+        log_likelihood: fit.log_likelihood.last().copied().unwrap_or(0.0),
         n_events: n_events_total,
         n_subjects,
-        n_iter,
-        converged,
+        n_iter: fit.iterations,
+        converged: fit.convergence_flag != CONVERGENCE_FLAG,
         mean_event_rate,
     })
 }

--- a/src/regression/recurrent_events/mod.rs
+++ b/src/regression/recurrent_events/mod.rs
@@ -1,8 +1,10 @@
 use pyo3::prelude::*;
 use rayon::prelude::*;
 
-use crate::constants::{DIVISION_FLOOR, exp_ci_bounds_95};
+use crate::constants::{CONVERGENCE_FLAG, DIVISION_FLOOR, exp_ci_bounds_95};
 use crate::internal::statistical::{chi2_cdf, ln_gamma, normal_cdf};
+use crate::regression::coxph::coxph_fit;
+use crate::regression::coxph_diagnostics::clustered_sandwich_variance;
 
 fn recurrent_value_error(message: impl Into<String>) -> PyErr {
     PyErr::new::<pyo3::exceptions::PyValueError, _>(message.into())

--- a/src/regression/recurrent_events/tests.rs
+++ b/src/regression/recurrent_events/tests.rs
@@ -225,9 +225,17 @@ mod tests {
         assert_eq!(ag.n_subjects, 85);
         assert_eq!(ag.n_events, 112);
         assert!(ag.converged);
-        assert_close(ag.coef[0], -0.45978826074398993, 1e-9);
-        assert_close(ag.coef[1], -0.04256340004595282, 1e-9);
-        assert_close(ag.coef[2], 0.17164542460626836, 1e-9);
+        assert_close(ag.coef[0], -0.464_686_952_943_429, 1e-9);
+        assert_close(ag.coef[1], -0.043_660_276_089_821_9, 1e-9);
+        assert_close(ag.coef[2], 0.174_960_381_319_399, 1e-9);
+        assert_close(ag.std_errors[0], 0.199_732_188_827_129, 1e-9);
+        assert_close(ag.std_errors[1], 0.069_050_852_511_246, 1e-9);
+        assert_close(ag.std_errors[2], 0.047_074_058_440_440_7, 1e-9);
+        assert_close(ag.robust_std_errors[0], 0.265_560_811_898_887, 1e-9);
+        assert_close(ag.robust_std_errors[1], 0.077_616_112_681_007_7, 1e-9);
+        assert_close(ag.robust_std_errors[2], 0.063_040_543_200_655_3, 1e-9);
+        assert_close(ag.log_likelihood, -449.980_642_001_765, 1e-9);
+        assert_eq!(ag.n_iter, 4);
 
         assert_eq!(wlw.n_subjects, 85);
         assert_eq!(wlw.n_events, 112);
@@ -270,6 +278,39 @@ mod tests {
         assert_eq!(result.n_subjects, 3);
         assert_eq!(result.n_events, 3);
         assert!(result.mean_event_rate > 0.0);
+    }
+
+    #[test]
+    fn anderson_gill_matches_tied_cluster_reference() {
+        let n_subjects = 20;
+        let mut id = Vec::with_capacity(n_subjects * 3);
+        let mut start = Vec::with_capacity(n_subjects * 3);
+        let mut stop = Vec::with_capacity(n_subjects * 3);
+        let mut event = Vec::with_capacity(n_subjects * 3);
+        let mut covariates = Vec::with_capacity(n_subjects * 6);
+        for subject in 1..=n_subjects {
+            for interval in 0..3 {
+                let row = id.len();
+                id.push(subject as i32);
+                start.push(interval as f64);
+                stop.push((interval + 1) as f64);
+                event.push(i32::from(row % 4 != 0));
+                covariates.push(((row * 3 + subject * 2) % 17) as f64 * 0.1);
+                covariates.push(((row * 7 + subject) % 13) as f64 * 0.1);
+            }
+        }
+
+        let result = anderson_gill_model(id, start, stop, event, covariates, 50, 1e-9).unwrap();
+
+        assert_close(result.coef[0], -0.176_545_463_952_229, 1e-10);
+        assert_close(result.coef[1], 0.038_681_549_424_786_2, 1e-10);
+        assert_close(result.std_errors[0], 0.309_771_133_238_645, 1e-10);
+        assert_close(result.std_errors[1], 0.407_236_351_321_3, 1e-10);
+        assert_close(result.robust_std_errors[0], 0.272_213_095_533_931, 1e-10);
+        assert_close(result.robust_std_errors[1], 0.341_977_219_513_29, 1e-10);
+        assert_close(result.log_likelihood, -112.465_975_135_154, 1e-10);
+        assert_eq!(result.n_iter, 3);
+        assert!(result.converged);
     }
 
     #[test]


### PR DESCRIPTION
## Summary\n- replace quadratic risk-set rescans and diagonal updates with the shared Efron counting-process Cox fit\n- derive naive standard errors from the full fitted covariance\n- derive subject-clustered robust errors from counting-process score residuals and the shared sandwich routine\n- add tied-event and bladder reference coverage plus a permanent benchmark\n\n## Correctness\nOn the deterministic 60-row tied-event fixture, coefficients, naive standard errors, robust standard errors, final partial log likelihood, and iterations all match the reference to 1e-10.\n\nThe 178-row bladder fixture now also matches the reconstructed reference:\n- coefficients: [-0.464686952943429, -0.0436602760898219, 0.174960381319399]\n- naive SE: [0.199732188827129, 0.069050852511246, 0.0470740584404407]\n- robust SE: [0.265560811898887, 0.0776161126810077, 0.0630405432006553]\n- final log likelihood: -449.980642001765\n- iterations: 4\n\n## Performance\nPython-facing median time:\n- 20 subjects: 75.3 us to 67.5 us (1.12x faster)\n- 100 subjects: 864.5 us to 185.1 us (4.67x faster)\n- 200 subjects: 4.182 ms to 435.6 us (9.60x faster)\n\nNative benchmark medians:\n- 20 subjects: 53.49 us\n- 100 subjects: 129.0 us\n- 200 subjects: 380.4 us\n\n## Validation\n- cargo test --all-features (1,695 passed)\n- cargo clippy --all-targets --all-features -- -D warnings\n- cargo fmt --check\n- pytest -q (870 passed, 18 skipped)\n- Ruff check and format check\n- mypy (37 source files)\n- R CMD check --no-manual --no-build-vignettes (1 source-preparation NOTE)