### PR TITLE
Add stratified multi-state Cox curves

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,8 +174,8 @@ counting-process responses, with transition-specific coefficients and
 baselines, automatic subject-clustered robust covariance, and matrix-valued
 linear-predictor and risk predictions. Model-based state-probability curves
 support direct or matrix-exponential transition updates for one or more
-covariate profiles, optional starting-state mixtures, and conditional start
-times.
+covariate profiles across unstratified or stratified baselines, optional
+starting-state mixtures, and conditional start times.
 Formula fits support `tt(...)` time-varying coefficient terms for right-censored
 and counting-process responses, including R's default O'Brien rank transform
 and custom `tt(x, time, riskset, weights)` callables.

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -419,6 +419,8 @@ class _MultiStateCoxFitMetadata:
     original_rows: tuple[tuple[float, ...], ...]
     original_offsets: tuple[float, ...]
     original_istate: tuple[Any, ...] | None
+    original_strata: tuple[Any, ...] | None
+    strata_levels: tuple[Any, ...]
     row_names: tuple[str, ...]
     original_width: int
     reported_means: tuple[float, ...]
@@ -14181,11 +14183,36 @@ def _cox_survfit_from_aggregates(
 
 
 def aggregate_survfit_result(
-    result: CoxSurvfitResult | SurvfitMultiStateCoxResult,
+    result: CoxSurvfitResult | SurvfitMultiStateCoxResult | Mapping[Any, Any],
     groups: Any | None = None,
     weights: Any | None = None,
-) -> CoxSurvfitResult | SurvfitMultiStateResult | SurvfitMultiStateCoxResult:
+) -> (
+    CoxSurvfitResult
+    | SurvfitMultiStateResult
+    | SurvfitMultiStateCoxResult
+    | dict[Any, SurvfitMultiStateResult | SurvfitMultiStateCoxResult]
+):
     """Average Cox survfit prediction curves, optionally by group code."""
+
+    if isinstance(result, Mapping):
+        if not result or not all(
+            isinstance(curve, SurvfitMultiStateCoxResult)
+            or (isinstance(curve, SurvfitMultiStateResult) and curve.cox_model)
+            for curve in result.values()
+        ):
+            raise TypeError("survfit object does not have a 'data' margin")
+        aggregated: dict[Any, SurvfitMultiStateResult | SurvfitMultiStateCoxResult] = {}
+        for label, curve in result.items():
+            batch = (
+                curve
+                if isinstance(curve, SurvfitMultiStateCoxResult)
+                else SurvfitMultiStateCoxResult((curve,), curve.model)
+            )
+            value = aggregate_survfit_result(batch, groups, weights)
+            if not isinstance(value, SurvfitMultiStateResult | SurvfitMultiStateCoxResult):
+                raise AssertionError("stratified multi-state aggregation returned invalid output")
+            aggregated[label] = value
+        return aggregated
 
     if isinstance(result, SurvfitMultiStateCoxResult):
         n_curves = result.curve_count
@@ -18354,8 +18381,11 @@ def _survfit_multistate_structure(
     result: SurvfitMultiStateResult | SurvfitMultiStateCoxResult | Mapping[Any, Any],
 ) -> dict[str, Any]:
     batch_curves: tuple[SurvfitMultiStateResult, ...] | None = None
+    grouped_batches: list[tuple[Any, SurvfitMultiStateCoxResult]] | None = None
+    cox_curve_count = 1
     if isinstance(result, SurvfitMultiStateCoxResult):
         batch_curves = result.curves
+        cox_curve_count = result.curve_count
         curves = [(None, result.curves[0])]
         grouped = False
     elif isinstance(result, SurvfitMultiStateResult):
@@ -18367,6 +18397,17 @@ def _survfit_multistate_structure(
         and all(isinstance(curve, SurvfitMultiStateResult) for curve in result.values())
     ):
         curves = list(result.items())
