### PR TITLE
Add survival-regression distribution validation

### DIFF
--- a/python/survival/__init__.py
+++ b/python/survival/__init__.py
@@ -155,6 +155,7 @@ _R_EXPORTS = [
     "survreg",
     "survreg_control",
     "survreg_distributions",
+    "survreg_dtest",
     "survreg_fit",
     "tdc",
     "tcut",

--- a/python/survival/__init__.pyi
+++ b/python/survival/__init__.pyi
@@ -123,6 +123,7 @@ from .r_api import (
     survobrien,
     survreg,
     survreg_distributions,
+    survreg_dtest,
     survreg_fit,
     survSplit,
     tcut,

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -141,6 +141,7 @@ __all__ = [
     "survreg",
     "survreg_control",
     "survreg_distributions",
+    "survreg_dtest",
     "survreg_fit",
     "tcut",
     "totimeline",
@@ -17941,6 +17942,100 @@ def _survreg_descriptor_deviance(
                 else 0.0
             )
     return SurvregDeviance(center, loglik)
+
+
+def _survreg_definition_component(definition: Any, name: str) -> Any | None:
+    if isinstance(definition, Mapping):
+        return definition.get(name)
+    return getattr(definition, name, None)
+
+
+def _survreg_definition_values(values: Any, name: str) -> list[float]:
+    return _survreg_numeric_vector(values, name)
+
+
+def _survreg_definition_density_valid(definition: Any, density: Any) -> bool:
+    points = [value / 10.0 for value in range(1, 11)]
+    parms = _survreg_definition_component(definition, "parms")
+    if parms is None:
+        values = density(points)
+    else:
+        parameter_values = _survreg_definition_values(parms, "parms")
+        parameter: Any = parameter_values[0] if len(parameter_values) == 1 else parameter_values
+        values = density(points, parameter)
+    try:
+        rows = _as_matrix_rows(values, "density result", allow_empty_columns=False)
+    except (TypeError, ValueError):
+        return False
+    return len(rows) == 10 and all(len(row) == 5 for row in rows)
+
+
+def survreg_dtest(dlist: Any, verbose: Any = False) -> bool | list[str]:
+    """Validate a survival-regression distribution definition like R ``survregDtest``."""
+
+    errors: list[str] = []
+    name = _survreg_definition_component(dlist, "name")
+    if name is None:
+        errors.append("Missing a name")
+    elif not isinstance(name, str):
+        errors.append("Invalid name")
+
+    dist = _survreg_definition_component(dlist, "dist")
+    if dist is not None:
+        if not isinstance(dist, str) or dist not in survreg_distributions:
+            errors.append("Reference distribution not found")
+        else:
+            trans = _survreg_definition_component(dlist, "trans")
+            itrans = _survreg_definition_component(dlist, "itrans")
+            dtrans = _survreg_definition_component(dlist, "dtrans")
+            if not callable(trans):
+                errors.append("Missing or invalid trans component")
+            if not callable(itrans):
+                errors.append("Missing or invalid itrans component")
+            if not callable(dtrans):
+                errors.append("Missing or invalid dtrans component")
+        if not errors:
+            sample = [float(value) for value in range(1, 11)]
+            transformed = _survreg_definition_component(dlist, "trans")(sample)
+            inverse = _survreg_definition_component(dlist, "itrans")(transformed)
+            try:
+                inverse_values = _survreg_definition_values(inverse, "itrans result")
+            except (TypeError, ValueError):
+                inverse_values = []
+            if len(inverse_values) != len(sample) or any(
+                not math.isclose(actual, expected, rel_tol=1e-8, abs_tol=1e-8)
+                for actual, expected in zip(inverse_values, sample, strict=False)
+            ):
+                errors.append("trans and itrans must be inverses of each other")
+            derivative = _survreg_definition_component(dlist, "dtrans")(sample)
+            try:
+                derivative_values = _survreg_definition_values(
+                    derivative,
+                    "dtrans result",
+                )
+            except (TypeError, ValueError):
+                derivative_values = []
+            if len(derivative_values) != 10:
+                errors.append("dtrans must be a 1-1 function")
+    else:
+        init = _survreg_definition_component(dlist, "init")
+        deviance = _survreg_definition_component(dlist, "deviance")
+        density = _survreg_definition_component(dlist, "density")
+        quantile = _survreg_definition_component(dlist, "quantile")
+        if not callable(init):
+            errors.append("Missing or invalid init function")
+        if not callable(deviance):
+            errors.append("Missing or invalid deviance function")
+        if not callable(density):
+            errors.append("Missing or invalid density function")
+        elif not _survreg_definition_density_valid(dlist, density):
+            errors.append("Density function must return a 5 column matrix")
+        if not callable(quantile):
+            errors.append("Missing or invalid quantile function")
+
+    if not errors:
+        return True
+    return errors if _normalize_bool_option(verbose, "verbose") else False
 
 
 def _expand_survreg_distribution_inputs(

--- a/python/survival/r_api.pyi
+++ b/python/survival/r_api.pyi
@@ -148,6 +148,7 @@ class SurvregFitResult:
     icoef_names: list[str]
 
 survreg_distributions: Mapping[str, SurvregDistribution]
+def survreg_dtest(dlist: Any, verbose: Any = False) -> bool | list[str]: ...
 
 class PyearsResult:
     pyears: list[float]

--- a/python/tests/test_binding_contract.py
+++ b/python/tests/test_binding_contract.py
@@ -12132,6 +12132,7 @@ def test_package_root_marks_curated_and_legacy_exports():
     assert "survSplit" in survival.__all__
     assert "survreg" in survival.__all__
     assert "survreg_distributions" in survival.__all__
+    assert "survreg_dtest" in survival.__all__
     assert "survreg_fit" in survival.__all__
     assert "tdc" in survival.__all__
     assert "tmerge" in survival.__all__
@@ -12220,6 +12221,7 @@ def test_package_root_marks_curated_and_legacy_exports():
     assert survival.survSplit is survival.r_api.survSplit
     assert survival.survreg is survival.r_api.survreg
     assert survival.survreg_distributions is survival.r_api.survreg_distributions
+    assert survival.survreg_dtest is survival.r_api.survreg_dtest
     assert survival.survreg_fit is survival.r_api.survreg_fit
     assert survival.survreg is not survival.regression.survreg
     assert survival.tdc is survival.r_api.tdc
@@ -12953,6 +12955,14 @@ def test_r_api_stub_tracks_survreg_fit_signature():
 
     assert list(inspect.signature(survival.r_api.survreg_fit).parameters) == expected
     assert _pyi_function_arg_names(stub_path, "survreg_fit") == expected
+    assert list(inspect.signature(survival.r_api.survreg_dtest).parameters) == [
+        "dlist",
+        "verbose",
+    ]
+    assert _pyi_function_arg_names(stub_path, "survreg_dtest") == [
+        "dlist",
+        "verbose",
+    ]
 
 
 def test_r_api_stub_tracks_survdiff_public_signature():

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -15732,6 +15732,57 @@ def test_survreg_distribution_registry_deviance_matches_reference_values():
     assert math.isnan(student_t.loglik[3])
 
 
+def test_survreg_dtest_validates_builtin_and_custom_distribution_definitions():
+    for definition in survival.survreg_distributions.values():
+        assert survival.survreg_dtest(definition) is True
+
+    custom_base = {
+        "name": "Custom",
+        "init": lambda x, weights, parms=None: [0.0, 1.0],
+        "deviance": lambda y, scale, parms=None: {"center": [], "loglik": []},
+        "density": lambda x, parms=None: [[0.5, 0.5, 0.25, 0.0, -0.5] for _ in x],
+        "quantile": lambda p, parms=None: list(p),
+    }
+    assert survival.survreg_dtest(custom_base) is True
+
+    custom_transform = {
+        "name": "Log custom",
+        "dist": "gaussian",
+        "trans": lambda values: [math.log(value) for value in values],
+        "itrans": lambda values: [math.exp(value) for value in values],
+        "dtrans": lambda values: [1.0 / value for value in values],
+    }
+    assert survival.survreg_dtest(custom_transform) is True
+
+    missing = {"name": None}
+    assert survival.survreg_dtest(missing) is False
+    assert survival.survreg_dtest(missing, verbose=True) == [
+        "Missing a name",
+        "Missing or invalid init function",
+        "Missing or invalid deviance function",
+        "Missing or invalid density function",
+        "Missing or invalid quantile function",
+    ]
+    assert survival.survreg_dtest(
+        {"name": "bad", "dist": "missing"},
+        verbose=True,
+    ) == ["Reference distribution not found"]
+
+    bad_density = {**custom_base, "density": lambda x: [[1.0] for _ in x]}
+    assert survival.survreg_dtest(bad_density, verbose=True) == [
+        "Density function must return a 5 column matrix"
+    ]
+    bad_inverse = {
+        **custom_transform,
+        "itrans": lambda values: [math.exp(value) + 1.0 for value in values],
+        "dtrans": lambda values: [1.0],
+    }
+    assert survival.survreg_dtest(bad_inverse, verbose=True) == [
+        "trans and itrans must be inverses of each other",
+        "dtrans must be a 1-1 function",
+    ]
+
+
 def test_survreg_fit_matches_reference_base_distribution_fits():
     x = [[1.0, value] for value in [-1.0, -0.5, 0.0, 0.5, 1.0, 1.5]]
     y = [


### PR DESCRIPTION
## Summary
- add public `survreg_dtest()` distribution-definition validation
- validate all typed built-in distribution descriptors
- support compatible custom mapping definitions
- check transformed-family references and inverse/derivative behavior
- check base-family callable components and five-column density output
- reproduce verbose reference diagnostics

## Compatibility
- matched survival 3.8-6 validation messages and boolean/verbose behavior
- validated all ten built-in registry entries
- covered valid custom base and transformed definitions

## Testing
- `.venv/bin/python -m pytest -q python/tests` (900 passed, 18 skipped)
- `.venv/bin/python -m ruff check python`
- `.venv/bin/python -m mypy python/survival`
- `git diff --check`