### PR TITLE
Add quadratic penalties to Cox fitting

### DIFF
--- a/benches/survival_benchmarks.rs
+++ b/benches/survival_benchmarks.rs
@@ -516,6 +516,7 @@ mod cox_regression {
                 None,
                 None,
                 None,
+                None,
             )
             .expect("benchmark Cox PH Efron fit should converge");
             black_box(fit);
@@ -543,6 +544,7 @@ mod cox_regression {
                 Some(entry_times.clone()),
                 None,
                 None,
+                None,
             )
             .expect("benchmark counting-process Cox PH Efron fit should converge");
             black_box(fit);
@@ -566,6 +568,7 @@ mod cox_regression {
                 Some(1e-7),
                 Some(1e-9),
                 Some("breslow"),
+                None,
                 None,
                 None,
                 None,
@@ -597,6 +600,7 @@ mod cox_regression {
                 None,
                 None,
                 None,
+                None,
             )
             .expect("benchmark weighted stratified Cox PH fit should converge");
             black_box(fit);
@@ -622,6 +626,7 @@ mod cox_regression {
             Some(1e-9),
             Some("efron"),
             Some(entry_times),
+            None,
             None,
             None,
         )
@@ -652,6 +657,7 @@ mod cox_regression {
             Some(1e-7),
             Some(1e-9),
             Some("efron"),
+            None,
             None,
             None,
             None,
@@ -689,6 +695,7 @@ mod cox_regression {
             Some(entry_times),
             None,
             None,
+            None,
         )
         .expect("benchmark Cox PH fit should converge");
 
@@ -719,6 +726,7 @@ mod cox_regression {
             Some(1e-9),
             Some("efron"),
             Some(entry_times),
+            None,
             None,
             None,
         )

--- a/python/survival/_survival.pyi
+++ b/python/survival/_survival.pyi
@@ -7169,6 +7169,7 @@ def coxph_fit(
     entry_times: list[float] | None = None,
     nocenter: list[float] | None = None,
     ridge_penalty: list[float] | None = None,
+    penalty_matrix: list[list[float]] | None = None,
 ) -> CoxPHFit: ...
 def coxph_detail(
     time: list[float],

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -22485,6 +22485,7 @@ def coxph(
     singular_ok: Any = True,
     nocenter: Any = (-1, 0, 1),
     ridge_penalty: Any | None = None,
+    penalty_matrix: Any | None = None,
     control: Any | None = None,
     **kwargs: Any,
 ):
@@ -22618,8 +22619,8 @@ def coxph(
             formula_design,
             len(response),
         )
-        if formula_ridge_blocks and ridge_penalty is not None:
-            raise ValueError("use only one of formula ridge(...) or ridge_penalty")
+        if formula_ridge_blocks and (ridge_penalty is not None or penalty_matrix is not None):
+            raise ValueError("use only one of formula ridge(...), ridge_penalty, or penalty_matrix")
         x = _design_rows_from_spec(data, formula_design, len(response))
         formula_x_matrix = [list(row) for row in x] if formula_x else None
         formula_model_data = data
@@ -22699,6 +22700,13 @@ def coxph(
     if len(rows) != len(response):
         raise ValueError("x must have the same number of rows as the Surv response")
     width = len(rows[0]) if rows else 0
+    if ridge_penalty is not None and penalty_matrix is not None:
+        raise ValueError("use only one of ridge_penalty or penalty_matrix")
+    fit_penalty_matrix = (
+        _as_matrix_rows(penalty_matrix, "penalty_matrix", allow_empty_columns=False)
+        if penalty_matrix is not None
+        else None
+    )
     ridge_thetas = [
         block.theta if block.theta is not None else 1.0 for block in formula_ridge_blocks
     ]
@@ -22788,6 +22796,7 @@ def coxph(
             entry_times=entry_times,
             nocenter=nocenter_values,
             ridge_penalty=penalty,
+            penalty_matrix=fit_penalty_matrix,
         )
 
     target_blocks = [

--- a/python/survival/r_api.pyi
+++ b/python/survival/r_api.pyi
@@ -1151,6 +1151,7 @@ def coxph(
     singular_ok: Any = True,
     nocenter: Any = (-1, 0, 1),
     ridge_penalty: Any | None = None,
+    penalty_matrix: Any | None = None,
     control: Any | None = None,
     **kwargs: Any,
 ) -> Any: ...

--- a/python/tests/test_binding_contract.py
+++ b/python/tests/test_binding_contract.py
@@ -816,6 +816,7 @@ def test_coxph_fit_detail_bindings_are_typed_to_runtime_surface():
             "entry_times",
             "nocenter",
             "ridge_penalty",
+            "penalty_matrix",
         ],
         "coxph_detail": [
             "time",
@@ -13112,6 +13113,7 @@ def test_r_api_stub_tracks_fit_control_public_signatures():
             "singular_ok",
             "nocenter",
             "ridge_penalty",
+            "penalty_matrix",
             "control",
         ],
         "survreg": [

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -9459,6 +9459,39 @@ def test_coxph_formula_ridge_calibrates_target_df_against_reference(
     )
 
 
+def test_coxph_quadratic_penalty_matches_pspline_reference():
+    time = [float(value) for value in range(1, 13)]
+    status = [1, 0, 1, 1, 0, 1, 0, 1, 1, 0, 1, 1]
+    x = [1.2, 0.7, 1.5, 0.2, 1.1, 0.4, 1.8, 0.9, 0.5, 1.4, 0.3, 1.0]
+    spline = survival.pspline(x, theta=0.5, nterm=4)
+
+    fit = survival.coxph(
+        survival.Surv(time, status),
+        x=spline["basis"],
+        penalty_matrix=spline["dmat"],
+        ties="breslow",
+        max_iter=50,
+        eps=1e-10,
+    )
+
+    assert fit.coefficients[0] == pytest.approx(
+        [
+            -0.41492053741738832,
+            -0.78864078647868041,
+            -1.03126164890587702,
+            -1.12718264236020893,
+            -1.30622837711029272,
+            -1.52834364408458501,
+        ],
+        abs=1e-9,
+    )
+    assert fit.log_likelihood == pytest.approx(
+        [-12.619505923287514, -12.317017585688493],
+        abs=1e-9,
+    )
+    assert survival.degrees_freedom(fit) == pytest.approx(1.5042707367453212, abs=1e-9)
+
+
 def test_coxph_formula_ridge_defaults_to_half_the_term_width():
     data = {
         "time": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
@@ -9519,6 +9552,19 @@ def test_coxph_ridge_rejects_ambiguous_or_invalid_penalties():
         survival.coxph(response, x=rows, ridge_penalty=[0.2])
     with pytest.raises(ValueError, match="non-negative"):
         survival.coxph(response, x=rows, ridge_penalty=[0.2, -0.1])
+    with pytest.raises(ValueError, match="use only one"):
+        survival.coxph(
+            response,
+            x=rows,
+            ridge_penalty=[0.2, 0.2],
+            penalty_matrix=[[1.0, 0.0], [0.0, 1.0]],
+        )
+    with pytest.raises(ValueError, match="shape"):
+        survival.coxph(response, x=rows, penalty_matrix=[[1.0]])
+    with pytest.raises(ValueError, match="symmetric"):
+        survival.coxph(response, x=rows, penalty_matrix=[[1.0, 0.0], [1.0, 1.0]])
+    with pytest.raises(ValueError, match="positive semidefinite"):
+        survival.coxph(response, x=rows, penalty_matrix=[[1.0, 2.0], [2.0, 1.0]])
     for option, message in (("df=0", "between"), ("df=3", "between"), ("eps=0", "positive")):
         with pytest.raises(ValueError, match=message):
             survival.coxph(

--- a/src/regression/cause_specific_cox.rs
+++ b/src/regression/cause_specific_cox.rs
@@ -414,6 +414,7 @@ pub(crate) fn cause_specific_cox_fit(
         None,
         None,
         None,
+        None,
     )?;
     let beta = fit
         .coefficients

--- a/src/regression/cch.rs
+++ b/src/regression/cch.rs
@@ -597,6 +597,7 @@ fn fit_weighted_cox(
         Some(start),
         Some(vec![-1.0, 0.0, 1.0]),
         None,
+        None,
     )
 }
 

--- a/src/regression/cox_optimizer.rs
+++ b/src/regression/cox_optimizer.rs
@@ -9,6 +9,11 @@ use super::exact_ties::{ExactRiskAccumulator, exact_tied_moments};
 
 const EXACT_COMPATIBILITY_DIRECT_THRESHOLD: usize = 64;
 
+enum CoxPenalty {
+    Diagonal(Vec<f64>),
+    Dense(Array2<f64>),
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct CoxFitConfig {
     pub method: Method,
@@ -154,7 +159,7 @@ pub(crate) struct CoxFit {
     eps: f64,
     toler: f64,
     scale: Vec<f64>,
-    ridge_penalty: Vec<f64>,
+    penalty: CoxPenalty,
     means: Vec<f64>,
     beta: Vec<f64>,
     u: Vec<f64>,
@@ -334,7 +339,7 @@ impl CoxFit {
             eps: config.eps,
             toler: config.toler,
             scale: vec![1.0; nvar],
-            ridge_penalty: vec![0.0; nvar],
+            penalty: CoxPenalty::Diagonal(vec![0.0; nvar]),
             means: vec![0.0; nvar],
             beta: initial_beta,
             u: vec![0.0; nvar],
@@ -350,13 +355,20 @@ impl CoxFit {
 
     pub(crate) fn set_ridge_penalty(&mut self, penalty: &[f64]) {
         debug_assert_eq!(penalty.len(), self.scale.len());
-        for (target, (&value, &scale)) in self
-            .ridge_penalty
-            .iter_mut()
-            .zip(penalty.iter().zip(&self.scale))
-        {
-            *target = value * scale * scale;
-        }
+        self.penalty = CoxPenalty::Diagonal(
+            penalty
+                .iter()
+                .zip(&self.scale)
+                .map(|(&value, &scale)| value * scale * scale)
+                .collect(),
+        );
+    }
+
+    pub(crate) fn set_quadratic_penalty(&mut self, penalty: &Array2<f64>) {
+        debug_assert_eq!(penalty.dim(), (self.scale.len(), self.scale.len()));
+        self.penalty = CoxPenalty::Dense(Array2::from_shape_fn(penalty.dim(), |(row, column)| {
+            penalty[(row, column)] * self.scale[row] * self.scale[column]
+        }));
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1181,14 +1193,33 @@ impl CoxFit {
         } else {
             self.iterate(beta)
         }?;
-        let mut penalty = 0.0;
-        for (variable, (&coefficient, &diagonal)) in
-            beta.iter().zip(&self.ridge_penalty).enumerate()
-        {
-            self.u[variable] -= diagonal * coefficient;
-            self.imat[(variable, variable)] += diagonal;
-            penalty += diagonal * coefficient * coefficient;
-        }
+        let penalty = match &self.penalty {
+            CoxPenalty::Diagonal(values) => {
+                let mut penalty = 0.0;
+                for (variable, (&coefficient, &diagonal)) in beta.iter().zip(values).enumerate() {
+                    self.u[variable] -= diagonal * coefficient;
+                    self.imat[(variable, variable)] += diagonal;
+                    penalty += diagonal * coefficient * coefficient;
+                }
+                penalty
+            }
+            CoxPenalty::Dense(matrix) => {
+                let mut penalty = 0.0;
+                for (row, &coefficient) in beta.iter().enumerate() {
+                    let penalty_score = beta
+                        .iter()
+                        .enumerate()
+                        .map(|(column, &other)| matrix[(row, column)] * other)
+                        .sum::<f64>();
+                    self.u[row] -= penalty_score;
+                    penalty += coefficient * penalty_score;
+                    for column in 0..beta.len() {
+                        self.imat[(row, column)] += matrix[(row, column)];
+                    }
+                }
+                penalty
+            }
+        };
         Ok(log_likelihood - 0.5 * penalty)
     }
 
@@ -1326,7 +1357,18 @@ impl CoxFit {
             for (j, &scale_j) in self.scale.iter().enumerate() {
                 self.imat[(i, j)] *= scale_i * scale_j;
             }
-            self.ridge_penalty[i] /= scale_i * scale_i;
+        }
+        match &mut self.penalty {
+            CoxPenalty::Diagonal(values) => {
+                for (value, &scale) in values.iter_mut().zip(&self.scale) {
+                    *value /= scale * scale;
+                }
+            }
+            CoxPenalty::Dense(matrix) => {
+                for ((row, column), value) in matrix.indexed_iter_mut() {
+                    *value /= self.scale[row] * self.scale[column];
+                }
+            }
         }
     }
     fn cholesky(mat: &mut Array2<f64>, toler: f64) -> i32 {
@@ -1427,13 +1469,29 @@ impl CoxFit {
     }
     pub(crate) fn results(self) -> CoxFitResults {
         let mut log_likelihood = self.loglik;
-        log_likelihood[1] += 0.5
-            * self
+        let penalty = match &self.penalty {
+            CoxPenalty::Diagonal(values) => self
                 .beta
                 .iter()
-                .zip(&self.ridge_penalty)
-                .map(|(&coefficient, &penalty)| penalty * coefficient * coefficient)
-                .sum::<f64>();
+                .zip(values)
+                .map(|(&coefficient, &value)| value * coefficient * coefficient)
+                .sum::<f64>(),
+            CoxPenalty::Dense(matrix) => self
+                .beta
+                .iter()
+                .enumerate()
+                .map(|(row, &coefficient)| {
+                    coefficient
+                        * self
+                            .beta
+                            .iter()
+                            .enumerate()
+                            .map(|(column, &other)| matrix[(row, column)] * other)
+                            .sum::<f64>()
+                })
+                .sum::<f64>(),
+        };
+        log_likelihood[1] += 0.5 * penalty;
         (
             self.beta,
             self.means,

--- a/src/regression/coxph.rs
+++ b/src/regression/coxph.rs
@@ -626,8 +626,81 @@ fn validate_method_weights(method: CoxMethod, weights: Option<&[f64]>) -> PyResu
     Ok(())
 }
 
+fn validate_penalty_matrix(values: &[Vec<f64>], nvar: usize) -> PyResult<Array2<f64>> {
+    if values.len() != nvar || values.iter().any(|row| row.len() != nvar) {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "penalty_matrix must have shape ({nvar}, {nvar})"
+        )));
+    }
+    for (row_index, row) in values.iter().enumerate() {
+        validate_finite_values(&format!("penalty_matrix[{row_index}]"), row)?;
+    }
+
+    let scale = values
+        .iter()
+        .flatten()
+        .map(|value| value.abs())
+        .fold(0.0_f64, f64::max);
+    let tolerance = 1e-10 * scale.max(f64::MIN_POSITIVE);
+    let mut matrix = Array2::zeros((nvar, nvar));
+    for row in 0..nvar {
+        for column in 0..nvar {
+            let left = values[row][column];
+            let right = values[column][row];
+            if (left - right).abs() > tolerance {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "penalty_matrix must be symmetric",
+                ));
+            }
+            matrix[(row, column)] = 0.5 * (left + right);
+        }
+    }
+
+    // A diagonally pivoted LDL decomposition accepts positive-semidefinite
+    // matrices, including rank-deficient and badly scaled difference penalties.
+    let mut factor = matrix.clone();
+    for pivot_index in 0..nvar {
+        let largest_diagonal = (pivot_index..nvar)
+            .max_by(|&left, &right| factor[(left, left)].total_cmp(&factor[(right, right)]))
+            .unwrap_or(pivot_index);
+        if largest_diagonal != pivot_index {
+            for column in 0..nvar {
+                factor.swap((pivot_index, column), (largest_diagonal, column));
+            }
+            for row in 0..nvar {
+                factor.swap((row, pivot_index), (row, largest_diagonal));
+            }
+        }
+        let pivot = factor[(pivot_index, pivot_index)];
+        if pivot < -tolerance {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "penalty_matrix must be positive semidefinite",
+            ));
+        }
+        if pivot <= tolerance {
+            if (pivot_index..nvar).any(|row| {
+                (pivot_index..nvar).any(|column| factor[(row, column)].abs() > tolerance)
+            }) {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "penalty_matrix must be positive semidefinite",
+                ));
+            }
+            continue;
+        }
+        for row in (pivot_index + 1)..nvar {
+            for column in row..nvar {
+                let updated = factor[(row, column)]
+                    - factor[(row, pivot_index)] * factor[(column, pivot_index)] / pivot;
+                factor[(row, column)] = updated;
+                factor[(column, row)] = updated;
+            }
+        }
+    }
+    Ok(matrix)
+}
+
 #[pyfunction]
-#[pyo3(signature = (time, status, covariates, strata=None, weights=None, offset=None, initial_beta=None, max_iter=None, eps=None, toler=None, method=None, entry_times=None, nocenter=None, ridge_penalty=None))]
+#[pyo3(signature = (time, status, covariates, strata=None, weights=None, offset=None, initial_beta=None, max_iter=None, eps=None, toler=None, method=None, entry_times=None, nocenter=None, ridge_penalty=None, penalty_matrix=None))]
 #[allow(clippy::too_many_arguments)]
 pub fn coxph_fit(
     time: Vec<f64>,
@@ -644,6 +717,7 @@ pub fn coxph_fit(
     entry_times: Option<Vec<f64>>,
     nocenter: Option<Vec<f64>>,
     ridge_penalty: Option<Vec<f64>>,
+    penalty_matrix: Option<Vec<Vec<f64>>>,
 ) -> PyResult<CoxPHFit> {
     let n = time.len();
     if n == 0 {
@@ -740,6 +814,15 @@ pub fn coxph_fit(
             ));
         }
     }
+    if ridge_penalty.is_some() && penalty_matrix.is_some() {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "use only one of ridge_penalty or penalty_matrix",
+        ));
+    }
+    let penalty_matrix = penalty_matrix
+        .as_deref()
+        .map(|values| validate_penalty_matrix(values, nvar))
+        .transpose()?;
     if let Some(value) = eps
         && (!value.is_finite() || value <= 0.0)
     {
@@ -830,6 +913,8 @@ pub fn coxph_fit(
     })?;
     if let Some(values) = ridge_penalty.as_ref() {
         cox_fit.set_ridge_penalty(values);
+    } else if let Some(values) = penalty_matrix.as_ref() {
+        cox_fit.set_quadratic_penalty(values);
     }
     cox_fit
         .fit()
@@ -852,13 +937,23 @@ pub fn coxph_fit(
         .outer_iter()
         .map(|row| row.iter().copied().collect())
         .collect::<Vec<Vec<f64>>>();
-    let degrees_of_freedom = match ridge_penalty.as_ref() {
-        Some(penalty) => (0..nvar)
+    let degrees_of_freedom = if let Some(penalty) = ridge_penalty.as_ref() {
+        (0..nvar)
             .map(|column| (1.0 - penalty[column] * information_matrix[column][column]).max(0.0))
-            .sum(),
-        None => (0..nvar)
+            .sum()
+    } else if let Some(penalty) = penalty_matrix.as_ref() {
+        let trace = (0..nvar)
+            .flat_map(|row| {
+                let information_matrix = &information_matrix;
+                (0..nvar)
+                    .map(move |column| penalty[(row, column)] * information_matrix[column][row])
+            })
+            .sum::<f64>();
+        (nvar as f64 - trace).clamp(0.0, nvar as f64)
+    } else {
+        (0..nvar)
             .filter(|&column| information_matrix[column][column] != 0.0)
-            .count() as f64,
+            .count() as f64
     };
 
     Ok(CoxPHFit {
@@ -1127,6 +1222,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .expect("default-control Efron fit should succeed");
 
@@ -1168,6 +1264,7 @@ mod tests {
             None,
             None,
             Some(vec![0.2, 0.2]),
+            None,
         )
         .expect("ridge-penalized fit should succeed");
 
@@ -1187,6 +1284,73 @@ mod tests {
             &fit.log_likelihood,
             &[-8.034_979_350_644_857, -3.234_095_317_374_364_5],
         );
+    }
+
+    #[test]
+    fn quadratic_penalty_matches_r_pspline_reference_fit() {
+        let time = (1..=12).map(f64::from).collect();
+        let status = vec![1, 0, 1, 1, 0, 1, 0, 1, 1, 0, 1, 1];
+        let x = vec![1.2, 0.7, 1.5, 0.2, 1.1, 0.4, 1.8, 0.9, 0.5, 1.4, 0.3, 1.0];
+        let (full_basis, _) = crate::core::pspline::pspline_basis_core(&x, 4, 3, (0.2, 1.8))
+            .expect("P-spline basis should be valid");
+        let covariates = full_basis
+            .into_iter()
+            .map(|row| row.into_iter().skip(1).collect())
+            .collect();
+        let penalty = vec![
+            vec![5.0, -4.0, 1.0, 0.0, 0.0, 0.0],
+            vec![-4.0, 6.0, -4.0, 1.0, 0.0, 0.0],
+            vec![1.0, -4.0, 6.0, -4.0, 1.0, 0.0],
+            vec![0.0, 1.0, -4.0, 6.0, -4.0, 1.0],
+            vec![0.0, 0.0, 1.0, -4.0, 5.0, -2.0],
+            vec![0.0, 0.0, 0.0, 1.0, -2.0, 1.0],
+        ];
+
+        let fit = coxph_fit(
+            time,
+            status,
+            covariates,
+            None,
+            None,
+            None,
+            None,
+            Some(50),
+            Some(1e-10),
+            None,
+            Some("breslow"),
+            None,
+            None,
+            None,
+            Some(penalty),
+        )
+        .expect("quadratic-penalized fit should succeed");
+
+        assert_close_vec(
+            &fit.coefficients[0],
+            &[
+                -0.414_920_537_417_388_3,
+                -0.788_640_786_478_680_4,
+                -1.031_261_648_905_877,
+                -1.127_182_642_360_209,
+                -1.306_228_377_110_292_7,
+                -1.528_343_644_084_585,
+            ],
+        );
+        assert_close_vec(
+            &fit.log_likelihood,
+            &[-12.619_505_923_287_514, -12.317_017_585_688_493],
+        );
+        assert!((fit.degrees_of_freedom - 1.504_270_736_745_321_2).abs() < 1e-10);
+    }
+
+    #[test]
+    fn quadratic_penalty_validation_rejects_invalid_matrices() {
+        assert!(validate_penalty_matrix(&[vec![1.0, -1.0], vec![-1.0, 1.0]], 2).is_ok());
+        assert!(validate_penalty_matrix(&[vec![1e-12, 1e-6], vec![1e-6, 1.0]], 2).is_ok());
+        assert!(validate_penalty_matrix(&[vec![1.0], vec![0.0]], 2).is_err());
+        assert!(validate_penalty_matrix(&[vec![1.0, 0.0], vec![1.0, 1.0]], 2).is_err());
+        assert!(validate_penalty_matrix(&[vec![1.0, 2.0], vec![2.0, 1.0]], 2).is_err());
+        assert!(validate_penalty_matrix(&[vec![1e-12, 2e-12], vec![2e-12, 1e-12]], 2).is_err());
     }
 
     #[test]
@@ -1244,6 +1408,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             )
             .expect("tied Cox fit should succeed");
             let actual = fit
@@ -1265,6 +1430,7 @@ mod tests {
             None,
             Some("efron"),
             Some(vec![0.0, 0.0, 0.0, 1.0, 1.0, 2.0, 3.0, 4.0]),
+            None,
             None,
             None,
         )
@@ -1318,6 +1484,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             )
             .expect("near-collinear fit should succeed")
         };
@@ -1360,6 +1527,7 @@ mod tests {
             None,
             None,
             Some("breslow"),
+            None,
             None,
             None,
             None,

--- a/src/regression/longitudinal_survival.rs
+++ b/src/regression/longitudinal_survival.rs
@@ -500,6 +500,7 @@ pub fn landmark_cox_analysis(
         None,
         None,
         None,
+        None,
     )?;
     let coefficients = fit.coefficients.first().cloned().unwrap_or_default();
     let standard_errors = (0..n_features)
@@ -754,6 +755,7 @@ fn fit_time_varying_interval(
         None,
         Some("efron"),
         Some(interval_rows.iter().map(|&idx| start_time[idx]).collect()),
+        None,
         None,
         None,
     )?;

--- a/src/regression/recurrent_events/anderson_gill.rs
+++ b/src/regression/recurrent_events/anderson_gill.rs
@@ -45,6 +45,7 @@ pub fn anderson_gill_model(
         Some(start),
         None,
         None,
+        None,
     )?;
     let beta = fit.coefficients.first().cloned().unwrap_or_default();
     let covariance = fit.information_matrix.clone();

--- a/src/regression/recurrent_events/pwp.rs
+++ b/src/regression/recurrent_events/pwp.rs
@@ -151,6 +151,7 @@ pub fn pwp_model(
         entry_times,
         None,
         None,
+        None,
     )?;
     let beta = fit.coefficients.first().cloned().unwrap_or_default();
     let covariance = fit.information_matrix.clone();

--- a/src/regression/recurrent_events/wlw.rs
+++ b/src/regression/recurrent_events/wlw.rs
@@ -109,6 +109,7 @@ pub fn wlw_model(
         None,
         None,
         None,
+        None,
     )?;
     let beta = fit.coefficients.first().cloned().unwrap_or_default();
     let covariance = fit.information_matrix.clone();


### PR DESCRIPTION
## Summary
- extend the Cox Newton optimizer from diagonal ridge penalties to full symmetric quadratic penalties
- expose penalty_matrix through the native and Python Cox APIs with shape, finiteness, symmetry, and positive-semidefinite validation
- report effective degrees of freedom using the full trace correction while preserving the fast diagonal path for ordinary and ridge fits
- update internal callers, type stubs, binding contracts, and benchmark targets

## Reference validation
- matches survival::coxph P-spline coefficients, partial log-likelihood, and effective degrees of freedom to numerical precision
- accepts rank-deficient and badly scaled positive-semidefinite difference penalties
- fits a 100,000-row, five-covariate dense-penalty smoke benchmark in about 0.020 seconds

## Testing
- cargo test --all-features: 1,734 passed
- cargo clippy --all-targets --all-features -- -D warnings
- cargo check --all-features --benches
- python -m pytest -q python/tests: 918 passed, 18 skipped
- Ruff format and lint checks
- mypy stub check
- git diff --check