### PR TITLE
Eliminate quadratic multistate initial-risk scans

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -12739,6 +12739,7 @@ def _survfit_multistate(
     p0_override = supplied_p0
     if p0_override is None and same_initial_state:
         p0_override = [float(state == initial_states[0]) for state in range(len(states))]
+    starts_at_observed_minimum = response.start is not None and t0 == min(response.start)
 
     def fit_curve(indices: list[int]) -> SurvfitMultiStateResult:
         curve_response = _subset_surv(response, indices)
@@ -12769,7 +12770,7 @@ def _survfit_multistate(
             [True] * len(indices)
             if curve_response.start is None
             else [
-                start <= t0 <= stop if t0 == min(response.start) else start < t0 <= stop
+                start <= t0 <= stop if starts_at_observed_minimum else start < t0 <= stop
                 for start, stop in zip(
                     curve_response.start,
                     curve_response.time,


### PR DESCRIPTION
## Summary
- compute the counting-process minimum start time once per multistate fit instead of once per row
- preserve R-compatible boundary handling for initial-risk rows, including grouped curves
- reduce a 10,000-row counting-process fixture from about 371 ms to 20 ms, roughly a 19x speedup

## Testing
- `.venv/bin/python -m pytest -q python/tests` (873 passed, 18 skipped)
- `.venv/bin/ruff check python`
- `.venv/bin/mypy python/survival/__init__.pyi python/survival/_survival.pyi --ignore-missing-imports`
- `git diff --check`