### PR TITLE
Add exact partial-likelihood Cox fitting

### DIFF
--- a/python/survival/__init__.py
+++ b/python/survival/__init__.py
@@ -76,6 +76,7 @@ _R_EXPORTS = [
     "YatesResult",
     "aic",
     "aareg",
+    "agexact_fit",
     "agreg_fit",
     "aeqSurv",
     "anova",

--- a/python/survival/__init__.pyi
+++ b/python/survival/__init__.pyi
@@ -50,6 +50,7 @@ from .r_api import (
     YatesPairwiseResult,
     YatesResult,
     aeqSurv,
+    agexact_fit,
     agreg_fit,
     aic,
     anova,

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -55,6 +55,7 @@ __all__ = [
     "TcutResult",
     "aic",
     "aareg",
+    "agexact_fit",
     "agreg_fit",
     "aeqSurv",
     "as_data_frame",
@@ -21616,8 +21617,9 @@ def _cox_low_level_fit(
     nocenter: Any | None,
     *,
     counting: bool,
+    exact: bool,
 ) -> _CoxLowLevelComputation:
-    function_name = "agreg_fit" if counting else "coxph_fit"
+    function_name = "agexact_fit" if exact else "agreg_fit" if counting else "coxph_fit"
 
     rows = _as_matrix_rows(x, "x", allow_empty_columns=True)
     time, status, entry_times = _cox_fit_response(y, counting=counting)
@@ -21627,6 +21629,8 @@ def _cox_low_level_fit(
     if len(rows) != n:
         raise ValueError("x and y have different numbers of rows")
     nvar = len(rows[0]) if rows else 0
+    if exact and nvar == 0:
+        raise ValueError("Cannot handle a null model with exact calculation")
     if any(len(row) != nvar for row in rows) or any(
         not math.isfinite(value) for row in rows for value in row
     ):
@@ -21645,6 +21649,8 @@ def _cox_low_level_fit(
     weight_values = None if weights is None else _float_vector(weights, "weights")
     if weight_values is not None and len(weight_values) != n:
         raise ValueError("weights and y have different numbers of rows")
+    if exact and weight_values is not None and any(value != 1.0 for value in weight_values):
+        raise ValueError("Case weights are not supported for the exact method")
     initial = None if init is None else _float_vector(init, "init")
     if initial is not None and len(initial) != nvar:
         raise ValueError("Wrong length for initial parameters")
@@ -21656,11 +21662,15 @@ def _cox_low_level_fit(
         raise ValueError("control.eps must be positive")
     if toler is not None and toler <= 0.0:
         raise ValueError("control.toler.chol must be positive")
-    method_name = _match_string_arg(
-        method,
-        "method",
-        ("efron", "breslow"),
-        f"{function_name} method must be 'efron' or 'breslow'",
+    method_name = (
+        _match_string_arg(method, "method", ("exact",), "agexact_fit method must be 'exact'")
+        if exact
+        else _match_string_arg(
+            method,
+            "method",
+            ("efron", "breslow"),
+            f"{function_name} method must be 'efron' or 'breslow'",
+        )
     )
     keep_residuals = _normalize_bool_option_with_default(resid, "resid", True)
     nocenter_values = _normalize_numeric_sequence_or_none(nocenter, "nocenter")
@@ -21763,6 +21773,7 @@ def coxph_fit(
         resid,
         nocenter,
         counting=False,
+        exact=False,
     ).result
 
 
@@ -21794,6 +21805,7 @@ def agreg_fit(
         resid,
         nocenter,
         counting=True,
+        exact=False,
     )
     fit = computation.fit
     result = computation.result
@@ -21819,6 +21831,49 @@ def agreg_fit(
             "convergence": int(flag == _COX_NONCONVERGENCE_FLAG),
         },
     )
+
+
+def agexact_fit(
+    x: Any,
+    y: Any,
+    strata: Any | None = None,
+    offset: Any | None = None,
+    init: Any | None = None,
+    control: Any | None = None,
+    weights: Any | None = None,
+    method: Any = "exact",
+    rownames: Any | None = None,
+    resid: Any = True,
+    nocenter: Any | None = None,
+) -> CoxphFitResult:
+    """Fit the exact partial-likelihood model exported as R ``agexact.fit``."""
+
+    if isinstance(y, Surv):
+        if y.type not in {"right", "counting"}:
+            raise ValueError("Invalid survival response")
+        counting = y.type == "counting"
+        response = y
+    else:
+        response = _as_matrix_rows(y, "y", allow_empty_columns=False)
+        if len(response[0]) not in {2, 3}:
+            raise ValueError("Invalid survival response")
+        counting = len(response[0]) == 3
+    computation = _cox_low_level_fit(
+        x,
+        response,
+        strata,
+        offset,
+        init,
+        control,
+        weights,
+        method,
+        rownames,
+        resid,
+        nocenter,
+        counting=counting,
+        exact=True,
+    )
+    return replace(computation.result, method="coxph")
 
 
 def coxph(

--- a/python/survival/r_api.pyi
+++ b/python/survival/r_api.pyi
@@ -1085,6 +1085,19 @@ def agreg_fit(
     resid: Any = True,
     nocenter: Any | None = None,
 ) -> AgregFitResult: ...
+def agexact_fit(
+    x: Any,
+    y: Any,
+    strata: Any | None = None,
+    offset: Any | None = None,
+    init: Any | None = None,
+    control: Any | None = None,
+    weights: Any | None = None,
+    method: Any = "exact",
+    rownames: Any | None = None,
+    resid: Any = True,
+    nocenter: Any | None = None,
+) -> CoxphFitResult: ...
 def cch(
     formula: str,
     data: Any,

--- a/python/tests/test_binding_contract.py
+++ b/python/tests/test_binding_contract.py
@@ -12075,6 +12075,7 @@ def test_package_root_marks_curated_and_legacy_exports():
     assert "TMergeOperation" in survival.__all__
     assert "aic" in survival.__all__
     assert "aeqSurv" in survival.__all__
+    assert "agexact_fit" in survival.__all__
     assert "agreg_fit" in survival.__all__
     assert "anova" in survival.__all__
     assert "as_data_frame" in survival.__all__
@@ -12164,6 +12165,7 @@ def test_package_root_marks_curated_and_legacy_exports():
     assert survival.TMergeOperation is survival.r_api.TMergeOperation
     assert survival.aic is survival.r_api.aic
     assert survival.aeqSurv is survival.r_api.aeqSurv
+    assert survival.agexact_fit is survival.r_api.agexact_fit
     assert survival.agreg_fit is survival.r_api.agreg_fit
     assert survival.anova is survival.r_api.anova
     assert survival.as_data_frame is survival.r_api.as_data_frame
@@ -12996,6 +12998,8 @@ def test_r_api_stub_tracks_coxph_fit_signature():
     assert _pyi_function_arg_names(stub_path, "coxph_fit") == expected
     assert list(inspect.signature(survival.r_api.agreg_fit).parameters) == expected
     assert _pyi_function_arg_names(stub_path, "agreg_fit") == expected
+    assert list(inspect.signature(survival.r_api.agexact_fit).parameters) == expected
+    assert _pyi_function_arg_names(stub_path, "agexact_fit") == expected
 
 
 def test_r_api_stub_tracks_survdiff_public_signature():

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -1046,6 +1046,107 @@ def test_agreg_fit_matches_reference_weighted_counting_process_fit():
         survival.agreg_fit(x, survival.Surv(start, stop, [0] * len(stop)))
 
 
+def test_agexact_fit_matches_reference_right_and_counting_process_fits():
+    x = {
+        "x1": [0.2, 0.8, 0.4, 1.1, 0.7, 0.3, 1.3, 0.5],
+        "x2": [1.0, 0.2, 0.7, 1.3, 0.4, 1.1, 0.5, 0.9],
+    }
+    stop = [1.0, 1.0, 2.0, 3.0, 3.0, 4.0, 5.0, 5.0]
+    status = [1, 1, 0, 1, 1, 0, 1, 0]
+    fixtures = [
+        (
+            survival.Surv(stop, status),
+            [0.189909180165605, -1.1018604712744],
+            [
+                [2.17021886721069, 1.01176740045738],
+                [1.01176740045738, 2.91144555149508],
+            ],
+            [-6.3279367837292, -6.02166478557382],
+            0.613318905217953,
+            4,
+            [
+                -0.349524857754264,
+                0.645909027364623,
+                0.0190151196611789,
+                -0.50916473698754,
+                0.406546015093182,
+                -0.440719986865143,
+                0.410305476065105,
+                -0.182366056577141,
+            ],
+            [
+                0.838273503739839,
+                0.562384575300701,
+                -0.233795450797506,
+                0.625837762907696,
+                0.0651367663178406,
+                -0.400668436041613,
+                -0.582362314565589,
+                -0.874806406861369,
+            ],
+        ),
+        (
+            survival.Surv([0, 0, 0, 1, 1, 2, 3, 4], stop, status),
+            [6.25393495620695, 1.77351117102195],
+            [
+                [125.483201267342, 80.1723633215414],
+                [80.1723633215414, 58.7122483503],
+            ],
+            [-2.89037175789616, -1.4457985963911],
+            2.30774005337968,
+            8,
+            [
+                -2.471236014128,
+                -0.137683977221393,
+                -1.7525023741932,
+                3.68935879776484,
+                -0.408375238637698,
+                -1.66849140140511,
+                3.52133685218867,
+                -0.772406644368111,
+            ],
+            [
+                0.850370489560222,
+                -0.543355691578768,
+                -0.307014797981455,
+                -0.958247626531567,
+                0.967472976120623,
+                -0.0092253495890561,
+                0.0134698039760716,
+                -0.0134698039760717,
+            ],
+        ),
+    ]
+    control = survival.coxph_control(iter_max=50, eps=1e-10)
+    for (
+        response,
+        coefficients,
+        variance,
+        loglik,
+        score,
+        iterations,
+        linear_predictors,
+        residuals,
+    ) in fixtures:
+        fit = survival.agexact_fit(x, response, control=control)
+        assert fit.coefficients == pytest.approx(coefficients)
+        for actual, expected in zip(fit.var, variance, strict=True):
+            assert actual == pytest.approx(expected)
+        assert fit.loglik == pytest.approx(loglik)
+        assert fit.score == pytest.approx(score)
+        assert fit.iter == iterations
+        assert fit.linear_predictors == pytest.approx(linear_predictors)
+        assert fit.residuals == pytest.approx(residuals)
+        assert fit.means == pytest.approx([0.6625, 0.7625])
+        assert fit.method == "coxph"
+        assert fit.coefficient_names == ["x1", "x2"]
+
+    with pytest.raises(ValueError, match="Case weights"):
+        survival.agexact_fit(x, fixtures[0][0], weights=[2.0] * len(stop))
+    with pytest.raises(ValueError, match="must be 'exact'"):
+        survival.agexact_fit(x, fixtures[0][0], method="efron")
+
+
 def test_r_api_brier_returns_r_style_cox_model_fields():
     data = {
         "time": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],


### PR DESCRIPTION
## Summary
- add public `agexact_fit()` exact partial-likelihood fitting
- support both right-censored and counting-process responses
- reuse the validated low-level Cox input and result contract
- enforce unit case weights and non-null exact designs
- preserve reference result labeling and centered predictors

## Compatibility
- matched survival 3.8-6 exact right-censored and delayed-entry fixtures
- matched coefficients, covariance, likelihoods, score tests, iterations, predictors, residuals, and means
- covered invalid weights and invalid tie-method selection

## Testing
- `.venv/bin/python -m pytest -q python/tests` (904 passed, 18 skipped)
- `.venv/bin/python -m ruff check python`
- `.venv/bin/python -m mypy python/survival`
- `git diff --check`