### PR TITLE
Encode Python labels in one pass

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -3900,8 +3900,14 @@ def _encode_groups(
 
 
 def _encode_labels(values: list[Any], name: str) -> list[int]:
-    labels = {value: idx for idx, value in enumerate(_label_levels(values, name))}
-    return [labels[value] for value in values]
+    labels: dict[Any, int] = {}
+    codes: list[int] = []
+    for value in values:
+        try:
+            codes.append(labels.setdefault(value, len(labels)))
+        except TypeError as exc:
+            raise TypeError(f"{name} contains unhashable labels") from exc
+    return codes
 
 
 def _encode_labels_with_levels(

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -12,6 +12,15 @@ from .helpers import setup_survival_import
 survival = setup_survival_import()
 
 
+def test_label_encoder_preserves_first_seen_order_and_validation():
+    values = ["later", "first", "later", 3, "first", 3, ("x", 1)]
+
+    assert survival.r_api._encode_labels(values, "group") == [0, 1, 0, 2, 1, 2, 3]
+    assert survival.r_api._encode_labels([], "group") == []
+    with pytest.raises(TypeError, match="group contains unhashable labels"):
+        survival.r_api._encode_labels([["nested"]], "group")
+
+
 def _toy_data():
     return {
         "time": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],


### PR DESCRIPTION
## Summary
- replace the three-pass label encoder with a single insertion-order dictionary pass
- preserve first-seen code assignment for mixed hashable labels and the existing unhashable-label error
- speed label encoding by about 1.3–1.4x and trim roughly 2.4 ms from a 75,000-row multistate fit where subject labels are encoded repeatedly

## Testing
- `.venv/bin/python -m pytest -q python/tests` (876 passed, 18 skipped)
- `.venv/bin/ruff check python`
- `.venv/bin/mypy python/survival/__init__.pyi python/survival/_survival.pyi --ignore-missing-imports`
- `git diff --check`