### PR TITLE
Add sparse Student-t Cox frailty

### DIFF
--- a/python/survival/_survival.pyi
+++ b/python/survival/_survival.pyi
@@ -1087,6 +1087,8 @@ class CoxPHFrailtyFit:
     @property
     def distribution(self) -> str: ...
     @property
+    def tdf(self) -> float | None: ...
+    @property
     def event_times(self) -> list[float]: ...
     @property
     def status(self) -> list[int]: ...
@@ -7275,6 +7277,7 @@ def coxph_frailty_fit(
     penalty_matrix: list[list[float]] | None = None,
     entry_times: list[float] | None = None,
     distribution: str | None = None,
+    tdf: float | None = None,
 ) -> CoxPHFrailtyFit: ...
 def coxph_fit(
     time: list[float],

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -262,6 +262,7 @@ class _ModelPSplineTerm:
 class _FrailtyFormulaTerm:
     term: _CovariateTerm
     distribution: str
+    tdf: float | None
     theta: float | None
     target_df: float | None
     eps: float
@@ -388,6 +389,7 @@ class _PSplinePenaltyBlock:
 class _FrailtyPenaltyBlock:
     label: str
     distribution: str
+    tdf: float | None
     columns: tuple[int, ...]
     theta: float | None
     target_df: float | None
@@ -3553,6 +3555,7 @@ def _parse_frailty_formula_term(term: str) -> _FrailtyFormulaTerm:
     distribution = "gamma"
     theta: float | None = None
     df: float | None = None
+    tdf: float | None = None
     method: str | None = None
     sparse: bool | None = None
     eps: float | None = None
@@ -3581,6 +3584,8 @@ def _parse_frailty_formula_term(term: str) -> _FrailtyFormulaTerm:
             theta = _finite_float(value, "frailty theta")
         elif name == "df":
             df = _finite_float(value, "frailty df")
+        elif name == "tdf":
+            tdf = _finite_float(value, "frailty tdf")
         elif name == "method":
             method = str(value).lower()
         elif name == "sparse":
@@ -3592,10 +3597,12 @@ def _parse_frailty_formula_term(term: str) -> _FrailtyFormulaTerm:
 
     if column is None:
         raise ValueError("frailty() requires one column")
-    if distribution not in {"gaussian", "gamma"}:
+    if distribution not in {"gaussian", "gamma", "t"}:
         raise NotImplementedError(
-            "frailty() formulas currently support gamma or Gaussian distributions"
+            "frailty() formulas currently support gamma, Gaussian, or Student-t distributions"
         )
+    if distribution != "t" and tdf is not None:
+        raise ValueError("frailty tdf is only valid for the Student-t distribution")
     if distribution == "gamma":
         if theta is not None and df is not None:
             raise ValueError("gamma frailty cannot include both theta and df")
@@ -3622,9 +3629,58 @@ def _parse_frailty_formula_term(term: str) -> _FrailtyFormulaTerm:
         return _FrailtyFormulaTerm(
             term=_CovariateTerm(column, transform="frailty"),
             distribution=distribution,
+            tdf=None,
             theta=theta,
             target_df=None,
             eps=1e-5 if eps is None else eps,
+            selection=selection,
+            sparse=sparse,
+            label=term,
+        )
+    if distribution == "t":
+        if tdf is None:
+            tdf = 5.0
+        if tdf <= 2.0:
+            raise ValueError("Student-t frailty tdf must be greater than 2")
+        if theta is not None and df is not None:
+            raise ValueError("Student-t frailty cannot include both theta and df")
+        if method is None:
+            method = "fixed" if theta is not None else "aic" if df in {None, 0.0} else "df"
+        if eps is not None and eps <= 0.0:
+            raise ValueError("frailty eps must be positive")
+        if method == "fixed":
+            if theta is None:
+                raise ValueError("fixed Student-t frailty requires theta")
+            if df is not None:
+                raise ValueError("fixed Student-t frailty cannot include df")
+            selection = "fixed"
+        elif method == "df":
+            if df is None:
+                raise ValueError("target-df Student-t frailty requires df")
+            if df <= 0.0:
+                raise ValueError("frailty df must be positive")
+            selection = "df"
+        elif method == "aic":
+            if theta is not None:
+                raise ValueError("AIC Student-t frailty cannot include theta")
+            if df not in {None, 0.0}:
+                raise ValueError("AIC Student-t frailty df must be zero")
+            selection = "aic"
+        else:
+            raise NotImplementedError(
+                "Student-t frailty formulas support fixed theta, target df, or AIC"
+            )
+        if theta is not None and theta <= 0.0:
+            raise ValueError("frailty theta must be positive")
+        if eps is None:
+            eps = 0.1 if selection == "df" else 1e-5
+        return _FrailtyFormulaTerm(
+            term=_CovariateTerm(column, transform="frailty"),
+            distribution=distribution,
+            tdf=tdf,
+            theta=theta,
+            target_df=df if selection == "df" else None,
+            eps=eps,
             selection=selection,
             sparse=sparse,
             label=term,
@@ -3673,6 +3729,7 @@ def _parse_frailty_formula_term(term: str) -> _FrailtyFormulaTerm:
     return _FrailtyFormulaTerm(
         term=_CovariateTerm(column, transform="frailty"),
         distribution=distribution,
+        tdf=None,
         theta=theta,
         target_df=df if selection == "df" else None,
         eps=eps,
@@ -4569,12 +4626,13 @@ def _frailty_formula_blocks(
                 else:
                     target_df = term.formula.target_df
                     if target_df is None:
-                        raise AssertionError("Gaussian frailty smoothing target is missing")
+                        raise AssertionError("frailty smoothing target is missing")
                     initial_theta = 3.0 * target_df / n
             blocks.append(
                 _FrailtyPenaltyBlock(
                     label=term.formula.label,
                     distribution=term.formula.distribution,
+                    tdf=term.formula.tdf,
                     columns=tuple(range(cursor, cursor + width)),
                     theta=term.formula.theta,
                     target_df=term.formula.target_df,
@@ -23704,9 +23762,10 @@ def coxph(
         if len(sparse_blocks) > 1:
             raise ValueError("coxph formulas support at most one sparse frailty term")
         if any(
-            block.distribution == "gamma" and not block.sparse for block in formula_frailty_blocks
+            block.distribution in {"gamma", "t"} and not block.sparse
+            for block in formula_frailty_blocks
         ):
-            raise NotImplementedError("gamma frailty currently requires sparse=True")
+            raise NotImplementedError("gamma and Student-t frailty currently require sparse=True")
         sparse_formula_frailty_block = sparse_blocks[0] if sparse_blocks else None
         sparse_formula_frailty_index = (
             formula_frailty_blocks.index(sparse_formula_frailty_block)
@@ -23950,6 +24009,7 @@ def coxph(
                 penalty_matrix=quadratic_penalty,
                 entry_times=entry_times,
                 distribution=sparse_formula_frailty_block.distribution,
+                tdf=sparse_formula_frailty_block.tdf,
             )
         return _core.coxph_fit(
             fit_times,
@@ -24181,9 +24241,7 @@ def coxph(
                 block = formula_frailty_blocks[block_index]
                 target = block.target_df
                 if target is None:
-                    raise AssertionError(
-                        "Gaussian frailty calibration requires a quadratic penalty"
-                    )
+                    raise AssertionError("frailty smoothing target is missing")
                 term_df = (
                     float(fit.frailty_degrees_of_freedom)
                     if block.sparse

--- a/python/tests/test_cox_frailty.py
+++ b/python/tests/test_cox_frailty.py
@@ -245,3 +245,98 @@ def test_sparse_gaussian_frailty_native_fit_validates_entry_times():
         survival.r_api._core.coxph_frailty_fit(*arguments, entry_times=[0.0])
     with pytest.raises(ValueError, match=r"entry_times\[0\] must be less"):
         survival.r_api._core.coxph_frailty_fit(*arguments, entry_times=[1.0, 0.0])
+
+
+def test_sparse_student_t_frailty_native_fit_matches_reference():
+    fit = survival.r_api._core.coxph_frailty_fit(
+        [float(value) for value in range(2, 20)],
+        [1, 1, 0, 1, 1, 0, 1, 0, 1, 1, 0, 1, 0, 1, 1, 0, 1, 1],
+        [
+            [value]
+            for value in [
+                -1.2,
+                -0.8,
+                -0.4,
+                0.0,
+                0.4,
+                0.8,
+                1.2,
+                -1.0,
+                -0.6,
+                -0.2,
+                0.2,
+                0.6,
+                1.0,
+                1.4,
+                -1.4,
+                -0.9,
+                0.1,
+                0.9,
+            ]
+        ],
+        [value // 3 for value in range(18)],
+        0.5,
+        max_iter=50,
+        eps=1e-10,
+        toler=1e-13,
+        method="breslow",
+        distribution="t",
+        tdf=5.0,
+    )
+
+    assert fit.coefficients[0] == pytest.approx([-0.19743147930125], abs=1e-12)
+    assert fit.frailty == pytest.approx(
+        [
+            0.426144390050408,
+            0.298550076830906,
+            0.136467056887759,
+            -0.00855828519712049,
+            -0.24217955197031,
+            -0.780582477534266,
+        ],
+        abs=1e-12,
+    )
+    assert fit.frailty_variance == pytest.approx(
+        [
+            0.317599821981425,
+            0.249342034909525,
+            0.203691040339686,
+            0.184566103436754,
+            0.18538781841236,
+            0.376879269003266,
+        ],
+        abs=1e-12,
+    )
+    assert fit.log_likelihood == pytest.approx(
+        [-23.6901985559574, -19.9806323372429],
+        abs=1e-12,
+    )
+    assert fit.covariate_degrees_of_freedom == pytest.approx([0.981376565411526], abs=1e-12)
+    assert fit.frailty_degrees_of_freedom == pytest.approx(1.63990825488468, abs=1e-12)
+    assert fit.distribution == "t"
+    assert fit.tdf == pytest.approx(5.0)
+
+
+@pytest.mark.parametrize("tdf", [2.0, 1.0, float("inf")])
+def test_sparse_student_t_frailty_native_fit_validates_tdf(tdf):
+    with pytest.raises(ValueError, match="greater than 2"):
+        survival.r_api._core.coxph_frailty_fit(
+            [1.0, 2.0],
+            [1, 0],
+            [[0.0], [1.0]],
+            [0, 0],
+            0.5,
+            distribution="t",
+            tdf=tdf,
+        )
+
+    with pytest.raises(ValueError, match="only valid"):
+        survival.r_api._core.coxph_frailty_fit(
+            [1.0, 2.0],
+            [1, 0],
+            [[0.0], [1.0]],
+            [0, 0],
+            0.5,
+            distribution="gaussian",
+            tdf=tdf,
+        )

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -10473,6 +10473,11 @@ def test_coxph_formula_frailty_rejects_unsupported_modes():
         ("distribution='gaussian',method='aic',theta=.5", ValueError, "cannot include theta"),
         ("distribution='gaussian',method='aic',df=2", ValueError, "must be zero"),
         ("distribution='gaussian',df=6,sparse=False", ValueError, "between"),
+        ("distribution='t',theta=.5,tdf=2", ValueError, "greater than 2"),
+        ("distribution='t',theta=.5,sparse=False", NotImplementedError, "sparse=True"),
+        ("distribution='t',method='fixed'", ValueError, "requires theta"),
+        ("distribution='t',method='reml'", NotImplementedError, "fixed theta"),
+        ("distribution='gaussian',theta=.5,tdf=5", ValueError, "only valid"),
     ):
         with pytest.raises(exception, match=message):
             survival.coxph(f"Surv(time,status) ~ frailty(g,{option})", data=data)
@@ -10491,6 +10496,142 @@ def test_coxph_formula_frailty_rejects_unsupported_modes():
             'Surv(time,status) ~ frailty(g,distribution="gaussian",theta=.5,sparse=False)',
             data=data,
         )
+
+
+@pytest.mark.parametrize(
+    (
+        "frailty_term",
+        "coefficient",
+        "loglik",
+        "x_df",
+        "frailty_df",
+        "theta",
+        "first_effect",
+    ),
+    [
+        (
+            'frailty(g,distribution="t",theta=.5,tdf=5,method="fixed")',
+            -0.19743147930125,
+            -19.9806323372429,
+            0.981376565411526,
+            1.63990825488468,
+            0.5,
+            0.426144390050408,
+        ),
+        (
+            'frailty(g,distribution="t",df=2,tdf=5,method="df")',
+            -0.190407075472797,
+            -19.1417404372198,
+            0.976067230723378,
+            2.05699039361143,
+            0.64210145918238,
+            0.569256434797679,
+        ),
+    ],
+)
+def test_coxph_formula_student_t_frailty_matches_reference(
+    frailty_term,
+    coefficient,
+    loglik,
+    x_df,
+    frailty_df,
+    theta,
+    first_effect,
+):
+    data = {
+        "time": [float(value) for value in range(2, 20)],
+        "status": [1, 1, 0, 1, 1, 0, 1, 0, 1, 1, 0, 1, 0, 1, 1, 0, 1, 1],
+        "x": [
+            -1.2,
+            -0.8,
+            -0.4,
+            0.0,
+            0.4,
+            0.8,
+            1.2,
+            -1.0,
+            -0.6,
+            -0.2,
+            0.2,
+            0.6,
+            1.0,
+            1.4,
+            -1.4,
+            -0.9,
+            0.1,
+            0.9,
+        ],
+        "g": [level for level in "abcdef" for _ in range(3)],
+    }
+    fit = survival.coxph(
+        f"Surv(time,status) ~ x + {frailty_term}",
+        data=data,
+        ties="breslow",
+        control={"iter.max": 50, "outer.max": 30, "eps": 1e-10, "toler.chol": 1e-13},
+    )
+
+    assert fit.coefficients[0] == pytest.approx([coefficient], abs=1e-12)
+    assert fit.frailty[0] == pytest.approx(first_effect, abs=1e-12)
+    assert fit.log_likelihood == pytest.approx([-23.6901985559574, loglik], abs=1e-12)
+    assert fit.term_degrees_of_freedom == pytest.approx(
+        {"x": x_df, frailty_term: frailty_df},
+        abs=1e-12,
+    )
+    assert fit.history[frailty_term]["theta"] == pytest.approx(theta, abs=1e-12)
+    assert fit.history[frailty_term]["done"] is True
+
+
+def test_coxph_formula_student_t_frailty_selects_variance_by_aic_reference():
+    group = [level for level in "abcdefgh" for _ in range(8)]
+    within_group = list(range(1, 9)) * 8
+    scales = [scale for scale in (1.0, 1.2, 1.5, 1.9, 2.4, 3.0, 3.8, 4.8) for _ in range(8)]
+    data = {
+        "time": [value * scale for value, scale in zip(within_group, scales, strict=True)],
+        "status": [1] * 64,
+        "g": group,
+    }
+    frailty_term = 'frailty(g,distribution="t",tdf=5,method="aic",eps=1e-7)'
+    fit = survival.coxph(
+        f"Surv(time,status) ~ {frailty_term}",
+        data=data,
+        ties="breslow",
+        control={"iter.max": 50, "outer.max": 30, "eps": 1e-10, "toler.chol": 1e-13},
+    )
+
+    assert fit.coefficients[0] == []
+    assert fit.frailty == pytest.approx(
+        [
+            1.30137042268428,
+            0.976780652387157,
+            0.618335062643476,
+            0.239187000816398,
+            -0.175741099680022,
+            -0.549327075649645,
+            -0.981891152145677,
+            -1.54111611341539,
+        ],
+        abs=1e-5,
+    )
+    assert fit.log_likelihood == pytest.approx(
+        [-206.196936338164, -186.924830886573],
+        abs=3e-5,
+    )
+    assert fit.term_degrees_of_freedom == pytest.approx({frailty_term: 7.35973447609057}, abs=3e-5)
+    history = fit.history[frailty_term]
+    assert history["theta"] == pytest.approx(2.86960257431007, abs=4e-4)
+    assert history["done"] is True
+    assert len(history["history"]) == 11
+
+
+def test_student_t_frailty_formula_defaults_match_r_selection():
+    parsed = survival.r_api._parse_frailty_formula_term('frailty(g,distribution="t")')
+
+    assert parsed.distribution == "t"
+    assert parsed.tdf == pytest.approx(5.0)
+    assert parsed.selection == "aic"
+    assert parsed.theta is None
+    assert parsed.target_df is None
+    assert parsed.eps == pytest.approx(1e-5)
 
 
 def test_coxph_formula_gaussian_frailty_calibrates_target_df_reference():

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -7958,3 +7958,38 @@ test_that("ordinary istate inputs match R model-frame semantics", {
   expect_length(fit_istate_name, 1L)
   expect_equal(as.character(bridged_fit_frame[[fit_istate_name]]), as.character(data$state))
 })
+
+test_that("Student-t frailty formulas match survival", {
+  skip_if_not_installed("reticulate")
+  skip_if_not_installed("survival")
+  skip_if_not(reticulate::py_module_available("survival"), "Python survival package is unavailable")
+
+  data <- data.frame(
+    time = 2:19,
+    status = c(1, 1, 0, 1, 1, 0, 1, 0, 1, 1, 0, 1, 0, 1, 1, 0, 1, 1),
+    x = c(-1.2, -0.8, -0.4, 0, 0.4, 0.8, 1.2, -1, -0.6, -0.2, 0.2, 0.6, 1, 1.4, -1.4, -0.9, 0.1, 0.9),
+    g = factor(rep(letters[1:6], each = 3))
+  )
+  bridged <- coxph(
+    Surv(time, status) ~ x + frailty(g, distribution = "t", theta = 0.5, tdf = 5, method = "fixed"),
+    data = data,
+    ties = "breslow",
+    control = coxph.control(iter.max = 50L, eps = 1e-10, toler.chol = 1e-13)
+  )
+  reference <- survival::coxph(
+    survival::Surv(time, status) ~ x + survival::frailty(g, distribution = "t", theta = 0.5, tdf = 5, method = "fixed"),
+    data = data,
+    ties = "breslow",
+    control = survival::coxph.control(iter.max = 50L, eps = 1e-10, toler.chol = 1e-13)
+  )
+
+  expect_equal(coef(bridged), coef(reference), tolerance = 1e-12)
+  expect_equal(bridged$frailty, reference$frail, tolerance = 1e-12)
+  expect_equal(bridged$frailty_variance, reference$fvar, tolerance = 1e-12)
+  expect_equal(bridged$log_likelihood, reference$loglik, tolerance = 1e-12)
+  expect_equal(
+    unname(unlist(bridged$term_degrees_of_freedom)),
+    unname(reference$df),
+    tolerance = 1e-12
+  )
+})

--- a/src/regression/cox_frailty.rs
+++ b/src/regression/cox_frailty.rs
@@ -2,6 +2,7 @@ use crate::constants::{
     CONVERGENCE_FLAG, COX_CONVERGENCE_TOLERANCE, COX_MAX_ITER, COX_RANK_TOLERANCE, EXP_CLAMP_MAX,
     EXP_CLAMP_MIN,
 };
+use crate::internal::statistical::ln_gamma;
 use crate::regression::coxph::CoxPHFit;
 use crate::regression::coxph_detail_module::CoxphDetail;
 use crate::regression::coxph_support::StratifiedBaselineLookup;
@@ -18,6 +19,16 @@ enum Ties {
 enum FrailtyDistribution {
     Gaussian,
     Gamma,
+    StudentT(f64),
+}
+
+fn student_t_location_terms(value: f64, denominator: f64) -> (f64, f64) {
+    let scaled_square = value * value / denominator;
+    let temp = 1.0 + scaled_square;
+    (
+        value / temp,
+        1.0 / temp - 2.0 * scaled_square / (temp * temp),
+    )
 }
 
 #[pyclass(skip_from_py_object)]
@@ -39,6 +50,8 @@ pub struct CoxPHFrailtyFit {
     pub theta: f64,
     #[pyo3(get)]
     pub distribution: String,
+    #[pyo3(get)]
+    pub tdf: Option<f64>,
     #[pyo3(get)]
     pub offset: Vec<f64>,
     diagnostic_fit: CoxPHFit,
@@ -488,6 +501,17 @@ impl SparseFrailtySolver {
                         / frailty.len() as f64)
                         .ln()
             }
+            FrailtyDistribution::StudentT(degrees_of_freedom) => {
+                let denominator = self.theta * (degrees_of_freedom - 2.0);
+                let (first_sum, second_sum) =
+                    frailty
+                        .iter()
+                        .fold((0.0, 0.0), |(first_sum, second_sum), &value| {
+                            let (first, second) = student_t_location_terms(value, denominator);
+                            (first_sum + first, second_sum + second)
+                        });
+                first_sum / second_sum
+            }
         };
         for value in frailty {
             *value -= center;
@@ -502,6 +526,17 @@ impl SparseFrailtySolver {
                 .iter()
                 .map(|value| value.exp() * precision)
                 .collect(),
+            FrailtyDistribution::StudentT(degrees_of_freedom) => {
+                let denominator = self.theta * (degrees_of_freedom - 2.0);
+                let scale = (degrees_of_freedom + 1.0) / denominator;
+                frailty
+                    .iter()
+                    .map(|value| {
+                        let (_, second) = student_t_location_terms(*value, denominator);
+                        scale * second
+                    })
+                    .collect()
+            }
         }
     }
 
@@ -546,6 +581,21 @@ impl SparseFrailtySolver {
                     .sum::<f64>()
             }
             FrailtyDistribution::Gamma => -frailty.iter().sum::<f64>() / self.theta,
+            FrailtyDistribution::StudentT(degrees_of_freedom) => {
+                let denominator = self.theta * (degrees_of_freedom - 2.0);
+                let constant = 0.5 * (std::f64::consts::PI * denominator).ln()
+                    + ln_gamma(degrees_of_freedom / 2.0)
+                    - ln_gamma((degrees_of_freedom + 1.0) / 2.0);
+                frailty
+                    .iter()
+                    .map(|value| {
+                        constant
+                            + 0.5
+                                * (degrees_of_freedom + 1.0)
+                                * (1.0 + value * value / denominator).ln()
+                    })
+                    .sum()
+            }
         }
     }
 
@@ -721,6 +771,15 @@ impl SparseFrailtySolver {
                     let relative_risk = frailty[group].exp();
                     score[group] -= (relative_risk - 1.0) * precision;
                     group_diagonal[group] += relative_risk * precision;
+                }
+            }
+            FrailtyDistribution::StudentT(degrees_of_freedom) => {
+                let denominator = self.theta * (degrees_of_freedom - 2.0);
+                let scale = (degrees_of_freedom + 1.0) / denominator;
+                for group in 0..nfrail {
+                    let (first, second) = student_t_location_terms(frailty[group], denominator);
+                    score[group] -= scale * first;
+                    group_diagonal[group] += scale * second;
                 }
             }
         }
@@ -1242,7 +1301,7 @@ fn validate_penalty(values: Option<Vec<Vec<f64>>>, nvar: usize) -> PyResult<Arra
 }
 
 #[pyfunction]
-#[pyo3(signature = (time, status, covariates, groups, theta, strata=None, weights=None, offset=None, initial_beta=None, initial_frailty=None, max_iter=None, eps=None, toler=None, method=None, nocenter=None, penalty_matrix=None, entry_times=None, distribution=None))]
+#[pyo3(signature = (time, status, covariates, groups, theta, strata=None, weights=None, offset=None, initial_beta=None, initial_frailty=None, max_iter=None, eps=None, toler=None, method=None, nocenter=None, penalty_matrix=None, entry_times=None, distribution=None, tdf=None))]
 #[allow(clippy::too_many_arguments)]
 pub fn coxph_frailty_fit(
     time: Vec<f64>,
@@ -1263,6 +1322,7 @@ pub fn coxph_frailty_fit(
     penalty_matrix: Option<Vec<Vec<f64>>>,
     entry_times: Option<Vec<f64>>,
     distribution: Option<&str>,
+    tdf: Option<f64>,
 ) -> PyResult<CoxPHFrailtyFit> {
     let n = time.len();
     if n == 0 {
@@ -1384,11 +1444,34 @@ pub fn coxph_frailty_fit(
         .to_ascii_lowercase()
         .as_str()
     {
-        "gaussian" => FrailtyDistribution::Gaussian,
-        "gamma" => FrailtyDistribution::Gamma,
+        "gaussian" => {
+            if tdf.is_some() {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "tdf is only valid for Student-t frailty",
+                ));
+            }
+            FrailtyDistribution::Gaussian
+        }
+        "gamma" => {
+            if tdf.is_some() {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "tdf is only valid for Student-t frailty",
+                ));
+            }
+            FrailtyDistribution::Gamma
+        }
+        "t" => {
+            let degrees_of_freedom = tdf.unwrap_or(5.0);
+            if !degrees_of_freedom.is_finite() || degrees_of_freedom <= 2.0 {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "tdf must be a finite value greater than 2",
+                ));
+            }
+            FrailtyDistribution::StudentT(degrees_of_freedom)
+        }
         _ => {
             return Err(pyo3::exceptions::PyValueError::new_err(
-                "distribution must be 'gaussian' or 'gamma'",
+                "distribution must be 'gaussian', 'gamma', or 't'",
             ));
         }
     };
@@ -1541,8 +1624,13 @@ pub fn coxph_frailty_fit(
         distribution: match distribution {
             FrailtyDistribution::Gaussian => "gaussian",
             FrailtyDistribution::Gamma => "gamma",
+            FrailtyDistribution::StudentT(_) => "t",
         }
         .to_string(),
+        tdf: match distribution {
+            FrailtyDistribution::StudentT(degrees_of_freedom) => Some(degrees_of_freedom),
+            FrailtyDistribution::Gaussian | FrailtyDistribution::Gamma => None,
+        },
         offset,
         diagnostic_fit,
     })
@@ -1551,6 +1639,29 @@ pub fn coxph_frailty_fit(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn student_t_penalty_derivatives_match_finite_differences() {
+        let theta = 0.7;
+        let degrees_of_freedom = 5.0;
+        let denominator = theta * (degrees_of_freedom - 2.0);
+        let scale = (degrees_of_freedom + 1.0) / denominator;
+        let value = 0.4;
+        let first_step = 1e-5;
+        let second_step = 1e-4;
+        let penalty = |point: f64| {
+            0.5 * (degrees_of_freedom + 1.0) * (1.0 + point * point / denominator).ln()
+        };
+        let (first, second) = student_t_location_terms(value, denominator);
+        let numeric_first =
+            (penalty(value + first_step) - penalty(value - first_step)) / (2.0 * first_step);
+        let numeric_second = (penalty(value + second_step) - 2.0 * penalty(value)
+            + penalty(value - second_step))
+            / (second_step * second_step);
+
+        assert!((scale * first - numeric_first).abs() < 1e-10);
+        assert!((scale * second - numeric_second).abs() < 1e-6);
+    }
 
     #[test]
     fn specialized_factorization_solves_diagonal_dense_system() {
@@ -1611,6 +1722,7 @@ mod tests {
                 11.0, 9.0,
             ]),
             None,
+            None,
         )
         .expect("counting-process frailty fit should compute");
 
@@ -1646,6 +1758,7 @@ mod tests {
             None,
             None,
             Some("gamma"),
+            None,
         )
         .expect("fixed gamma frailty fit should compute");
 


### PR DESCRIPTION
## Summary
- add a native sparse Student-t frailty penalty with R-compatible recentering, score, curvature, density normalization, and effective degrees of freedom
- support `distribution="t"` and `tdf` in Cox formulas for fixed variance, target degrees of freedom, and AIC variance selection
- expose the fitted Student-t parameter in the Python binding and reject unsupported dense Student-t penalties explicitly
- add native, Python formula, controller, validation, and R bridge parity coverage

## Validation
- `PYTHONPATH=python .venv/bin/pytest -q` — 965 passed, 18 skipped
- `cargo test --lib` — 1,517 passed
- `cargo clippy --all-targets --all-features -- -D warnings`
- `R CMD check --no-manual --no-build-vignettes r/survivalr` — tests passed; one standard source-directory note
- `.venv/bin/ruff check python/ test/`
- `.venv/bin/ruff format --check` on all modified Python files
- `.venv/bin/mypy python/survival/__init__.pyi python/survival/_survival.pyi --ignore-missing-imports`
- `.venv/bin/python scripts/generate_binding_manifest.py --check`
- `git diff --check`