### PR TITLE
Support counting-process sparse frailty

### DIFF
--- a/python/survival/_survival.pyi
+++ b/python/survival/_survival.pyi
@@ -1089,6 +1089,8 @@ class CoxPHFrailtyFit:
     @property
     def status(self) -> list[int]: ...
     @property
+    def entry_times(self) -> list[float] | None: ...
+    @property
     def weights(self) -> list[float]: ...
     @property
     def covariates(self) -> list[list[float]]: ...
@@ -7269,6 +7271,7 @@ def coxph_frailty_fit(
     method: str | None = None,
     nocenter: list[float] | None = None,
     penalty_matrix: list[list[float]] | None = None,
+    entry_times: list[float] | None = None,
 ) -> CoxPHFrailtyFit: ...
 def coxph_fit(
     time: list[float],

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -23629,9 +23629,6 @@ def coxph(
         raise NotImplementedError(
             "coxph currently supports right-censored and counting Surv responses"
         )
-    if sparse_formula_frailty_block is not None and response.type == "counting":
-        raise NotImplementedError("sparse frailty currently supports right-censored responses")
-
     if time_transform_terms:
         if formula_design is None or formula_model_data is None:
             raise AssertionError("tt terms require formula design metadata")
@@ -23794,6 +23791,7 @@ def coxph(
                 method=method_name,
                 nocenter=nocenter_values,
                 penalty_matrix=quadratic_penalty,
+                entry_times=entry_times,
             )
         return _core.coxph_fit(
             fit_times,

--- a/python/tests/test_cox_frailty.py
+++ b/python/tests/test_cox_frailty.py
@@ -61,7 +61,109 @@ def test_sparse_gaussian_frailty_native_fit_matches_reference():
     )
 
 
-def test_sparse_gaussian_frailty_native_fit_scales_with_group_indices():
+def test_sparse_gaussian_frailty_native_counting_fit_matches_reference():
+    entry_times = [
+        0.0,
+        0.0,
+        0.5,
+        1.0,
+        0.0,
+        2.0,
+        3.0,
+        1.0,
+        4.0,
+        2.0,
+        6.0,
+        5.0,
+        7.0,
+        8.0,
+        6.0,
+        10.0,
+        11.0,
+        9.0,
+    ]
+    fit = survival.r_api._core.coxph_frailty_fit(
+        [float(value) for value in range(1, 19)],
+        [1, 0, 1, 1, 0, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1],
+        [
+            [value]
+            for value in [
+                1.2,
+                0.7,
+                1.5,
+                0.2,
+                1.1,
+                0.4,
+                1.8,
+                0.9,
+                0.5,
+                1.4,
+                0.3,
+                1.0,
+                0.6,
+                1.7,
+                0.1,
+                1.3,
+                0.8,
+                1.6,
+            ]
+        ],
+        [0, 1, 2, 3, 4, 5] * 3,
+        0.5,
+        max_iter=50,
+        eps=1e-12,
+        toler=1e-13,
+        method="breslow",
+        entry_times=entry_times,
+    )
+
+    assert fit.coefficients[0] == pytest.approx([-0.736602816003447], abs=1e-12)
+    assert fit.frailty == pytest.approx(
+        [
+            -0.00812087501187664,
+            0.218837152806033,
+            0.0991854342400643,
+            -0.173140923804785,
+            -0.0974646990423705,
+            -0.0392960891870656,
+        ],
+        abs=1e-12,
+    )
+    assert fit.log_likelihood == pytest.approx(
+        [-18.2340928191392, -17.1661166752336],
+        abs=1e-12,
+    )
+    assert fit.covariate_degrees_of_freedom == pytest.approx([0.888227879539063], abs=1e-12)
+    assert fit.frailty_degrees_of_freedom == pytest.approx(2.25629339890398, abs=1e-12)
+    assert fit.information_matrix[0] == pytest.approx([0.448731919320106], abs=1e-12)
+    assert fit.naive_information_matrix[0] == pytest.approx([0.398576201179192], abs=1e-12)
+    assert fit.entry_times == pytest.approx(entry_times)
+    assert fit.linear_predictors == pytest.approx(
+        [
+            -0.192271579012738,
+            0.402987856806895,
+            -0.305946114561832,
+            0.379311188197801,
+            -0.207955121442888,
+            0.36583545961483,
+            -0.634233268614807,
+            0.255667293606205,
+            0.430656701441615,
+            -0.504612191006336,
+            0.38132713135987,
+            -0.076126229987238,
+            0.24969011058933,
+            -0.333614959196552,
+            0.725297827842994,
+            -0.430951909405991,
+            0.0130257233581464,
+            -0.518087919589306,
+        ],
+        abs=1e-12,
+    )
+
+
+def test_sparse_gaussian_frailty_native_counting_fit_scales_with_group_indices():
     n = 10_000
     groups = 2_000
     fit = survival.r_api._core.coxph_frailty_fit(
@@ -70,6 +172,7 @@ def test_sparse_gaussian_frailty_native_fit_scales_with_group_indices():
         [[math.sin(value / 97.0)] for value in range(n)],
         [value % groups for value in range(n)],
         0.25,
+        entry_times=[max(0.0, float(value - 1_000)) for value in range(1, n + 1)],
         max_iter=3,
         eps=1e-7,
         method="breslow",
@@ -80,7 +183,7 @@ def test_sparse_gaussian_frailty_native_fit_scales_with_group_indices():
     assert all(math.isfinite(value) for value in fit.coefficients[0])
 
 
-def test_sparse_gaussian_frailty_native_fit_combines_dense_penalty_and_strata():
+def test_sparse_gaussian_frailty_native_counting_fit_combines_penalty_strata_and_ties():
     fit = survival.r_api._core.coxph_frailty_fit(
         [1.0, 2.0, 2.0, 3.0, 4.0, 4.0, 5.0, 6.0, 6.0, 7.0, 8.0, 9.0],
         [1, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1],
@@ -89,26 +192,27 @@ def test_sparse_gaussian_frailty_native_fit_combines_dense_penalty_and_strata():
         0.5,
         strata=[1] * 6 + [2] * 6,
         penalty_matrix=[[0.2]],
+        entry_times=[0.0, 0.0, 0.5, 1.0, 0.0, 2.0, 3.0, 1.0, 4.0, 2.0, 6.0, 5.0],
         max_iter=50,
         eps=1e-12,
         toler=1e-13,
         method="efron",
     )
 
-    assert fit.coefficients[0] == pytest.approx([0.203649783606771], abs=1e-12)
+    assert fit.coefficients[0] == pytest.approx([-0.396637670196876], abs=1e-12)
     assert fit.frailty == pytest.approx(
-        [0.199233197374958, -0.0987328693476504, 0.150110660953487, -0.250610988980794],
+        [0.130597126706777, -0.0946235856514112, 0.29620046214582, -0.332174003201186],
         abs=1e-12,
     )
     assert fit.frailty_variance == pytest.approx(
-        [0.302173996806596, 0.295847015106486, 0.320966626237654, 0.328803061516902],
+        [0.280997264733325, 0.30112511706187, 0.371283991529981, 0.327119681253034],
         abs=1e-12,
     )
-    assert fit.covariate_degrees_of_freedom == pytest.approx([0.819597722065366], abs=1e-12)
-    assert fit.frailty_degrees_of_freedom == pytest.approx(1.49535374602864, abs=1e-12)
-    assert fit.information_matrix[0] == pytest.approx([0.702283308058964], abs=1e-12)
-    assert fit.naive_information_matrix[0] == pytest.approx([0.575589799529657], abs=1e-12)
-    assert fit.log_likelihood == pytest.approx([-9.16951837745593, -8.71619272199139], abs=1e-12)
+    assert fit.covariate_degrees_of_freedom == pytest.approx([0.805320383723899], abs=1e-12)
+    assert fit.frailty_degrees_of_freedom == pytest.approx(1.43059887013871, abs=1e-12)
+    assert fit.information_matrix[0] == pytest.approx([0.799519783795863], abs=1e-12)
+    assert fit.naive_information_matrix[0] == pytest.approx([0.643869579081333], abs=1e-12)
+    assert fit.log_likelihood == pytest.approx([-7.74240202181578, -7.08840456550056], abs=1e-12)
 
 
 @pytest.mark.parametrize(
@@ -127,3 +231,17 @@ def test_sparse_gaussian_frailty_native_fit_validates_groups_and_theta(groups, t
             groups,
             theta,
         )
+
+
+def test_sparse_gaussian_frailty_native_fit_validates_entry_times():
+    arguments = (
+        [1.0, 2.0],
+        [1, 0],
+        [[0.0], [1.0]],
+        [0, 0],
+        0.5,
+    )
+    with pytest.raises(ValueError, match="entry_times has 1 rows"):
+        survival.r_api._core.coxph_frailty_fit(*arguments, entry_times=[0.0])
+    with pytest.raises(ValueError, match=r"entry_times\[0\] must be less"):
+        survival.r_api._core.coxph_frailty_fit(*arguments, entry_times=[1.0, 0.0])

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -10073,6 +10073,111 @@ def test_coxph_formula_sparse_gaussian_frailty_diagnostics_match_reference():
         survival.r_api._core.chi_square_survival(1.0, 0.0)
 
 
+def test_coxph_formula_sparse_gaussian_frailty_counting_diagnostics_match_reference():
+    data = {
+        "start": [
+            0.0,
+            0.0,
+            0.5,
+            1.0,
+            0.0,
+            2.0,
+            3.0,
+            1.0,
+            4.0,
+            2.0,
+            6.0,
+            5.0,
+            7.0,
+            8.0,
+            6.0,
+            10.0,
+            11.0,
+            9.0,
+        ],
+        "stop": [float(value) for value in range(1, 19)],
+        "status": [1, 0, 1, 1, 0, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1],
+        "x": [
+            1.2,
+            0.7,
+            1.5,
+            0.2,
+            1.1,
+            0.4,
+            1.8,
+            0.9,
+            0.5,
+            1.4,
+            0.3,
+            1.0,
+            0.6,
+            1.7,
+            0.1,
+            1.3,
+            0.8,
+            1.6,
+        ],
+        "g": list("abcdef") * 3,
+    }
+    frailty_term = "frailty(g,distribution='gaussian',theta=.5,sparse=True)"
+    fit = survival.coxph(
+        f"Surv(start,stop,status) ~ x + {frailty_term}",
+        data=data,
+        ties="breslow",
+        control={"iter.max": 50, "eps": 1e-12, "toler.chol": 1e-13},
+    )
+
+    assert fit.coefficients[0] == pytest.approx([-0.736602816003447], abs=1e-12)
+    assert fit.frailty == pytest.approx(
+        [
+            -0.00812087501187664,
+            0.218837152806033,
+            0.0991854342400643,
+            -0.173140923804785,
+            -0.0974646990423705,
+            -0.0392960891870656,
+        ],
+        abs=1e-12,
+    )
+    assert fit.log_likelihood == pytest.approx([-18.2340928191392, -17.1661166752336], abs=1e-12)
+    assert fit.term_degrees_of_freedom == pytest.approx(
+        {"x": 0.888227879539063, frailty_term: 2.25629339890398},
+        abs=1e-12,
+    )
+    assert fit.entry_times == pytest.approx(data["start"])
+    martingale = survival.r_api.residuals(fit, type="martingale")
+    assert martingale == pytest.approx(
+        [
+            0.78680259343823,
+            -0.386633789125276,
+            0.693678564362922,
+            0.531790739907214,
+            -0.47013144359686,
+            0.310373469321417,
+            -0.170120512926997,
+            0.241542077524079,
+            0.410472033926048,
+            -0.424822874893011,
+            0.47997124924087,
+            0.396718673574081,
+            -0.632923875384168,
+            0.58276595714111,
+            -0.905779412034988,
+            -0.453249742653264,
+            -0.204769370324214,
+            -0.785684337497186,
+        ],
+        abs=1e-12,
+    )
+    zph = survival.cox_zph(fit)
+    assert zph.variable_names == ["x"]
+    assert zph.chi2_values == pytest.approx([0.4639006607031987], abs=1e-12)
+    assert zph.df == pytest.approx([0.8882278795390629], abs=1e-12)
+    assert zph.p_values == pytest.approx([0.4493447341614195], abs=5e-12)
+    assert zph.global_df == pytest.approx(3.1445212784430461, abs=1e-12)
+    assert zph.global_p_value == pytest.approx(0.9375988048538871, abs=5e-12)
+
+
 def test_coxph_formula_gaussian_frailty_rejects_unsupported_modes():
     data = {
         "time": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],

--- a/src/regression/cox_frailty.rs
+++ b/src/regression/cox_frailty.rs
@@ -112,6 +112,11 @@ impl CoxPHFrailtyFit {
     }
 
     #[getter]
+    pub fn entry_times(&self) -> Option<Vec<f64>> {
+        self.diagnostic_fit.entry_times.clone()
+    }
+
+    #[getter]
     pub fn weights(&self) -> Vec<f64> {
         self.diagnostic_fit.weights.clone()
     }
@@ -427,6 +432,8 @@ struct IterationState {
 struct SparseFrailtySolver {
     time: Vec<f64>,
     status: Vec<i32>,
+    entry_times: Option<Vec<f64>>,
+    entry_order: Option<Vec<usize>>,
     covariates: Array2<f64>,
     groups: Vec<usize>,
     strata_end: Vec<bool>,
@@ -459,6 +466,32 @@ struct SolverResult {
 }
 
 impl SparseFrailtySolver {
+    fn update_risk_moments(
+        &self,
+        person: usize,
+        risk: f64,
+        direction: f64,
+        denominator: &mut f64,
+        risk_sum: &mut [f64],
+        cross_sum: &mut Array2<f64>,
+    ) {
+        let nfrail = risk_sum.len() - self.covariates.ncols();
+        let adjusted_risk = direction * risk;
+        let group = self.groups[person];
+        *denominator += adjusted_risk;
+        risk_sum[group] += adjusted_risk;
+        for variable in 0..self.covariates.ncols() {
+            let value = self.covariates[(person, variable)];
+            let weighted = adjusted_risk * value;
+            risk_sum[nfrail + variable] += weighted;
+            cross_sum[(variable, group)] += weighted;
+            for other in 0..=variable {
+                cross_sum[(variable, nfrail + other)] +=
+                    weighted * self.covariates[(person, other)];
+            }
+        }
+    }
+
     fn partial_log_likelihood(&self, beta: &[f64], frailty: &[f64]) -> f64 {
         self.iteration(beta, frailty).penalized_log_likelihood + self.penalty_value(beta, frailty)
     }
@@ -500,6 +533,22 @@ impl SparseFrailtySolver {
         let mut risk_means = vec![0.0; width];
         let mut log_likelihood = 0.0;
         let mut stratum_start = 0usize;
+        let linear_predictors = (0..self.time.len())
+            .map(|person| {
+                let mut value = self.offset[person] + frailty[self.groups[person]];
+                for (variable, coefficient) in beta.iter().enumerate() {
+                    value += coefficient * self.covariates[(person, variable)];
+                }
+                value
+            })
+            .collect::<Vec<_>>();
+        let risks = linear_predictors
+            .iter()
+            .zip(&self.weights)
+            .map(|(linear_predictor, weight)| {
+                linear_predictor.clamp(EXP_CLAMP_MIN, EXP_CLAMP_MAX).exp() * weight
+            })
+            .collect::<Vec<_>>();
 
         while stratum_start < self.time.len() {
             let mut stratum_end = stratum_start;
@@ -509,6 +558,7 @@ impl SparseFrailtySolver {
             let mut denominator = 0.0;
             risk_sum.fill(0.0);
             cross_sum.fill(0.0);
+            let mut entry_ptr = stratum_start;
 
             let mut time_start = stratum_start;
             while time_start <= stratum_end {
@@ -526,24 +576,16 @@ impl SparseFrailtySolver {
 
                 for person in time_start..=time_end {
                     let group = self.groups[person];
-                    let mut linear_predictor = self.offset[person] + frailty[group];
-                    for (variable, &coefficient) in beta.iter().enumerate() {
-                        linear_predictor += coefficient * self.covariates[(person, variable)];
-                    }
-                    let risk = linear_predictor.clamp(EXP_CLAMP_MIN, EXP_CLAMP_MAX).exp()
-                        * self.weights[person];
-                    denominator += risk;
-                    risk_sum[group] += risk;
-                    for variable in 0..nvar {
-                        let value = self.covariates[(person, variable)];
-                        let weighted = risk * value;
-                        risk_sum[nfrail + variable] += weighted;
-                        cross_sum[(variable, group)] += weighted;
-                        for other in 0..=variable {
-                            cross_sum[(variable, nfrail + other)] +=
-                                weighted * self.covariates[(person, other)];
-                        }
-                    }
+                    let linear_predictor = linear_predictors[person];
+                    let risk = risks[person];
+                    self.update_risk_moments(
+                        person,
+                        risk,
+                        1.0,
+                        &mut denominator,
+                        &mut risk_sum,
+                        &mut cross_sum,
+                    );
 
                     if self.status[person] != 0 {
                         death_count += 1;
@@ -563,6 +605,24 @@ impl SparseFrailtySolver {
                                     weighted * self.covariates[(person, other)];
                             }
                         }
+                    }
+                }
+                if let (Some(entry_times), Some(entry_order)) =
+                    (self.entry_times.as_ref(), self.entry_order.as_ref())
+                {
+                    while entry_ptr <= stratum_end
+                        && entry_times[entry_order[entry_ptr]] >= event_time
+                    {
+                        let person = entry_order[entry_ptr];
+                        self.update_risk_moments(
+                            person,
+                            risks[person],
+                            -1.0,
+                            &mut denominator,
+                            &mut risk_sum,
+                            &mut cross_sum,
+                        );
+                        entry_ptr += 1;
                     }
                 }
 
@@ -1135,7 +1195,7 @@ fn validate_penalty(values: Option<Vec<Vec<f64>>>, nvar: usize) -> PyResult<Arra
 }
 
 #[pyfunction]
-#[pyo3(signature = (time, status, covariates, groups, theta, strata=None, weights=None, offset=None, initial_beta=None, initial_frailty=None, max_iter=None, eps=None, toler=None, method=None, nocenter=None, penalty_matrix=None))]
+#[pyo3(signature = (time, status, covariates, groups, theta, strata=None, weights=None, offset=None, initial_beta=None, initial_frailty=None, max_iter=None, eps=None, toler=None, method=None, nocenter=None, penalty_matrix=None, entry_times=None))]
 #[allow(clippy::too_many_arguments)]
 pub fn coxph_frailty_fit(
     time: Vec<f64>,
@@ -1154,6 +1214,7 @@ pub fn coxph_frailty_fit(
     method: Option<&str>,
     nocenter: Option<Vec<f64>>,
     penalty_matrix: Option<Vec<Vec<f64>>>,
+    entry_times: Option<Vec<f64>>,
 ) -> PyResult<CoxPHFrailtyFit> {
     let n = time.len();
     if n == 0 {
@@ -1216,6 +1277,7 @@ pub fn coxph_frailty_fit(
     check_optional("strata", strata.as_ref().map(Vec::len))?;
     check_optional("weights", weights.as_ref().map(Vec::len))?;
     check_optional("offset", offset.as_ref().map(Vec::len))?;
+    check_optional("entry_times", entry_times.as_ref().map(Vec::len))?;
     if let Some(values) = weights.as_ref() {
         validate_finite("weights", values)?;
         if values.iter().any(|value| *value <= 0.0) {
@@ -1226,6 +1288,16 @@ pub fn coxph_frailty_fit(
     }
     if let Some(values) = offset.as_ref() {
         validate_finite("offset", values)?;
+    }
+    if let Some(values) = entry_times.as_ref() {
+        validate_finite("entry_times", values)?;
+        for (index, (&start, &stop)) in values.iter().zip(&time).enumerate() {
+            if start >= stop {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "entry_times[{index}] must be less than time[{index}]"
+                )));
+            }
+        }
     }
     let beta = initial_beta.unwrap_or_else(|| vec![0.0; nvar]);
     if beta.len() != nvar {
@@ -1294,6 +1366,19 @@ pub fn coxph_frailty_fit(
     let sorted_status = order.iter().map(|&index| status[index]).collect::<Vec<_>>();
     let sorted_groups = order.iter().map(|&index| groups[index]).collect::<Vec<_>>();
     let sorted_offset = order.iter().map(|&index| offset[index]).collect::<Vec<_>>();
+    let sorted_entry_times = entry_times
+        .as_ref()
+        .map(|values| order.iter().map(|&index| values[index]).collect::<Vec<_>>());
+    let entry_order = sorted_entry_times.as_ref().map(|values| {
+        let mut positions = (0..n).collect::<Vec<_>>();
+        positions.sort_by(|&left, &right| {
+            strata[order[left]]
+                .cmp(&strata[order[right]])
+                .then_with(|| values[right].total_cmp(&values[left]))
+                .then_with(|| left.cmp(&right))
+        });
+        positions
+    });
     let sorted_weights = order
         .iter()
         .map(|&index| weights[index])
@@ -1308,6 +1393,8 @@ pub fn coxph_frailty_fit(
     let solver = SparseFrailtySolver {
         time: sorted_time,
         status: sorted_status,
+        entry_times: sorted_entry_times,
+        entry_order,
         covariates: sorted_covariates,
         groups: sorted_groups,
         strata_end,
@@ -1373,7 +1460,7 @@ pub fn coxph_frailty_fit(
         event_times: time,
         status,
         linear_predictors,
-        entry_times: None,
+        entry_times,
         weights,
         covariates,
         strata,
@@ -1425,5 +1512,42 @@ mod tests {
     #[test]
     fn penalty_validation_rejects_indefinite_zero_diagonal_matrix() {
         assert!(validate_penalty(Some(vec![vec![0.0, 1.0], vec![1.0, 0.0]]), 2).is_err());
+    }
+
+    #[test]
+    fn counting_process_fit_matches_reference() {
+        let fit = coxph_frailty_fit(
+            (1..=18).map(f64::from).collect(),
+            vec![1, 0, 1, 1, 0, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1],
+            [
+                1.2, 0.7, 1.5, 0.2, 1.1, 0.4, 1.8, 0.9, 0.5, 1.4, 0.3, 1.0, 0.6, 1.7, 0.1, 1.3,
+                0.8, 1.6,
+            ]
+            .into_iter()
+            .map(|value| vec![value])
+            .collect(),
+            (0..18).map(|value| value % 6).collect(),
+            0.5,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(50),
+            Some(1e-12),
+            Some(1e-13),
+            Some("breslow"),
+            None,
+            None,
+            Some(vec![
+                0.0, 0.0, 0.5, 1.0, 0.0, 2.0, 3.0, 1.0, 4.0, 2.0, 6.0, 5.0, 7.0, 8.0, 6.0, 10.0,
+                11.0, 9.0,
+            ]),
+        )
+        .expect("counting-process frailty fit should compute");
+
+        assert!((fit.coefficients()[0][0] - -0.736602816003447).abs() < 1e-12);
+        assert!((fit.frailty_degrees_of_freedom - 2.25629339890398).abs() < 1e-12);
+        assert!((fit.log_likelihood()[1] - -17.1661166752336).abs() < 1e-12);
     }
 }


### PR DESCRIPTION
## Summary
- extend the sparse Gaussian frailty solver to counting-process responses with left truncation
- maintain risk sets with monotone stop-time additions and entry-time removals per stratum
- expose entry times through the native fit and reuse the existing baseline, residual, and proportional-hazards diagnostics
- match reference coefficients, frailty effects, covariance, effective degrees of freedom, likelihoods, residuals, and diagnostic tests
- cover Breslow and tied-event Efron fits, strata, simultaneous dense penalties, validation, and a 10,000-row sparse fixture

## Validation
- `.venv/bin/python -m pytest -q python/tests` (948 passed, 18 skipped)
- `cargo test --all-targets` (1514 passed)
- `cargo clippy --all-targets -- -D warnings`
- `ruff format --check`
- `ruff check`
- `python scripts/generate_binding_manifest.py --check`
- `git diff --check`