### PR TITLE
Stabilize fractional chi-square upper tails

### DIFF
--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -10067,6 +10067,16 @@ def test_coxph_formula_sparse_gaussian_frailty_diagnostics_match_reference():
     assert zph.global_chi2 == pytest.approx(2.07213302673791, abs=1e-12)
     assert zph.global_df == pytest.approx(2.44623562895911, abs=1e-12)
     assert zph.global_p_value == pytest.approx(0.448331695640693, abs=5e-12)
+    assert survival.r_api._core.chi_square_survival(100.0, 0.5) == pytest.approx(
+        2.788194848158256e-24,
+        rel=1e-9,
+        abs=0.0,
+    )
+    assert survival.r_api._core.chi_square_survival(1000.0, 10.5) == pytest.approx(
+        6.031085185928643e-208,
+        rel=1e-9,
+        abs=0.0,
+    )
     with pytest.raises(ValueError, match="non-negative"):
         survival.r_api._core.chi_square_survival(-1.0, 1.0)
     with pytest.raises(ValueError, match="positive"):

--- a/src/internal/statistical.rs
+++ b/src/internal/statistical.rs
@@ -981,12 +981,21 @@ fn gamma_pdf(x: f64, a: f64) -> f64 {
 
 #[inline]
 pub(crate) fn chi2_sf(x: f64, df: usize) -> f64 {
-    if x <= 0.0 || df == 0 {
+    chi2_sf_continuous(x, df as f64)
+}
+
+#[inline]
+pub(crate) fn chi2_sf_continuous(x: f64, df: f64) -> f64 {
+    if x <= 0.0 || df == 0.0 {
         return 1.0;
     }
-    let k = df as f64 / 2.0;
+    let k = df / 2.0;
     let x_half = x / 2.0;
-    1.0 - lower_incomplete_gamma(k, x_half)
+    if x_half < k + 1.0 {
+        1.0 - gamma_series(k, x_half)
+    } else {
+        gamma_continued_fraction(k, x_half)
+    }
 }
 
 #[inline]
@@ -1755,6 +1764,22 @@ mod tests {
         assert!((chi2_sf(0.0, 1) - 1.0).abs() < 1e-10);
         assert!((chi2_sf(-1.0, 1) - 1.0).abs() < 1e-10);
         assert!((chi2_sf(1.0, 0) - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn continuous_chi2_sf_preserves_extreme_upper_tails() {
+        for (statistic, df, expected) in [
+            (100.0, 0.5, 2.788194848158256e-24),
+            (50.0, 1.3, 3.2074176568958654e-12),
+            (1000.0, 10.5, 6.031085185928643e-208),
+            (1e-8, 0.25, 0.9026269019296275),
+        ] {
+            let actual = chi2_sf_continuous(statistic, df);
+            assert!(
+                ((actual - expected) / expected).abs() <= 1e-9,
+                "{actual} != {expected}"
+            );
+        }
     }
 
     #[test]

--- a/src/regression/coxph_diagnostics.rs
+++ b/src/regression/coxph_diagnostics.rs
@@ -1,6 +1,6 @@
 use crate::constants::{EXP_CLAMP_MAX, EXP_CLAMP_MIN, TIME_EPSILON, same_time};
 use crate::internal::matrix::{lu_solve, matrix_inverse};
-use crate::internal::statistical::{chi2_cdf, chi2_sf};
+use crate::internal::statistical::{chi2_sf, chi2_sf_continuous};
 use crate::regression::cox_optimizer::Method as CoxMethod;
 use crate::regression::coxph::CoxPHFit;
 use crate::regression::coxph_detail_module::{
@@ -53,7 +53,7 @@ pub fn chi_square_survival(statistic: f64, degrees_of_freedom: f64) -> PyResult<
             "degrees_of_freedom must be a finite positive value",
         ));
     }
-    Ok((1.0 - chi2_cdf(statistic, degrees_of_freedom)).clamp(0.0, 1.0))
+    Ok(chi2_sf_continuous(statistic, degrees_of_freedom).clamp(0.0, 1.0))
 }
 
 fn validate_square_matrix(matrix: &[Vec<f64>], width: usize, name: &str) -> PyResult<()> {


### PR DESCRIPTION
## Summary
- compute real-degree chi-square survival probabilities through the direct regularized upper-gamma branch
- retain the existing integer-degree interface while sharing the stable continuous implementation
- avoid catastrophic cancellation for very small proportional-hazards diagnostic probabilities
- validate reference tails from ordinary values down to approximately `6e-208`

## Validation
- `.venv/bin/python -m pytest -q python/tests` (949 passed, 18 skipped)
- `cargo test --all-targets` (1515 passed)
- `cargo clippy --all-targets -- -D warnings`
- `ruff format --check`
- `ruff check`
- `python scripts/generate_binding_manifest.py --check`
- `git diff --check`