### PR TITLE
Use effective df in penalized Cox diagnostics

### DIFF
--- a/python/survival/_binding_manifest.py
+++ b/python/survival/_binding_manifest.py
@@ -553,6 +553,7 @@ BINDINGS = (
     "cause_specific_cox_all",
     "cch_borgan_fit",
     "cch_fit",
+    "chi_square_survival",
     "cipoisson",
     "cipoisson_anscombe",
     "cipoisson_exact",

--- a/python/survival/_survival.pyi
+++ b/python/survival/_survival.pyi
@@ -1137,6 +1137,7 @@ class CoxPHFrailtyFit:
         information_matrix: list[list[float]],
         single_df: bool,
         global_test: bool,
+        penalty_matrix: list[list[float]] | None = None,
     ) -> tuple[list[list[float]], ProportionalityTest]: ...
     def partial_residuals(self) -> list[list[float]]: ...
     def score_residuals(self) -> list[list[float]]: ...
@@ -1212,6 +1213,7 @@ class CoxPHFit:
         information_matrix: list[list[float]],
         single_df: bool,
         global_test: bool,
+        penalty_matrix: list[list[float]] | None = None,
     ) -> tuple[list[list[float]], ProportionalityTest]: ...
     def partial_residuals(self) -> list[list[float]]: ...
     @property
@@ -7358,6 +7360,7 @@ def cox_dfbeta_from_score_residuals(
     information_matrix: list[list[float]],
     scaled: bool = False,
 ) -> list[list[float]]: ...
