### PR TITLE
Select Gaussian frailty variance by REML

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -3539,7 +3539,7 @@ def _parse_frailty_formula_term(term: str) -> _FrailtyFormulaTerm:
     df: float | None = None
     method: str | None = None
     sparse: bool | None = None
-    eps = 0.1
+    eps: float | None = None
     saw_option = False
     seen_options: set[str] = set()
     for part in parts:
@@ -3591,7 +3591,7 @@ def _parse_frailty_formula_term(term: str) -> _FrailtyFormulaTerm:
             method = "reml"
     if theta is not None and df is not None:
         raise ValueError("Gaussian frailty cannot include both theta and df")
-    if eps <= 0.0:
+    if eps is not None and eps <= 0.0:
         raise ValueError("frailty eps must be positive")
     if method == "fixed":
         if theta is None:
@@ -3609,12 +3609,18 @@ def _parse_frailty_formula_term(term: str) -> _FrailtyFormulaTerm:
         if df not in {None, 0.0}:
             raise ValueError("AIC Gaussian frailty df must be zero")
         selection = "aic"
+    elif method == "reml":
+        if theta is not None or df is not None:
+            raise ValueError("REML Gaussian frailty cannot include theta or df")
+        selection = "reml"
     else:
         raise NotImplementedError(
-            "Gaussian frailty formulas currently support fixed theta, target df, or AIC"
+            "Gaussian frailty formulas support fixed theta, target df, AIC, or REML"
         )
     if theta is not None and theta <= 0.0:
         raise ValueError("frailty theta must be positive")
