### PR TITLE
Add formula-based expected survival

### DIFF
--- a/python/survival/__init__.py
+++ b/python/survival/__init__.py
@@ -60,6 +60,7 @@ _R_EXPORTS = [
     "PyearsResult",
     "SurvObrienResult",
     "SurvExpResult",
+    "SurvExpFormulaResult",
     "SurvfitConfidenceIntervalResult",
     "SurvfitMultiStateResult",
     "TMergeFrame",

--- a/python/survival/__init__.pyi
+++ b/python/survival/__init__.pyi
@@ -33,6 +33,7 @@ from .r_api import (
     Surv,
     Surv2,
     Surv2data,
+    SurvExpFormulaResult,
     SurvExpResult,
     SurvfitConfidenceIntervalResult,
     SurvfitMultiStateResult,

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -41,6 +41,7 @@ __all__ = [
     "StrataFactor",
     "SurvObrienResult",
     "SurvExpResult",
+    "SurvExpFormulaResult",
     "SurvfitResult",
     "SurvfitMultiStateResult",
     "SurvfitConfidenceIntervalResult",
@@ -604,6 +605,23 @@ class SurvExpResult:
     cumhaz: list[float]
     method: str
     n: int
+
+
+@dataclass(frozen=True)
+class SurvExpFormulaResult:
+    """Expected-survival curves produced from a formula and mapped rate data."""
+
+    time: list[float]
+    surv: list[list[float]]
+    n_risk: list[list[float]]
+    cumhaz: list[list[float]]
+    method: str
+    n: int
+    group_labels: list[str]
+    summary: str | None = None
+    model: Any | None = None
+    x: list[int] | None = None
+    y: Surv | None = None
 
 
 @dataclass(frozen=True)
@@ -6110,21 +6128,265 @@ def _survexp_result_from_core(result: Any, scale: float) -> SurvExpResult:
     )
 
 
+def _survexp_rmap_columns(
+    formula: str,
+    data: Any,
+    ratetable: RateTable,
+    rmap: Any | None,
+) -> dict[str, list[Any]]:
+    dimension_names = [str(dimension.name) for dimension in ratetable.dimension_specs()]
+    if rmap is None:
+        mapping: Mapping[Any, Any] = {}
+    elif isinstance(rmap, Mapping):
+        mapping = rmap
+    else:
+        raise TypeError("rmap must be a mapping from rate-table dimensions to data columns")
+    unknown = sorted(str(name) for name in mapping if str(name) not in dimension_names)
+    if unknown:
+        raise KeyError(f"rate-table dimensions not found: {', '.join(unknown)}")
+
+    response_columns = _formula_response_args(formula)
+    n = len(_column(data, response_columns[0]))
+    columns: dict[str, list[Any]] = {}
+    for name in dimension_names:
+        source = mapping.get(name, name)
+        if isinstance(source, str):
+            values = _column(data, source)
+        else:
+            values = _materialize_1d(source, f"rmap[{name!r}]")
+            if len(values) == 1 and n != 1:
+                values *= n
+        if len(values) != n:
+            raise ValueError(f"rmap value for {name!r} must have length {n}")
+        columns[name] = values
+    return columns
+
+
+def _survexp_formula_coordinates(
+    matched: Mapping[str, Any],
+    ratetable: RateTable,
+) -> tuple[list[float], list[float], list[int] | None]:
+    dimensions = list(ratetable.dimension_specs())
+    age_dimensions = [
+        dimension for dimension in dimensions if dimension.dim_type == _core.DimType.Age
+    ]
+    year_dimensions = [
+        dimension for dimension in dimensions if dimension.dim_type == _core.DimType.Year
+    ]
+    sex_dimensions = [
+        dimension
+        for dimension in dimensions
+        if dimension.dim_type == _core.DimType.Factor and "sex" in str(dimension.name).casefold()
+    ]
+    unsupported = [
+        dimension
+        for dimension in dimensions
+        if dimension.dim_type == _core.DimType.Continuous
+        or (
+            dimension.dim_type == _core.DimType.Factor
+            and dimension not in sex_dimensions
+        )
+    ]
+    if len(age_dimensions) != 1 or len(year_dimensions) != 1 or len(sex_dimensions) > 1:
+        raise ValueError(
+            "survexp formula rate tables need one age, one year, and at most one sex dimension"
+        )
+    if unsupported:
+        names = ", ".join(str(dimension.name) for dimension in unsupported)
+        raise ValueError(f"survexp formula does not yet support rate dimensions: {names}")
+
+    coords = matched["coords"]
+    age = [float(value) for value in coords[str(age_dimensions[0].name)]]
+    year = [float(value) for value in coords[str(year_dimensions[0].name)]]
+    sex = (
+        [int(value) for value in coords[str(sex_dimensions[0].name)]]
+        if sex_dimensions
+        else None
+    )
+    return age, year, sex
+
+
+def _survexp_group_label(value: Any) -> str:
+    if isinstance(value, tuple):
+        return ", ".join(str(item) for item in value)
+    return str(value)
+
+
+def _survexp_formula(
+    formula: str,
+    data: Any,
+    ratetable: Any | None,
+    times: Any | None,
+    method: Any | None,
+    cohort: Any,
+    conditional: Any,
+    scale: Any,
+    se_fit: Any | None,
+    weights: Any | None,
+    subset: Any | None,
+    na_action: str | None,
+    rmap: Any | None,
+    model: Any,
+    include_x: Any,
+    include_y: Any,
+) -> SurvExpFormulaResult | list[float]:
+    table = _survexp_ratetable(ratetable)
+    mapped_columns = _survexp_rmap_columns(formula, data, table, rmap)
+    weight_values = _formula_weight_values(data, weights)
+    aligned: dict[str, Any] = {
+        **{f"rate_{name}": values for name, values in mapped_columns.items()},
+        "weights": weight_values,
+    }
+    if subset is not None:
+        data, aligned = _subset_formula_inputs(formula, data, subset, **aligned)
+    data, aligned = _apply_formula_na_action(formula, data, na_action, **aligned)
+    mapped_columns = {
+        name: aligned[f"rate_{name}"] for name in mapped_columns
+    }
+    weight_values = aligned["weights"]
+
+    response, terms = _parse_formula(formula, data)
+    if response.type != "right":
+        raise ValueError("survexp formula requires a right-censored Surv response")
+    if terms.offsets or terms.clusters:
+        raise ValueError("survexp formula does not support offset() or cluster() terms")
+    if any(isinstance(term, _InteractionTerm) for term in terms.covariates):
+        raise ValueError("survexp formula does not support interaction terms")
+    if weight_values is not None:
+        fitted_weights = _concordance_weight_values(weight_values, len(response))
+        if fitted_weights is not None and any(value != 1.0 for value in fitted_weights):
+            warnings.warn(
+                "weights ignored for population rate tables",
+                RuntimeWarning,
+                stacklevel=3,
+            )
+    if se_fit is not None and _normalize_bool_option(se_fit, "se_fit"):
+        warnings.warn("se_fit value ignored", RuntimeWarning, stacklevel=3)
+
+    matched = match_ratetable(mapped_columns, table)
+    age_values, year_values, sex_values = _survexp_formula_coordinates(matched, table)
+    time_values = [float(value) for value in response.time]
+    method_value = _normalize_survexp_method(method, cohort, conditional)
+    scale_value = _normalize_positive_scale(scale)
+    if method_value in {"individual.h", "individual.s"}:
+        individual = [
+            float(value)
+            for value in _core.survexp_individual(
+                time_values,
+                age_values,
+                year_values,
+                table,
+                sex_values,
+            )
+        ]
+        if method_value == "individual.s":
+            return individual
+        return [-math.log(value) if value > 0.0 else math.inf for value in individual]
+
+    if terms.covariates or terms.strata:
+        groups = _combined_formula_groups(data, terms.strata, terms.covariates, len(response))
+    else:
+        groups = ["all"] * len(response)
+    levels = _label_levels(groups, "survexp groups")
+    eval_times = (
+        sorted(set(time_values))
+        if times is None
+        else _float_vector(times, "times")
+    )
+    curves: list[SurvExpResult] = []
+    group_codes = [0] * len(response)
+    for group_index, level in enumerate(levels):
+        indices = [row for row, value in enumerate(groups) if value == level]
+        for row in indices:
+            group_codes[row] = group_index
+        core_result = _core.survexp(
+            [time_values[index] for index in indices],
+            [age_values[index] for index in indices],
+            [year_values[index] for index in indices],
+            table,
+            None if sex_values is None else [sex_values[index] for index in indices],
+            eval_times,
+            method_value,
+        )
+        curves.append(_survexp_result_from_core(core_result, scale_value))
+
+    return SurvExpFormulaResult(
+        time=[value / scale_value for value in eval_times],
+        surv=[curve.surv for curve in curves],
+        n_risk=[curve.n_risk for curve in curves],
+        cumhaz=[curve.cumhaz for curve in curves],
+        method=method_value,
+        n=len(response),
+        group_labels=[_survexp_group_label(level) for level in levels],
+        summary=str(matched["summ"]) if matched.get("summ") is not None else None,
+        model=data if _normalize_bool_option(model, "model") else None,
+        x=group_codes if _normalize_bool_option(include_x, "x") else None,
+        y=response if _normalize_bool_option(include_y, "y") else None,
+    )
+
+
 def survexp(
     time: Any,
-    age: Any,
-    year: Any,
+    age: Any | None = None,
+    year: Any | None = None,
     ratetable: Any | None = None,
     sex: Any | None = None,
     times: Any | None = None,
     method: Any | None = None,
     *,
+    data: Any | None = None,
+    weights: Any | None = None,
+    subset: Any | None = None,
+    na_action: str | None = "fail",
+    rmap: Any | None = None,
     cohort: Any = True,
     conditional: Any = False,
     scale: Any = 1.0,
     se_fit: Any | None = None,
-) -> SurvExpResult | list[float]:
-    """Compute expected survival from direct vectors and a population rate table."""
+    model: Any = False,
+    x: Any = False,
+    y: Any = False,
+) -> SurvExpResult | SurvExpFormulaResult | list[float]:
+    """Compute expected survival from direct vectors or an R-style formula."""
+
+    if isinstance(time, str):
+        if data is None and age is not None:
+            data = age
+            age = None
+        elif data is not None and age is not None:
+            raise TypeError("formula survexp received data both positionally and by keyword")
+        if data is None:
+            raise ValueError("data is required when survexp uses a formula")
+        if year is not None or sex is not None:
+            raise TypeError("formula survexp uses data and rmap instead of age, year, and sex")
+        return _survexp_formula(
+            time,
+            data,
+            ratetable,
+            times,
+            method,
+            cohort,
+            conditional,
+            scale,
+            se_fit,
+            weights,
+            subset,
+            na_action,
+            rmap,
+            model,
+            x,
+            y,
+        )
+
+    if age is None or year is None:
+        raise TypeError("direct survexp requires age and year")
+    if any(value is not None for value in (data, weights, subset, rmap)) or na_action != "fail":
+        raise TypeError(
+            "data, weights, subset, na_action, and rmap are only valid with formula survexp"
+        )
+    output_flags = ((model, "model"), (x, "x"), (y, "y"))
+    if any(_normalize_bool_option(value, name) for value, name in output_flags):
+        raise TypeError("model, x, and y are only valid with formula survexp")
 
     if se_fit is not None and _normalize_bool_option(se_fit, "se_fit"):
         warnings.warn("se_fit value ignored", RuntimeWarning, stacklevel=2)
@@ -16310,6 +16572,42 @@ def _surv_response_frame(response: Surv) -> dict[str, list[Any]]:
     return frame
 
 
+def _survexp_formula_frame(result: SurvExpFormulaResult) -> dict[str, list[Any]]:
+    frame: dict[str, list[Any]] = {
+        "group": [],
+        "time": [],
+        "surv": [],
+        "n.risk": [],
+        "cumhaz": [],
+    }
+    for label, survival, n_risk, cumhaz in zip(
+        result.group_labels,
+        result.surv,
+        result.n_risk,
+        result.cumhaz,
+        strict=True,
+    ):
+        if not (len(survival) == len(n_risk) == len(cumhaz) == len(result.time)):
+            raise ValueError("survexp formula curves must match the time grid")
+        frame["group"].extend([label] * len(result.time))
+        frame["time"].extend(result.time)
+        frame["surv"].extend(survival)
+        frame["n.risk"].extend(n_risk)
+        frame["cumhaz"].extend(cumhaz)
+    return frame
+
+
+def _survexp_frame(result: SurvExpResult) -> dict[str, list[Any]]:
+    if not (len(result.time) == len(result.surv) == len(result.n_risk) == len(result.cumhaz)):
+        raise ValueError("survexp result columns must have the same length")
+    return {
+        "time": list(result.time),
+        "surv": list(result.surv),
+        "n.risk": list(result.n_risk),
+        "cumhaz": list(result.cumhaz),
+    }
+
+
 def as_data_frame(result: Any) -> dict[str, list[Any]]:
     """Return a plain column-oriented table for common R-style result objects."""
 
@@ -16341,6 +16639,10 @@ def as_data_frame(result: Any) -> dict[str, list[Any]]:
         return _coxph_detail_frame(result)
     if isinstance(result, ConcordanceResult):
         return _concordance_frame(result)
+    if isinstance(result, SurvExpFormulaResult):
+        return _survexp_formula_frame(result)
+    if isinstance(result, SurvExpResult):
+        return _survexp_frame(result)
     if isinstance(result, PyearsResult):
         return _pyears_result_frame(result)
     if isinstance(result, FineGrayFrame):

--- a/python/survival/r_api.pyi
+++ b/python/survival/r_api.pyi
@@ -78,6 +78,19 @@ class SurvExpResult:
     method: str
     n: int
 
+class SurvExpFormulaResult:
+    time: list[float]
+    surv: list[list[float]]
+    n_risk: list[list[float]]
+    cumhaz: list[list[float]]
+    method: str
+    n: int
+    group_labels: list[str]
+    summary: str | None
+    model: Any | None
+    x: list[int] | None
+    y: Surv | None
+
 class PyearsResult:
     pyears: list[float]
     n: list[float]
@@ -214,18 +227,26 @@ def ratetableDate(
 ) -> Any: ...
 def survexp(
     time: Any,
-    age: Any,
-    year: Any,
+    age: Any | None = None,
+    year: Any | None = None,
     ratetable: Any | None = None,
     sex: Any | None = None,
     times: Any | None = None,
     method: Any | None = None,
     *,
+    data: Any | None = None,
+    weights: Any | None = None,
+    subset: Any | None = None,
+    na_action: str | None = "fail",
+    rmap: Any | None = None,
     cohort: Any = True,
     conditional: Any = False,
     scale: Any = 1.0,
     se_fit: Any | None = None,
-) -> SurvExpResult | list[float]: ...
+    model: Any = False,
+    x: Any = False,
+    y: Any = False,
+) -> SurvExpResult | SurvExpFormulaResult | list[float]: ...
 def survexp_individual(
     time: Any,
     age: Any,

--- a/python/tests/test_binding_contract.py
+++ b/python/tests/test_binding_contract.py
@@ -12039,6 +12039,7 @@ def test_package_root_marks_curated_and_legacy_exports():
     assert "PyearsResult" in survival.__all__
     assert "SurvObrienResult" in survival.__all__
     assert "SurvExpResult" in survival.__all__
+    assert "SurvExpFormulaResult" in survival.__all__
     assert "TMergeFrame" in survival.__all__
     assert "TMergeOperation" in survival.__all__
     assert "aic" in survival.__all__
@@ -12115,6 +12116,7 @@ def test_package_root_marks_curated_and_legacy_exports():
     assert survival.PyearsResult is survival.r_api.PyearsResult
     assert survival.SurvObrienResult is survival.r_api.SurvObrienResult
     assert survival.SurvExpResult is survival.r_api.SurvExpResult
+    assert survival.SurvExpFormulaResult is survival.r_api.SurvExpFormulaResult
     assert survival.TMergeFrame is survival.r_api.TMergeFrame
     assert survival.TMergeOperation is survival.r_api.TMergeOperation
     assert survival.aic is survival.r_api.aic
@@ -12510,17 +12512,23 @@ def test_r_api_stub_tracks_survexp_public_signature():
         "sex",
         "times",
         "method",
+        "data",
+        "weights",
+        "subset",
+        "na_action",
+        "rmap",
         "cohort",
         "conditional",
         "scale",
         "se_fit",
+        "model",
+        "x",
+        "y",
     ]
     runtime_params = inspect.signature(survival.r_api.survexp).parameters
     assert list(runtime_params) == expected