+def chi_square_survival(statistic: float, degrees_of_freedom: float) -> float: ...
 def cox_zph_term_matrix(
     scaled: list[list[float]],
     groups: list[list[int]],

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -426,6 +426,7 @@ class _FormulaFit:
     effective_degrees_of_freedom: float | None = None
     term_degrees_of_freedom: dict[str, float] | None = None
     reported_log_likelihood: list[float] | None = None
+    penalty_matrix: list[list[float]] | None = None
     conditional_logistic: bool = False
     n_observations: int | None = None
     sparse_frailty: _SparseFrailtyFitMetadata | None = None
@@ -977,7 +978,7 @@ class TMergeFrame(Mapping[str, list[Any]]):
 class CoxZPHResult:
     variable_names: list[str]
     chi2_values: list[float]
-    df: list[int]
+    df: list[float | int]
     p_values: list[float]
     x: list[float]
     time: list[float]
@@ -985,7 +986,7 @@ class CoxZPHResult:
     var: list[list[float]]
     transform: str
     global_chi2: float | None
-    global_df: int | None
+    global_df: float | int | None
     global_p_value: float | None
     strata: list[Any] | None = None
 
@@ -15869,6 +15870,7 @@ def cox_zph(
             [[float(value) for value in row] for row in variance],
             single_df,
             include_global,
+            fit.penalty_matrix if isinstance(fit, _FormulaFit) else None,
         )
         grouped_y = [[float(value) for value in row] for row in grouped_result]
         if len(event_indices) != len(grouped_y):
@@ -15900,19 +15902,60 @@ def cox_zph(
             if group_terms and groups
             else _matrix_columns(scaled, [idx for _name, columns in groups for idx in columns])
         )
+    term_df = (
+        fit.term_degrees_of_freedom
+        if isinstance(fit, _FormulaFit)
+        and fit.term_degrees_of_freedom is not None
+        and group_terms
+        and not single_df
+        else None
+    )
+    reported_df: list[float | int] = [
+        (
+            float(term_df.get(name, len(columns)))
+            if term_df is not None
+            else 1
+            if single_df
+            else len(columns)
+        )
+        for name, columns in groups
+    ]
+    effective_df = (
+        float(fit.effective_degrees_of_freedom)
+        if isinstance(fit, _FormulaFit) and fit.effective_degrees_of_freedom is not None
+        else None
+    )
+    p_values = (
+        [
+            float(_core.chi_square_survival(float(chi2), float(df)))
+            for chi2, df in zip(test.chi2_values, reported_df, strict=True)
+        ]
+        if term_df is not None
+        else [float(value) for value in test.p_values]
+    )
+    global_df: float | int | None = (
+        effective_df if effective_df is not None else int(test.global_df)
+    )
+    global_p_value = (
+        float(_core.chi_square_survival(float(test.global_chi2), effective_df))
+        if include_global and effective_df is not None
+        else float(test.global_p_value)
+        if include_global
+        else None
+    )
     return CoxZPHResult(
         variable_names=[name for name, _columns in groups],
         chi2_values=[float(value) for value in test.chi2_values],
-        df=[1 if single_df else len(columns) for _name, columns in groups],
-        p_values=[float(value) for value in test.p_values],
+        df=reported_df,
+        p_values=p_values,
         x=transformed_time,
         time=event_times,
         y=grouped_y,
         var=_cox_zph_group_variance(fit, groups, active_beta, active_columns, len(event_indices)),
         transform=transform_name,
         global_chi2=float(test.global_chi2) if include_global else None,
-        global_df=int(test.global_df) if include_global else None,
-        global_p_value=float(test.global_p_value) if include_global else None,
+        global_df=global_df if include_global else None,
+        global_p_value=global_p_value,
         strata=event_strata,
     )
 
@@ -16524,16 +16567,15 @@ def _cox_zph_column_groups(
     design = _formula_design_for_fit(fit)
     if design is None:
         return [(f"var{idx}", [idx]) for idx in range(nvar)]
+    if terms:
+        return _cox_predict_term_groups(fit, nvar)
 
     groups: list[tuple[str, list[int]]] = []
     cursor = 0
     for term in design.covariates:
         output_names = _design_term_output_names(term)
         indices = list(range(cursor, cursor + len(output_names)))
-        if terms:
-            groups.append((_design_term_name(term), indices))
-        else:
-            groups.extend((name, [idx]) for name, idx in zip(output_names, indices, strict=True))
+        groups.extend((name, [idx]) for name, idx in zip(output_names, indices, strict=True))
         cursor += len(output_names)
 
     if cursor != nvar:
@@ -24249,6 +24291,15 @@ def coxph(
             effective_degrees_of_freedom=effective_degrees_of_freedom,
             term_degrees_of_freedom=term_degrees_of_freedom,
             reported_log_likelihood=reported_log_likelihood,
+            penalty_matrix=(
+                fit_penalty_matrix
+                if fit_penalty_matrix is not None
+                else (
+                    [[float(value)] * len(fit_ridge_penalty) for value in fit_ridge_penalty]
+                    if fit_ridge_penalty is not None
+                    else None
+                )
+            ),
             n_observations=time_transform_observed_n,
             sparse_frailty=sparse_frailty_metadata,
         )

--- a/python/tests/test_binding_contract.py
+++ b/python/tests/test_binding_contract.py
@@ -862,6 +862,7 @@ def test_coxph_fit_detail_bindings_are_typed_to_runtime_surface():
             "information_matrix",
             "single_df",
             "global_test",
+            "penalty_matrix",
         ],
         "partial_residuals": ["self"],
     }

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -9308,19 +9308,30 @@ def test_ridge_helper_builds_fixed_theta_penalty_metadata():
 
 
 @pytest.mark.parametrize(
-    ("scale", "expected_coef", "expected_df", "expected_loglik"),
+    (
+        "scale",
+        "expected_coef",
+        "expected_df",
+        "expected_loglik",
+        "expected_zph_chi2",
+        "expected_zph_p",
+    ),
     [
         (
             False,
             [-3.15621362600671, -0.0283415400908598],
             1.40741844687792,
             -1.8006078084384,
+            2.51367498000039,
+            0.178019246067111,
         ),
         (
             True,
             [-3.77032966237141, 0.0106220916824879],
             1.54340846194763,
             -1.45946489798387,
+            1.92613828135728,
+            0.280898827095077,
         ),
     ],
 )
@@ -9329,6 +9340,8 @@ def test_coxph_formula_ridge_matches_fixed_theta_reference(
     expected_coef,
     expected_df,
     expected_loglik,
+    expected_zph_chi2,
+    expected_zph_p,
 ):
     data = {
         "time": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
@@ -9362,6 +9375,12 @@ def test_coxph_formula_ridge_matches_fixed_theta_reference(
         2.0 * (expected_loglik + 6.5792512120101),
         abs=1e-9,
     )
+    zph = survival.cox_zph(fit)
+    assert zph.chi2_values == pytest.approx([expected_zph_chi2], abs=1e-9)
+    assert zph.df == pytest.approx([expected_df], abs=1e-9)
+    assert zph.p_values == pytest.approx([expected_zph_p], abs=1e-9)
+    assert zph.global_df == pytest.approx(expected_df, abs=1e-9)
+    assert zph.global_p_value == pytest.approx(expected_zph_p, abs=1e-9)
 
     if not scale:
         rows = [[x1, x2] for x1, x2 in zip(data["x1"], data["x2"], strict=True)]
@@ -9942,6 +9961,18 @@ def test_coxph_formula_sparse_gaussian_frailty_diagnostics_match_reference():
     )
     partial = survival.r_api.residuals(fit, type="partial")
     assert all(len(row) == 1 for row in partial)