+    if eps is None:
+        eps = 0.1 if selection in {"fixed", "df"} else 1e-5
     return _FrailtyFormulaTerm(
         term=_CovariateTerm(column, transform="frailty"),
         distribution=distribution,
@@ -4489,6 +4495,8 @@ def _frailty_formula_blocks(design: _FormulaDesign, n: int) -> list[_FrailtyPena
             if initial_theta is None:
                 if term.formula.selection == "aic":
                     initial_theta = 0.1
+                elif term.formula.selection == "reml":
+                    initial_theta = 1.0
                 else:
                     target_df = term.formula.target_df
                     if target_df is None:
@@ -4844,6 +4852,87 @@ def _frailty_aic_next_theta(
         new_theta = 2.0 * max(theta)
     else:
         new_theta = _frailty_brent(theta, criterion, 0.0, None)
+    return new_theta, converged
+
+
+def _frailty_reml_history_row(
+    fit: Any,
+    columns: Sequence[int],
+    theta: float,
+) -> dict[str, float]:
+    coefficients = [float(fit.coefficients[0][column]) for column in columns]
+    center = math.fsum(coefficients) / len(coefficients)
+    fsum = math.fsum((coefficient - center) ** 2 for coefficient in coefficients)
+    trace = math.fsum(float(fit.information_matrix[column][column]) for column in columns)
+    degrees_of_freedom = len(columns) - trace / theta
+    residual = fsum / degrees_of_freedom - theta
+    return {"theta": theta, "resid": residual, "fsum": fsum, "trace": trace}
+
+
+def _frailty_reml_fallback_theta(history: Sequence[Mapping[str, float]]) -> float:
+    ordered = sorted((float(row["theta"]), float(row["resid"])) for row in history)
+    for (left_theta, left_residual), (right_theta, right_residual) in zip(
+        ordered,
+        ordered[1:],
+        strict=False,
+    ):
+        if left_residual * right_residual <= 0.0:
+            return (left_theta + right_theta) / 2.0
+    theta, residual = ordered[-1]
+    return theta * 2.0 if residual > 0.0 else theta / 2.0
+
+
+def _frailty_reml_next_theta(
+    eps: float,
+    iteration: int,
+    history: Sequence[Mapping[str, float]],
+) -> tuple[float, bool]:
+    current_theta = float(history[-1]["theta"])
+    current_residual = float(history[-1]["resid"])
+    if iteration == 1:
+        return current_theta * 3.0 if current_residual > 0.0 else current_theta / 3.0, False
+
+    residuals = [float(row["resid"]) for row in history]
+    if iteration == 2:
+        if all(residual > 0.0 for residual in residuals):
+            return current_theta * 2.0, False
+        if all(residual < 0.0 for residual in residuals):
+            return current_theta / 2.0, False
+        return math.fsum(float(row["theta"]) for row in history) / len(history), False
+
+    converged = abs(current_residual) < eps
+    theta = [float(row["theta"]) for row in history]
+    if all(residual > 0.0 for residual in residuals):
+        return 2.0 * max(theta), converged
+    if all(residual < 0.0 for residual in residuals):
+        return 0.5 * min(theta), converged
+
+    order = sorted(range(len(history)), key=theta.__getitem__)
+    ordered_theta = [theta[index] for index in order]
+    ordered_residual = [residuals[index] for index in order]
+    center = order.index(len(history) - 1)
+    if center == 0:
+        center = 1
+    elif center == len(history) - 1:
+        center -= 1
+    try:
+        ratio_right = ordered_residual[center] / ordered_residual[center + 1]
+        ratio_left = ordered_residual[center] / ordered_residual[center - 1]
+        ratio = ratio_right / ratio_left
+        numerator = ratio_left * (
+            ratio * (ratio_right - ratio) * (ordered_theta[center + 1] - ordered_theta[center])
+            - (1.0 - ratio_right) * (ordered_theta[center] - ordered_theta[center - 1])
+        )
+        denominator = (ratio - 1.0) * (ratio_right - 1.0) * (ratio_left - 1.0)
+        new_theta = ordered_theta[center] + numerator / denominator
+    except (ValueError, ZeroDivisionError, OverflowError):
+        new_theta = _frailty_reml_fallback_theta(history)
+    if not math.isfinite(new_theta) or new_theta <= 0.0:
+        new_theta = _frailty_reml_fallback_theta(history)
+    elif new_theta > ordered_theta[center + 1]:
+        new_theta = (ordered_theta[center] + ordered_theta[center + 1]) / 2.0
+    elif new_theta < ordered_theta[center - 1]:
+        new_theta = (ordered_theta[center - 1] + ordered_theta[center]) / 2.0
     return new_theta, converged
 
 
@@ -23520,6 +23609,9 @@ def coxph(
     aic_frailty_blocks = [
         index for index, block in enumerate(formula_frailty_blocks) if block.selection == "aic"
     ]
+    reml_frailty_blocks = [
+        index for index, block in enumerate(formula_frailty_blocks) if block.selection == "reml"
+    ]
     ridge_history: dict[str, dict[str, Any]] | None = None
     reported_log_likelihood: list[float] | None = None
     if (
@@ -23528,6 +23620,7 @@ def coxph(
         or aic_pspline_blocks
         or target_frailty_blocks
         or aic_frailty_blocks
+        or reml_frailty_blocks
     ):
         ridge_histories = [
             [(0.0, float(len(block.columns)))] if block.target_df is not None else []
@@ -23544,6 +23637,9 @@ def coxph(
             [(0.0, 0.0)] if block.target_df is not None else [] for block in formula_frailty_blocks
         ]
         frailty_aic_histories: list[list[dict[str, float]]] = [
+            [] for _block in formula_frailty_blocks
+        ]
+        frailty_reml_histories: list[list[dict[str, float]]] = [
             [] for _block in formula_frailty_blocks
         ]
         ridge_halves = [0] * len(formula_ridge_blocks)
@@ -23714,6 +23810,23 @@ def coxph(
                 next_reported_frailty_thetas[block_index] = next_theta
                 next_frailty_thetas[block_index] = max(next_theta, 1e-12)
                 frailty_done[block_index] = converged
+            for block_index in reml_frailty_blocks:
+                block = formula_frailty_blocks[block_index]
+                frailty_reml_histories[block_index].append(
+                    _frailty_reml_history_row(
+                        fit,
+                        block.columns,
+                        fitted_frailty_thetas[block_index],
+                    )
+                )
+                next_theta, converged = _frailty_reml_next_theta(
+                    block.eps,
+                    outer_iteration,
+                    frailty_reml_histories[block_index],
+                )
+                next_reported_frailty_thetas[block_index] = next_theta
+                next_frailty_thetas[block_index] = max(next_theta, 1e-12)
+                frailty_done[block_index] = converged
             reported_ridge_thetas = next_ridge_thetas
             reported_pspline_thetas = next_reported_pspline_thetas
             reported_frailty_thetas = next_reported_frailty_thetas
@@ -23816,7 +23929,15 @@ def coxph(
                             "history": frailty_aic_histories[index],
                         }
                         if block.selection == "aic"
-                        else {"theta": frailty_thetas[index], "done": True}
+                        else (
+                            {
+                                "theta": reported_frailty_thetas[index],
+                                "done": frailty_done[index],
+                                "history": frailty_reml_histories[index],
+                            }
+                            if block.selection == "reml"
+                            else {"theta": frailty_thetas[index], "done": True}
+                        )
                     )
                 )
                 for index, block in enumerate(formula_frailty_blocks)

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -9709,8 +9709,9 @@ def test_coxph_formula_gaussian_frailty_rejects_unsupported_modes():
     }
     for option, exception, message in (
         ("distribution='gamma',theta=.5", NotImplementedError, "only distribution"),
-        ("distribution='gaussian'", NotImplementedError, "fixed theta"),
-        ("distribution='gaussian',method='reml'", NotImplementedError, "fixed theta"),
+        ("distribution='gaussian',method='ml'", NotImplementedError, "support fixed"),
+        ("distribution='gaussian',method='reml',theta=.5", ValueError, "cannot include"),
+        ("distribution='gaussian',method='reml',df=2", ValueError, "cannot include"),
         ("distribution='gaussian',method='fixed'", ValueError, "requires theta"),
         ("distribution='gaussian',method='df'", ValueError, "requires df"),
         ("distribution='gaussian',theta=0", ValueError, "positive"),
@@ -9875,6 +9876,133 @@ def test_coxph_formula_gaussian_frailty_selects_variance_by_aic_reference():
     )
     assert method_alias.coefficients[0] == pytest.approx(fit.coefficients[0], abs=1e-12)
     assert method_alias.log_likelihood == pytest.approx(fit.log_likelihood, abs=1e-12)
+
+
+def test_coxph_formula_gaussian_frailty_selects_variance_by_reml_reference():
+    data = {
+        "time": [float(value) for value in range(1, 13)],
+        "status": [1, 0, 1, 1, 0, 1, 0, 1, 1, 0, 1, 1],
+        "x": [1.2, 0.7, 1.5, 0.2, 1.1, 0.4, 1.8, 0.9, 0.5, 1.4, 0.3, 1.0],
+        "g": list("abcd") * 3,
+    }
+    frailty_term = 'frailty(g,distribution="gaussian",eps=1e-8,sparse=False)'
+    fit = survival.coxph(
+        f"Surv(time,status) ~ x + {frailty_term}",
+        data=data,
+        ties="breslow",
+        control={"iter.max": 50, "outer.max": 30, "eps": 1e-10},
+    )
+
+    assert fit.coefficients[0] == pytest.approx(
+        [
+            -0.594635790457627,
+            6.26646469092777e-09,
+            -2.66538075201931e-09,
+            -1.55435294924874e-09,
+            -2.04673098965972e-09,
+        ],
+        abs=1e-14,
+    )
+    assert fit.log_likelihood == pytest.approx(
+        [-16.2952600561062, -12.3745234323089],
+        abs=1e-12,
+    )
+    assert fit.term_degrees_of_freedom == pytest.approx(
+        {"x": 0.999999998279189, frailty_term: 4.698081260588e-08},
+        abs=5e-15,
+    )
+    history = fit.history[frailty_term]
+    assert history["theta"] == pytest.approx(4.96705373128255e-09, abs=1e-20)
+    assert history["done"] is True
+    assert len(history["history"]) == 27
+    assert history["history"][0] == pytest.approx(
+        {
+            "theta": 1.0,
+            "resid": -0.951019400228325,
+            "fsum": 0.0890149835387062,
+            "trace": 2.18264815143848,
+        },
+        abs=1e-12,
+    )
+    assert history["history"][-1] == pytest.approx(
+        {
+            "theta": 9.9341074625651e-09,
+            "resid": -8.8064565939002e-09,
+            "fsum": 5.29779551107513e-17,
+            "trace": 3.9736429383548e-08,
+        },
+        abs=1e-15,
+    )
+    assert [row[index] for index, row in enumerate(survival.vcov(fit))] == pytest.approx(
+        [
+            0.757893891710502,
+            9.93410736018337e-09,
+            9.93410736869208e-09,
+            9.93410733434179e-09,
+            9.93410732033074e-09,
+        ],
+        abs=1e-14,
+    )
+
+    method_alias = survival.coxph(
+        "Surv(time,status) ~ x + "
+        'frailty(g,distribution="gaussian",method="reml",eps=1e-8,sparse=False)',
+        data=data,
+        ties="breslow",
+        control={"iter.max": 50, "outer.max": 30, "eps": 1e-10},
+    )
+    assert method_alias.coefficients[0] == pytest.approx(fit.coefficients[0], abs=1e-14)
+
+    default_term = 'frailty(g,distribution="gaussian",sparse=False)'
+    with pytest.warns(RuntimeWarning, match="did not converge"):
+        default = survival.coxph(f"Surv(time,status) ~ x + {default_term}", data=data)
+    assert default.history[default_term]["theta"] == pytest.approx(0.000651041666666667)
+    assert default.history[default_term]["done"] is False
+    assert len(default.history[default_term]["history"]) == 10
+
+
+def test_coxph_formula_gaussian_frailty_reml_interpolates_bracketed_variance():
+    group = [level for level in "abcd" for _ in range(8)]
+    within_group = list(range(1, 9)) * 4
+    scales = [1.0] * 8 + [1.4] * 8 + [2.0] * 8 + [3.0] * 8
+    data = {
+        "time": [value * scale for value, scale in zip(within_group, scales, strict=True)],
+        "status": [1] * 32,
+        "g": group,
+    }
+    frailty_term = 'frailty(g,distribution="gaussian",eps=1e-7,sparse=False)'
+    fit = survival.coxph(
+        f"Surv(time,status) ~ {frailty_term}",
+        data=data,
+        control={"iter.max": 50, "outer.max": 30, "eps": 1e-10},
+    )
+
+    assert fit.coefficients[0] == pytest.approx(
+        [0.85744529968117, 0.353362586933522, -0.246510407574222, -0.96429747904047],
+        abs=1e-12,
+    )
+    assert fit.log_likelihood == pytest.approx(
+        [-85.2337135889337, -74.4461748981272],
+        abs=1e-12,
+    )
+    history = fit.history[frailty_term]
+    assert history["theta"] == pytest.approx(0.751556384595393, abs=1e-12)
+    assert history["done"] is True
+    assert [row["theta"] for row in history["history"]] == pytest.approx(
+        [1.0, 1.0 / 3.0, 2.0 / 3.0, 0.762850856958159, 0.751444483021004, 0.751556455642174],
+        abs=1e-12,
+    )
+    assert [row["resid"] for row in history["history"]] == pytest.approx(
+        [
+            -0.192335663309711,
+            0.228278667100855,
+            0.0593344640977733,
+            -0.00819315206454252,
+            8.08518529218372e-05,
+            -5.13351791076033e-08,
+        ],
+        abs=1e-12,
+    )
 
 
 def test_coxph_formula_pspline_calibrates_target_df_against_reference():


### PR DESCRIPTION
## Summary
- make REML the default Gaussian frailty variance selector
- port residual updates from centered random-effect sums and covariance traces
- preserve one-third, halving, expansion, bracketing, and rational interpolation steps
- retain the controller's post-fit variance proposal and full theta/residual/fsum/trace history
- apply selection-specific convergence defaults while preserving df controller behavior

## Reference validation
- matches survival::coxph's 27-step near-zero boundary trajectory, coefficients, likelihoods, covariance, and effective df
- matches a six-step bracketed interior optimum including rational interpolation
- matches explicit method='reml' and default outer-limit behavior
- 100,000-row REML fit: 14 warm-started fits in about 0.40 seconds at eps=1e-4

## Testing
- python -m pytest -q python/tests: 930 passed, 18 skipped
- focused boundary, bracketed optimum, default limit, AIC, target-df, fixed-theta, and spline regression coverage
- Ruff format and lint checks
- git diff --check
- parent native suite: 1,734 passed