-    assert runtime_params["cohort"].kind is inspect.Parameter.KEYWORD_ONLY
-    assert runtime_params["conditional"].kind is inspect.Parameter.KEYWORD_ONLY
-    assert runtime_params["scale"].kind is inspect.Parameter.KEYWORD_ONLY
-    assert runtime_params["se_fit"].kind is inspect.Parameter.KEYWORD_ONLY
+    for name in expected[7:]:
+        assert runtime_params[name].kind is inspect.Parameter.KEYWORD_ONLY
     assert _pyi_function_arg_names(stub_path, "survexp") == expected
 
     expected_individual = ["time", "age", "year", "ratetable", "sex"]

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -3046,6 +3046,12 @@ def test_r_style_ratetable_helpers_delegate_to_population_core():
     assert isinstance(scaled, survival.SurvExpResult)
     assert scaled.time == pytest.approx([1.0, 2.0])
     assert scaled.method == "ederer"
+    assert survival.as_data_frame(scaled) == {
+        "time": scaled.time,
+        "surv": scaled.surv,
+        "n.risk": scaled.n_risk,
+        "cumhaz": scaled.cumhaz,
+    }
     assert conditional.method == "conditional"
     assert individual_surv == pytest.approx(direct_individual)
     assert individual_hazard == pytest.approx([-math.log(value) for value in direct_individual])
