### PR TITLE
Accelerate counting-process rttright

### DIFF
--- a/python/survival/_binding_manifest.py
+++ b/python/survival/_binding_manifest.py
@@ -903,6 +903,7 @@ BINDINGS = (
     "royston",
     "royston_from_model",
     "rttright",
+    "rttright_counting_matrix",
     "rttright_matrix",
     "rttright_stratified",
     "rttright_time_matrix",

--- a/python/survival/_survival.pyi
+++ b/python/survival/_survival.pyi
@@ -5729,6 +5729,16 @@ def rttright(
     timefix: bool = True,
     renorm: bool = True,
 ) -> RttrightResult: ...
+def rttright_counting_matrix(
+    start: list[float],
+    stop: list[float],
+    status: list[int],
+    weights: list[float],
+    last: list[bool],
+    strata: list[int],
+    delta: float,
+    times: list[float] | None = None,
+) -> list[list[float]]: ...
 def rttright_matrix(
     time: list[float],
     status: list[int],

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -8059,14 +8059,6 @@ def _rttright_binary_status(response: Surv) -> list[int]:
     return [1 if int(value) > 0 else 0 for value in response.event]
 
 
-def _rttright_divide(numerator: float, denominator: float) -> float:
-    if denominator != 0.0:
-        return numerator / denominator
-    if numerator == 0.0:
-        return math.nan
-    return math.inf
-
-
 def _rttright_counting_common_start(
     start: Sequence[float],
     id_values: Sequence[Any],
@@ -8170,43 +8162,6 @@ def _rttright_counting_delta(
     return min(diffs) / 2.0
 
 
-def _rttright_counting_km(
-    start: Sequence[float],
-    stop: Sequence[float],
-    censor: Sequence[int],
-    weights: Sequence[float],
-) -> tuple[list[float], list[float]]:
-    event_times = sorted({float(stop[idx]) for idx, value in enumerate(censor) if value == 1})
-    survival_times: list[float] = []
-    survival_values: list[float] = []
-    current = 1.0
-    for event_time in event_times:
-        risk = sum(
-            float(weight)
-            for left, right, weight in zip(start, stop, weights, strict=True)
-            if float(left) < event_time <= float(right)
-        )
-        events = sum(
-            float(weights[idx])
-            for idx, value in enumerate(censor)
-            if value == 1 and float(stop[idx]) == event_time
-        )
-        if risk > 0.0:
-            current *= 1.0 - events / risk
-        survival_times.append(event_time)
-        survival_values.append(current)
-    return survival_times, survival_values
-
-
-def _rttright_km_survival_at(
-    survival_times: Sequence[float],
-    survival_values: Sequence[float],
-    time: float,
-) -> float:
-    index = bisect_left(survival_times, float(time))
-    return 1.0 if index == 0 else float(survival_values[index - 1])
-
-
 def _rttright_time_matrix(
     time: Sequence[float],
     status: Sequence[int],
@@ -8247,60 +8202,6 @@ def _rttright_time_matrix(
 
     if len(query_times) == 1:
         return [row[0] for row in matrix]
-    return matrix
-
-
-def _rttright_counting_group_result(
-    start: Sequence[float],
-    stop: Sequence[float],
-    status: Sequence[int],
-    weights: Sequence[float],
-    last: Sequence[bool],
-    query_times: Sequence[float] | None,
-    delta: float,
-) -> list[float] | list[list[float]]:
-    km_stop = [float(value) for value in stop]
-    censor = [
-        1 if is_last and int(event) == 0 else 0 for is_last, event in zip(last, status, strict=True)
-    ]
-    for row_idx, value in enumerate(censor):
-        if value == 1:
-            km_stop[row_idx] += delta
-    survival_times, survival_values = _rttright_counting_km(start, km_stop, censor, weights)
-
-    if query_times is None:
-        result: list[float] = []
-        for row_stop, row_status, row_weight, is_last in zip(
-            stop,
-            status,
-            weights,
-            last,
-            strict=True,
-        ):
-            if is_last and int(row_status) > 0:
-                gwt = _rttright_km_survival_at(survival_times, survival_values, float(row_stop))
-                result.append(_rttright_divide(float(row_weight), gwt))
-            else:
-                result.append(0.0)
-        return result
-
-    matrix = [[0.0] * len(query_times) for _ in range(len(start))]
-    gwt = [_rttright_km_survival_at(survival_times, survival_values, time) for time in query_times]
-    gwt2 = [
-        _rttright_km_survival_at(survival_times, survival_values, row_stop) for row_stop in stop
-    ]
-    for row_idx, (row_start, row_stop, _row_status, row_weight, is_last) in enumerate(
-        zip(start, stop, status, weights, last, strict=True)
-    ):
-        for col_idx, query_time in enumerate(query_times):
-            if float(row_start) < float(query_time) <= float(row_stop):
-                matrix[row_idx][col_idx] = _rttright_divide(float(row_weight), gwt[col_idx])
-        if is_last and float(row_stop) > 0.0:
-            for col_idx, query_gwt in enumerate(gwt):
-                matrix[row_idx][col_idx] = _rttright_divide(
-                    float(row_weight),
-                    max(gwt2[row_idx], query_gwt),
-                )
     return matrix
 
 
@@ -8354,38 +8255,18 @@ def _rttright_counting_result(
     case_weights = _rttright_counting_case_weights(weights, id_labels, group_values, n, renorm)
     delta = _rttright_counting_delta(start, stop, query_times)
 
-    matrix: list[list[float]] | None = None
-    vector = [0.0] * n
-    if query_times is not None:
-        matrix = [[0.0] * len(query_times) for _ in range(n)]
-
-    group_indices: dict[int, list[int]] = {}
-    for row_idx, group_value in enumerate(group_values):
-        group_indices.setdefault(group_value, []).append(row_idx)
-
-    for indices in group_indices.values():
-        group_result = _rttright_counting_group_result(
-            [start[idx] for idx in indices],
-            [stop[idx] for idx in indices],
-            [status_values[idx] for idx in indices],
-            [case_weights[idx] for idx in indices],
-            [last[idx] for idx in indices],
-            query_times,
-            delta,
-        )
-        if query_times is None:
-            for local_idx, row_idx in enumerate(indices):
-                vector[row_idx] = float(group_result[local_idx])
-        else:
-            if matrix is None:
-                raise RuntimeError("rttright counting matrix was not initialized")
-            for local_idx, row_idx in enumerate(indices):
-                matrix[row_idx] = [float(value) for value in group_result[local_idx]]
-
+    matrix = _core.rttright_counting_matrix(
+        start,
+        stop,
+        status_values,
+        case_weights,
+        last,
+        group_values,
+        delta,
+        query_times,
+    )
     if query_times is None:
-        return vector
-    if matrix is None:
-        raise RuntimeError("rttright counting matrix was not initialized")
+        return [float(row[0]) for row in matrix]
     if len(query_times) == 1:
         return [row[0] for row in matrix]
     return matrix

--- a/python/tests/test_binding_contract.py
+++ b/python/tests/test_binding_contract.py
@@ -3462,6 +3462,7 @@ def test_data_prep_low_level_bindings_are_typed():
         "neardate",
         "neardate_str",
         "rttright",
+        "rttright_counting_matrix",
         "rttright_matrix",
         "rttright_stratified",
         "rttright_time_matrix",
@@ -3500,6 +3501,16 @@ def test_data_prep_low_level_bindings_are_typed():
         "neardate": ["id1", "date1", "id2", "date2", "best", "nomatch"],
         "neardate_str": ["id1", "date1", "id2", "date2", "best", "nomatch"],
         "rttright": ["time", "status", "weights", "timefix", "renorm"],
+        "rttright_counting_matrix": [
+            "start",
+            "stop",
+            "status",
+            "weights",
+            "last",
+            "strata",
+            "delta",
+            "times",
+        ],
         "rttright_matrix": [
             "time",
             "status",
@@ -3642,6 +3653,20 @@ def test_data_prep_low_level_bindings_are_typed():
     assert timed_weights[0] == pytest.approx([1.0 / 3.0, 0.5, 0.5])
     assert timed_weights[1] == pytest.approx([1.0 / 3.0, 0.0, 0.0])
     assert timed_weights[2] == pytest.approx([1.0 / 3.0, 0.5, 0.5])
+
+    counting_weights = core.rttright_counting_matrix(
+        [0.0, 0.0, 0.0],
+        [3.0, 2.0, 4.0],
+        [1, 0, 1],
+        [1.0 / 3.0] * 3,
+        [True] * 3,
+        [0] * 3,
+        0.25,
+        [1.0, 2.0, 3.0, 4.0],
+    )
+    assert counting_weights[0] == pytest.approx([1.0 / 3.0, 1.0 / 3.0, 0.5, 0.5])
+    assert counting_weights[1] == pytest.approx([1.0 / 3.0] * 4)
+    assert counting_weights[2] == pytest.approx([1.0 / 3.0, 1.0 / 3.0, 0.5, 0.5])
 
 
 def test_cox_counting_low_level_bindings_are_typed():

--- a/src/api/python/classical/data_prep.rs
+++ b/src/api/python/classical/data_prep.rs
@@ -16,6 +16,25 @@ fn rttright_time_matrix_py(
     py.detach(move || rttright_time_matrix(time, status, times, weights, strata, timefix, renorm))
 }
 
+#[pyfunction(name = "rttright_counting_matrix")]
+#[pyo3(signature = (start, stop, status, weights, last, strata, delta, times=None))]
+#[allow(clippy::too_many_arguments)]
+fn rttright_counting_matrix_py(
+    py: Python<'_>,
+    start: Vec<f64>,
+    stop: Vec<f64>,
+    status: Vec<i32>,
+    weights: Vec<f64>,
+    last: Vec<bool>,
+    strata: Vec<i32>,
+    delta: f64,
+    times: Option<Vec<f64>>,
+) -> PyResult<Vec<Vec<f64>>> {
+    py.detach(move || {
+        rttright_counting_matrix(start, stop, status, weights, last, strata, delta, times)
+    })
+}
+
 pub(super) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(tmerge, m)?)?;
     m.add_function(wrap_pyfunction!(tmerge_plan, m)?)?;
@@ -47,6 +66,7 @@ pub(super) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(tcut, m)?)?;
     m.add_function(wrap_pyfunction!(tcut_expand, m)?)?;
     m.add_function(wrap_pyfunction!(rttright, m)?)?;
+    m.add_function(wrap_pyfunction!(rttright_counting_matrix_py, m)?)?;
     m.add_function(wrap_pyfunction!(rttright_matrix, m)?)?;
     m.add_function(wrap_pyfunction!(rttright_stratified, m)?)?;
     m.add_function(wrap_pyfunction!(rttright_time_matrix_py, m)?)?;

--- a/src/data_prep/mod.rs
+++ b/src/data_prep/mod.rs
@@ -34,7 +34,8 @@ pub use nostutter::{
     nostutter_str_numeric, nostutter_str_str,
 };
 pub use rttright_module::{
-    RttrightResult, rttright, rttright_matrix, rttright_stratified, rttright_time_matrix,
+    RttrightResult, rttright, rttright_counting_matrix, rttright_matrix, rttright_stratified,
+    rttright_time_matrix,
 };
 pub use strata_module::{StrataResult, strata, strata_compact, strata_str};
 pub use surv2data_module::{

--- a/src/data_prep/rttright.rs
+++ b/src/data_prep/rttright.rs
@@ -357,6 +357,259 @@ pub fn rttright_time_matrix(
     Ok(matrix)
 }
 
+struct RttrightCountingInputs<'a> {
+    start: &'a [f64],
+    stop: &'a [f64],
+    status: &'a [i32],
+    weights: &'a [f64],
+    last: &'a [bool],
+    strata: &'a [i32],
+    times: Option<&'a [f64]>,
+    delta: f64,
+}
+
+fn validate_rttright_counting_inputs(inputs: &RttrightCountingInputs<'_>) -> PyResult<()> {
+    let n = inputs.stop.len();
+    for (name, len) in [
+        ("start", inputs.start.len()),
+        ("status", inputs.status.len()),
+        ("weights", inputs.weights.len()),
+        ("last", inputs.last.len()),
+        ("strata", inputs.strata.len()),
+    ] {
+        if len != n {
+            return Err(PyValueError::new_err(format!(
+                "{name} must have same length as stop"
+            )));
+        }
+    }
+    validate_finite(inputs.start, "start")?;
+    validate_finite(inputs.stop, "stop")?;
+    validate_binary_i32(inputs.status, "status")?;
+    validate_finite(inputs.weights, "weights")?;
+    validate_non_negative(inputs.weights, "weights")?;
+    if let Some(times) = inputs.times {
+        validate_finite(times, "times")?;
+    }
+    if !inputs.delta.is_finite() || inputs.delta <= 0.0 {
+        return Err(PyValueError::new_err(
+            "delta must be finite and greater than zero",
+        ));
+    }
+    if let Some(index) = inputs
+        .start
+        .iter()
+        .zip(inputs.stop)
+        .position(|(&left, &right)| left >= right)
+    {
+        return Err(PyValueError::new_err(format!(
+            "start must be less than stop at index {index}"
+        )));
+    }
+    Ok(())
+}
+
+fn counting_censor_survival(
+    start: &[f64],
+    km_stop: &[f64],
+    censor: &[bool],
+    weights: &[f64],
+    indices: &[usize],
+) -> (Vec<f64>, Vec<f64>) {
+    let mut censor_events = indices
+        .iter()
+        .filter_map(|&index| censor[index].then_some((km_stop[index], weights[index])))
+        .collect::<Vec<_>>();
+    censor_events.sort_unstable_by(|left, right| left.0.total_cmp(&right.0));
+    if censor_events.is_empty() {
+        return (Vec::new(), Vec::new());
+    }
+
+    let mut start_order = indices.to_vec();
+    start_order.sort_unstable_by(|&left, &right| {
+        start[left]
+            .total_cmp(&start[right])
+            .then_with(|| left.cmp(&right))
+    });
+    let mut stop_order = indices.to_vec();
+    stop_order.sort_unstable_by(|&left, &right| {
+        km_stop[left]
+            .total_cmp(&km_stop[right])
+            .then_with(|| left.cmp(&right))
+    });
+
+    let mut event_times = Vec::with_capacity(censor_events.len());
+    let mut survival_values = Vec::with_capacity(censor_events.len());
+    let mut current = 1.0;
+    let mut active_weight = 0.0;
+    let mut active_positive_rows = 0usize;
+    let mut start_position = 0;
+    let mut stop_position = 0;
+    let mut event_position = 0;
+
+    while event_position < censor_events.len() {
+        let event_time = censor_events[event_position].0;
+        let mut event_end = event_position + 1;
+        let mut event_weight = censor_events[event_position].1;
+        let mut event_positive_rows = usize::from(event_weight > 0.0);
+        while event_end < censor_events.len() && censor_events[event_end].0 == event_time {
+            event_weight += censor_events[event_end].1;
+            event_positive_rows += usize::from(censor_events[event_end].1 > 0.0);
+            event_end += 1;
+        }
+
+        while start_position < start_order.len() && start[start_order[start_position]] < event_time
+        {
+            let weight = weights[start_order[start_position]];
+            active_weight += weight;
+            active_positive_rows += usize::from(weight > 0.0);
+            start_position += 1;
+        }
+        while stop_position < stop_order.len() && km_stop[stop_order[stop_position]] < event_time {
+            let weight = weights[stop_order[stop_position]];
+            active_weight -= weight;
+            active_positive_rows -= usize::from(weight > 0.0);
+            stop_position += 1;
+        }
+
+        if active_positive_rows == event_positive_rows {
+            active_weight = event_weight;
+        }
+        if active_weight > 0.0 {
+            current *= 1.0 - event_weight / active_weight;
+        }
+        event_times.push(event_time);
+        survival_values.push(current);
+        event_position = event_end;
+    }
+
+    (event_times, survival_values)
+}
+
+#[inline]
+fn counting_survival_before(event_times: &[f64], survival_values: &[f64], time: f64) -> f64 {
+    let event_index = event_times.partition_point(|&event_time| event_time < time);
+    if event_index == 0 {
+        1.0
+    } else {
+        survival_values[event_index - 1]
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn compute_rttright_counting_group(
+    start: &[f64],
+    stop: &[f64],
+    km_stop: &[f64],
+    status: &[i32],
+    weights: &[f64],
+    last: &[bool],
+    censor: &[bool],
+    indices: &[usize],
+    times: Option<&[f64]>,
+) -> Vec<Vec<f64>> {
+    let (survival_times, survival_values) =
+        counting_censor_survival(start, km_stop, censor, weights, indices);
+
+    let Some(times) = times else {
+        return indices
+            .iter()
+            .map(|&index| {
+                let value = if last[index] && status[index] > 0 {
+                    let g =
+                        counting_survival_before(&survival_times, &survival_values, stop[index]);
+                    rttright_divide(weights[index], g)
+                } else {
+                    0.0
+                };
+                vec![value]
+            })
+            .collect();
+    };
+
+    let query_g = times
+        .iter()
+        .map(|&time| counting_survival_before(&survival_times, &survival_values, time))
+        .collect::<Vec<_>>();
+    let make_row = |&index: &usize| {
+        let mut row = vec![0.0; times.len()];
+        for (column, (&query_time, &g)) in times.iter().zip(&query_g).enumerate() {
+            if start[index] < query_time && query_time <= stop[index] {
+                row[column] = rttright_divide(weights[index], g);
+            }
+        }
+        if last[index] && stop[index] > 0.0 {
+            let stop_g = counting_survival_before(&survival_times, &survival_values, stop[index]);
+            for (value, &g) in row.iter_mut().zip(&query_g) {
+                *value = rttright_divide(weights[index], stop_g.max(g));
+            }
+        }
+        row
+    };
+    let work = indices.len().saturating_mul(times.len());
+    if work >= PARALLEL_TIME_MATRIX_WORK {
+        indices.par_iter().map(make_row).collect()
+    } else {
+        indices.iter().map(make_row).collect()
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn rttright_counting_matrix(
+    start: Vec<f64>,
+    stop: Vec<f64>,
+    status: Vec<i32>,
+    weights: Vec<f64>,
+    last: Vec<bool>,
+    strata: Vec<i32>,
+    delta: f64,
+    times: Option<Vec<f64>>,
+) -> PyResult<Vec<Vec<f64>>> {
+    validate_rttright_counting_inputs(&RttrightCountingInputs {
+        start: &start,
+        stop: &stop,
+        status: &status,
+        weights: &weights,
+        last: &last,
+        strata: &strata,
+        times: times.as_deref(),
+        delta,
+    })?;
+
+    let mut strata_indices: BTreeMap<i32, Vec<usize>> = BTreeMap::new();
+    for (index, stratum) in strata.into_iter().enumerate() {
+        strata_indices.entry(stratum).or_default().push(index);
+    }
+    let censor = (0..stop.len())
+        .map(|index| last[index] && status[index] == 0)
+        .collect::<Vec<_>>();
+    let mut km_stop = stop.clone();
+    for (index, &is_censor) in censor.iter().enumerate() {
+        if is_censor {
+            km_stop[index] += delta;
+        }
+    }
+    let width = times.as_ref().map_or(1, Vec::len);
+    let mut matrix = vec![vec![0.0; width]; stop.len()];
+    for indices in strata_indices.values() {
+        let rows = compute_rttright_counting_group(
+            &start,
+            &stop,
+            &km_stop,
+            &status,
+            &weights,
+            &last,
+            &censor,
+            indices,
+            times.as_deref(),
+        );
+        for (&row_index, row) in indices.iter().zip(rows) {
+            matrix[row_index] = row;
+        }
+    }
+    Ok(matrix)
+}
+
 #[pyfunction]
 #[pyo3(signature = (time, status, strata, weights=None, timefix=true, renorm=true))]
 pub fn rttright_stratified(
@@ -592,6 +845,44 @@ mod tests {
         for (actual_row, expected_row) in actual.iter().zip(expected) {
             assert_close_slice(actual_row, expected_row);
         }
+    }
+
+    fn naive_counting_censor_survival(
+        start: &[f64],
+        km_stop: &[f64],
+        censor: &[bool],
+        weights: &[f64],
+    ) -> (Vec<f64>, Vec<f64>) {
+        let mut event_times = (0..start.len())
+            .filter_map(|index| censor[index].then_some(km_stop[index]))
+            .collect::<Vec<_>>();
+        event_times.sort_unstable_by(f64::total_cmp);
+        event_times.dedup_by(|left, right| *left == *right);
+
+        let mut survival_values = Vec::with_capacity(event_times.len());
+        let mut current = 1.0;
+        for &event_time in &event_times {
+            let risk = (0..start.len())
+                .filter(|&index| start[index] < event_time && event_time <= km_stop[index])
+                .map(|index| weights[index])
+                .sum::<f64>();
+            let events = (0..start.len())
+                .filter(|&index| censor[index] && km_stop[index] == event_time)
+                .map(|index| weights[index])
+                .sum::<f64>();
+            if risk > 0.0 {
+                current *= 1.0 - events / risk;
+            }
+            survival_values.push(current);
+        }
+        (event_times, survival_values)
+    }
+
+    fn next_random(seed: &mut u64) -> u64 {
+        *seed = seed
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+        *seed
     }
 
     #[test]
@@ -844,6 +1135,136 @@ mod tests {
         .unwrap();
         assert_close_slice(&tiny[0], &[0.5]);
         assert_close_slice(&tiny[1], &[0.5]);
+    }
+
+    #[test]
+    fn test_rttright_counting_matrix_matches_r_layout() {
+        let vector = rttright_counting_matrix(
+            vec![0.0, 0.0, 0.0],
+            vec![3.0, 2.0, 4.0],
+            vec![1, 0, 1],
+            vec![1.0 / 3.0; 3],
+            vec![true; 3],
+            vec![0; 3],
+            0.25,
+            None,
+        )
+        .unwrap();
+        assert_nested_close(&vector, &[vec![0.5], vec![0.0], vec![0.5]]);
+
+        let matrix = rttright_counting_matrix(
+            vec![0.0, 0.0, 0.0],
+            vec![3.0, 2.0, 4.0],
+            vec![1, 0, 1],
+            vec![1.0 / 3.0; 3],
+            vec![true; 3],
+            vec![0; 3],
+            0.25,
+            Some(vec![1.0, 2.0, 3.0, 4.0]),
+        )
+        .unwrap();
+        assert_nested_close(
+            &matrix,
+            &[
+                vec![1.0 / 3.0, 1.0 / 3.0, 0.5, 0.5],
+                vec![1.0 / 3.0; 4],
+                vec![1.0 / 3.0, 1.0 / 3.0, 0.5, 0.5],
+            ],
+        );
+    }
+
+    #[test]
+    fn test_rttright_counting_matrix_preserves_strata() {
+        let result = rttright_counting_matrix(
+            vec![0.0, 0.0, 0.0, 0.0],
+            vec![3.0, 2.0, 4.0, 2.0],
+            vec![1, 0, 1, 1],
+            vec![0.5, 0.5, 0.5, 0.5],
+            vec![true; 4],
+            vec![0, 0, 1, 1],
+            0.25,
+            None,
+        )
+        .unwrap();
+
+        assert_nested_close(&result, &[vec![1.0], vec![0.0], vec![0.5], vec![0.5]]);
+    }
+
+    #[test]
+    fn test_rttright_counting_matrix_validates_inputs() {
+        initialize_python();
+        let length_error = rttright_counting_matrix(
+            vec![0.0],
+            vec![1.0, 2.0],
+            vec![1, 0],
+            vec![1.0, 1.0],
+            vec![true, true],
+            vec![0, 0],
+            0.5,
+            None,
+        )
+        .unwrap_err();
+        assert!(
+            length_error
+                .to_string()
+                .contains("start must have same length as stop")
+        );
+
+        let interval_error = rttright_counting_matrix(
+            vec![1.0],
+            vec![1.0],
+            vec![1],
+            vec![1.0],
+            vec![true],
+            vec![0],
+            0.5,
+            None,
+        )
+        .unwrap_err();
+        assert!(
+            interval_error
+                .to_string()
+                .contains("start must be less than stop")
+        );
+
+        let delta_error = rttright_counting_matrix(
+            vec![0.0],
+            vec![1.0],
+            vec![1],
+            vec![1.0],
+            vec![true],
+            vec![0],
+            0.0,
+            None,
+        )
+        .unwrap_err();
+        assert!(delta_error.to_string().contains("delta must be finite"));
+    }
+
+    #[test]
+    fn test_counting_censor_survival_sweep_matches_naive_risk_sets() {
+        let mut seed = 20_260_820_u64;
+        for _ in 0..500 {
+            let n = (next_random(&mut seed) % 40 + 1) as usize;
+            let mut start = Vec::with_capacity(n);
+            let mut km_stop = Vec::with_capacity(n);
+            let mut censor = Vec::with_capacity(n);
+            let mut weights = Vec::with_capacity(n);
+            for _ in 0..n {
+                let left = (next_random(&mut seed) % 20) as f64 / 3.0;
+                let right = left + (next_random(&mut seed) % 20 + 1) as f64 / 4.0;
+                start.push(left);
+                km_stop.push(right);
+                censor.push(next_random(&mut seed).is_multiple_of(4));
+                weights.push((next_random(&mut seed) % 17) as f64 / 11.0);
+            }
+            let indices = (0..n).collect::<Vec<_>>();
+            let expected = naive_counting_censor_survival(&start, &km_stop, &censor, &weights);
+            let actual = counting_censor_survival(&start, &km_stop, &censor, &weights, &indices);
+
+            assert_eq!(actual.0, expected.0);
+            assert_close_slice(&actual.1, &expected.1);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- replace counting-process rttright censoring risk-set scans and row-by-time Python loops with a grouped native kernel
- compute censoring Kaplan-Meier weights with sorted start/stop sweeps, exact empty-risk boundaries, binary-search step lookup, and parallel matrix filling above the existing work threshold
- retain Python-side subject, interval, normalization, and R-compatibility validation while preserving vector, single-time, multi-time, weighted, and stratified outputs
- add typed binding coverage, fixed R-layout cases, validation cases, and a 500-fixture deterministic sweep oracle

## Performance
End-to-end counting-process rttright with 40 query times:

| Rows | Python | Rust | Speedup |
| ---: | ---: | ---: | ---: |
| 300 | 1.662 ms | 0.478 ms | 3.48x |
| 1200 | 12.251 ms | 1.864 ms | 6.57x |
| 2400 | 39.561 ms | 3.669 ms | 10.78x |

## Testing
- 1000 randomized native-versus-reference counting-process cases
- cargo test (1482 passed)
- pytest -q python/tests (873 passed, 18 skipped)
- cargo clippy --all-targets --all-features -- -D warnings
- ruff check python/survival python/tests/test_binding_contract.py
- mypy python/survival/__init__.pyi python/survival/_survival.pyi --ignore-missing-imports
- R CMD check --no-manual --no-build-vignettes r/survivalr (1 expected source-directory note)