### PR TITLE
Reuse stratified Cox kernel for WLW

### DIFF
--- a/benches/survival_benchmarks.rs
+++ b/benches/survival_benchmarks.rs
@@ -1,8 +1,8 @@
 use std::hint::black_box;
 use survival::regression::{
-    ClogitDataSet, ConditionalLogisticRegression, CoxPHModel, SplineConfig, aareg_fit, agexact,
-    anderson_gill_model, cch_borgan_fit, cch_fit, coxph_fit, finegray, flexible_parametric_model,
-    landmark_cox_analysis, survreg, time_varying_cox,
+    ClogitDataSet, ConditionalLogisticRegression, CoxPHModel, SplineConfig, WLWConfig, aareg_fit,
+    agexact, anderson_gill_model, cch_borgan_fit, cch_fit, coxph_fit, finegray,
+    flexible_parametric_model, landmark_cox_analysis, survreg, time_varying_cox, wlw_model,
 };
 use survival::residuals::smooth_schoenfeld;
 use survival::{
@@ -963,6 +963,49 @@ mod anderson_gill_bench {
                 1e-9,
             )
             .expect("benchmark Andersen-Gill fit should succeed");
+            black_box(result);
+        });
+    }
+}
+
+mod wlw_bench {
+    use super::*;
+
+    type WlwData = (Vec<i32>, Vec<f64>, Vec<i32>, Vec<i32>, Vec<f64>);
+
+    fn recurrent_data(n_subjects: usize) -> WlwData {
+        let mut id = Vec::with_capacity(n_subjects * 3);
+        let mut time = Vec::with_capacity(n_subjects * 3);
+        let mut event = Vec::with_capacity(n_subjects * 3);
+        let mut stratum = Vec::with_capacity(n_subjects * 3);
+        let mut covariates = Vec::with_capacity(n_subjects * 6);
+        for subject in 1..=n_subjects {
+            for event_order in 1..=3 {
+                let row = id.len();
+                id.push(subject as i32);
+                stratum.push(event_order as i32);
+                time.push(((row * 5 + subject * 3 + event_order) % 40 + 1) as f64);
+                event.push(i32::from((row + subject + event_order) % 4 != 0));
+                covariates.push(((row * 3 + subject * 2) % 17) as f64 * 0.1);
+                covariates.push(((row * 7 + subject) % 13) as f64 * 0.1);
+            }
+        }
+        (id, time, event, stratum, covariates)
+    }
+
+    #[divan::bench(args = [30, 100, 200])]
+    fn fit(bencher: divan::Bencher, n_subjects: usize) {
+        let (id, time, event, stratum, covariates) = recurrent_data(n_subjects);
+        bencher.bench_local(|| {
+            let result = wlw_model(
+                id.clone(),
+                time.clone(),
+                event.clone(),
+                stratum.clone(),
+                covariates.clone(),
+                &WLWConfig::new(50, 1e-9, true, false),
+            )
+            .expect("benchmark WLW fit should succeed");
             black_box(result);
         });
     }

--- a/python/tests/test_regression.py
+++ b/python/tests/test_regression.py
@@ -1148,6 +1148,62 @@ def test_anderson_gill_matches_tied_cluster_reference():
     assert result.converged is True
 
 
+def test_wlw_matches_stratified_cluster_reference():
+    n_subjects = 30
+    subject_id = []
+    time = []
+    event = []
+    stratum = []
+    covariates = []
+    for subject in range(1, n_subjects + 1):
+        for event_order in range(1, 4):
+            row = len(subject_id)
+            subject_id.append(subject)
+            stratum.append(event_order)
+            time.append(float((row * 5 + subject * 3 + event_order) % 40 + 1))
+            event.append(int((row + subject + event_order) % 4 != 0))
+            covariates.extend(
+                [
+                    ((row * 3 + subject * 2) % 17) * 0.1,
+                    ((row * 7 + subject) % 13) * 0.1,
+                ]
+            )
+
+    result = survival.wlw_model(
+        subject_id,
+        time,
+        event,
+        stratum,
+        covariates,
+        survival.WLWConfig(50, 1e-9, True, False),
+    )
+
+    assert result.coef == pytest.approx([-0.262198198154192, 0.207452690273597], abs=1e-10)
+    assert result.std_errors == pytest.approx([0.267872851791448, 0.352068828626283], abs=1e-10)
+    assert result.robust_std_errors == pytest.approx(
+        [0.251017039175710, 0.273495948040538], abs=1e-10
+    )
+    assert result.log_likelihood == pytest.approx(-148.584208908079, abs=1e-10)
+    assert result.global_test_stat == pytest.approx(1.69574121084369, abs=1e-10)
+    assert result.n_iter == 3
+    assert result.converged is True
+
+    common_baseline = survival.wlw_model(
+        subject_id,
+        time,
+        event,
+        stratum,
+        covariates,
+        survival.WLWConfig(50, 1e-9, True, True),
+    )
+    assert common_baseline.coef == pytest.approx(
+        [-0.0408282543484413, 0.024655056553873553], abs=1e-10
+    )
+    assert common_baseline.log_likelihood == pytest.approx(-215.9962288916436, abs=1e-10)
+    assert common_baseline.global_test_stat == pytest.approx(0.04643133748986993, abs=1e-10)
+    assert common_baseline.n_iter == 2
+
+
 def test_recurrent_event_regression_validates_public_inputs():
     with pytest.raises(ValueError, match="x length"):
         survival.gap_time_model([0, 1], [0.0, 0.0], [1.0, 1.0], [1, 0], [0.5], 2, 1, 10, 1e-6)

--- a/src/regression/recurrent_events/mod.rs
+++ b/src/regression/recurrent_events/mod.rs
@@ -2,6 +2,7 @@ use pyo3::prelude::*;
 use rayon::prelude::*;
 
 use crate::constants::{CONVERGENCE_FLAG, DIVISION_FLOOR, exp_ci_bounds_95};
+use crate::internal::matrix::invert_matrix;
 use crate::internal::statistical::{chi2_cdf, ln_gamma, normal_cdf};
 use crate::regression::coxph::coxph_fit;
 use crate::regression::coxph_diagnostics::clustered_sandwich_variance;

--- a/src/regression/recurrent_events/tests.rs
+++ b/src/regression/recurrent_events/tests.rs
@@ -150,6 +150,63 @@ mod tests {
     }
 
     #[test]
+    fn wlw_matches_stratified_cluster_reference() {
+        let n_subjects = 30;
+        let mut id = Vec::with_capacity(n_subjects * 3);
+        let mut time = Vec::with_capacity(n_subjects * 3);
+        let mut event = Vec::with_capacity(n_subjects * 3);
+        let mut stratum = Vec::with_capacity(n_subjects * 3);
+        let mut covariates = Vec::with_capacity(n_subjects * 6);
+        for subject in 1..=n_subjects {
+            for event_order in 1..=3 {
+                let row = id.len();
+                id.push(subject as i32);
+                stratum.push(event_order as i32);
+                time.push(((row * 5 + subject * 3 + event_order) % 40 + 1) as f64);
+                event.push(i32::from((row + subject + event_order) % 4 != 0));
+                covariates.push(((row * 3 + subject * 2) % 17) as f64 * 0.1);
+                covariates.push(((row * 7 + subject) % 13) as f64 * 0.1);
+            }
+        }
+
+        let result = wlw_model(
+            id.clone(),
+            time.clone(),
+            event.clone(),
+            stratum.clone(),
+            covariates.clone(),
+            &WLWConfig::new(50, 1e-9, true, false),
+        )
+        .expect("WLW reference fit should succeed");
+
+        assert_close(result.coef[0], -0.262_198_198_154_192, 1e-10);
+        assert_close(result.coef[1], 0.207_452_690_273_597, 1e-10);
+        assert_close(result.std_errors[0], 0.267_872_851_791_448, 1e-10);
+        assert_close(result.std_errors[1], 0.352_068_828_626_283, 1e-10);
+        assert_close(result.robust_std_errors[0], 0.251_017_039_175_710, 1e-10);
+        assert_close(result.robust_std_errors[1], 0.273_495_948_040_538, 1e-10);
+        assert_close(result.log_likelihood, -148.584_208_908_079, 1e-10);
+        assert_close(result.global_test_stat, 1.695_741_210_843_69, 1e-10);
+        assert_eq!(result.n_iter, 3);
+        assert!(result.converged);
+
+        let common_baseline = wlw_model(
+            id,
+            time,
+            event,
+            stratum,
+            covariates,
+            &WLWConfig::new(50, 1e-9, true, true),
+        )
+        .expect("common-baseline WLW reference fit should succeed");
+        assert_close(common_baseline.coef[0], -0.040_828_254_348_441_3, 1e-10);
+        assert_close(common_baseline.coef[1], 0.024_655_056_553_873_553, 1e-10);
+        assert_close(common_baseline.log_likelihood, -215.996_228_891_643_6, 1e-10);
+        assert_close(common_baseline.global_test_stat, 0.046_431_337_489_869_93, 1e-10);
+        assert_eq!(common_baseline.n_iter, 2);
+    }
+
+    #[test]
     fn test_bladder_recurrent_event_models() {
         let bladder = load_legacy_bladder_data();
 
@@ -241,11 +298,19 @@ mod tests {
         assert_eq!(wlw.n_events, 112);
         assert_eq!(wlw.n_strata, 4);
         assert!(wlw.converged);
-        assert_close(wlw.coef[0], -0.5798694870405632, 1e-9);
-        assert_close(wlw.coef[1], -0.050935433404071695, 1e-9);
-        assert_close(wlw.coef[2], 0.20849094150265948, 1e-9);
-        assert_close(wlw.global_test_stat, 12.37081136240878, 1e-9);
-        assert_close(wlw.global_test_pvalue, 0.006215083463136151, 1e-12);
+        assert_close(wlw.coef[0], -0.584_793_457_410_789_8, 1e-9);
+        assert_close(wlw.coef[1], -0.051_616_982_656_100_99, 1e-9);
+        assert_close(wlw.coef[2], 0.210_293_707_384_945_54, 1e-9);
+        assert_close(wlw.std_errors[0], 0.201_050_602_379_388_63, 1e-9);
+        assert_close(wlw.std_errors[1], 0.069_734_320_003_082_08, 1e-9);
+        assert_close(wlw.std_errors[2], 0.046_754_789_784_791_15, 1e-9);
+        assert_close(wlw.robust_std_errors[0], 0.307_946_258_183_588_84, 1e-9);
+        assert_close(wlw.robust_std_errors[1], 0.094_586_644_025_190_86, 1e-9);
+        assert_close(wlw.robust_std_errors[2], 0.066_641_686_829_874_4, 1e-9);
+        assert_close(wlw.log_likelihood, -426.146_832_546_882_1, 1e-9);
+        assert_close(wlw.global_test_stat, 15.537_046_791_588_393, 1e-9);
+        assert_close(wlw.global_test_pvalue, 0.001_410_738_150_921_807, 1e-12);
+        assert_eq!(wlw.n_iter, 4);
 
         assert!(gap.hazard_ratios[0] < 1.0);
         assert!(total.hazard_ratios[0] < gap.hazard_ratios[0]);

--- a/src/regression/recurrent_events/wlw.rs
+++ b/src/regression/recurrent_events/wlw.rs
@@ -90,184 +90,62 @@ pub fn wlw_model(
 
     let n_events_total = event.iter().filter(|&&e| e == 1).count();
 
+    let covariate_rows = x_mat
+        .chunks_exact(p)
+        .map(<[f64]>::to_vec)
+        .collect::<Vec<_>>();
+    let fit = coxph_fit(
+        time,
+        event,
+        covariate_rows,
+        (!config.common_baseline).then_some(stratum),
+        None,
+        None,
+        None,
+        Some(config.max_iter),
+        Some(config.tol),
+        None,
+        Some("efron"),
+        None,
+        None,
+    )?;
+    let beta = fit.coefficients.first().cloned().unwrap_or_default();
+    let covariance = fit.information_matrix.clone();
+
     let id_to_idx = index_by_i32(&unique_ids);
+    let clusters = id
+        .iter()
+        .map(|value| id_to_idx[value])
+        .collect::<Vec<_>>();
+    let robust_covariance = clustered_sandwich_variance(
+        fit.score_residuals()?,
+        vec![1.0; n],
+        clusters,
+        covariance.clone(),
+    )?;
 
-    let mut beta = vec![0.0; p];
-    let mut converged = false;
-    let mut n_iter = 0;
-    let mut prev_loglik = f64::NEG_INFINITY;
-
-    for iter in 0..config.max_iter {
-        n_iter = iter + 1;
-
-        let mut loglik = 0.0;
-        let mut gradient = vec![0.0; p];
-        let mut hessian = vec![vec![0.0; p]; p];
-
-        for &strat in &unique_strata {
-            let strata_indices: Vec<usize> = (0..n).filter(|&i| stratum[i] == strat).collect();
-
-            let mut sorted_indices = strata_indices.clone();
-            sorted_indices.sort_by(|&a, &b| {
-                time[b].total_cmp(&time[a])
-            });
-
-            for &i in &sorted_indices {
-                if event[i] != 1 {
-                    continue;
-                }
-
-                let mut eta_i = 0.0;
-                for j in 0..p {
-                    eta_i += x_mat[i * p + j] * beta[j];
-                }
-
-                let mut risk_sum = 0.0;
-                let mut risk_x_sum = vec![0.0; p];
-                let mut risk_xx_sum = vec![vec![0.0; p]; p];
-
-                for &k in &sorted_indices {
-                    if time[k] >= time[i] {
-                        let mut eta_k = 0.0;
-                        for j in 0..p {
-                            eta_k += x_mat[k * p + j] * beta[j];
-                        }
-                        let exp_eta_k = eta_k.exp();
-
-                        risk_sum += exp_eta_k;
-                        for j in 0..p {
-                            risk_x_sum[j] += x_mat[k * p + j] * exp_eta_k;
-                        }
-                        for j1 in 0..p {
-                            for j2 in 0..p {
-                                risk_xx_sum[j1][j2] +=
-                                    x_mat[k * p + j1] * x_mat[k * p + j2] * exp_eta_k;
-                            }
-                        }
-                    }
-                }
-
-                if risk_sum > DIVISION_FLOOR {
-                    loglik += eta_i - risk_sum.ln();
-
-                    for j in 0..p {
-                        let x_bar = risk_x_sum[j] / risk_sum;
-                        gradient[j] += x_mat[i * p + j] - x_bar;
-                    }
-
-                    for j1 in 0..p {
-                        let x_bar1 = risk_x_sum[j1] / risk_sum;
-                        for j2 in 0..p {
-                            let x_bar2 = risk_x_sum[j2] / risk_sum;
-                            hessian[j1][j2] += risk_xx_sum[j1][j2] / risk_sum - x_bar1 * x_bar2;
-                        }
-                    }
-                }
-            }
-        }
-
-        for j in 0..p {
-            if hessian[j][j].abs() > DIVISION_FLOOR {
-                beta[j] += gradient[j] / hessian[j][j];
-                beta[j] = beta[j].clamp(-10.0, 10.0);
-            }
-        }
-
-        if (loglik - prev_loglik).abs() < config.tol {
-            converged = true;
-            break;
-        }
-        prev_loglik = loglik;
-    }
-
-    let mut info_matrix = vec![vec![0.0; p]; p];
-    let mut score_residuals: Vec<Vec<f64>> = unique_ids.iter().map(|_| vec![0.0; p]).collect();
-
-    for &strat in &unique_strata {
-        let strata_indices: Vec<usize> = (0..n).filter(|&i| stratum[i] == strat).collect();
-        let mut sorted_indices = strata_indices.clone();
-        sorted_indices.sort_by(|&a, &b| {
-            time[b].total_cmp(&time[a])
-        });
-
-        for &i in &sorted_indices {
-            if event[i] != 1 {
-                continue;
-            }
-
-            let mut risk_sum = 0.0;
-            let mut risk_x_sum = vec![0.0; p];
-            let mut risk_xx_sum = vec![vec![0.0; p]; p];
-
-            for &k in &sorted_indices {
-                if time[k] >= time[i] {
-                    let mut eta_k = 0.0;
-                    for j in 0..p {
-                        eta_k += x_mat[k * p + j] * beta[j];
-                    }
-                    let exp_eta_k = eta_k.exp();
-
-                    risk_sum += exp_eta_k;
-                    for j in 0..p {
-                        risk_x_sum[j] += x_mat[k * p + j] * exp_eta_k;
-                    }
-                    for j1 in 0..p {
-                        for j2 in 0..p {
-                            risk_xx_sum[j1][j2] +=
-                                x_mat[k * p + j1] * x_mat[k * p + j2] * exp_eta_k;
-                        }
-                    }
-                }
-            }
-
-            if risk_sum > DIVISION_FLOOR {
-                for j1 in 0..p {
-                    let x_bar1 = risk_x_sum[j1] / risk_sum;
-                    for j2 in 0..p {
-                        let x_bar2 = risk_x_sum[j2] / risk_sum;
-                        info_matrix[j1][j2] += risk_xx_sum[j1][j2] / risk_sum - x_bar1 * x_bar2;
-                    }
-                }
-
-                if let Some(&subj_idx) = id_to_idx.get(&id[i]) {
-                    for j in 0..p {
-                        let x_bar = risk_x_sum[j] / risk_sum;
-                        score_residuals[subj_idx][j] += x_mat[i * p + j] - x_bar;
-                    }
-                }
-            }
-        }
-    }
-
-    let std_errors: Vec<f64> = (0..p)
-        .map(|j| {
-            if info_matrix[j][j] > DIVISION_FLOOR {
-                (1.0 / info_matrix[j][j]).sqrt()
-            } else {
-                f64::INFINITY
-            }
+    let std_errors = (0..p)
+        .map(|idx| {
+            covariance
+                .get(idx)
+                .and_then(|row| row.get(idx))
+                .copied()
+                .unwrap_or(0.0)
+                .max(0.0)
+                .sqrt()
         })
-        .collect();
-
-    let mut robust_var = vec![vec![0.0; p]; p];
-    for subj_scores in &score_residuals {
-        for j1 in 0..p {
-            for j2 in 0..p {
-                robust_var[j1][j2] += subj_scores[j1] * subj_scores[j2];
-            }
-        }
-    }
-
-    let robust_std_errors: Vec<f64> = (0..p)
-        .map(|j| {
-            let inv_info = if info_matrix[j][j] > DIVISION_FLOOR {
-                1.0 / info_matrix[j][j]
-            } else {
-                0.0
-            };
-            (inv_info * robust_var[j][j] * inv_info).sqrt()
+        .collect::<Vec<_>>();
+    let robust_std_errors = (0..p)
+        .map(|idx| {
+            robust_covariance
+                .get(idx)
+                .and_then(|row| row.get(idx))
+                .copied()
+                .unwrap_or(0.0)
+                .max(0.0)
+                .sqrt()
         })
-        .collect();
+        .collect::<Vec<_>>();
 
     let se_to_use = if config.robust_variance {
         &robust_std_errors
@@ -298,7 +176,26 @@ pub fn wlw_model(
 
     let stratum_coef: Vec<Vec<f64>> = unique_strata.iter().map(|_| beta.clone()).collect();
 
-    let global_test_stat: f64 = z_scores.iter().map(|&z| z * z).sum();
+    let test_covariance = if config.robust_variance {
+        &robust_covariance
+    } else {
+        &covariance
+    };
+    let global_test_stat = invert_matrix(test_covariance)
+        .map(|inverse| {
+            beta.iter()
+                .enumerate()
+                .map(|(row, &left)| {
+                    left * beta
+                        .iter()
+                        .enumerate()
+                        .map(|(column, &right)| inverse[row][column] * right)
+                        .sum::<f64>()
+                })
+                .sum::<f64>()
+        })
+        .unwrap_or_else(|| z_scores.iter().map(|&z| z * z).sum())
+        .max(0.0);
     let global_test_pvalue = 1.0 - chi2_cdf(global_test_stat, p as f64);
 
     Ok(WLWResult {
@@ -310,12 +207,12 @@ pub fn wlw_model(
         hazard_ratios,
         hr_lower,
         hr_upper,
-        log_likelihood: prev_loglik,
+        log_likelihood: fit.log_likelihood.last().copied().unwrap_or(0.0),
         n_events: n_events_total,
         n_subjects,
         n_strata,
-        n_iter,
-        converged,
+        n_iter: fit.iterations,
+        converged: fit.convergence_flag != CONVERGENCE_FLAG,
         stratum_coef,
         global_test_stat,
         global_test_pvalue,


### PR DESCRIPTION
## Summary
- replace the duplicated diagonal WLW optimizer with the shared stratified Efron Cox kernel
- honor common versus event-order-specific baselines and compute clustered sandwich covariance plus a covariance-aware joint Wald test
- add independent R reference coverage for both baseline modes and a permanent scaling benchmark

## Performance
Python API median latency at 30/100/200 subjects changed from 89/494/1,787 microseconds to 87/146/302 microseconds (1.03x, 3.40x, and 5.92x faster).

## Testing
- cargo test --all-features -q (1696 passed)
- cargo clippy --all-targets --all-features -- -D warnings
- python -m pytest python/tests -q (871 passed, 18 skipped)
- ruff format python/ --check
- ruff check python/
- mypy python/survival/__init__.pyi python/survival/_survival.pyi --ignore-missing-imports
- R CMD check --no-manual --no-build-vignettes r/survivalr (1 expected source-directory note)