@@ -3075,6 +3081,105 @@ def test_r_style_ratetable_helpers_delegate_to_population_core():
         survival.ratetableDate(2001, 2, 29)
     with pytest.raises(TypeError, match="month and day"):
         survival.ratetableDate(2000, month=2)
+
+
+def test_survexp_formula_maps_rate_data_and_returns_grouped_curves():
+    data = {
+        "futime": [365.25, 730.5, 1095.75],
+        "status": [1, 0, 1],
+        "age": [50 * 365.25, 60 * 365.25, 70 * 365.25],
+        "sex": ["male", "female", "male"],
+        "entry": [date(2000, 1, 1), date(2001, 1, 1), date(2002, 1, 1)],
+        "group": ["a", "a", "b"],
+    }
+
+    result = survival.survexp(
+        "Surv(futime, status) ~ group",
+        data=data,
+        rmap={"year": "entry"},
+        times=[365.25, 730.5],
+        scale=365.25,
+        model=True,
+        x=True,
+        y=True,
+    )
+    group_a = survival.survexp(
+        [365.25, 730.5],
+        [50 * 365.25, 60 * 365.25],
+        [2000.0, 2001.0],
+        sex=[0, 1],
+        times=[365.25, 730.5],
+    )
+    group_b = survival.survexp(
+        [1095.75],
+        [70 * 365.25],
+        [2002.0],
+        sex=[0],
+        times=[365.25, 730.5],
+    )
+
+    assert isinstance(result, survival.SurvExpFormulaResult)
+    assert result.time == pytest.approx([1.0, 2.0])
+    assert result.group_labels == ["a", "b"]
+    assert result.surv[0] == pytest.approx(group_a.surv)
+    assert result.surv[1] == pytest.approx(group_b.surv)
+    assert result.n_risk[0] == pytest.approx(group_a.n_risk)
+    assert result.n_risk[1] == pytest.approx(group_b.n_risk)
+    assert result.x == [0, 0, 1]
+    assert result.y is not None
+    assert result.model == data
+    frame = survival.as_data_frame(result)
+    assert frame["group"] == ["a", "a", "b", "b"]
+    assert frame["time"] == pytest.approx([1.0, 2.0, 1.0, 2.0])
+    assert frame["surv"] == pytest.approx([*group_a.surv, *group_b.surv])
+
+
+def test_survexp_formula_supports_positional_data_subset_na_and_individual_output():
+    data = {
+        "futime": [365.25, 730.5, 1095.75, 1461.0],
+        "status": [1, 0, 1, 1],
+        "age_days": [40 * 365.25, 50 * 365.25, 60 * 365.25, 70 * 365.25],
+        "sex_code": ["male", None, "female", "male"],
+        "entry": [date(1999, 1, 1), date(2000, 1, 1), date(2001, 1, 1), date(2002, 1, 1)],
+    }
+    mapping = {"age": "age_days", "sex": "sex_code", "year": "entry"}
+
+    result = survival.survexp(
+        "Surv(futime, status) ~ 1",
+        data,
+        rmap=mapping,
+        subset=[True, True, True, False],
+        na_action="omit",
+        times=[365.25],
+    )
+    individual = survival.survexp(
+        "Surv(futime, status) ~ 1",
+        data,
+        rmap=mapping,
+        na_action="omit",
+        method="individual.s",
+    )
+
+    assert isinstance(result, survival.SurvExpFormulaResult)
+    assert result.n == 2
+    assert result.group_labels == ["all"]
+    assert len(individual) == 3
+    with pytest.warns(RuntimeWarning, match="weights ignored"):
+        survival.survexp(
+            "Surv(futime, status) ~ 1",
+            data,
+            rmap=mapping,
+            na_action="omit",
+            weights=[2.0, 2.0, 1.0, 1.0],
+            times=[365.25],
+        )
+    with pytest.raises(ValueError, match="interaction"):
+        survival.survexp(
+            "Surv(futime, status) ~ age_days * status",
+            data,
+            rmap=mapping,
+            na_action="omit",
+        )
 
 
 def test_match_ratetable_reorders_columns_and_encodes_factor_levels():


### PR DESCRIPTION
## Summary
- extend `survexp()` with formula and data input while preserving direct vectors
- map date, numeric, and factor columns through public rate-table dimensions
- return grouped curves on one evaluation grid with model, x, and y retention
- support subset, NA handling, individual methods, scaling, and tabular conversion

## Testing
- `.venv/bin/python -m pytest -q python/tests` (892 passed, 18 skipped)
- grouped formula curves compared with equivalent direct native calls
- `.venv/bin/python -m ruff check python`
- `.venv/bin/python -m mypy python/survival`
- `git diff --check`