+        grouped = True
+    elif (
+        isinstance(result, Mapping)
+        and result
+        and all(isinstance(curve, SurvfitMultiStateCoxResult) for curve in result.values())
+    ):
+        grouped_batches = list(result.items())
+        cox_curve_count = grouped_batches[0][1].curve_count
+        if any(batch.curve_count != cox_curve_count for _label, batch in grouped_batches):
+            raise ValueError("stratified multi-state Cox results must share a data dimension")
+        curves = [(label, batch.curves[0]) for label, batch in grouped_batches]
         grouped = True
     else:
         raise TypeError("survfit structure requires a multi-state result")
@@ -18389,6 +18430,17 @@ def _survfit_multistate_structure(
         return [[float(value) for value in row] for matrix in matrices for row in matrix]
 
     def model_curve_matrix(name: str) -> list[list[float]] | None:
+        if grouped_batches is not None:
+            matrices = [
+                getattr(batch.curves[curve_index], name)
+                for curve_index in range(cox_curve_count)
+                for _label, batch in grouped_batches
+            ]
+            if all(matrix is None for matrix in matrices):
+                return None
+            if any(matrix is None for matrix in matrices):
+                raise ValueError(f"stratified multi-state Cox curves must share {name} output")
+            return [[float(value) for value in row] for matrix in matrices for row in matrix]
         if batch_curves is None:
             return combined_matrix(name)
         matrices = [getattr(curve, name) for curve in batch_curves]
@@ -18472,7 +18524,7 @@ def _survfit_multistate_structure(
             "t0": first.t0,
             "_transition_names": transition_names,
             "_cox_model": first.cox_model,
-            "_cox_curve_count": 1 if batch_curves is None else len(batch_curves),
+            "_cox_curve_count": cox_curve_count,
         }
     )
     if first.oldstate is not None:
@@ -21646,6 +21698,7 @@ def _cox_multistate_baseline_increments(
     fit: _FormulaFit,
     times: Sequence[float],
     start_time: float,
+    user_stratum: int = 0,
 ) -> list[list[float]]:
     metadata = fit.multi_state
     if metadata is None:
