### PR TITLE
Move survobrien risk-set expansion into Rust

### DIFF
--- a/python/survival/_binding_manifest.py
+++ b/python/survival/_binding_manifest.py
@@ -976,6 +976,7 @@ BINDINGS = (
     "survival_meta_analysis",
     "survival_quantile",
     "survobrien",
+    "survobrien_event_sets",
     "survobrien_transform_groups",
     "survreg",
     "survreg_dfbeta_residuals",

--- a/python/survival/_survival.pyi
+++ b/python/survival/_survival.pyi
@@ -6616,6 +6616,12 @@ def survobrien(
     covariate: list[float],
     strata: list[int] | None = None,
 ) -> SurvObrienResult: ...
+def survobrien_event_sets(
+    start: list[float] | None,
+    stop: list[float],
+    status: list[int],
+    strata: list[int] | None = None,
+) -> tuple[list[int], list[int], list[float], list[int]]: ...
 def survobrien_transform_groups(
     columns: list[list[float]],
     row_indices: list[int],

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -7144,114 +7144,21 @@ def _survobrien_formula_terms(
 def _survobrien_event_sets(
     response: Surv,
     strata_values: list[Any] | None,
-) -> list[tuple[float, list[int]]]:
-    if response.type == "right":
-        if strata_values is None:
-            event_times = sorted(
-                {
-                    float(time)
-                    for time, event in zip(response.time, response.event, strict=True)
-                    if event == 1
-                }
-            )
-            return [
-                (
-                    event_time,
-                    [idx for idx, time in enumerate(response.time) if float(time) >= event_time],
-                )
-                for event_time in event_times
-            ]
+) -> tuple[list[int], list[int], list[float], list[int]]:
+    if response.type not in {"right", "counting"}:
+        raise ValueError("Response must be right censored or (start, stop] data")
+    if response.type == "counting" and response.start is None:
+        raise ValueError("counting Surv response is missing start times")
 
-        seen: set[tuple[float, Any]] = set()
-        result: list[tuple[float, list[int]]] = []
-        for event_time, event, stratum in zip(
-            response.time,
-            response.event,
-            strata_values,
-            strict=True,
-        ):
-            if event != 1:
-                continue
-            key = (float(event_time), _hashable_group_value(stratum))
-            if key in seen:
-                continue
-            seen.add(key)
-            result.append(
-                (
-                    float(event_time),
-                    [
-                        idx
-                        for idx, (row_event, row_stratum) in enumerate(
-                            zip(response.event, strata_values, strict=True)
-                        )
-                        if float(row_event) >= float(event_time) and row_stratum == stratum
-                    ],
-                )
-            )
-        return result
-
-    if response.type == "counting":
-        if response.start is None:
-            raise ValueError("counting Surv response is missing start times")
-        if strata_values is None:
-            event_times = sorted(
-                {
-                    float(stop)
-                    for stop, event in zip(response.time, response.event, strict=True)
-                    if event == 1
-                }
-            )
-            return [
-                (
-                    event_time,
-                    [
-                        idx
-                        for idx, (start, stop) in enumerate(
-                            zip(response.start, response.time, strict=True)
-                        )
-                        if float(start) < event_time <= float(stop)
-                    ],
-                )
-                for event_time in event_times
-            ]
-
-        seen: set[tuple[float, Any]] = set()
-        result: list[tuple[float, list[int]]] = []
-        for event_time, event, stratum in zip(
-            response.time,
-            response.event,
-            strata_values,
-            strict=True,
-        ):
-            if event != 1:
-                continue
-            event_time_float = float(event_time)
-            stratum_key = _hashable_group_value(stratum)
-            key = (event_time_float, stratum_key)
-            if key in seen:
-                continue
-            seen.add(key)
-            result.append(
-                (
-                    event_time_float,
-                    [
-                        idx
-                        for idx, (start, stop, row_stratum) in enumerate(
-                            zip(
-                                response.start,
-                                response.time,
-                                strata_values,
-                                strict=True,
-                            )
-                        )
-                        if float(start) < event_time_float <= float(stop)
-                        and _hashable_group_value(row_stratum) != stratum_key
-                    ],
-                )
-            )
-        return result
-
-    raise ValueError("Response must be right censored or (start, stop] data")
+    strata_groups = (
+        None if strata_values is None else _encode_groups(strata_values, len(response))
+    )
+    return _core.survobrien_event_sets(
+        None if response.start is None else list(response.start),
+        list(response.time),
+        [int(event) for event in response.event],
+        strata_groups,
+    )
 
 
 def _survobrien_formula_frame(
@@ -7273,15 +7180,10 @@ def _survobrien_formula_frame(
     n = len(response)
     keepers, continuous = _survobrien_formula_terms(data, terms, n)
     strata_values = _combined_columns(data, terms.strata, n) if terms.strata else None
-    event_sets = _survobrien_event_sets(response, strata_values)
-
-    row_indices: list[int] = []
-    set_numbers: list[int] = []
-    event_times: list[float] = []
-    for set_idx, (event_time, indices) in enumerate(event_sets, start=1):
-        row_indices.extend(indices)
-        set_numbers.extend([set_idx] * len(indices))
-        event_times.extend([event_time] * len(indices))
+    row_indices, group_sizes, event_times, set_numbers = _survobrien_event_sets(
+        response,
+        strata_values,
+    )
 
     frame: dict[str, list[Any]] = {}
     if response.type == "counting":
@@ -7300,7 +7202,6 @@ def _survobrien_formula_frame(
     if not terms.clusters:
         frame[".id."] = [idx + 1 for idx in row_indices]
 
-    group_sizes = [len(indices) for _event_time, indices in event_sets]
     if transform is None:
         transformed_columns = _core.survobrien_transform_groups(
             [values for _name, values in continuous],

--- a/python/tests/test_binding_contract.py
+++ b/python/tests/test_binding_contract.py
@@ -3860,6 +3860,7 @@ def test_survobrien_and_trend_bindings_are_typed():
         "SurvObrienResult",
         "TrendTestResult",
         "survobrien",
+        "survobrien_event_sets",
         "survobrien_transform_groups",
         "logrank_trend",
     } <= stub_names
@@ -3868,6 +3869,12 @@ def test_survobrien_and_trend_bindings_are_typed():
         "time",
         "status",
         "covariate",
+        "strata",
+    ]
+    assert list(inspect.signature(core.survobrien_event_sets).parameters) == [
+        "start",
+        "stop",
+        "status",
         "strata",
     ]
     assert list(inspect.signature(core.survobrien_transform_groups).parameters) == [
@@ -3885,6 +3892,12 @@ def test_survobrien_and_trend_bindings_are_typed():
         "time",
         "status",
         "covariate",
+        "strata",
+    ]
+    assert _pyi_function_arg_names(stub_path, "survobrien_event_sets") == [
+        "start",
+        "stop",
+        "status",
         "strata",
     ]
     assert _pyi_function_arg_names(stub_path, "survobrien_transform_groups") == [
@@ -3919,6 +3932,12 @@ def test_survobrien_and_trend_bindings_are_typed():
         [0.2, 0.5, 0.9],
         None,
     )
+    event_sets = core.survobrien_event_sets(
+        None,
+        [1.0, 2.0, 3.0],
+        [1, 0, 1],
+        None,
+    )
     transformed = core.survobrien_transform_groups(
         [[4.0, 1.0, 1.0, 3.0]],
         [0, 1, 2, 3, 2],
@@ -3932,6 +3951,7 @@ def test_survobrien_and_trend_bindings_are_typed():
     )
 
     assert type(obrien).__name__ == "SurvObrienResult"
+    assert event_sets == ([0, 1, 2, 2], [3, 1], [1.0, 1.0, 1.0, 3.0], [1, 1, 1, 2])
     assert transformed[0] == pytest.approx(
         [
             1.9459101490553132,

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -3823,6 +3823,78 @@ def test_survobrien_group_transform_matches_python_reference():
             assert actual_column == pytest.approx(expected_column)
 
 
+def test_survobrien_event_sets_match_python_reference():
+    def reference(
+        stop: list[float],
+        status: list[int],
+        start: list[float] | None,
+        strata: list[int] | None,
+    ) -> tuple[list[int], list[int], list[float], list[int]]:
+        if strata is None:
+            unique_event_times = {
+                stop[idx] for idx in range(len(stop)) if status[idx] == 1
+            }
+            event_sets = [(time, None) for time in sorted(unique_event_times)]
+        else:
+            event_sets = []
+            seen: set[tuple[float, int]] = set()
+            for event_time, event, stratum in zip(stop, status, strata, strict=True):
+                key = (event_time, stratum)
+                if event == 1 and key not in seen:
+                    seen.add(key)
+                    event_sets.append((event_time, stratum))
+
+        row_indices: list[int] = []
+        group_sizes: list[int] = []
+        event_times: list[float] = []
+        set_numbers: list[int] = []
+        for set_number, (event_time, event_stratum) in enumerate(event_sets, start=1):
+            group_start = len(row_indices)
+            for idx in range(len(stop)):
+                if start is None and strata is None:
+                    at_risk = stop[idx] >= event_time
+                elif start is None:
+                    assert strata is not None
+                    assert event_stratum is not None
+                    at_risk = status[idx] >= event_time and strata[idx] == event_stratum
+                elif strata is None:
+                    at_risk = start[idx] < event_time <= stop[idx]
+                else:
+                    assert event_stratum is not None
+                    at_risk = (
+                        start[idx] < event_time <= stop[idx]
+                        and strata[idx] != event_stratum
+                    )
+                if at_risk:
+                    row_indices.append(idx)
+            group_size = len(row_indices) - group_start
+            group_sizes.append(group_size)
+            event_times.extend([event_time] * group_size)
+            set_numbers.extend([set_number] * group_size)
+        return row_indices, group_sizes, event_times, set_numbers
+
+    rng = random.Random(20260820)  # noqa: S311
+    for _ in range(200):
+        n_rows = rng.randrange(1, 40)
+        stop = [float(rng.randrange(1, 15)) for _ in range(n_rows)]
+        status = [rng.randrange(2) for _ in range(n_rows)]
+        start = [float(rng.randrange(int(value))) for value in stop]
+        strata = [rng.randrange(4) for _ in range(n_rows)]
+        for row_start, row_strata in (
+            (None, None),
+            (None, strata),
+            (start, None),
+            (start, strata),
+        ):
+            actual = survival._survival.survobrien_event_sets(
+                row_start,
+                stop,
+                status,
+                row_strata,
+            )
+            assert actual == reference(stop, status, row_start, row_strata)
+
+
 def test_r_style_yates_direct_helpers_wrap_rust_kernels():
     result = survival.yates(
         [1.0, 2.0, 4.0, 8.0],

--- a/src/api/python/classical/survival_models.rs
+++ b/src/api/python/classical/survival_models.rs
@@ -32,6 +32,7 @@ pub(super) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(brier, m)?)?;
     m.add_function(wrap_pyfunction!(integrated_brier, m)?)?;
     m.add_function(wrap_pyfunction!(survobrien, m)?)?;
+    m.add_function(wrap_pyfunction!(survobrien_event_sets, m)?)?;
     m.add_function(wrap_pyfunction!(survobrien_transform_groups, m)?)?;
     m.add_function(wrap_pyfunction!(nelson_aalen_estimator, m)?)?;
     m.add_function(wrap_pyfunction!(stratified_kaplan_meier, m)?)?;

--- a/src/validation/mod.rs
+++ b/src/validation/mod.rs
@@ -118,7 +118,9 @@ pub use rmst_module::{
 };
 pub use royston_module::{RoystonResult, royston, royston_from_model};
 pub use survcheck_module::{SurvCheckResult, survcheck, survcheck_simple};
-pub use survobrien_module::{SurvObrienResult, survobrien, survobrien_transform_groups};
+pub use survobrien_module::{
+    SurvObrienResult, survobrien, survobrien_event_sets, survobrien_transform_groups,
+};
 pub use time_dependent_auc_module::{
     CumulativeDynamicAUCResult, TimeDepAUCResult, cumulative_dynamic_auc,
     cumulative_dynamic_auc_core, time_dependent_auc, time_dependent_auc_core,

--- a/src/validation/survobrien.rs
+++ b/src/validation/survobrien.rs
@@ -1,5 +1,5 @@
 use crate::constants::same_time;
-use crate::internal::numpy_utils::{extract_vec_f64, extract_vec_i32};
+use crate::internal::numpy_utils::{extract_optional_vec_f64, extract_vec_f64, extract_vec_i32};
 use crate::internal::statistical::chi2_sf;
 use crate::internal::validation::{
     validate_binary_i32, validate_finite, validate_length, validate_no_nan, validate_non_negative,
@@ -7,8 +7,10 @@ use crate::internal::validation::{
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use std::cmp::Ordering;
+use std::collections::HashSet;
 
 const RANK_TIE_TOLERANCE: f64 = 1e-10;
+type SurvobrienEventSetExpansion = (Vec<usize>, Vec<usize>, Vec<f64>, Vec<usize>);
 
 fn validate_survobrien_inputs(
     time: &[f64],
@@ -90,6 +92,132 @@ pub fn survobrien(
     validate_survobrien_inputs(&time_vec, &status_vec, &covariate_vec, strata)?;
     let result = compute_survobrien(&time_vec, &status_vec, &covariate_vec, strata);
     Ok(result)
+}
+
+fn validate_survobrien_event_set_inputs(
+    start: Option<&[f64]>,
+    stop: &[f64],
+    status: &[i32],
+    strata: Option<&[i32]>,
+) -> PyResult<()> {
+    validate_length(stop.len(), status.len(), "status")?;
+    if let Some(start) = start {
+        validate_length(stop.len(), start.len(), "start")?;
+        validate_finite(start, "start")?;
+    }
+    if let Some(strata) = strata {
+        validate_length(stop.len(), strata.len(), "strata")?;
+    }
+    validate_finite(stop, "stop")?;
+    validate_binary_i32(status, "status")?;
+    Ok(())
+}
+
+fn survobrien_event_key(time: f64, stratum: i32) -> (u64, i32) {
+    let normalized_time = if time == 0.0 { 0.0 } else { time };
+    (normalized_time.to_bits(), stratum)
+}
+
+fn expand_survobrien_event_sets(
+    start: Option<&[f64]>,
+    stop: &[f64],
+    status: &[i32],
+    strata: Option<&[i32]>,
+) -> SurvobrienEventSetExpansion {
+    let event_sets = if let Some(strata) = strata {
+        let mut seen = HashSet::new();
+        stop.iter()
+            .zip(status)
+            .zip(strata)
+            .filter_map(|((&event_time, &event), &stratum)| {
+                if event != 1 || !seen.insert(survobrien_event_key(event_time, stratum)) {
+                    None
+                } else {
+                    Some((event_time, Some(stratum)))
+                }
+            })
+            .collect::<Vec<_>>()
+    } else {
+        let mut event_times = stop
+            .iter()
+            .zip(status)
+            .filter_map(|(&event_time, &event)| (event == 1).then_some(event_time))
+            .collect::<Vec<_>>();
+        event_times.sort_unstable_by(f64::total_cmp);
+        event_times.dedup_by(|left, right| *left == *right);
+        event_times
+            .into_iter()
+            .map(|event_time| (event_time, None))
+            .collect::<Vec<_>>()
+    };
+
+    let mut row_indices = Vec::new();
+    let mut group_sizes = Vec::with_capacity(event_sets.len());
+    let mut event_times = Vec::new();
+    let mut set_numbers = Vec::new();
+
+    for (set_index, (event_time, event_stratum)) in event_sets.into_iter().enumerate() {
+        let group_start = row_indices.len();
+        for row_index in 0..stop.len() {
+            let at_risk = match (start, strata, event_stratum) {
+                (None, None, None) => stop[row_index] >= event_time,
+                // Preserve survival::survobrien's stratified formula selection exactly.
+                (None, Some(row_strata), Some(stratum)) => {
+                    f64::from(status[row_index]) >= event_time && row_strata[row_index] == stratum
+                }
+                (Some(row_start), None, None) => {
+                    row_start[row_index] < event_time && event_time <= stop[row_index]
+                }
+                // Preserve survival::survobrien's counting-process stratum complement.
+                (Some(row_start), Some(row_strata), Some(stratum)) => {
+                    row_start[row_index] < event_time
+                        && event_time <= stop[row_index]
+                        && row_strata[row_index] != stratum
+                }
+                _ => unreachable!("event strata and row strata must be present together"),
+            };
+            if at_risk {
+                row_indices.push(row_index);
+            }
+        }
+
+        let group_size = row_indices.len() - group_start;
+        group_sizes.push(group_size);
+        event_times.extend(std::iter::repeat_n(event_time, group_size));
+        set_numbers.extend(std::iter::repeat_n(set_index + 1, group_size));
+    }
+
+    (row_indices, group_sizes, event_times, set_numbers)
+}
+
+#[pyfunction]
+#[pyo3(signature = (start, stop, status, strata=None))]
+pub fn survobrien_event_sets(
+    py: Python<'_>,
+    start: Option<&Bound<'_, PyAny>>,
+    stop: &Bound<'_, PyAny>,
+    status: &Bound<'_, PyAny>,
+    strata: Option<&Bound<'_, PyAny>>,
+) -> PyResult<SurvobrienEventSetExpansion> {
+    let start_vec = extract_optional_vec_f64(start)?;
+    let stop_vec = extract_vec_f64(stop)?;
+    let status_vec = extract_vec_i32(status)?;
+    let strata_vec = strata.map(extract_vec_i32).transpose()?;
+    validate_survobrien_event_set_inputs(
+        start_vec.as_deref(),
+        &stop_vec,
+        &status_vec,
+        strata_vec.as_deref(),
+    )?;
+
+    Ok(py.detach(move || {
+        expand_survobrien_event_sets(
+            start_vec.as_deref(),
+            &stop_vec,
+            &status_vec,
+            strata_vec.as_deref(),
+        )
+    }))
 }
 
 fn validate_survobrien_transform_groups(
@@ -377,6 +505,69 @@ mod tests {
         let result = compute_survobrien(&[], &[], &[], None);
         assert_eq!(result.statistic, 0.0);
         assert_eq!(result.p_value, 1.0);
+    }
+
+    #[test]
+    fn test_survobrien_event_sets_expand_right_censored_risk_sets() {
+        let actual = expand_survobrien_event_sets(None, &[1.0, 2.0, 3.0], &[1, 0, 1], None);
+
+        assert_eq!(actual.0, vec![0, 1, 2, 2]);
+        assert_eq!(actual.1, vec![3, 1]);
+        assert_eq!(actual.2, vec![1.0, 1.0, 1.0, 3.0]);
+        assert_eq!(actual.3, vec![1, 1, 1, 2]);
+    }
+
+    #[test]
+    fn test_survobrien_event_sets_match_r_stratified_selection() {
+        let right = expand_survobrien_event_sets(
+            None,
+            &[1.0, 2.0, 3.0, 4.0],
+            &[1, 0, 1, 1],
+            Some(&[0, 0, 1, 1]),
+        );
+        assert_eq!(right.0, vec![0]);
+        assert_eq!(right.1, vec![1, 0, 0]);
+        assert_eq!(right.2, vec![1.0]);
+        assert_eq!(right.3, vec![1]);
+
+        let counting = expand_survobrien_event_sets(
+            Some(&[0.0, 0.0, 1.0, 2.0, 0.0, 3.0]),
+            &[1.0, 2.0, 3.0, 4.0, 2.0, 5.0],
+            &[1, 0, 1, 1, 1, 0],
+            Some(&[0, 0, 1, 1, 0, 1]),
+        );
+        assert_eq!(counting.0, vec![2]);
+        assert_eq!(counting.1, vec![0, 0, 0, 1]);
+        assert_eq!(counting.2, vec![2.0]);
+        assert_eq!(counting.3, vec![4]);
+    }
+
+    #[test]
+    fn test_survobrien_event_sets_validate_shapes_and_values() {
+        let length_error =
+            validate_survobrien_event_set_inputs(None, &[1.0], &[], None).unwrap_err();
+        assert!(length_error.to_string().contains("status length mismatch"));
+
+        let start_error =
+            validate_survobrien_event_set_inputs(Some(&[0.0]), &[1.0, 2.0], &[1, 0], None)
+                .unwrap_err();
+        assert!(start_error.to_string().contains("start length mismatch"));
+
+        let status_error =
+            validate_survobrien_event_set_inputs(None, &[1.0], &[2], None).unwrap_err();
+        assert!(
+            status_error
+                .to_string()
+                .contains("status must contain only 0/1")
+        );
+
+        let time_error =
+            validate_survobrien_event_set_inputs(None, &[f64::INFINITY], &[1], None).unwrap_err();
+        assert!(
+            time_error
+                .to_string()
+                .contains("stop contains non-finite value")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- replace nested Python risk-set scans with a native expansion helper that emits row indices, group sizes, event times, and set numbers together
- preserve R-compatible right-censored, counting-process, tied-event, and stratified ordering semantics while encoding arbitrary Python strata once
- add strict input validation, typed binding coverage, and randomized parity checks across all four response/strata modes

## Performance
Minimum single-call time for the formula risk-set stage:

| Input | Rows | Python | Rust | Speedup |
| --- | ---: | ---: | ---: | ---: |
| right-censored | 200 | 92.7 us | 31.1 us | 2.98x |
| right-censored | 800 | 1378.9 us | 625.9 us | 2.20x |
| right-censored | 1600 | 6053.5 us | 3005.2 us | 2.01x |
| counting-process | 200 | 115.5 us | 15.1 us | 7.66x |
| counting-process | 800 | 1921.8 us | 110.2 us | 17.44x |
| counting-process | 1600 | 7966.8 us | 329.0 us | 24.21x |

## Testing
- cargo test (1478 passed)
- pytest -q python/tests (873 passed, 18 skipped)
- cargo clippy --all-targets --all-features -- -D warnings
- ruff check python/survival python/tests/test_r_api.py python/tests/test_binding_contract.py
- mypy python/survival/__init__.pyi python/survival/_survival.pyi --ignore-missing-imports
- R CMD check --no-manual --no-build-vignettes r/survivalr (1 expected source-directory note)