### PR TITLE
Align multi-state Cox zph diagnostics

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -16366,7 +16366,9 @@ def cox_zph(
     event_strata_codes = [row_strata[idx] for idx in event_indices]
     design = _formula_design_for_fit(fit)
     event_strata = None
-    if (design is not None and design.strata) or len(set(row_strata)) > 1:
+    if isinstance(fit, _FormulaFit) and fit.multi_state is not None:
+        event_strata = [value + 1 for value in event_strata_codes]
+    elif (design is not None and design.strata) or len(set(row_strata)) > 1:
         event_strata = _cox_strata_labels_for_fit(fit, event_strata_codes)
         if event_strata is None:
             event_strata = event_strata_codes
@@ -17087,6 +17089,8 @@ def _cox_zph_column_groups(
     nvar: int,
     terms: bool,
 ) -> list[tuple[str, list[int]]]:
+    if isinstance(fit, _FormulaFit) and fit.multi_state is not None:
+        return _cox_zph_multistate_column_groups(fit, nvar, terms)
     design = _formula_design_for_fit(fit)
     if design is None:
         return [(f"var{idx}", [idx]) for idx in range(nvar)]
@@ -17104,6 +17108,51 @@ def _cox_zph_column_groups(
     if cursor != nvar:
         return [(f"var{idx}", [idx]) for idx in range(nvar)]
     return groups
+
+
+def _cox_zph_multistate_column_groups(
+    fit: _FormulaFit,
+    nvar: int,
+    terms: bool,
+) -> list[tuple[str, list[int]]]:
+    metadata = fit.multi_state
+    if metadata is None:
+        raise AssertionError("multi-state Cox diagnostic metadata is missing")
+    coefficient_names = (
+        list(fit.coefficient_names)
+        if fit.coefficient_names is not None and len(fit.coefficient_names) == nvar
+        else _fallback_coef_names(nvar)
+    )
+    if not terms:
+        return [(name, [idx]) for idx, name in enumerate(coefficient_names)]
+
+    assignments = _model_matrix_assignments(fit, metadata.original_width)
+    design_names = _model_matrix_column_names(fit, metadata.original_width)
+    transition_names = _coxph_multistate_transition_names(metadata)
+    groups: dict[str, list[int]] = {}
+    seen: set[int] = set()
+
+    for transition, transition_name in enumerate(transition_names):
+        for column, coefficient in enumerate(metadata.coefficient_map[transition]):
+            if coefficient < 0 or coefficient in seen:
+                continue
+            assignment = assignments[column]
+            if fit.design is not None and 0 < assignment <= len(fit.design.term_labels):
+                term_name = fit.design.term_labels[assignment - 1]
+            else:
+                term_name = design_names[column]
+            groups.setdefault(f"{term_name}_{transition_name}", []).append(coefficient)
+            seen.add(coefficient)
+
+        ph_coefficient = metadata.ph_coefficient_map[transition]
+        if ph_coefficient >= 0 and ph_coefficient not in seen:
+            groups[coefficient_names[ph_coefficient]] = [ph_coefficient]
+            seen.add(ph_coefficient)
+
+    for coefficient, name in enumerate(coefficient_names):
+        if coefficient not in seen:
+            groups[name] = [coefficient]
+    return list(groups.items())
 
 
 def _cox_zph_active_groups(

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -13379,6 +13379,16 @@ def test_coxph_multistate_competing_risks_matches_r_reference():
     ):
         assert actual == pytest.approx(expected)
 
+    zph = survival.cox_zph(fit, transform="rank")
+    assert zph.variable_names == ["x_1:2", "x_1:3"]
+    assert zph.df == [1, 1]
+    assert zph.chi2_values == pytest.approx(
+        [1.2069072243140258, 0.06051259985681031],
+        abs=1e-12,
+    )
+    assert zph.global_chi2 == pytest.approx(1.2674198241708354, abs=1e-12)
+    assert zph.strata == [1, 1, 1, 1, 2, 2, 2, 2]
+
     predicted = survival.predict(fit, type="lp")
     assert predicted[0] == pytest.approx([1.119748345585229, 0.37210961641001666])
     assert predicted[-1] == pytest.approx([-1.4262057875348704, -0.4739501430064422])
@@ -13664,6 +13674,17 @@ def test_coxph_multistate_formula_lists_match_r_reference():
     }
     assert common_fit.assign == {"x": [1]}
     assert common_fit.share is None
+    common_zph = survival.cox_zph(common_fit, transform="rank")
+    assert common_zph.variable_names == ["x_1:2"]
+    assert common_zph.df == [1]
+    assert common_zph.chi2_values == pytest.approx([0.41439233839228745], abs=1e-12)
+    assert common_zph.strata == [1, 1, 1, 1, 2, 2, 2, 2]
+    common_zph_columns = survival.cox_zph(common_fit, transform="rank", terms=False)
+    assert common_zph_columns.variable_names == ["x"]
+    assert common_zph_columns.chi2_values == pytest.approx(
+        common_zph.chi2_values,
+        abs=1e-12,
+    )
     for actual, expected in zip(
         survival.predict(common_fit, newdata=data.iloc[:2], type="lp"),
         [
@@ -13692,6 +13713,24 @@ def test_coxph_multistate_formula_lists_match_r_reference():
         "columns": ["1:2", "1:3"],
     }
     assert selective_fit.assign == {"x": [1], "z": [2]}
+    selective_zph = survival.cox_zph(selective_fit, transform="rank")
+    assert selective_zph.variable_names == ["x_1:2", "x_1:3", "z_1:3"]
+    assert selective_zph.df == [1, 1, 1]
+    assert selective_zph.chi2_values == pytest.approx(
+        [1.2069072243140258, 0.0031752395090040614, 0.2874867710043486],
+        abs=1e-12,
+    )
+    assert selective_zph.strata == [1, 1, 1, 1, 2, 2, 2, 2]
+    selective_zph_columns = survival.cox_zph(
+        selective_fit,
+        transform="rank",
+        terms=False,
+    )
+    assert selective_zph_columns.variable_names == ["x_1:2", "x_1:3", "z"]
+    assert selective_zph_columns.chi2_values == pytest.approx(
+        selective_zph.chi2_values,
+        abs=1e-12,
+    )
     for actual, expected in zip(
         survival.predict(selective_fit, newdata=data.iloc[:2], type="lp"),
         [
@@ -13730,6 +13769,10 @@ def test_coxph_multistate_formula_lists_match_r_reference():
     assert shared_fit.assign == {"x": [1]}
     assert shared_fit.share["vtype"] == [0, 2]
     assert shared_fit.share["scale"] == pytest.approx([1.0, 0.3377879753621159], abs=1e-12)
+    shared_zph = survival.cox_zph(shared_fit, transform="rank")
+    assert shared_zph.variable_names == ["x_1:2", "x_1:3", "ph(1:3/1:2)"]
+    assert shared_zph.df == [1, 1, 1]
+    assert shared_zph.strata == [1] * 8
     shared_curve = survival.survfit(
         shared_fit,
         newdata=pandas.DataFrame({"x": [0.5]}),
@@ -13781,6 +13824,49 @@ def test_coxph_multistate_formula_lists_match_r_reference():
             data=data,
             id="id",
         )
+
+
+def test_cox_zph_multistate_groups_expanded_factor_terms_like_r():
+    pandas = pytest.importorskip("pandas")
+    data = pandas.DataFrame(
+        {
+            "id": list(range(1, 13)),
+            "time": list(range(1, 13)),
+            "status": pandas.Categorical(
+                ["a", "b", "0", "a", "0", "b", "a", "b", "0", "a", "b", "0"],
+                categories=["0", "a", "b"],
+            ),
+            "x": [0.2, 0.8, 0.3, 1.1, 0.4, 1.4, 0.6, 1.6, 0.7, 1.8, 1.0, 2.0],
+            "q": pandas.Categorical(
+                ["u", "v", "w", "u", "u", "v", "w", "u", "u", "v", "w", "u"],
+                categories=["u", "v", "w"],
+            ),
+        }
+    )
+    fit = survival.coxph(
+        "Surv(time, status) ~ x + q",
+        data=data,
+        id="id",
+        max_iter=20,
+        eps=1e-9,
+    )
+
+    by_term = survival.cox_zph(fit, transform="rank")
+    by_column = survival.cox_zph(fit, transform="rank", terms=False)
+
+    assert by_term.variable_names == ["x_1:2", "q_1:2", "x_1:3", "q_1:3"]
+    assert by_term.df == [1, 2, 1, 2]
+    assert by_column.variable_names == [
+        "x_1:2",
+        "qv_1:2",
+        "qw_1:2",
+        "x_1:3",
+        "qv_1:3",
+        "qw_1:3",
+    ]
+    assert by_column.df == [1, 1, 1, 1, 1, 1]
+    assert by_term.global_chi2 == pytest.approx(by_column.global_chi2, abs=1e-12)
+    assert by_term.strata == by_column.strata == [1, 1, 1, 1, 2, 2, 2, 2]
 
 
 def test_coxph_multistate_counting_histories_match_r_reference():

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -8424,8 +8424,49 @@ test_that("single-formula multi-state Cox models match survival", {
 
   formula_data <- transform(
     competing,
-    z = c(0.9, -0.2, 0.4, 1.3, -0.5, 0.7, 1.1, -0.8, 0.2, 1.7, -1.2, 0.6)
+    z = c(0.9, -0.2, 0.4, 1.3, -0.5, 0.7, 1.1, -0.8, 0.2, 1.7, -1.2, 0.6),
+    q = factor(
+      c("u", "v", "w", "u", "u", "v", "w", "u", "u", "v", "w", "u"),
+      levels = c("u", "v", "w")
+    )
   )
+  compare_multistate_zph <- function(bridged_fit, reference_fit) {
+    for (group_terms in c(TRUE, FALSE)) {
+      bridged_zph <- cox.zph(
+        bridged_fit,
+        transform = "rank",
+        terms = group_terms
+      )
+      reference_zph <- survival::cox.zph(
+        reference_fit,
+        transform = "rank",
+        terms = group_terms
+      )
+      bridged_frame <- as.data.frame(bridged_zph)
+
+      expect_equal(bridged_frame$name, rownames(reference_zph$table))
+      expect_equal(bridged_frame$df, as.integer(reference_zph$table[, "df"]))
+      expect_equal(
+        bridged_frame$chisq,
+        unname(reference_zph$table[, "chisq"]),
+        tolerance = 1e-09
+      )
+      expect_equal(
+        bridged_frame$p,
+        unname(reference_zph$table[, "p"]),
+        tolerance = 1e-09
+      )
+      expect_equal(bridged_zph$x, reference_zph$x, tolerance = 1e-12)
+      expect_equal(bridged_zph$time, reference_zph$time, tolerance = 1e-12)
+      expect_equal(as.character(bridged_zph$transform), reference_zph$transform)
+      expect_equal(
+        as.integer(bridged_zph$strata),
+        as.integer(reference_zph$strata)
+      )
+    }
+  }
+  compare_multistate_zph(bridged, reference)
+
   bridged_common <- coxph(
     list(
       Surv(time, status) ~ 1,
@@ -8474,6 +8515,7 @@ test_that("single-formula multi-state Cox models match survival", {
     predict(reference_common, newdata = formula_data[1:2, ], type = "lp"),
     tolerance = 1e-12
   )
+  compare_multistate_zph(bridged_common, reference_common)
 
   bridged_selective <- coxph(
     list(
@@ -8507,6 +8549,21 @@ test_that("single-formula multi-state Cox models match survival", {
     predict(reference_selective, newdata = formula_data[1:2, ], type = "lp"),
     tolerance = 1e-12
   )
+  compare_multistate_zph(bridged_selective, reference_selective)
+
+  bridged_factor_zph <- coxph(
+    Surv(time, status) ~ x + q,
+    data = formula_data,
+    id = id,
+    control = coxph.control(iter.max = 20L, eps = 1e-9)
+  )
+  reference_factor_zph <- survival::coxph(
+    survival::Surv(time, status) ~ x + q,
+    data = formula_data,
+    id = id,
+    control = survival::coxph.control(iter.max = 20L, eps = 1e-9)
+  )
+  compare_multistate_zph(bridged_factor_zph, reference_factor_zph)
 
   bridged_shared <- coxph(
     list(


### PR DESCRIPTION
## Summary
- expand multi-state proportional-hazards diagnostic terms from transition coefficient maps
- preserve common, selective, shared, and multi-column factor group names in grouped and per-coefficient output
- return one-based transition strata codes and compare diagnostic tables, transforms, times, and strata with R survival

## Testing
- `PYTHONPATH=python .venv/bin/pytest -q python/tests` (978 passed, 18 skipped)
- `cargo test --lib --no-default-features` (1524 passed)
- `cargo test --lib --features ml` (1733 passed)
- `cargo test --lib --features python,ml` (1747 passed)
- strict Clippy checks for all three feature configurations
- Ruff format/check, mypy, binding manifest check, and `git diff --check`
- `R CMD check --no-manual r/survivalr` reached 3553 passing assertions; the four failures are inherited attribute-only curve post-processing mismatches