@@ -21654,7 +21707,8 @@ def _cox_multistate_baseline_increments(
     baselines = _cox_baselines_by_stratum(base_times, base_hazards, base_strata)
     cumulative_by_transition: list[list[float]] = []
     for transition_idx in range(len(metadata.transitions)):
-        transition_times, transition_hazards = baselines.get(transition_idx, ([], []))
+        stratum = transition_idx * metadata.user_strata_count + user_stratum
+        transition_times, transition_hazards = baselines.get(stratum, ([], []))
         at_start = _core.step_values_at(
             transition_times,
             transition_hazards,
@@ -21720,14 +21774,14 @@ def _cox_multistate_survfit_result(
     conf_level: float,
     conf_type: str,
     keep_model: bool,
-) -> SurvfitMultiStateResult | SurvfitMultiStateCoxResult:
+) -> (
+    SurvfitMultiStateResult
+    | SurvfitMultiStateCoxResult
+    | dict[Any, SurvfitMultiStateResult | SurvfitMultiStateCoxResult]
+):
     metadata = fit.multi_state
     if metadata is None:
         raise AssertionError("multi-state Cox metadata is missing")
-    if metadata.user_strata_count != 1:
-        raise NotImplementedError(
-            "model-based multi-state Cox curves are currently limited to unstratified fits"
-        )
     if rows is None:
         raise ValueError("newdata is required for multi-state Cox survival curves")
     if not rows:
@@ -21738,9 +21792,9 @@ def _cox_multistate_survfit_result(
     if len(row_offsets) != len(rows):
         raise ValueError("multi-state Cox survival curves require one offset per newdata row")
 
-    shell = _survfit_multistate(
+    shells = _survfit_multistate(
         metadata.response,
-        None,
+        metadata.original_strata,
         fit.case_weights,
         fit.id_values,
         None,
@@ -21753,50 +21807,68 @@ def _cox_multistate_survfit_result(
         conf_level=conf_level,
         conf_type=conf_type,
         timefix=metadata.timefix,
-        group_levels=None,
+        group_levels=metadata.strata_levels or None,
         model_frame=None,
     )
-    if not isinstance(shell, SurvfitMultiStateResult):
-        raise AssertionError("multi-state Cox counts unexpectedly produced grouped curves")
-    if not include_censor:
-        transition_counts = shell.n_transition_count or shell.n_transition
-        keep = [
-            index
-            for index, (time, counts) in enumerate(zip(shell.time, transition_counts, strict=True))
-            if any(value > 0.0 for value in counts)
-            or (include_time0 and math.isclose(time, shell.t0, rel_tol=0.0, abs_tol=1e-12))
-        ]
-        shell = _select_multistate_curve_times(shell, keep)
-
-    increments = _cox_multistate_baseline_increments(fit, shell.time, shell.t0)
-    native_curves = _core.cox_multistate_curves(
-        increments,
-        [list(transition) for transition in metadata.transitions],
-        [
-            _cox_multistate_curve_risk(fit, row, offset)
-            for row, offset in zip(rows, row_offsets, strict=True)
-        ],
-        shell.p0,
-        stype == 2,
-    )
     model_frame = _cox_survfit_model_frame(fit, newdata) if keep_model else None
-    curves = tuple(
-        replace(
-            shell,
-            pstate=[[float(value) for value in row] for row in profile_pstate],
-            cumhaz=[[float(value) for value in row] for row in profile_cumhaz],
-            model=model_frame,
-            cox_model=True,
+    risks = [
+        _cox_multistate_curve_risk(fit, row, offset)
+        for row, offset in zip(rows, row_offsets, strict=True)
+    ]
+
+    def fit_shell(
+        shell: SurvfitMultiStateResult,
+        user_stratum: int,
+    ) -> SurvfitMultiStateResult | SurvfitMultiStateCoxResult:
+        if not include_censor:
+            transition_counts = shell.n_transition_count or shell.n_transition
+            keep = [
+                index
+                for index, (time, counts) in enumerate(
+                    zip(shell.time, transition_counts, strict=True)
+                )
+                if any(value > 0.0 for value in counts)
+                or (include_time0 and math.isclose(time, shell.t0, rel_tol=0.0, abs_tol=1e-12))
+            ]
+            shell = _select_multistate_curve_times(shell, keep)
+
+        increments = _cox_multistate_baseline_increments(
+            fit,
+            shell.time,
+            shell.t0,
+            user_stratum,
         )
-        for profile_pstate, profile_cumhaz in zip(
-            native_curves.pstate,
-            native_curves.cumhaz,
-            strict=True,
+        native_curves = _core.cox_multistate_curves(
+            increments,
+            [list(transition) for transition in metadata.transitions],
+            risks,
+            shell.p0,
+            stype == 2,
         )
-    )
-    if len(curves) == 1:
-        return curves[0]
-    return SurvfitMultiStateCoxResult(curves=curves, model=model_frame)
+        curves = tuple(
+            replace(
+                shell,
+                pstate=[[float(value) for value in row] for row in profile_pstate],
+                cumhaz=[[float(value) for value in row] for row in profile_cumhaz],
+                model=model_frame,
+                cox_model=True,
+            )
+            for profile_pstate, profile_cumhaz in zip(
+                native_curves.pstate,
+                native_curves.cumhaz,
+                strict=True,
+            )
+        )
+        if len(curves) == 1:
+            return curves[0]
+        return SurvfitMultiStateCoxResult(curves=curves, model=model_frame)
+
+    if isinstance(shells, SurvfitMultiStateResult):
+        return fit_shell(shells, 0)
+    return {
+        label: fit_shell(shell, user_stratum)
+        for user_stratum, (label, shell) in enumerate(shells.items())
+    }
 
 
 def _cox_survival_curve_with_se(
@@ -24596,7 +24668,15 @@ def coxph(
     istate_values = _materialize_1d(istate, "istate") if istate is not None else None
     if istate_values is not None and len(istate_values) != n:
         raise ValueError("istate must have the same length as the Surv response")
-    fit_strata = _encode_groups(strata, n) if strata is not None else None
+    original_strata_values = _materialize_labels(strata, "strata") if strata is not None else None
+    strata_levels = (
+        _label_levels(original_strata_values, "strata")
+        if original_strata_values is not None
+        else ()
+    )
+    fit_strata = (
+        _encode_groups(original_strata_values, n) if original_strata_values is not None else None
+    )
     fit_weights = _optional_float_vector(weights, "weights", n)
     case_weights = fit_weights if explicit_weights else None
     fit_offset = _optional_float_vector(offset, "offset", n)
@@ -24685,10 +24765,14 @@ def coxph(
                 [0.0] * len(rows) if fit_offset is None else map(float, fit_offset)
             ),
             original_istate=None if istate_values is None else tuple(istate_values),
+            original_strata=(
+                None if original_strata_values is None else tuple(original_strata_values)
+            ),
+            strata_levels=strata_levels,
             row_names=tuple(row_names or (str(index + 1) for index in range(len(rows)))),
             original_width=original_width,
             reported_means=_cox_multistate_reported_means(rows, nocenter_values),
-            user_strata_count=(max(fit_strata) + 1 if fit_strata else 1),
+            user_strata_count=len(strata_levels) or 1,
             timefix=fix_time,
         )
         response = Surv._from_normalized(

--- a/python/survival/r_api.pyi
+++ b/python/survival/r_api.pyi
@@ -878,10 +878,15 @@ def survfitkm_counting_influence(
 ) -> Any: ...
 def survfit0(x: Any, *args: Any, **kwargs: Any) -> Any: ...
 def aggregate_survfit_result(
-    result: CoxSurvfitResult | SurvfitMultiStateCoxResult,
+    result: CoxSurvfitResult | SurvfitMultiStateCoxResult | Mapping[Any, Any],
     groups: Any | None = None,
     weights: Any | None = None,
-) -> CoxSurvfitResult | SurvfitMultiStateResult | SurvfitMultiStateCoxResult: ...
+) -> (
+    CoxSurvfitResult
+    | SurvfitMultiStateResult
+    | SurvfitMultiStateCoxResult
+    | dict[Any, SurvfitMultiStateResult | SurvfitMultiStateCoxResult]
+): ...
 def survfit_confint(
     p: Any,
     se: Any,

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -13510,6 +13510,62 @@ def test_coxph_multistate_competing_risks_matches_r_reference():
         survival.r_api.aggregate_survfit_result(aggregate_source, groups=[1])
     with pytest.raises(ValueError, match="positive integer"):
         survival.r_api.aggregate_survfit_result(aggregate_source, groups=[0, 1, 1])
+    stratified_data = data.assign(
+        g=pandas.Categorical(["g1"] * 6 + ["g2"] * 6),
+    )
+    stratified_fit = survival.coxph(
+        "Surv(time, status) ~ x + strata(g)",
+        data=stratified_data,
+        id="id",
+        max_iter=20,
+        eps=1e-9,
+    )
+    assert survival.coef(stratified_fit) == pytest.approx(
+        [-1.0317081235160794, -0.4847370380673689],
+        abs=1e-12,
+    )
+    stratified_curves = survival.survfit(
+        stratified_fit,
+        newdata=pandas.DataFrame({"x": [0.5, 1.5]}),
+        time0=True,
+    )
+    assert list(stratified_curves) == ["g1", "g2"]
+    assert all(
+        isinstance(curve, survival.SurvfitMultiStateCoxResult)
+        for curve in stratified_curves.values()
+    )
+    assert stratified_curves["g1"].time == pytest.approx(list(range(7)))
+    assert stratified_curves["g2"].time == pytest.approx([0, 7, 8, 9, 10, 11, 12])
+    assert stratified_curves["g1"].pstate[0][-1] == pytest.approx(
+        [0.08632813976911419, 0.42612488659895686, 0.4875469736319289],
+        abs=1e-12,
+    )
+    assert stratified_curves["g2"].pstate[1][-1] == pytest.approx(
+        [0.32630515678228655, 0.31765547564010083, 0.35603936757761256],
+        abs=1e-12,
+    )
+    assert stratified_curves["g1"].cumhaz[1][-1] == pytest.approx(
+        [0.24090235858391046, 1.0923263551568523],
+        abs=1e-12,
+    )
+    stratified_structure = survival.r_api._survfit_multistate_structure(stratified_curves)
+    assert stratified_structure["strata"] == {"g1": 7, "g2": 7}
+    assert stratified_structure["_cox_curve_count"] == 2
+    assert len(stratified_structure["pstate"]) == 28
+    stratified_average = survival.r_api.aggregate_survfit_result(stratified_curves)
+    assert list(stratified_average) == ["g1", "g2"]
+    for label in stratified_curves:
+        assert stratified_average[label].pstate[-1] == pytest.approx(
+            [
+                sum(values) / 2.0
+                for values in zip(
+                    stratified_curves[label].pstate[0][-1],
+                    stratified_curves[label].pstate[1][-1],
+                    strict=True,
+                )
+            ],
+            abs=1e-12,
+        )
     selected_curve = survival.r_api._subset_survfit_multistate(batched_curve, [0, 2], [1])
     assert isinstance(selected_curve, survival.SurvfitMultiStateResult)
     assert selected_curve.cox_model is True

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -11607,7 +11607,17 @@ dim.survival_py_survfit <- function(x) {
   if (.is_survival_py_multistate_survfit(x)) {
     state_count <- length(.survival_py_multistate_states(x))
     if (.is_grouped_survival_py_survfit(x)) {
-      return(c(strata = length(unclass(x)), states = state_count))
+      curves <- unclass(x)
+      first <- curves[[1L]]
+      if (isTRUE(.result_field(first, "cox_model"))) {
+        data_count <- as.integer(.result_field(first, "curve_count"))[[1L]]
+        return(c(
+          strata = length(curves),
+          data = data_count,
+          states = state_count
+        ))
+      }
+      return(c(strata = length(curves), states = state_count))
     }
     if (isTRUE(.result_field(x, "cox_model"))) {
       data_count <- as.integer(.result_field(x, "curve_count"))[[1L]]
@@ -11827,21 +11837,69 @@ plot.survival_py_cox_zph <- function(x, resid = TRUE, se = TRUE, df = 4,
   invisible(NULL)
 }
 
-`[.survival_py_survfit` <- function(x, i, j, ..., drop = TRUE) {
+`[.survival_py_survfit` <- function(x, i, j, k, ..., drop = TRUE) {
   if (length(list(...)) > 0L) {
     stop("incorrect number of dimensions", call. = FALSE)
   }
   call_names <- names(match.call(expand.dots = FALSE))
   has_second_dimension <- !missing(j) ||
     (nargs() >= 3L && missing(j) && !("drop" %in% call_names))
-  if (missing(i) && missing(j)) {
+  has_third_dimension <- !missing(k) ||
+    (nargs() >= 4L && missing(k) && !("drop" %in% call_names))
+  if (missing(i) && missing(j) && missing(k)) {
     return(x)
   }
   if (.is_survival_py_multistate_survfit(x)) {
     states <- .survival_py_multistate_states(x)
     dimensions <- dim(x)
     data_count <- if ("data" %in% names(dimensions)) dimensions[["data"]] else NULL
+    if (.is_grouped_survival_py_survfit(x) && !is.null(data_count)) {
+      if (!has_third_dimension) {
+        stop(
+          paste(
+            "three index subscripts are required for a survfit object",
+            "with strata, data, and state dimensions"
+          ),
+          call. = FALSE
+        )
+      }
+      curves <- unclass(x)
+      strata_selector <- if (missing(i)) seq_along(curves) else i
+      data_selector <- if (missing(j)) seq_len(data_count) else j
+      state_selector <- if (missing(k)) seq_along(states) else k
+      strata_indices <- .survival_py_survfit_group_indices(
+        strata_selector,
+        names(curves)
+      )
+      data_indices <- .survival_py_survfit_group_indices(
+        data_selector,
+        seq_len(data_count),
+        dimension = "data"
+      )
+      state_indices <- .survival_py_survfit_group_indices(
+        state_selector,
+        states,
+        dimension = "states"
+      )
+      selected <- lapply(curves[strata_indices], function(curve) {
+        .wrap_python(
+          .python_attr("_subset_survfit_multistate")(
+            curve,
+            as.list(as.integer(state_indices - 1L)),
+            as.list(as.integer(data_indices - 1L))
+          ),
+          c("survival_py_survfit", "survival_py_object")
+        )
+      })
+      return(structure(
+        selected,
+        class = c("survival_py_survfit", "survival_py_object", "list")
+      ))
+    }
     if (!is.null(data_count)) {
+      if (has_third_dimension) {
+        stop("incorrect number of dimensions", call. = FALSE)
+      }
       if (!has_second_dimension) {
         stop(
           paste(
@@ -11892,6 +11950,9 @@ plot.survival_py_cox_zph <- function(x, resid = TRUE, se = TRUE, df = 4,
       )
     }
     if (.is_grouped_survival_py_survfit(x)) {
+      if (has_third_dimension) {
+        stop("incorrect number of dimensions", call. = FALSE)
+      }
       if (!has_second_dimension) {
         stop(
           paste(

--- a/r/survivalr/man/survivalr.Rd
+++ b/r/survivalr/man/survivalr.Rd
@@ -612,7 +612,7 @@ survfitKM(x, y, weights = rep(1, length(x)), stype = 1, ctype = 1,
 
 \method{[[}{survival_py_survfit}(x, i, ..., exact = TRUE)
 
-\method{[}{survival_py_survfit}(x, i, j, ..., drop = TRUE)
+\method{[}{survival_py_survfit}(x, i, j, k, ..., drop = TRUE)
 
 \method{$}{survival_py_survfit}(x, name)
 
@@ -1180,9 +1180,10 @@ Cox coefficient tables.}
 compatibility.}
 \item{quote}{Logical flag controlling whether printed survival-time labels are
 quoted.}
-\item{i, j, rows, cols, name, exact, drop}{Row and column subset controls for
-native \code{Surv}, \code{Surv2}, and \code{ratetable2} objects, plus
-list-field extraction controls for Python-backed \code{survfit} objects.}
+\item{i, j, rows, cols, name, exact, drop}{Row and column subset controls
+for native \code{Surv}, \code{Surv2}, and \code{ratetable2} objects, plus
+strata, data, and state subset and list-field extraction controls for
+Python-backed \code{survfit} objects.}
 \item{centered}{Logical flag for centered baseline hazards.}
 \item{rho}{Fleming--Harrington weight exponent for \code{survdiff}.}
 \item{riskmat, rorder}{Logical risk-matrix request and data/time row-order
@@ -1223,8 +1224,9 @@ logical flag controlling whether \code{ridge} scales the penalty by column
 variance. It also scales \code{aareg} summary coefficients.}
 \item{maxtime}{Optional upper time limit for \code{aareg} summaries and
 cumulative-coefficient plots.}
-\item{k}{Penalty multiplier for \code{extractAIC}, or observed Poisson event
-count for \code{cipoisson}.}
+\item{k}{Penalty multiplier for \code{extractAIC}, observed Poisson event
+count for \code{cipoisson}, or the state-dimension selector for stratified
+model-based multi-state \code{survfit} curves.}
 \item{test}{Test name for bridged model analysis of variance, \code{aareg}
 test selector, or contrast test selector for \code{yates}.}
 \item{...}{Additional arguments passed to the Python API. For \code{tmerge},

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -8306,6 +8306,83 @@ test_that("single-formula multi-state Cox models match survival", {
   expect_false("cumhaz" %in% names(as.list(bridged_grouped_average)))
   expect_equal(dim(bridged_grouped_average), c(data = 2L, states = 3L))
 
+  stratified_competing <- transform(
+    competing,
+    g = factor(rep(c("g1", "g2"), each = 6L))
+  )
+  bridged_stratified <- coxph(
+    Surv(time, status) ~ x + strata(g),
+    data = stratified_competing,
+    id = id,
+    control = coxph.control(iter.max = 20L, eps = 1e-9)
+  )
+  reference_stratified <- survival::coxph(
+    survival::Surv(time, status) ~ x + strata(g),
+    data = stratified_competing,
+    id = id,
+    control = survival::coxph.control(iter.max = 20L, eps = 1e-9)
+  )
+  expect_equal(coef(bridged_stratified), coef(reference_stratified), tolerance = 1e-12)
+
+  bridged_stratified_curves <- survfit(
+    bridged_stratified,
+    newdata = profile_data,
+    time0 = TRUE
+  )
+  reference_stratified_curves <- survival::survfit(
+    reference_stratified,
+    newdata = profile_data,
+    se.fit = FALSE,
+    time0 = TRUE
+  )
+  bridged_stratified_list <- as.list(bridged_stratified_curves)
+  for (field in c(
+    "n", "time", "strata", "pstate", "cumhaz", "n.risk", "n.event",
+    "n.censor", "n.transition", "n.id", "p0", "states", "transitions"
+  )) {
+    expect_equal(
+      bridged_stratified_list[[field]],
+      reference_stratified_curves[[field]],
+      tolerance = 1e-12,
+      info = paste("stratified field", field)
+    )
+  }
+  expect_equal(
+    dim(bridged_stratified_curves),
+    c(strata = 2L, data = 2L, states = 3L)
+  )
+
+  bridged_stratified_subset <- bridged_stratified_curves[
+    "g2",
+    2L,
+    c("(s0)", "b"),
+    drop = FALSE
+  ]
+  reference_stratified_subset <- reference_stratified_curves[
+    "g2",
+    2L,
+    c("(s0)", "b"),
+    drop = FALSE
+  ]
+  expect_equal(
+    as.list(bridged_stratified_subset)$pstate,
+    reference_stratified_subset$pstate,
+    tolerance = 1e-12
+  )
+  expect_equal(
+    dim(bridged_stratified_subset),
+    c(strata = 1L, data = 1L, states = 2L)
+  )
+
+  bridged_stratified_average <- aggregate(bridged_stratified_curves)
+  reference_stratified_average <- aggregate(reference_stratified_curves)
+  expect_equal(
+    as.list(bridged_stratified_average)$pstate,
+    reference_stratified_average$pstate,
+    tolerance = 1e-12
+  )
+  expect_equal(dim(bridged_stratified_average), c(strata = 2L, states = 3L))
+
   histories <- data.frame(
     id = c(1, 1, 2, 2, 3, 4, 5, 5, 6, 6, 7, 7, 8, 9, 9, 10),
     start = c(0, 1, 0, 2, 0, 0, 0, 1.5, 0, 2.5, 0, 3, 0, 0, 2.2, 0),


### PR DESCRIPTION
## Summary
- retain original multi-state Cox strata and apply each transition-specific baseline within its user stratum
- compute all covariate profiles for every fitted stratum while preserving stratum-specific time grids and counts
- return R-compatible strata-by-data-by-state dimensions with exact three-dimensional subsetting
- extend multi-state curve aggregation across stratified batches
- add exact Python and R comparisons for stratified competing-risk curves, subsetting, and aggregation
- document stratified model-based curve support

## Validation
- `.venv/bin/python -m pytest -q` (976 passed, 18 skipped)
- `R CMD check r/survivalr --no-manual --no-build-vignettes --ignore-vignettes` passed all tests with the standard source-tree note only
- Ruff format and lint checks passed
- public stub type checks passed
- generated binding manifest check passed
- `git diff --check` passed