### PR TITLE
Select Gaussian frailty variance by AIC

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -391,6 +391,7 @@ class _FrailtyPenaltyBlock:
     target_df: float | None
     eps: float
     initial_theta: float
+    selection: str
 
 
 @dataclass(frozen=True)
@@ -3602,9 +3603,15 @@ def _parse_frailty_formula_term(term: str) -> _FrailtyFormulaTerm:
         if df <= 0.0:
             raise ValueError("frailty df must be positive")
         selection = "df"
+    elif method == "aic":
+        if theta is not None:
+            raise ValueError("AIC Gaussian frailty cannot include theta")
+        if df not in {None, 0.0}:
+            raise ValueError("AIC Gaussian frailty df must be zero")
+        selection = "aic"
     else:
         raise NotImplementedError(
-            "Gaussian frailty formulas currently support fixed theta or target df"
+            "Gaussian frailty formulas currently support fixed theta, target df, or AIC"
         )
     if theta is not None and theta <= 0.0:
         raise ValueError("frailty theta must be positive")
@@ -4480,10 +4487,13 @@ def _frailty_formula_blocks(design: _FormulaDesign, n: int) -> list[_FrailtyPena
         if isinstance(term, _FrailtyDesignTerm):
             initial_theta = term.formula.theta
             if initial_theta is None:
-                target_df = term.formula.target_df
-                if target_df is None:
-                    raise AssertionError("Gaussian frailty smoothing target is missing")
-                initial_theta = 3.0 * target_df / n
+                if term.formula.selection == "aic":
+                    initial_theta = 0.1
+                else:
+                    target_df = term.formula.target_df
+                    if target_df is None:
+                        raise AssertionError("Gaussian frailty smoothing target is missing")
+                    initial_theta = 3.0 * target_df / n
             blocks.append(
                 _FrailtyPenaltyBlock(
                     label=term.formula.label,
@@ -4492,6 +4502,7 @@ def _frailty_formula_blocks(design: _FormulaDesign, n: int) -> list[_FrailtyPena
                     target_df=term.formula.target_df,
                     eps=term.formula.eps,
                     initial_theta=initial_theta,
+                    selection=term.formula.selection,
                 )
             )
         cursor += width
@@ -4720,7 +4731,7 @@ def _ridge_control_next_theta(
     return theta, converged, 0
 
 
-def _pspline_aic_history_row(
+def _penalty_aic_history_row(
     theta: float,
     log_likelihood: float,
     degrees_of_freedom: float,
@@ -4750,8 +4761,8 @@ def _pspline_aic_history_row(
 def _frailty_brent(
     theta: Sequence[float],
     criterion: Sequence[float],
-    lower: float,
-    upper: float,
+    lower: float | None,
+    upper: float | None,
 ) -> float:
     if len(theta) != len(criterion):
         raise ValueError("theta and criterion histories must have equal lengths")
@@ -4767,12 +4778,12 @@ def _frailty_brent(
     center = best[0]
     if center == 0:
         new_theta = x[0] - 3.0 * (x[1] - x[0])
-        if new_theta < lower:
+        if lower is not None and new_theta < lower:
             new_theta = lower + (min(value for value in x if value > lower) - lower) / 10.0
         return new_theta
     if center == len(x) - 1:
         new_theta = x[-1] + 3.0 * (x[-1] - x[-2])
-        if new_theta > upper:
+        if upper is not None and new_theta > upper:
             new_theta = upper + (max(value for value in x if value < upper) - upper) / 10.0
         return new_theta
 
@@ -4813,6 +4824,26 @@ def _pspline_aic_next_theta(
         new_theta = 2.0 * max(theta)
     else:
         new_theta = _frailty_brent(theta, criterion, 0.0, 1.0)
+    return new_theta, converged
+
+
+def _frailty_aic_next_theta(
+    eps: float,
+    iteration: int,
+    history: Sequence[Mapping[str, float]],
+) -> tuple[float, bool]:
+    if iteration == 1:
+        return 1.0, False
+    theta = [float(row["theta"]) for row in history]
+    if iteration == 2:
+        return math.fsum(theta) / len(theta), False
+    criterion = [float(row["aic"]) for row in history]
+    previous = criterion[-2]
+    converged = previous != 0.0 and abs(1.0 - criterion[-1] / previous) < eps
+    if theta[-1] == max(criterion) and theta[-1] == max(theta):
+        new_theta = 2.0 * max(theta)
+    else:
+        new_theta = _frailty_brent(theta, criterion, 0.0, None)
     return new_theta, converged
 
 
@@ -23486,9 +23517,18 @@ def coxph(
     target_frailty_blocks = [
         index for index, block in enumerate(formula_frailty_blocks) if block.target_df is not None
     ]
+    aic_frailty_blocks = [
+        index for index, block in enumerate(formula_frailty_blocks) if block.selection == "aic"
+    ]
     ridge_history: dict[str, dict[str, Any]] | None = None
     reported_log_likelihood: list[float] | None = None
-    if target_ridge_blocks or target_pspline_blocks or aic_pspline_blocks or target_frailty_blocks:
+    if (
+        target_ridge_blocks
+        or target_pspline_blocks
+        or aic_pspline_blocks
+        or target_frailty_blocks
+        or aic_frailty_blocks
+    ):
         ridge_histories = [
             [(0.0, float(len(block.columns)))] if block.target_df is not None else []
             for block in formula_ridge_blocks
@@ -23503,12 +23543,15 @@ def coxph(
         frailty_histories = [
             [(0.0, 0.0)] if block.target_df is not None else [] for block in formula_frailty_blocks
         ]
+        frailty_aic_histories: list[list[dict[str, float]]] = [
+            [] for _block in formula_frailty_blocks
+        ]
         ridge_halves = [0] * len(formula_ridge_blocks)
         pspline_halves = [0] * len(formula_pspline_blocks)
         frailty_halves = [0] * len(formula_frailty_blocks)
         ridge_done = [block.target_df is None for block in formula_ridge_blocks]
         pspline_done = [block.selection == "fixed" for block in formula_pspline_blocks]
-        frailty_done = [block.target_df is None for block in formula_frailty_blocks]
+        frailty_done = [block.selection == "fixed" for block in formula_frailty_blocks]
         event_count = sum(int(value) for value in response.event)
         start = initial_values
         initial_log_likelihood = None
@@ -23605,7 +23648,7 @@ def coxph(
                     block.columns,
                 )
                 pspline_aic_histories[block_index].append(
-                    _pspline_aic_history_row(
+                    _penalty_aic_history_row(
                         fitted_pspline_thetas[block_index],
                         float(fit.log_likelihood[-1]),
                         term_df,
@@ -23644,6 +23687,33 @@ def coxph(
                 next_frailty_thetas[block_index] = max(next_theta, 1e-12)
                 frailty_done[block_index] = converged
                 frailty_halves[block_index] = half
+            for block_index in aic_frailty_blocks:
+                block = formula_frailty_blocks[block_index]
+                if fit_penalty_matrix is None:
+                    raise AssertionError(
+                        "Gaussian frailty AIC selection requires a quadratic penalty"
+                    )
+                term_df = _quadratic_term_degrees_of_freedom(
+                    fit,
+                    fit_penalty_matrix,
+                    block.columns,
+                )
+                frailty_aic_histories[block_index].append(
+                    _penalty_aic_history_row(
+                        fitted_frailty_thetas[block_index],
+                        float(fit.log_likelihood[-1]),
+                        term_df,
+                        event_count,
+                    )
+                )
+                next_theta, converged = _frailty_aic_next_theta(
+                    block.eps,
+                    outer_iteration,
+                    frailty_aic_histories[block_index],
+                )
+                next_reported_frailty_thetas[block_index] = next_theta
+                next_frailty_thetas[block_index] = max(next_theta, 1e-12)
+                frailty_done[block_index] = converged
             reported_ridge_thetas = next_ridge_thetas
             reported_pspline_thetas = next_reported_pspline_thetas
             reported_frailty_thetas = next_reported_frailty_thetas
@@ -23739,7 +23809,15 @@ def coxph(
                         "half": frailty_halves[index],
                     }
                     if block.target_df is not None
-                    else {"theta": frailty_thetas[index], "done": True}
+                    else (
+                        {
+                            "theta": reported_frailty_thetas[index],
+                            "done": frailty_done[index],
+                            "history": frailty_aic_histories[index],
+                        }
+                        if block.selection == "aic"
+                        else {"theta": frailty_thetas[index], "done": True}
+                    )
                 )
                 for index, block in enumerate(formula_frailty_blocks)
             }

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -9710,13 +9710,15 @@ def test_coxph_formula_gaussian_frailty_rejects_unsupported_modes():
     for option, exception, message in (
         ("distribution='gamma',theta=.5", NotImplementedError, "only distribution"),
         ("distribution='gaussian'", NotImplementedError, "fixed theta"),
-        ("distribution='gaussian',method='aic'", NotImplementedError, "fixed theta"),
+        ("distribution='gaussian',method='reml'", NotImplementedError, "fixed theta"),
         ("distribution='gaussian',method='fixed'", ValueError, "requires theta"),
         ("distribution='gaussian',method='df'", ValueError, "requires df"),
         ("distribution='gaussian',theta=0", ValueError, "positive"),
         ("distribution='gaussian',df=-1", ValueError, "positive"),
         ("distribution='gaussian',df=2,eps=0", ValueError, "positive"),
         ("distribution='gaussian',theta=.5,df=2", ValueError, "both"),
+        ("distribution='gaussian',method='aic',theta=.5", ValueError, "cannot include theta"),
+        ("distribution='gaussian',method='aic',df=2", ValueError, "must be zero"),
         ("distribution='gaussian',df=6,sparse=False", ValueError, "between"),
         ("distribution='gaussian',theta=.5,sparse=True", NotImplementedError, "sparse"),
     ):
@@ -9803,6 +9805,78 @@ def test_coxph_formula_gaussian_frailty_calibrates_target_df_reference():
     ) == pytest.approx([-0.0770749029582383, -0.288527919654661], abs=1e-12)
 
 
+def test_coxph_formula_gaussian_frailty_selects_variance_by_aic_reference():
+    data = {
+        "time": [float(value) for value in range(1, 13)],
+        "status": [1, 0, 1, 1, 0, 1, 0, 1, 1, 0, 1, 1],
+        "x": [1.2, 0.7, 1.5, 0.2, 1.1, 0.4, 1.8, 0.9, 0.5, 1.4, 0.3, 1.0],
+        "g": list("abcd") * 3,
+    }
+    frailty_term = 'frailty(g,distribution="gaussian",df=0,eps=1e-5,sparse=False)'
+    fit = survival.coxph(
+        f"Surv(time,status) ~ x + {frailty_term}",
+        data=data,
+        ties="breslow",
+        control={"iter.max": 50, "outer.max": 30, "eps": 1e-10},
+    )
+
+    assert fit.coefficients[0] == pytest.approx(
+        [
+            -0.594635689882725,
+            6.30802133373296e-07,
+            -2.68305721642421e-07,
+            -1.56466049342734e-07,
+            -2.0603036238814e-07,
+        ],
+        abs=1e-12,
+    )
+    assert fit.log_likelihood == pytest.approx(
+        [-11.6900898701181, -12.3745229008121],
+        abs=1e-12,
+    )
+    assert fit.term_degrees_of_freedom == pytest.approx(
+        {"x": 0.999999826778145, frailty_term: 4.72923581254938e-06},
+        abs=1e-12,
+    )
+    history = fit.history[frailty_term]
+    assert history["theta"] == pytest.approx(1e-7, abs=1e-18)
+    assert history["done"] is True
+    assert [row["theta"] for row in history["history"]] == pytest.approx(
+        [0.1, 1.0, 0.55, 0.01, 0.001, 0.0001, 0.00001, 0.000001],
+        abs=1e-15,
+    )
+    assert history["history"][0] == pytest.approx(
+        {
+            "theta": 0.1,
+            "loglik": -12.3302130527257,
+            "df": 0.407054874024239,
+            "aic": -12.7372679267499,
+            "aicc": -13.3428269330076,
+        },
+        abs=1e-12,
+    )
+    assert history["history"][-1] == pytest.approx(
+        {
+            "theta": 1e-6,
+            "loglik": -12.3745229008121,
+            "df": 4.72923581254938e-06,
+            "aic": -12.3745276300479,
+            "aicc": -12.7078635907402,
+        },
+        abs=1e-12,
+    )
+
+    method_alias = survival.coxph(
+        "Surv(time,status) ~ x + "
+        'frailty(g,distribution="gaussian",method="aic",eps=1e-5,sparse=False)',
+        data=data,
+        ties="breslow",
+        control={"iter.max": 50, "outer.max": 30, "eps": 1e-10},
+    )
+    assert method_alias.coefficients[0] == pytest.approx(fit.coefficients[0], abs=1e-12)
+    assert method_alias.log_likelihood == pytest.approx(fit.log_likelihood, abs=1e-12)
+
+
 def test_coxph_formula_pspline_calibrates_target_df_against_reference():
     data = {
         "time": [float(value) for value in range(1, 13)],
@@ -9869,7 +9943,7 @@ def test_penalty_df_controller_safeguards_nonmonotone_history_boundary():
     assert theta == pytest.approx(1.5)
     assert done is False
     assert half == 1
-    assert survival.r_api._pspline_aic_history_row(0.5, -3.0, 2.0, 4)["aicc"] == -math.inf
+    assert survival.r_api._penalty_aic_history_row(0.5, -3.0, 2.0, 4)["aicc"] == -math.inf
 
 
 def test_coxph_formula_pspline_selects_smoothing_by_aic_reference():


### PR DESCRIPTION
## Summary
- support Gaussian frailty selection through df=0 and method='aic'
- use reference 0.1/1.0 probes, midpoint initialization, and lower-bounded variance search
- share event-count AIC/AICc history construction across penalized formula terms
- preserve unbounded upper expansion for frailty variance while retaining bounded spline search
- expose fitted history separately from the controller's final reported proposal

## Reference validation
- matches survival::coxph coefficients, likelihoods, effective df, and the complete eight-row AIC/AICc history
- matches both df=0 and method='aic' spellings
- 100,000-row AIC search completes three warm-started fits in about 0.22 seconds

## Testing
- python -m pytest -q python/tests: 928 passed, 18 skipped
- focused AIC trajectory, alias, validation, fixed-theta, target-df, and spline AIC regression coverage
- Ruff format and lint checks
- git diff --check
- parent native suite: 1,734 passed