### PR TITLE
Add gamma frailty variance selection

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -3607,7 +3607,12 @@ def _parse_frailty_formula_term(term: str) -> _FrailtyFormulaTerm:
         if theta is not None and df is not None:
             raise ValueError("gamma frailty cannot include both theta and df")
         if method is None:
-            method = "fixed" if theta is not None else "em"
+            if theta is not None:
+                method = "fixed"
+            elif df is not None:
+                method = "df"
+            else:
+                method = "em"
         if eps is not None and eps <= 0.0:
             raise ValueError("frailty eps must be positive")
         if method == "fixed":
@@ -3620,19 +3625,33 @@ def _parse_frailty_formula_term(term: str) -> _FrailtyFormulaTerm:
             if theta is not None or df is not None:
                 raise ValueError("EM gamma frailty cannot include theta or df")
             selection = "em"
+        elif method == "df":
+            if theta is not None:
+                raise ValueError("target-df gamma frailty cannot include theta")
+            if df is None:
+                raise ValueError("target-df gamma frailty requires df")
+            if df <= 0.0:
+                raise ValueError("frailty df must be positive")
+            selection = "df"
+        elif method == "aic":
+            if theta is not None or df is not None:
+                raise ValueError("AIC gamma frailty cannot include theta or df")
+            selection = "aic"
         else:
             raise NotImplementedError(
-                "gamma frailty formulas currently support fixed theta or EM with sparse=True"
+                "gamma frailty formulas support fixed theta, EM, target df, or AIC"
             )
         if theta is not None and theta <= 0.0:
             raise ValueError("frailty theta must be positive")
+        if eps is None:
+            eps = 0.1 if selection == "df" else 1e-5
         return _FrailtyFormulaTerm(
             term=_CovariateTerm(column, transform="frailty"),
             distribution=distribution,
             tdf=None,
             theta=theta,
-            target_df=None,
-            eps=1e-5 if eps is None else eps,
+            target_df=df if selection == "df" else None,
+            eps=eps,
             selection=selection,
             sparse=sparse,
             label=term,
@@ -24460,6 +24479,16 @@ def coxph(
                 for index, block in enumerate(formula_frailty_blocks)
             }
         )
+        for index, block in enumerate(formula_frailty_blocks):
+            if block.distribution != "gamma":
+                continue
+            corrected = _gamma_frailty_history_row(
+                frailty_thetas[index],
+                float(fit.penalized_log_likelihood),
+                list(response.event),
+                block.groups,
+            )
+            ridge_history[block.label]["c.loglik"] = corrected["c.loglik"]
     term_degrees_of_freedom = None
     effective_degrees_of_freedom = None
     if (

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -10253,6 +10253,10 @@ def test_coxph_formula_fixed_sparse_gamma_frailty_matches_reference():
     )
     assert fit.information_matrix[0] == pytest.approx([0.478590809971639], abs=1e-12)
     assert fit.naive_information_matrix[0] == pytest.approx([0.351763771750402], abs=1e-12)
+    assert fit.history[frailty_term] == pytest.approx(
+        {"theta": 0.5, "done": True, "c.loglik": -24.3690750173844},
+        abs=1e-11,
+    )
 
 
 def test_coxph_formula_gamma_frailty_em_matches_reference():
@@ -10449,6 +10453,131 @@ def test_coxph_formula_gamma_frailty_em_matches_reference():
     assert history["c.loglik"] == pytest.approx(-70.5935332072113, abs=2e-11)
 
 