+    zph = survival.cox_zph(fit)
+    assert zph.variable_names == ["x"]
+    assert zph.chi2_values == pytest.approx([2.07213302673791], abs=1e-12)
+    assert zph.df == pytest.approx([0.967518101717635], abs=1e-12)
+    assert zph.p_values == pytest.approx([0.143944240115272], abs=5e-12)
+    assert zph.global_chi2 == pytest.approx(2.07213302673791, abs=1e-12)
+    assert zph.global_df == pytest.approx(2.44623562895911, abs=1e-12)
+    assert zph.global_p_value == pytest.approx(0.448331695640693, abs=5e-12)
+    with pytest.raises(ValueError, match="non-negative"):
+        survival.r_api._core.chi_square_survival(-1.0, 1.0)
+    with pytest.raises(ValueError, match="positive"):
+        survival.r_api._core.chi_square_survival(1.0, 0.0)
 
 
 def test_coxph_formula_gaussian_frailty_rejects_unsupported_modes():
@@ -10373,6 +10404,14 @@ def test_coxph_formula_pspline_calibrates_target_df_against_reference():
     assert history["history"][:2] == [{"theta": 1.0, "df": 1.0}, {"theta": 0.0, "df": 4.0}]
     assert history["history"][-1]["df"] == pytest.approx(3.0, abs=1e-8)
     assert history["half"] == 0
+    zph = survival.cox_zph(fit)
+    assert zph.variable_names == [spline_term]
+    assert zph.chi2_values == pytest.approx([2.54889507880129], abs=2e-11)
+    assert zph.df == pytest.approx([2.99999999999752], abs=2e-11)
+    assert zph.p_values == pytest.approx([0.466519416614471], abs=5e-12)
+    assert zph.global_chi2 == pytest.approx(2.54889507880129, abs=2e-11)
+    assert zph.global_df == pytest.approx(2.99999999999752, abs=2e-11)
+    assert zph.global_p_value == pytest.approx(0.466519416614471, abs=5e-12)
 
     default = survival.coxph(
         "Surv(time,status) ~ pspline(x)",

--- a/src/api/python/classical/diagnostics.rs
+++ b/src/api/python/classical/diagnostics.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 pub(super) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(chi_square_survival, m)?)?;
     m.add_function(wrap_pyfunction!(dfbeta_cox, m)?)?;
     m.add_function(wrap_pyfunction!(clustered_crossprod, m)?)?;
     m.add_function(wrap_pyfunction!(clustered_sandwich_variance, m)?)?;

