### PR TITLE
Support sparse frailty with Cox time transforms

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -23582,8 +23582,6 @@ def coxph(
             if sparse_formula_frailty_block is not None
             else None
         )
-        if sparse_formula_frailty_block is not None and time_transform_terms:
-            raise NotImplementedError("sparse frailty is not supported with tt() terms")
         if (formula_ridge_blocks or formula_pspline_blocks or formula_frailty_blocks) and (
             ridge_penalty is not None or penalty_matrix is not None
         ):
@@ -23636,6 +23634,16 @@ def coxph(
         expansion = _cox_time_transform_expansion(response, strata, fix_time)
         source_indices = expansion.source_indices
         expanded_n = len(source_indices)
+        if sparse_formula_frailty_block is not None:
+            if sparse_formula_frailty_index is None:
+                raise AssertionError("sparse frailty index is missing")
+            sparse_formula_frailty_block = replace(
+                sparse_formula_frailty_block,
+                groups=tuple(
+                    sparse_formula_frailty_block.groups[index] for index in source_indices
+                ),
+            )
+            formula_frailty_blocks[sparse_formula_frailty_index] = sparse_formula_frailty_block
         expanded_data = _subset_data(formula_model_data, source_indices)
         weights = _subset_optional_sequence(weights, source_indices, "weights")
         offset = _subset_optional_sequence(offset, source_indices, "offset")

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -14639,6 +14639,66 @@ def test_coxph_accepts_unused_tt_argument_without_time_transform_terms():
     assert unused_tt.log_likelihood == pytest.approx(baseline.log_likelihood)
 
 
+def test_coxph_sparse_gaussian_frailty_with_tt_matches_reference():
+    data = {
+        "time": [float(value) for value in range(1, 19)],
+        "status": [1, 0, 1, 1, 0, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1],
+        "x": [
+            1.2,
+            0.7,
+            1.5,
+            0.2,
+            1.1,
+            0.4,
+            1.8,
+            0.9,
+            0.5,
+            1.4,
+            0.3,
+            1.0,
+            0.6,
+            1.7,
+            0.1,
+            1.3,
+            0.8,
+            1.6,
+        ],
+        "g": list("abcdef") * 3,
+    }
+    frailty_term = "frailty(g,distribution='gaussian',theta=.5,sparse=True)"
+
+    def transform(values, times, _riskset, _weights):
+        return [value * math.log(time + 1.0) for value, time in zip(values, times, strict=True)]
+
+    fit = survival.coxph(
+        f"Surv(time,status) ~ tt(x) + {frailty_term}",
+        data=data,
+        tt=transform,
+        ties="breslow",
+        control={"iter.max": 50, "eps": 1e-12, "toler.chol": 1e-13},
+    )
+
+    assert fit.coefficients[0] == pytest.approx([-0.430128845950534], abs=1e-12)
+    assert fit.frailty == pytest.approx(
+        [
+            -0.0338836197577876,
+            0.389864514018792,
+            -0.0441141563108985,
+            -0.0994720978792039,
+            -0.245657480406089,
+            0.0332628403351868,
+        ],
+        abs=1e-12,
+    )
+    assert fit.log_likelihood == pytest.approx([-23.3506715493412, -21.6755087910397], abs=1e-12)
+    assert fit.term_degrees_of_freedom == pytest.approx(
+        {"tt(x)": 0.70759025968027, frailty_term: 2.09784752792522},
+        abs=1e-12,
+    )
+    assert fit.n_observations == len(data["time"])
+    assert len(fit.event_times) > len(data["time"])
+
+
 def test_coxph_right_censored_tt_transform_matches_r():
     data = {
         "time": [5, 1, 9, 3, 12, 7, 2, 10, 4, 11, 6, 8],


### PR DESCRIPTION
## Summary
- carry sparse frailty group identities through event-specific time-transform row expansion
- allow sparse Gaussian frailty and `tt()` terms to share the existing expanded risk-set fit path
- preserve original observation counts while fitting the expanded rows
- match reference coefficients, group effects, likelihoods, and fractional term degrees of freedom

## Validation
- `.venv/bin/python -m pytest -q python/tests` (949 passed, 18 skipped)
- `cargo test --all-targets` (1514 passed)
- `cargo clippy --all-targets -- -D warnings`
- `ruff format --check`
- `ruff check`
- `python scripts/generate_binding_manifest.py --check`
- `git diff --check`