+def test_coxph_formula_gamma_frailty_calibrates_target_df_reference():
+    data = {
+        "time": [float(value) for value in range(1, 19)],
+        "status": [1, 0, 1, 1, 0, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1],
+        "x": [
+            1.2,
+            0.7,
+            1.5,
+            0.2,
+            1.1,
+            0.4,
+            1.8,
+            0.9,
+            0.5,
+            1.4,
+            0.3,
+            1.0,
+            0.6,
+            1.7,
+            0.1,
+            1.3,
+            0.8,
+            1.6,
+        ],
+        "g": list("abcdef") * 3,
+    }
+    frailty_term = 'frailty(g,distribution="gamma",df=2)'
+    fit = survival.coxph(
+        f"Surv(time,status) ~ x + {frailty_term}",
+        data=data,
+        ties="breslow",
+        control={"iter.max": 50, "outer.max": 30, "eps": 1e-10, "toler.chol": 1e-13},
+    )
+
+    assert fit.coefficients[0] == pytest.approx([-0.768418933256273], abs=1e-12)
+    assert fit.frailty == pytest.approx(
+        [
+            -0.0208733978148822,
+            0.305820524276599,
+            0.0298178781906759,
+            -0.140015016714592,
+            -0.230954162657359,
+            -0.030943304440632,
+        ],
+        abs=1e-12,
+    )
+    assert fit.log_likelihood == pytest.approx(
+        [-23.3506715493412, -22.0626964958843],
+        abs=1e-12,
+    )
+    assert fit.term_degrees_of_freedom == pytest.approx(
+        {"x": 0.74332073610608, frailty_term: 2.09154881877917},
+        abs=1e-12,
+    )
+    history = fit.history[frailty_term]
+    assert history["theta"] == pytest.approx(0.430546900360188, abs=1e-12)
+    assert history["done"] is True
+    assert history["half"] == 0
+    assert [row["theta"] for row in history["history"]] == pytest.approx(
+        [0.0, 1.0 / 3.0, 0.594577701730334, 0.463955517531834],
+        abs=1e-12,
+    )
+    assert [row["df"] for row in history["history"]] == pytest.approx(
+        [0.0, 1.68186596485171, 2.42348281123581, 2.09154881877917],
+        abs=1e-12,
+    )
+    assert history["c.loglik"] == pytest.approx(-24.2656193278319, abs=1e-12)
+
+
+def test_coxph_formula_gamma_frailty_selects_variance_by_aic_reference():
+    group = [level for level in "abcdefgh" for _ in range(8)]
+    within_group = list(range(1, 9)) * 8
+    scales = [scale for scale in (1.0, 1.2, 1.5, 1.9, 2.4, 3.0, 3.8, 4.8) for _ in range(8)]
+    data = {
+        "time": [value * scale for value, scale in zip(within_group, scales, strict=True)],
+        "status": [1] * 64,
+        "g": group,
+    }
+    frailty_term = 'frailty(g,distribution="gamma",method="aic")'
+    fit = survival.coxph(
+        f"Surv(time,status) ~ {frailty_term}",
+        data=data,
+        ties="breslow",
+        control={"iter.max": 50, "outer.max": 30, "eps": 1e-10, "toler.chol": 1e-13},
+    )
+
+    assert fit.coefficients[0] == []
+    assert fit.frailty == pytest.approx(
+        [
+            0.865250002647932,
+            0.605909342502875,
+            0.295070655591725,
+            -0.0560772831867553,
+            -0.460267163205522,
+            -0.834866798165431,
+            -1.27440888793327,
+            -1.84420455145919,
+        ],
+        abs=4e-4,
+    )
+    assert fit.log_likelihood == pytest.approx(
+        [-206.196936338164, -187.142249671341],
+        abs=1e-3,
+    )
+    assert fit.term_degrees_of_freedom == pytest.approx(
+        {frailty_term: 6.93224380874699},
+        abs=1e-3,
+    )
+    history = fit.history[frailty_term]
+    assert history["theta"] == pytest.approx(0.997907754769582, abs=4e-3)
+    assert history["done"] is True
+    assert len(history["history"]) == 8
+    assert history["history"][0] == pytest.approx(
+        {
+            "theta": 0.1,
+            "loglik": -195.231781928953,
+            "df": 3.16838255486095,
+            "aic": -198.400164483814,
+            "aicc": -198.766358659907,
+        },
+        abs=1e-11,
+    )
+    assert history["c.loglik"] == pytest.approx(-199.220570986039, abs=2e-3)
+
+
 def test_coxph_formula_frailty_rejects_unsupported_modes():
     data = {
         "time": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
@@ -10456,9 +10585,12 @@ def test_coxph_formula_frailty_rejects_unsupported_modes():
         "g": list("abcdef"),
     }
     for option, exception, message in (
-        ("distribution='gamma',method='aic'", NotImplementedError, "fixed theta or EM"),
         ("distribution='gamma',method='em',theta=.5", ValueError, "cannot include"),
         ("distribution='gamma',method='em',df=2", ValueError, "cannot include"),
+        ("distribution='gamma',method='aic',theta=.5", ValueError, "cannot include"),
+        ("distribution='gamma',method='aic',df=2", ValueError, "cannot include"),
+        ("distribution='gamma',method='df'", ValueError, "requires df"),
+        ("distribution='gamma',df=0", ValueError, "positive"),
         ("distribution='gamma',theta=.5,sparse=False", NotImplementedError, "sparse=True"),
         ("distribution='gamma',theta=0,sparse=True", ValueError, "positive"),
         ("distribution='gaussian',method='ml'", NotImplementedError, "support fixed"),

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -7993,3 +7993,44 @@ test_that("Student-t frailty formulas match survival", {
     tolerance = 1e-12
   )
 })
