### PR TITLE
Support stratified multi-state curve post-processing

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -14039,6 +14039,20 @@ def _coerce_turnbull_result_like(value: Any) -> TurnbullSurvfitResult:
 
 
 def _survfit0_any_result(value: Any, t0: float | None = None) -> Any:
+    if (
+        isinstance(value, Mapping)
+        and value
+        and all(
+            isinstance(curve, SurvfitMultiStateResult | SurvfitMultiStateCoxResult)
+            for curve in value.values()
+        )
+    ):
+        transformed = {label: _survfit0_any_result(curve, t0) for label, curve in value.items()}
+        return (
+            value
+            if all(transformed[label] is curve for label, curve in value.items())
+            else transformed
+        )
     if isinstance(value, SurvfitMultiStateCoxResult):
         return _survfit0_multistate_cox_result(value, t0)
     if isinstance(value, SurvfitMultiStateResult):
@@ -18290,6 +18304,45 @@ def _survfit_multistate_cox_frame(
     return frame
 
 
+def _survfit_multistate_grouped_frame(
+    result: Mapping[Any, SurvfitMultiStateCoxResult],
+) -> dict[str, list[Any]]:
+    batches = list(result.items())
+    curve_count = batches[0][1].curve_count
+    if any(batch.curve_count != curve_count for _label, batch in batches):
+        raise ValueError("stratified multi-state Cox results must share a data dimension")
+    first = batches[0][1].curves[0]
+    columns = list(_survfit_multistate_frame(first))
+    batch_frames = [
+        (label, tuple(_survfit_multistate_frame(curve) for curve in batch.curves))
+        for label, batch in batches
+    ]
+    if any(
+        list(curve_frame) != columns for _label, frames in batch_frames for curve_frame in frames
+    ):
+        raise ValueError("stratified multi-state curve frames must share columns")
+    frame: dict[str, list[Any]] = {
+        "curve": [],
+        **{name: [] for name in columns if name != "state"},
+        "strata": [],
+        "state": [],
+    }
+    for curve_index in range(curve_count):
+        for state in first.states:
+            for label, frames in batch_frames:
+                curve_frame = frames[curve_index]
+                indices = [
+                    index for index, value in enumerate(curve_frame["state"]) if value == state
+                ]
+                frame["curve"].extend([curve_index + 1] * len(indices))
+                frame["strata"].extend([label] * len(indices))
+                frame["state"].extend([state] * len(indices))
+                for name in columns:
+                    if name != "state":
+                        frame[name].extend(curve_frame[name][index] for index in indices)
+    return frame
+
+
 def _subset_survfit_multistate(
     result: SurvfitMultiStateResult | SurvfitMultiStateCoxResult,
     state_indices: Any,
@@ -18883,6 +18936,12 @@ def as_data_frame(result: Any) -> dict[str, list[Any]]:
         return _cox_survfit_frame(result)
     if isinstance(result, CoxBaseHazardResult):
         return _cox_basehaz_frame(result)
+    if (
+        isinstance(result, Mapping)
+        and result
+        and all(isinstance(curve, SurvfitMultiStateCoxResult) for curve in result.values())
+    ):
+        return _survfit_multistate_grouped_frame(result)
     if isinstance(result, SurvfitMultiStateCoxResult):
         return _survfit_multistate_cox_frame(result)
     if isinstance(result, SurvfitMultiStateResult):

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -13566,6 +13566,26 @@ def test_coxph_multistate_competing_risks_matches_r_reference():
             ],
             abs=1e-12,
         )
+    stratified_unpadded = survival.survfit(
+        stratified_fit,
+        newdata=pandas.DataFrame({"x": [0.5, 1.5]}),
+    )
+    stratified_padded = survival.survfit0(stratified_unpadded)
+    assert all(curve.time[0] == pytest.approx(0.0) for curve in stratified_padded.values())
+    stratified_frame = survival.as_data_frame(stratified_curves)
+    assert list(stratified_frame) == [
+        "curve",
+        "time",
+        "n.risk",
+        "n.event",
+        "n.censor",
+        "pstate",
+        "strata",
+        "state",
+    ]
+    assert len(stratified_frame["time"]) == 84
+    assert stratified_frame["strata"].count("g1") == 42
+    assert stratified_frame["strata"].count("g2") == 42
     selected_curve = survival.r_api._subset_survfit_multistate(batched_curve, [0, 2], [1])
     assert isinstance(selected_curve, survival.SurvfitMultiStateResult)
     assert selected_curve.cox_model is True

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -8383,6 +8383,37 @@ test_that("single-formula multi-state Cox models match survival", {
   )
   expect_equal(dim(bridged_stratified_average), c(strata = 2L, states = 3L))
 
+  bridged_stratified_unpadded <- survfit(
+    bridged_stratified,
+    newdata = profile_data
+  )
+  reference_stratified_unpadded <- survival::survfit(
+    reference_stratified,
+    newdata = profile_data,
+    se.fit = FALSE
+  )
+  bridged_stratified_padded <- as.list(survfit0(bridged_stratified_unpadded))
+  reference_stratified_padded <- survival::survfit0(reference_stratified_unpadded)
+  for (field in c("time", "strata", "pstate", "cumhaz")) {
+    expect_equal(
+      bridged_stratified_padded[[field]],
+      reference_stratified_padded[[field]],
+      tolerance = 1e-12,
+      info = paste("stratified survfit0 field", field)
+    )
+  }
+
+  stratified_frame <- as.data.frame(bridged_stratified_curves)
+  expect_equal(
+    names(stratified_frame),
+    c(
+      "curve", "time", "n.risk", "n.event", "n.censor", "pstate",
+      "strata", "state"
+    )
+  )
+  expect_equal(nrow(stratified_frame), 84L)
+  expect_equal(table(stratified_frame$strata), c(g1 = 42L, g2 = 42L))
+
   histories <- data.frame(
     id = c(1, 1, 2, 2, 3, 4, 5, 5, 6, 6, 7, 7, 8, 9, 9, 10),
     start = c(0, 1, 0, 2, 0, 0, 0, 1.5, 0, 2.5, 0, 3, 0, 0, 2.2, 0),


### PR DESCRIPTION
## Summary
- extend `survfit0` across stratified multi-state Cox result groups while preserving every stratum and profile
- add state-major tabular conversion for stratified batches with explicit curve and stratum columns
- cache per-profile curve frames during flattening to avoid repeated conversion work
- preserve the established grouped Aalen-Johansen frame ordering
- add Python and R coverage for origin-row insertion and stratified data frames

## Validation
- `.venv/bin/python -m pytest -q` (976 passed, 18 skipped)
- `R CMD check r/survivalr --no-manual --no-build-vignettes --ignore-vignettes` passed all tests with the standard source-tree note only
- Ruff format and lint checks passed
- public stub type checks passed
- generated binding manifest check passed
- `git diff --check` passed