--- a/src/regression/cox_frailty.rs
+++ b/src/regression/cox_frailty.rs
@@ -239,6 +239,7 @@ impl CoxPHFrailtyFit {
     }
 
     #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (transformed_events, active_columns, groups, information_matrix, single_df, global_test, penalty_matrix=None))]
     pub fn cox_zph_diagnostics(
         &self,
         transformed_events: Vec<f64>,
@@ -247,6 +248,7 @@ impl CoxPHFrailtyFit {
         information_matrix: Vec<Vec<f64>>,
         single_df: bool,
         global_test: bool,
+        penalty_matrix: Option<Vec<Vec<f64>>>,
     ) -> PyResult<(Vec<Vec<f64>>, crate::validation::ProportionalityTest)> {
         self.diagnostic_fit.cox_zph_diagnostics(
             transformed_events,
@@ -255,6 +257,7 @@ impl CoxPHFrailtyFit {
             information_matrix,
             single_df,
             global_test,
+            penalty_matrix,
         )
     }
 

--- a/src/regression/coxph.rs
+++ b/src/regression/coxph.rs
@@ -552,6 +552,7 @@ impl CoxPHFit {
     }
 
     #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (transformed_events, active_columns, groups, information_matrix, single_df, global_test, penalty_matrix=None))]
     pub fn cox_zph_diagnostics(
         &self,
         transformed_events: Vec<f64>,
@@ -560,6 +561,7 @@ impl CoxPHFit {
         information_matrix: Vec<Vec<f64>>,
         single_df: bool,
         global_test: bool,
+        penalty_matrix: Option<Vec<Vec<f64>>>,
     ) -> PyResult<(Vec<Vec<f64>>, crate::validation::ProportionalityTest)> {
         self.cox_zph_diagnostics_internal(
             transformed_events,
@@ -568,6 +570,7 @@ impl CoxPHFit {
             information_matrix,
             single_df,
             global_test,
+            penalty_matrix,
         )
     }
 

--- a/src/regression/coxph_diagnostics.rs
+++ b/src/regression/coxph_diagnostics.rs
@@ -1,6 +1,6 @@
 use crate::constants::{EXP_CLAMP_MAX, EXP_CLAMP_MIN, TIME_EPSILON, same_time};
 use crate::internal::matrix::{lu_solve, matrix_inverse};
-use crate::internal::statistical::chi2_sf;
+use crate::internal::statistical::{chi2_cdf, chi2_sf};
 use crate::regression::cox_optimizer::Method as CoxMethod;
 use crate::regression::coxph::CoxPHFit;
 use crate::regression::coxph_detail_module::{
@@ -41,6 +41,19 @@ fn validate_matrix_width(matrix: &[Vec<f64>], width: usize, name: &str) -> PyRes
         validate_finite_slice(row, name)?;
     }
     Ok(())
+}
+
+#[pyfunction]
+pub fn chi_square_survival(statistic: f64, degrees_of_freedom: f64) -> PyResult<f64> {
+    if !statistic.is_finite() || statistic < 0.0 {
+        return Err(value_error("statistic must be a finite non-negative value"));
+    }
+    if !degrees_of_freedom.is_finite() || degrees_of_freedom <= 0.0 {
+        return Err(value_error(
+            "degrees_of_freedom must be a finite positive value",
+        ));
+    }
+    Ok((1.0 - chi2_cdf(statistic, degrees_of_freedom)).clamp(0.0, 1.0))
 }
 
 fn validate_square_matrix(matrix: &[Vec<f64>], width: usize, name: &str) -> PyResult<()> {
@@ -339,6 +352,31 @@ pub fn cox_zph_tests(
     single_df: bool,
     global_test: bool,
 ) -> PyResult<ProportionalityTest> {
+    cox_zph_tests_with_penalty(
+        event_scores,
+        event_information,
+        transformed_time,
+        event_counts,
+        groups,
+        beta,
+        single_df,
+        global_test,
+        None,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn cox_zph_tests_with_penalty(
+    event_scores: Vec<Vec<f64>>,
+    event_information: Vec<Vec<Vec<f64>>>,
+    transformed_time: Vec<f64>,
+    event_counts: Vec<usize>,
+    groups: Vec<Vec<usize>>,
+    beta: Vec<f64>,
+    single_df: bool,
+    global_test: bool,
+    penalty_matrix: Option<&[Vec<f64>]>,
+) -> PyResult<ProportionalityTest> {
     let nvar = beta.len();
     let ntime = event_scores.len();
     if event_information.len() != ntime
@@ -362,6 +400,9 @@ pub fn cox_zph_tests(
         validate_square_matrix(information, nvar, &format!("event_information[{time_idx}]"))?;
     }
     validate_column_groups(&groups, nvar)?;
+    if let Some(penalty) = penalty_matrix {
+        validate_square_matrix(penalty, nvar, "penalty_matrix")?;
+    }
 
     let total_events: usize = event_counts.iter().sum();
     let mean_time = transformed_time
@@ -390,6 +431,14 @@ pub fn cox_zph_tests(
                 full_information[row][nvar + col] += time * value;
                 full_information[nvar + row][col] += time * value;
                 full_information[nvar + row][nvar + col] += time * time * value;
+            }
+        }
+    }
+    if let Some(penalty) = penalty_matrix {
+        for row in 0..nvar {
+            for col in 0..nvar {
+                full_information[row][col] += penalty[row][col];
+                full_information[nvar + row][nvar + col] += penalty[row][col];
             }
         }
     }
@@ -568,6 +617,7 @@ fn cox_zph_tests_from_detail(
     beta: Vec<f64>,
     single_df: bool,
     global_test: bool,
+    penalty_matrix: Option<Vec<Vec<f64>>>,
 ) -> PyResult<ProportionalityTest> {
     let full_width = detail.n_covariates;
     if beta.len() != columns.len() {
@@ -596,7 +646,7 @@ fn cox_zph_tests_from_detail(
         );
         event_counts.push(row.n_event);
     }
-    cox_zph_tests(
+    cox_zph_tests_with_penalty(
         event_scores,
         event_information,
         transformed_time,
@@ -605,6 +655,7 @@ fn cox_zph_tests_from_detail(
         beta,
         single_df,
         global_test,
+        penalty_matrix.as_deref(),
     )
 }
 
@@ -662,6 +713,7 @@ pub fn cox_zph_tests_from_data(
         coefficients,
         single_df,
         global_test,
+        None,
     )
 }
 
@@ -1581,6 +1633,7 @@ impl CoxPHFit {
         information_matrix: Vec<Vec<f64>>,
         single_df: bool,
         global_test: bool,
+        penalty_matrix: Option<Vec<Vec<f64>>>,
     ) -> PyResult<(Vec<Vec<f64>>, ProportionalityTest)> {
         let beta = self.coefficients.first().ok_or_else(|| {
             pyo3::exceptions::PyValueError::new_err("model has no fitted coefficients")
@@ -1589,6 +1642,9 @@ impl CoxPHFit {
         validate_selected_columns(&active_columns, nvar)?;
         validate_column_groups(&groups, active_columns.len())?;
         validate_square_matrix(&information_matrix, nvar, "information_matrix")?;
+        if let Some(penalty) = penalty_matrix.as_ref() {
+            validate_square_matrix(penalty, nvar, "penalty_matrix")?;
+        }
 
         let scaled_full =
             self.scaled_schoenfeld_residuals_with_variance_internal(&information_matrix)?;
@@ -1629,6 +1685,17 @@ impl CoxPHFit {
             include_riskmat: false,
         })?;
         let active_beta: Vec<f64> = active_columns.iter().map(|&column| beta[column]).collect();
+        let active_penalty = penalty_matrix.map(|penalty| {
+            active_columns
+                .iter()
+                .map(|&row| {
+                    active_columns
+                        .iter()
+                        .map(|&column| penalty[row][column])
+                        .collect()
+                })
+                .collect()
+        });
         let grouped = cox_zph_term_matrix(scaled, groups.clone(), active_beta.clone())?;
         let test = cox_zph_tests_from_detail(
             detail,
@@ -1638,6 +1705,7 @@ impl CoxPHFit {
             active_beta,
             single_df,
             global_test,
+            active_penalty,
         )?;
         Ok((grouped, test))
     }
@@ -2356,6 +2424,7 @@ mod tests {
                 variance.clone(),
                 false,
                 true,
+                None,
             )
             .expect("fit-owned Cox zph diagnostic should compute");
         let expected_scaled = fit
@@ -2372,6 +2441,7 @@ mod tests {
                 variance.clone(),
                 false,
                 true,
+                None,
             )
             .expect("grouped fit-owned Cox zph diagnostic should compute");
         for (actual, expected) in grouped_term.iter().zip(&expected_scaled) {

--- a/src/regression/mod.rs
+++ b/src/regression/mod.rs
@@ -56,10 +56,10 @@ pub use cox_frailty::{CoxPHFrailtyFit, coxph_frailty_fit};
 pub use coxph::{CoxPHFit, CoxPHModel, Subject, coxph_fit};
 pub use coxph_detail_module::{CoxphDetail, CoxphDetailRow, coxph_detail};
 pub use coxph_diagnostics::{
-    clustered_crossprod, clustered_sandwich_variance, cox_dfbeta_from_score_residuals,
-    cox_event_indices, cox_interval_cumulative_hazard_se, cox_zph_group_variance,
-    cox_zph_term_matrix, cox_zph_tests, cox_zph_tests_from_data, prediction_se_from_variance,
-    scale_schoenfeld_residuals, term_prediction_se_from_variance,
+    chi_square_survival, clustered_crossprod, clustered_sandwich_variance,
+    cox_dfbeta_from_score_residuals, cox_event_indices, cox_interval_cumulative_hazard_se,
+    cox_zph_group_variance, cox_zph_term_matrix, cox_zph_tests, cox_zph_tests_from_data,
+    prediction_se_from_variance, scale_schoenfeld_residuals, term_prediction_se_from_variance,
 };
 pub use coxph_wtest_module::coxph_wtest;
 pub use cure_models::{


### PR DESCRIPTION
## Summary
- carry fitted penalty curvature into proportional-hazards diagnostics for ridge, penalized splines, and sparse frailty
- group formula terms consistently and report fractional term and global effective degrees of freedom
- compute chi-square probabilities for real-valued degrees of freedom through the native statistical core
- match reference results for both ridge scaling modes, penalized splines, and sparse Gaussian frailty

## Validation
- `.venv/bin/python -m pytest -q python/tests` (940 passed, 18 skipped)
- `cargo test --all-targets` (1513 passed)
- `cargo clippy --all-targets -- -D warnings`
- `ruff format --check`
- `ruff check`
- `python scripts/generate_binding_manifest.py --check`
- `git diff --check`