+
+test_that("gamma frailty target degrees of freedom match survival", {
+  skip_if_not_installed("reticulate")
+  skip_if_not_installed("survival")
+  skip_if_not(reticulate::py_module_available("survival"), "Python survival package is unavailable")
+
+  data <- data.frame(
+    time = seq_len(18L),
+    status = c(1, 0, 1, 1, 0, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1),
+    x = c(1.2, 0.7, 1.5, 0.2, 1.1, 0.4, 1.8, 0.9, 0.5, 1.4, 0.3, 1, 0.6, 1.7, 0.1, 1.3, 0.8, 1.6),
+    g = factor(rep(letters[1:6], 3))
+  )
+  bridged <- coxph(
+    Surv(time, status) ~ x + frailty(g, distribution = "gamma", df = 2),
+    data = data,
+    ties = "breslow",
+    control = coxph.control(iter.max = 50L, eps = 1e-10, toler.chol = 1e-13, outer.max = 30L)
+  )
+  reference <- survival::coxph(
+    survival::Surv(time, status) ~ x + survival::frailty(g, distribution = "gamma", df = 2),
+    data = data,
+    ties = "breslow",
+    control = survival::coxph.control(iter.max = 50L, eps = 1e-10, toler.chol = 1e-13, outer.max = 30L)
+  )
+
+  expect_equal(coef(bridged), coef(reference), tolerance = 1e-12)
+  expect_equal(bridged$frailty, reference$frail, tolerance = 1e-12)
+  expect_equal(bridged$frailty_variance, reference$fvar, tolerance = 1e-12)
+  expect_equal(bridged$log_likelihood, reference$loglik, tolerance = 1e-12)
+  expect_equal(
+    unname(unlist(bridged$term_degrees_of_freedom)),
+    unname(reference$df),
+    tolerance = 1e-12
+  )
+  expect_equal(bridged$history[[1L]]$theta, reference$history[[1L]]$theta, tolerance = 1e-12)
+  expect_equal(
+    bridged$history[[1L]]$c.loglik,
+    reference$history[[1L]]$c.loglik,
+    tolerance = 1e-12
+  )
+})


### PR DESCRIPTION
## Summary
- support gamma Cox frailty variance selection by target degrees of freedom and AIC, completing the fixed, EM, target-DF, and AIC method set
- match R’s method defaults, initial variance guesses, convergence tolerances, and invalid argument combinations
- report the integrated gamma log-likelihood correction as `c.loglik` for fixed and selected-variance fits
- add exact target-DF, AIC, validation, and end-to-end R bridge parity coverage

## Validation
- `PYTHONPATH=python .venv/bin/pytest -q` — 967 passed, 18 skipped
- `cargo test --lib` — 1,517 passed
- `cargo clippy --all-targets --all-features -- -D warnings`
- `R CMD check --no-manual --no-build-vignettes r/survivalr` — tests passed; one standard source-directory note
- `.venv/bin/ruff check python/ test/`
- `.venv/bin/ruff format --check` on all modified Python files
- `.venv/bin/mypy python/survival/__init__.pyi python/survival/_survival.pyi --ignore-missing-imports`
- `.venv/bin/python scripts/generate_binding_manifest.py --check`
- `git diff --check`