### PR TITLE
Match penalized Cox robust variance behavior

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -24233,6 +24233,16 @@ def coxph(
             stacklevel=2,
         )
         cluster = None
+    if use_robust_variance and (
+        formula_ridge_blocks or formula_pspline_blocks or formula_frailty_blocks
+    ):
+        warnings.warn(
+            "the robust variance is not defined for a penalized model, option ignored",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        use_robust_variance = False
+        cluster = None
 
     robust_cluster = None
     if use_robust_variance:
@@ -24247,8 +24257,6 @@ def coxph(
     naive_variance = None
     cluster_values = None
     if robust_cluster is not None:
-        if sparse_formula_frailty_block is not None:
-            raise NotImplementedError("robust variance is not yet supported with sparse frailty")
         robust_variance, naive_variance, cluster_values = _cox_robust_variance_matrix(
             fit,
             robust_cluster,

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -9410,6 +9410,104 @@ def test_coxph_formula_ridge_matches_fixed_theta_reference(
 
 
 @pytest.mark.parametrize(
+    "penalty_term",
+    [
+        "ridge(x,z,theta=.2)",
+        "pspline(x,df=3,nterm=4,eps=1e-8)",
+        "frailty(g,distribution='gaussian',theta=.5,sparse=False)",
+        "frailty(g,distribution='gaussian',theta=.5,sparse=True)",
+    ],
+)
+def test_coxph_formula_penalties_ignore_robust_variance_like_reference(penalty_term):
+    data = {
+        "time": [float(value) for value in range(1, 19)],
+        "status": [1, 0, 1, 1, 0, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1],
+        "x": [
+            1.2,
+            0.7,
+            1.5,
+            0.2,
+            1.1,
+            0.4,
+            1.8,
+            0.9,
+            0.5,
+            1.4,
+            0.3,
+            1.0,
+            0.6,
+            1.7,
+            0.1,
+            1.3,
+            0.8,
+            1.6,
+        ],
+        "z": [
+            0.2,
+            0.5,
+            0.8,
+            1.0,
+            1.4,
+            1.8,
+            2.1,
+            2.5,
+            0.1,
+            0.6,
+            1.2,
+            1.7,
+            0.3,
+            0.9,
+            1.5,
+            2.0,
+            2.3,
+            2.7,
+        ],
+        "g": list("abcdef") * 3,
+    }
+    with pytest.warns(
+        RuntimeWarning,
+        match="robust variance is not defined for a penalized model, option ignored",
+    ):
+        fit = survival.coxph(
+            f"Surv(time,status) ~ {penalty_term}",
+            data=data,
+            ties="breslow",
+            robust=True,
+            control={"iter.max": 50, "outer.max": 30, "eps": 1e-10},
+        )
+
+    assert fit.robust is False
+    assert fit.naive_var is None
+    for actual, expected in zip(survival.vcov(fit), fit.fit.information_matrix, strict=True):
+        assert actual == pytest.approx(expected)
+
+
+def test_coxph_formula_penalty_ignores_implicitly_requested_robust_variance():
+    data = {
+        "time": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+        "status": [1, 0, 1, 1, 0, 1, 0, 1],
+        "x": [0.2, 0.5, 0.8, 1.0, 1.4, 1.8, 2.1, 2.5],
+        "g": list("aabbccdd"),
+    }
+    for kwargs in (
+        {"cluster": data["g"]},
+        {"weights": [0.5, 1.0] * 4},
+    ):
+        with pytest.warns(
+            RuntimeWarning,
+            match="robust variance is not defined for a penalized model, option ignored",
+        ):
+            fit = survival.coxph(
+                "Surv(time,status) ~ ridge(x,theta=.2)",
+                data=data,
+                ties="breslow",
+                **kwargs,
+            )
+        assert fit.robust is False
+        assert fit.naive_var is None
+
+
+@pytest.mark.parametrize(
     ("scale", "expected_coef", "expected_term_df", "expected_theta", "expected_loglik"),
     [
         (


### PR DESCRIPTION
## Summary
- warn and ignore robust variance requests for penalized Cox formula fits
- preserve the fitted penalized covariance instead of attempting a sandwich estimate or rejecting sparse frailty
- cover ridge, penalized splines, dense and sparse Gaussian frailty, clustering, and fractional weights

## Validation
- `.venv/bin/python -m pytest -q python/tests` (945 passed, 18 skipped)
- `cargo test --all-targets` (1513 passed)
- `cargo clippy --all-targets -- -D warnings`
- `ruff format --check`
- `ruff check`
- `python scripts/generate_binding_manifest.py --check`
- `git diff --check`