### PR TITLE
Add low-level counting-process Cox fitting

### DIFF
--- a/python/survival/__init__.py
+++ b/python/survival/__init__.py
@@ -49,6 +49,7 @@ _SKLEARN_EXPORTS = [
 
 _R_EXPORTS = [
     "AaregModelResult",
+    "AgregFitResult",
     "StrataFactor",
     "CchModelResult",
     "CoxphFitResult",
@@ -75,6 +76,7 @@ _R_EXPORTS = [
     "YatesResult",
     "aic",
     "aareg",
+    "agreg_fit",
     "aeqSurv",
     "anova",
     "as_data_frame",

--- a/python/survival/__init__.pyi
+++ b/python/survival/__init__.pyi
@@ -24,6 +24,7 @@ from . import spatial as spatial
 from . import surv_analysis as surv_analysis
 from . import validation as validation
 from .r_api import (
+    AgregFitResult,
     CchModelResult,
     CoxphFitResult,
     FineGrayFrame,
@@ -49,6 +50,7 @@ from .r_api import (
     YatesPairwiseResult,
     YatesResult,
     aeqSurv,
+    agreg_fit,
     aic,
     anova,
     as_data_frame,

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -25,6 +25,7 @@ __all__ = [
     "Surv",
     "Surv2",
     "Surv2data",
+    "AgregFitResult",
     "CoxSurvfitResult",
     "CoxBaseHazardResult",
     "CoxPHDetailResult",
@@ -54,6 +55,7 @@ __all__ = [
     "TcutResult",
     "aic",
     "aareg",
+    "agreg_fit",
     "aeqSurv",
     "as_data_frame",
     "basehaz",
@@ -986,6 +988,14 @@ class CoxphFitResult:
     method: str
     coefficient_names: list[str]
     row_names: list[str]
+
+
+@dataclass(frozen=True)
+class AgregFitResult(CoxphFitResult):
+    """Counting-process matrix fit returned by ``agreg_fit()``."""
+
+    first: list[float]
+    info: dict[str, int]
 
 
 @dataclass(frozen=True)
@@ -21534,43 +21544,85 @@ def aareg(
     )
 
 
-def _coxph_fit_response(y: Any) -> tuple[list[float], list[int]]:
+@dataclass(frozen=True)
+class _CoxLowLevelComputation:
+    fit: Any
+    result: CoxphFitResult
+
+
+def _cox_fit_response(
+    y: Any,
+    *,
+    counting: bool,
+) -> tuple[list[float], list[int], list[float] | None]:
     if isinstance(y, Surv):
-        if y.type != "right":
+        expected_type = "counting" if counting else "right"
+        if y.type != expected_type:
             raise ValueError("Invalid survival response")
         if any(value is None for value in y.event):
             raise ValueError("Invalid survival response")
-        return [float(value) for value in y.time], [int(value) for value in y.event]
+        return (
+            [float(value) for value in y.time],
+            [int(value) for value in y.event],
+            [float(value) for value in y.start] if counting and y.start is not None else None,
+        )
 
     response = _as_matrix_rows(y, "y", allow_empty_columns=False)
     width = len(response[0])
-    if width != 2 or any(len(row) != width for row in response):
+    expected_width = 3 if counting else 2
+    if width != expected_width or any(len(row) != width for row in response):
         raise ValueError("Invalid survival response")
     if any(not math.isfinite(value) for row in response for value in row):
         raise ValueError("Invalid survival response")
     status = [row[-1] for row in response]
     if any(not value.is_integer() or int(value) not in {0, 1} for value in status):
         raise ValueError("Invalid survival response")
-    return [row[0] for row in response], [int(value) for value in status]
+    if counting and any(row[0] >= row[1] for row in response):
+        raise ValueError("Invalid survival response")
+    return (
+        [row[1] if counting else row[0] for row in response],
+        [int(value) for value in status],
+        [row[0] for row in response] if counting else None,
+    )
 
 
-def coxph_fit(
+def _agreg_fit_means(
+    rows: list[list[float]],
+    nocenter: list[float] | None,
+) -> list[float]:
+    width = len(rows[0]) if rows else 0
+    return [
+        (
+            0.0
+            if nocenter is not None
+            and all(any(row[col_idx] == value for value in nocenter) for row in rows)
+            else math.fsum(row[col_idx] for row in rows) / len(rows)
+        )
+        for col_idx in range(width)
+    ]
+
+
+def _cox_low_level_fit(
     x: Any,
     y: Any,
-    strata: Any | None = None,
-    offset: Any | None = None,
-    init: Any | None = None,
-    control: Any | None = None,
-    weights: Any | None = None,
-    method: Any = "efron",
-    rownames: Any | None = None,
-    resid: Any = True,
-    nocenter: Any | None = None,
-) -> CoxphFitResult:
-    """Fit the matrix-oriented low-level model exported as R ``coxph.fit``."""
+    strata: Any | None,
+    offset: Any | None,
+    init: Any | None,
+    control: Any | None,
+    weights: Any | None,
+    method: Any,
+    rownames: Any | None,
+    resid: Any,
+    nocenter: Any | None,
+    *,
+    counting: bool,
+) -> _CoxLowLevelComputation:
+    function_name = "agreg_fit" if counting else "coxph_fit"
 
     rows = _as_matrix_rows(x, "x", allow_empty_columns=True)
-    time, status = _coxph_fit_response(y)
+    time, status, entry_times = _cox_fit_response(y, counting=counting)
+    if counting and not any(status):
+        raise ValueError("Can't fit a Cox model with 0 failures")
     n = len(time)
     if len(rows) != n:
         raise ValueError("x and y have different numbers of rows")
@@ -21608,7 +21660,7 @@ def coxph_fit(
         method,
         "method",
         ("efron", "breslow"),
-        "coxph_fit method must be 'efron' or 'breslow'",
+        f"{function_name} method must be 'efron' or 'breslow'",
     )
     keep_residuals = _normalize_bool_option_with_default(resid, "resid", True)
     nocenter_values = _normalize_numeric_sequence_or_none(nocenter, "nocenter")
@@ -21632,14 +21684,14 @@ def coxph_fit(
         eps=eps,
         toler=toler,
         method=method_name,
-        entry_times=None,
+        entry_times=entry_times,
         nocenter=nocenter_values,
     )
     if max_iter > 1 and int(fit.convergence_flag) == _COX_NONCONVERGENCE_FLAG:
         warnings.warn(
             "Ran out of iterations and did not converge",
             RuntimeWarning,
-            stacklevel=2,
+            stacklevel=3,
         )
 
     raw_coefficients = [float(value) for value in fit.coefficients[0]]
@@ -21648,7 +21700,11 @@ def coxph_fit(
         math.nan if aliases[index] else value
         for index, value in enumerate(raw_coefficients)
     ]
-    means = [float(value) for value in fit.means]
+    means = (
+        _agreg_fit_means(rows, nocenter_values)
+        if counting
+        else [float(value) for value in fit.means]
+    )
     center = math.fsum(
         mean * coefficient
         for mean, coefficient in zip(means, raw_coefficients, strict=True)
@@ -21659,7 +21715,7 @@ def coxph_fit(
         if input_names is not None
         else [f"X{index + 1}" for index in range(nvar)]
     )
-    return CoxphFitResult(
+    result = CoxphFitResult(
         coefficients=coefficients,
         var=[[float(value) for value in row] for row in fit.information_matrix],
         loglik=[float(value) for value in fit.log_likelihood],
@@ -21675,6 +21731,93 @@ def coxph_fit(
         method=method_name,
         coefficient_names=coefficient_names,
         row_names=row_names,
+    )
+    return _CoxLowLevelComputation(fit=fit, result=result)
+
+
+def coxph_fit(
+    x: Any,
+    y: Any,
+    strata: Any | None = None,
+    offset: Any | None = None,
+    init: Any | None = None,
+    control: Any | None = None,
+    weights: Any | None = None,
+    method: Any = "efron",
+    rownames: Any | None = None,
+    resid: Any = True,
+    nocenter: Any | None = None,
+) -> CoxphFitResult:
+    """Fit the matrix-oriented low-level model exported as R ``coxph.fit``."""
+
+    return _cox_low_level_fit(
+        x,
+        y,
+        strata,
+        offset,
+        init,
+        control,
+        weights,
+        method,
+        rownames,
+        resid,
+        nocenter,
+        counting=False,
+    ).result
+
+
+def agreg_fit(
+    x: Any,
+    y: Any,
+    strata: Any | None = None,
+    offset: Any | None = None,
+    init: Any | None = None,
+    control: Any | None = None,
+    weights: Any | None = None,
+    method: Any = "efron",
+    rownames: Any | None = None,
+    resid: Any = True,
+    nocenter: Any | None = None,
+) -> AgregFitResult:
+    """Fit the counting-process model exported as R ``agreg.fit``."""
+
+    computation = _cox_low_level_fit(
+        x,
+        y,
+        strata,
+        offset,
+        init,
+        control,
+        weights,
+        method,
+        rownames,
+        resid,
+        nocenter,
+        counting=True,
+    )
+    fit = computation.fit
+    result = computation.result
+    flag = int(fit.convergence_flag)
+    rank = len(result.coefficients) if flag == _COX_NONCONVERGENCE_FLAG else flag
+    return AgregFitResult(
+        coefficients=result.coefficients,
+        var=result.var,
+        loglik=result.loglik,
+        score=result.score,
+        iter=result.iter,
+        linear_predictors=result.linear_predictors,
+        residuals=result.residuals,
+        means=result.means,
+        method=result.method,
+        coefficient_names=result.coefficient_names,
+        row_names=result.row_names,
+        first=[float(value) for value in fit.score_vector],
+        info={
+            "rank": rank,
+            "rescale": 0,
+            "step halving": 0,
+            "convergence": int(flag == _COX_NONCONVERGENCE_FLAG),
+        },
     )
 
 

--- a/python/survival/r_api.pyi
+++ b/python/survival/r_api.pyi
@@ -586,6 +586,21 @@ class CoxphFitResult:
     coefficient_names: list[str]
     row_names: list[str]
 
+class AgregFitResult(CoxphFitResult):
+    coefficients: list[float]
+    var: list[list[float]]
+    loglik: list[float]
+    score: float
+    iter: int
+    linear_predictors: list[float]
+    residuals: list[float] | None
+    means: list[float]
+    method: str
+    coefficient_names: list[str]
+    row_names: list[str]
+    first: list[float]
+    info: dict[str, int]
+
 class CoxBaseHazardResult:
     time: list[float]
     cumhaz: list[float] | list[list[float]]
@@ -1057,6 +1072,19 @@ def coxph_fit(
     resid: Any = True,
     nocenter: Any | None = None,
 ) -> CoxphFitResult: ...
+def agreg_fit(
+    x: Any,
+    y: Any,
+    strata: Any | None = None,
+    offset: Any | None = None,
+    init: Any | None = None,
+    control: Any | None = None,
+    weights: Any | None = None,
+    method: Any = "efron",
+    rownames: Any | None = None,
+    resid: Any = True,
+    nocenter: Any | None = None,
+) -> AgregFitResult: ...
 def cch(
     formula: str,
     data: Any,

--- a/python/tests/test_binding_contract.py
+++ b/python/tests/test_binding_contract.py
@@ -12058,6 +12058,7 @@ def test_package_root_marks_curated_and_legacy_exports():
     assert "regression" in survival.__all__
     assert "StrataFactor" in survival.__all__
     assert "Surv" in survival.__all__
+    assert "AgregFitResult" in survival.__all__
     assert "CoxphFitResult" in survival.__all__
     assert "FineGrayFrame" in survival.__all__
     assert "FineGrayOutput" in survival.__all__
@@ -12074,6 +12075,7 @@ def test_package_root_marks_curated_and_legacy_exports():
     assert "TMergeOperation" in survival.__all__
     assert "aic" in survival.__all__
     assert "aeqSurv" in survival.__all__
+    assert "agreg_fit" in survival.__all__
     assert "anova" in survival.__all__
     assert "as_data_frame" in survival.__all__
     assert "basehaz" in survival.__all__
@@ -12144,6 +12146,7 @@ def test_package_root_marks_curated_and_legacy_exports():
     assert "ridge_fit" in survival.__deprecated_root_exports__
     assert "ridge_fit" not in vars(survival)
     assert survival.StrataFactor is survival.r_api.StrataFactor
+    assert survival.AgregFitResult is survival.r_api.AgregFitResult
     assert survival.CoxphFitResult is survival.r_api.CoxphFitResult
     assert survival.Surv is survival.r_api.Surv
     assert survival.FineGrayFrame is survival.r_api.FineGrayFrame
@@ -12161,6 +12164,7 @@ def test_package_root_marks_curated_and_legacy_exports():
     assert survival.TMergeOperation is survival.r_api.TMergeOperation
     assert survival.aic is survival.r_api.aic
     assert survival.aeqSurv is survival.r_api.aeqSurv
+    assert survival.agreg_fit is survival.r_api.agreg_fit
     assert survival.anova is survival.r_api.anova
     assert survival.as_data_frame is survival.r_api.as_data_frame
     assert survival.basehaz is survival.r_api.basehaz
@@ -12990,6 +12994,8 @@ def test_r_api_stub_tracks_coxph_fit_signature():
 
     assert list(inspect.signature(survival.r_api.coxph_fit).parameters) == expected
     assert _pyi_function_arg_names(stub_path, "coxph_fit") == expected
+    assert list(inspect.signature(survival.r_api.agreg_fit).parameters) == expected
+    assert _pyi_function_arg_names(stub_path, "agreg_fit") == expected
 
 
 def test_r_api_stub_tracks_survdiff_public_signature():

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -964,6 +964,88 @@ def test_coxph_fit_matches_reference_tied_event_fits():
     assert stratified.residuals[1::2] == pytest.approx(expected["efron"]["residuals"])
 
 
+def test_agreg_fit_matches_reference_weighted_counting_process_fit():
+    x = {
+        "x1": [0.2, 0.8, 0.4, 1.1, 0.7, 0.3, 1.3, 0.5],
+        "x2": [1.0, 0.2, 0.7, 1.3, 0.4, 1.1, 0.5, 0.9],
+    }
+    start = [0.0, 0.0, 0.0, 1.0, 1.0, 2.0, 3.0, 4.0]
+    stop = [1.0, 1.0, 2.0, 3.0, 3.0, 4.0, 5.0, 5.0]
+    status = [1, 1, 0, 1, 1, 0, 1, 0]
+    response = survival.Surv(start, stop, status)
+    control = survival.coxph_control(iter_max=50, eps=1e-10)
+    fit = survival.agreg_fit(
+        x,
+        response,
+        offset=[0.1, -0.1, 0.0, 0.2, -0.2, 0.0, 0.1, -0.1],
+        weights=[1.0, 2.0, 1.0, 1.0, 1.5, 1.0, 1.0, 1.0],
+        control=control,
+        rownames=[f"r{index}" for index in range(1, 9)],
+    )
+
+    assert fit.coefficients == pytest.approx([1.76410174709304, -0.862933647039358])
+    for actual, expected in zip(
+        fit.var,
+        [
+            [2.59123300754202, 0.216795183663814],
+            [0.216795183663814, 1.47156616986026],
+        ],
+        strict=True,
+    ):
+        assert actual == pytest.approx(expected)
+    assert fit.loglik == pytest.approx([-6.74131413711341, -5.51281874396037])
+    assert fit.score == pytest.approx(2.22409095009432)
+    assert fit.iter == 5
+    assert fit.linear_predictors == pytest.approx(
+        [
+            -0.92084379920238,
+            0.627964166684932,
+            -0.409143355671964,
+            0.507967679069551,
+            0.178967262567756,
+            -0.930726989197011,
+            1.45113494611965,
+            -0.505319910370531,
+        ]
+    )
+    assert fit.residuals == pytest.approx(
+        [
+            0.76671911432341,
+            -0.097786557750981,
+            -0.571145998821449,
+            -0.0290004043812491,
+            0.259487353182028,
+            -0.360230625391793,
+            0.123851225826562,
+            -0.123851225826562,
+        ]
+    )
+    assert fit.means == pytest.approx([0.6625, 0.7625])
+    assert fit.first == pytest.approx([0.0, 0.0], abs=1e-12)
+    assert fit.info == {
+        "rank": 2,
+        "rescale": 0,
+        "step halving": 0,
+        "convergence": 0,
+    }
+    assert fit.coefficient_names == ["x1", "x2"]
+    assert fit.row_names == [f"r{index}" for index in range(1, 9)]
+
+    matrix_response = [
+        [left, right, float(event)]
+        for left, right, event in zip(start, stop, status, strict=True)
+    ]
+    without_residuals = survival.agreg_fit(
+        [[left, right] for left, right in zip(x["x1"], x["x2"], strict=True)],
+        matrix_response,
+        control=control,
+        resid=False,
+    )
+    assert without_residuals.residuals is None
+    with pytest.raises(ValueError, match="0 failures"):
+        survival.agreg_fit(x, survival.Surv(start, stop, [0] * len(stop)))
+
+
 def test_r_api_brier_returns_r_style_cox_model_fields():
     data = {
         "time": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],

--- a/src/regression/coxph.rs
+++ b/src/regression/coxph.rs
@@ -1170,6 +1170,39 @@ mod tests {
                 .expect("martingale residuals should compute");
             assert_close_vec(&actual, &expected);
         }
+
+        let counting_fit = coxph_fit(
+            vec![1.0, 1.0, 2.0, 3.0, 3.0, 4.0, 5.0, 5.0],
+            status,
+            covariates,
+            None,
+            Some(vec![1.0, 2.0, 1.0, 1.0, 1.5, 1.0, 1.0, 1.0]),
+            Some(vec![0.1, -0.1, 0.0, 0.2, -0.2, 0.0, 0.1, -0.1]),
+            None,
+            Some(50),
+            Some(1e-10),
+            None,
+            Some("efron"),
+            Some(vec![0.0, 0.0, 0.0, 1.0, 1.0, 2.0, 3.0, 4.0]),
+            None,
+        )
+        .expect("counting-process Cox fit should succeed");
+        let actual = counting_fit
+            .martingale_residuals()
+            .expect("counting-process martingale residuals should compute");
+        assert_close_vec(
+            &actual,
+            &[
+                0.766_719_114_323_41,
+                -0.097_786_557_750_981,
+                -0.571_145_998_821_449,
+                -0.029_000_404_381_249_1,
+                0.259_487_353_182_028,
+                -0.360_230_625_391_793,
+                0.123_851_225_826_562,
+                -0.123_851_225_826_562,
+            ],
+        );
     }
 
     #[test]

--- a/src/regression/coxph_diagnostics.rs
+++ b/src/regression/coxph_diagnostics.rs
@@ -8,6 +8,7 @@ use crate::regression::coxph_detail_module::{
 };
 use crate::regression::coxph_support::{ActiveRiskSet, CoxSweepRow, StratifiedBaselineLookup};
 use crate::regression::exact_ties::{exact_inclusion_probabilities, exact_tied_moments};
+use crate::residuals::agmart_module::{AgmartData, compute_agmart};
 use crate::residuals::coxmart_module::{CoxMartSurvivalData, CoxMartWeights, compute_coxmart};
 use crate::scoring::coxscore2::{CoxScoreData, CoxScoreParams, compute_cox_score_residuals};
 use crate::validation::ProportionalityTest;
@@ -816,6 +817,70 @@ pub fn cox_interval_cumulative_hazard_se(
 }
 
 impl CoxPHFit {
+    fn counting_process_expected_events(
+        &self,
+        entry_times: &[f64],
+        method: i32,
+    ) -> PyResult<Vec<f64>> {
+        let n = self.event_times.len();
+        if entry_times.len() != n
+            || self.status.len() != n
+            || self.linear_predictors.len() != n
+            || self.weights.len() != n
+            || self.strata.len() != n
+        {
+            return Err(value_error(
+                "fitted Cox model diagnostic arrays have inconsistent lengths",
+            ));
+        }
+
+        let mut order: Vec<usize> = (0..n).collect();
+        order.sort_by(|&lhs, &rhs| {
+            self.strata[lhs]
+                .cmp(&self.strata[rhs])
+                .then_with(|| self.event_times[lhs].total_cmp(&self.event_times[rhs]))
+                .then_with(|| self.status[rhs].cmp(&self.status[lhs]))
+                .then_with(|| lhs.cmp(&rhs))
+        });
+        let start: Vec<f64> = order.iter().map(|&idx| entry_times[idx]).collect();
+        let stop: Vec<f64> = order.iter().map(|&idx| self.event_times[idx]).collect();
+        let event: Vec<i32> = order.iter().map(|&idx| self.status[idx]).collect();
+        let score: Vec<f64> = order
+            .iter()
+            .map(|&idx| {
+                self.linear_predictors[idx]
+                    .clamp(EXP_CLAMP_MIN, EXP_CLAMP_MAX)
+                    .exp()
+            })
+            .collect();
+        let weights: Vec<f64> = order.iter().map(|&idx| self.weights[idx]).collect();
+        let mut strata = vec![0; n];
+        for sorted_idx in 0..n {
+            if sorted_idx + 1 == n
+                || self.strata[order[sorted_idx + 1]] != self.strata[order[sorted_idx]]
+            {
+                strata[sorted_idx] = 1;
+            }
+        }
+        let residuals = compute_agmart(
+            method,
+            AgmartData {
+                start: &start,
+                stop: &stop,
+                event: &event,
+                score: &score,
+                wt: &weights,
+                strata: &strata,
+            },
+        );
+
+        let mut expected = vec![0.0; n];
+        for (sorted_idx, &original_idx) in order.iter().enumerate() {
+            expected[original_idx] = self.status[original_idx] as f64 - residuals[sorted_idx];
+        }
+        Ok(expected)
+    }
+
     fn right_censored_expected_events(&self, method: i32) -> PyResult<Vec<f64>> {
         let n = self.event_times.len();
         if self.status.len() != n
@@ -872,12 +937,16 @@ impl CoxPHFit {
     }
 
     pub(crate) fn expected_events_internal(&self) -> PyResult<Vec<f64>> {
-        if self.entry_times.is_none() {
-            match self.tie_method() {
-                CoxMethod::Breslow => return self.right_censored_expected_events(0),
-                CoxMethod::Efron => return self.right_censored_expected_events(1),
-                CoxMethod::Exact => {}
+        match (self.entry_times.as_deref(), self.tie_method()) {
+            (None, CoxMethod::Breslow) => return self.right_censored_expected_events(0),
+            (None, CoxMethod::Efron) => return self.right_censored_expected_events(1),
+            (Some(entry_times), CoxMethod::Breslow) => {
+                return self.counting_process_expected_events(entry_times, 0);
             }
+            (Some(entry_times), CoxMethod::Efron) => {
+                return self.counting_process_expected_events(entry_times, 1);
+            }
+            (_, CoxMethod::Exact) => {}
         }
 
         let (times, hazards, hazard_strata) = self.basehaz_with_strata_internal(false)?;

--- a/src/residuals/agmart.rs
+++ b/src/residuals/agmart.rs
@@ -1,85 +1,133 @@
 use crate::internal::typed_inputs::{AndersenGillInput, CountingProcessData, Weights};
 use pyo3::prelude::*;
 
-struct AgmartData<'a> {
-    start: &'a [f64],
-    stop: &'a [f64],
-    event: &'a [i32],
-    score: &'a [f64],
-    wt: &'a [f64],
-    strata: &'a [i32],
+#[derive(Clone, Copy)]
+pub(crate) struct AgmartData<'a> {
+    pub(crate) start: &'a [f64],
+    pub(crate) stop: &'a [f64],
+    pub(crate) event: &'a [i32],
+    pub(crate) score: &'a [f64],
+    pub(crate) wt: &'a [f64],
+    pub(crate) strata: &'a [i32],
 }
 
-fn compute_agmart(method: i32, input: AgmartData) -> Vec<f64> {
-    let n = input.start.len();
-    let start_slice = input.start;
-    let stop_slice = input.stop;
-    let event_slice = input.event;
-    let score_slice = input.score;
-    let wt_slice = input.wt;
-    let strata_slice = input.strata;
-    let mut resid = vec![0.0; n];
-    let nused = n;
-    for i in 0..nused {
-        resid[i] = event_slice[i] as f64;
+fn cumulative_hazard_at(times: &[f64], cumulative: &[f64], time: f64) -> f64 {
+    let position = times.partition_point(|&value| value <= time);
+    if position == 0 {
+        0.0
+    } else {
+        cumulative[position - 1]
     }
-    let mut person = 0;
-    while person < nused {
-        if event_slice[person] == 0 {
-            person += 1;
-            continue;
+}
+
+fn compute_stratum_agmart(method: i32, input: &AgmartData<'_>, rows: &[usize], resid: &mut [f64]) {
+    if rows.is_empty() {
+        return;
+    }
+
+    let mut start_order = rows.to_vec();
+    start_order.sort_by(|&lhs, &rhs| {
+        input.start[lhs]
+            .total_cmp(&input.start[rhs])
+            .then_with(|| lhs.cmp(&rhs))
+    });
+    let mut stop_order = rows.to_vec();
+    stop_order.sort_by(|&lhs, &rhs| {
+        input.stop[lhs]
+            .total_cmp(&input.stop[rhs])
+            .then_with(|| lhs.cmp(&rhs))
+    });
+    let mut event_order: Vec<usize> = rows
+        .iter()
+        .copied()
+        .filter(|&idx| input.event[idx] != 0)
+        .collect();
+    event_order.sort_by(|&lhs, &rhs| {
+        input.stop[lhs]
+            .total_cmp(&input.stop[rhs])
+            .then_with(|| lhs.cmp(&rhs))
+    });
+    if event_order.is_empty() {
+        return;
+    }
+
+    let mut event_times = Vec::new();
+    let mut cumulative_hazard = Vec::new();
+    let mut hazard_increment = Vec::new();
+    let mut event_hazard_increment = Vec::new();
+    let mut active_risk = 0.0;
+    let mut start_ptr = 0usize;
+    let mut stop_ptr = 0usize;
+    let mut event_ptr = 0usize;
+    let mut cumulative = 0.0;
+
+    while event_ptr < event_order.len() {
+        let time = input.stop[event_order[event_ptr]];
+        while start_ptr < start_order.len() && input.start[start_order[start_ptr]] < time {
+            let idx = start_order[start_ptr];
+            active_risk += input.score[idx] * input.wt[idx];
+            start_ptr += 1;
         }
-        let time = stop_slice[person];
-        let mut denom = 0.0;
-        let mut e_denom = 0.0;
-        let mut deaths = 0;
-        let mut wtsum = 0.0;
-        let mut k = person;
-        while k < nused {
-            if start_slice[k] < time {
-                denom += score_slice[k] * wt_slice[k];
-                if stop_slice[k] == time && event_slice[k] == 1 {
-                    deaths += 1;
-                    wtsum += wt_slice[k];
-                    e_denom += score_slice[k] * wt_slice[k];
-                }
-            }
-            if strata_slice[k] == 1 || k == nused - 1 {
-                break;
-            }
-            k += 1;
+        while stop_ptr < stop_order.len() && input.stop[stop_order[stop_ptr]] < time {
+            let idx = stop_order[stop_ptr];
+            active_risk -= input.score[idx] * input.wt[idx];
+            stop_ptr += 1;
         }
-        let (hazard, e_hazard) = if deaths == 0 {
-            (0.0, 0.0)
-        } else {
-            let wtsum_normalized = wtsum / deaths as f64;
-            let mut hazard_total = 0.0;
-            let mut e_hazard_total = 0.0;
-            for i in 0..deaths {
-                let temp = method as f64 * (i as f64 / deaths as f64);
-                let denominator = denom - temp * e_denom;
-                hazard_total += wtsum_normalized / denominator;
-                e_hazard_total += wtsum_normalized * (1.0 - temp) / denominator;
-            }
-            (hazard_total, e_hazard_total)
-        };
-        let initial_person = person;
-        let mut k = initial_person;
-        while k < nused {
-            if start_slice[k] < time {
-                if stop_slice[k] == time && event_slice[k] == 1 {
-                    resid[k] -= score_slice[k] * e_hazard;
-                } else {
-                    resid[k] -= score_slice[k] * hazard;
-                }
-            }
-            if stop_slice[k] == time {
-                person += 1;
-            }
-            if strata_slice[k] == 1 || k == nused - 1 {
-                break;
-            }
-            k += 1;
+
+        let group_start = event_ptr;
+        while event_ptr < event_order.len() && input.stop[event_order[event_ptr]] == time {
+            event_ptr += 1;
+        }
+        let deaths = event_ptr - group_start;
+        let mut death_weight = 0.0;
+        let mut death_risk = 0.0;
+        for &idx in &event_order[group_start..event_ptr] {
+            death_weight += input.wt[idx];
+            death_risk += input.score[idx] * input.wt[idx];
+        }
+        let step_weight = death_weight / deaths as f64;
+        let mut hazard = 0.0;
+        let mut event_hazard = 0.0;
+        for step in 0..deaths {
+            let fraction = if method == 0 {
+                0.0
+            } else {
+                step as f64 / deaths as f64
+            };
+            let denominator = active_risk - fraction * death_risk;
+            hazard += step_weight / denominator;
+            event_hazard += step_weight * (1.0 - fraction) / denominator;
+        }
+        cumulative += hazard;
+        event_times.push(time);
+        cumulative_hazard.push(cumulative);
+        hazard_increment.push(hazard);
+        event_hazard_increment.push(event_hazard);
+    }
+
+    for &idx in rows {
+        let mut integrated_hazard =
+            cumulative_hazard_at(&event_times, &cumulative_hazard, input.stop[idx])
+                - cumulative_hazard_at(&event_times, &cumulative_hazard, input.start[idx]);
+        if input.event[idx] != 0 {
+            let event_idx = event_times
+                .binary_search_by(|value| value.total_cmp(&input.stop[idx]))
+                .expect("an event row must have a matching event time");
+            integrated_hazard += event_hazard_increment[event_idx] - hazard_increment[event_idx];
+        }
+        resid[idx] = input.event[idx] as f64 - input.score[idx] * integrated_hazard;
+    }
+}
+
+pub(crate) fn compute_agmart(method: i32, input: AgmartData) -> Vec<f64> {
+    let n = input.start.len();
+    let mut resid = vec![0.0; n];
+    let mut stratum_start = 0usize;
+    for idx in 0..n {
+        if input.strata[idx] == 1 || idx + 1 == n {
+            let rows: Vec<usize> = (stratum_start..=idx).collect();
+            compute_stratum_agmart(method, &input, &rows, &mut resid);
+            stratum_start = idx + 1;
         }
     }
     resid
@@ -124,4 +172,91 @@ pub(crate) fn agmart_typed(input: &AndersenGillInput, method: Option<i32>) -> Py
         strata: strata.as_ref(),
     };
     Ok(compute_agmart(method.unwrap_or(0), data))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn brute_force_agmart(method: i32, input: &AgmartData<'_>) -> Vec<f64> {
+        let mut residuals: Vec<f64> = input.event.iter().map(|&value| value as f64).collect();
+        let mut stratum_start = 0usize;
+        for stratum_end in 0..input.start.len() {
+            if input.strata[stratum_end] != 1 && stratum_end + 1 != input.start.len() {
+                continue;
+            }
+            let rows: Vec<usize> = (stratum_start..=stratum_end).collect();
+            let mut event_times: Vec<f64> = rows
+                .iter()
+                .filter(|&&idx| input.event[idx] != 0)
+                .map(|&idx| input.stop[idx])
+                .collect();
+            event_times.sort_by(f64::total_cmp);
+            event_times.dedup();
+            for time in event_times {
+                let risk_rows: Vec<usize> = rows
+                    .iter()
+                    .copied()
+                    .filter(|&idx| input.start[idx] < time && input.stop[idx] >= time)
+                    .collect();
+                let death_rows: Vec<usize> = rows
+                    .iter()
+                    .copied()
+                    .filter(|&idx| input.stop[idx] == time && input.event[idx] != 0)
+                    .collect();
+                let denominator: f64 = risk_rows
+                    .iter()
+                    .map(|&idx| input.score[idx] * input.wt[idx])
+                    .sum();
+                let death_risk: f64 = death_rows
+                    .iter()
+                    .map(|&idx| input.score[idx] * input.wt[idx])
+                    .sum();
+                let death_weight: f64 = death_rows.iter().map(|&idx| input.wt[idx]).sum();
+                let step_weight = death_weight / death_rows.len() as f64;
+                let mut hazard = 0.0;
+                let mut event_hazard = 0.0;
+                for step in 0..death_rows.len() {
+                    let fraction = if method == 0 {
+                        0.0
+                    } else {
+                        step as f64 / death_rows.len() as f64
+                    };
+                    let adjusted = denominator - fraction * death_risk;
+                    hazard += step_weight / adjusted;
+                    event_hazard += step_weight * (1.0 - fraction) / adjusted;
+                }
+                for idx in risk_rows {
+                    let increment = if input.stop[idx] == time && input.event[idx] != 0 {
+                        event_hazard
+                    } else {
+                        hazard
+                    };
+                    residuals[idx] -= input.score[idx] * increment;
+                }
+            }
+            stratum_start = stratum_end + 1;
+        }
+        residuals
+    }
+
+    #[test]
+    fn cumulative_sweep_matches_direct_counting_process_risk_sets() {
+        let input = AgmartData {
+            start: &[1.0, 0.0, 0.5, 0.0, 2.0, 0.0, 1.5, 0.5, 2.5, 1.0],
+            stop: &[3.0, 1.0, 3.0, 2.0, 4.0, 2.0, 4.0, 1.5, 5.0, 3.5],
+            event: &[1, 1, 0, 1, 0, 1, 1, 0, 1, 0],
+            score: &[0.7, 1.2, 0.8, 1.5, 0.9, 0.6, 1.1, 1.3, 0.75, 1.4],
+            wt: &[1.0, 2.0, 0.5, 1.5, 1.0, 0.8, 1.2, 1.0, 1.7, 0.9],
+            strata: &[0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
+        };
+
+        for method in [0, 1] {
+            let actual = compute_agmart(method, AgmartData { ..input });
+            let expected = brute_force_agmart(method, &input);
+            for (actual, expected) in actual.iter().zip(expected.iter()) {
+                assert!((actual - expected).abs() < 1e-12);
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add public `agreg_fit()` and typed `AgregFitResult`
- share validated low-level Cox inputs and result shaping with `coxph_fit()`
- support delayed entry, Efron and Breslow ties, strata, offsets, starts, controls, weights, row names, and no-centering values
- return reference-shaped score vectors and convergence metadata
- correct counting-process martingale residuals for tied events
- replace repeated risk-set scans with a sorted cumulative-hazard sweep

## Compatibility
- matched survival 3.8-6 weighted delayed-entry coefficients, covariance, likelihood, score, iterations, predictors, residuals, means, first derivatives, and fit metadata
- covered `Surv` and matrix responses, residual omission, and zero-failure validation
- verified the cumulative sweep against direct risk-set calculations across ties, weights, delayed entry, and multiple strata

## Performance
- 100,000-row counting-process martingale residuals: 3.34 ms median in the optimized build

## Testing
- `cargo test --all-features` (1,729 passed)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `.venv/bin/python -m pytest -q python/tests` (903 passed, 18 skipped)
- `.venv/bin/python -m ruff check python`
- `.venv/bin/python -m mypy python/survival`
- `cargo fmt --all -- --check`
- `git diff --check`