### PR TITLE
Scale multi-state Cox zph residuals by strata

### DIFF
--- a/python/survival/_survival.pyi
+++ b/python/survival/_survival.pyi
@@ -1255,6 +1255,14 @@ class CoxPHFit:
         global_test: bool,
         penalty_matrix: list[list[float]] | None = None,
     ) -> tuple[list[list[float]], ProportionalityTest]: ...
+    def cox_zph_diagnostics_with_surface(
+        self,
+        transformed_events: list[float],
+        active_columns: list[int],
+        groups: list[list[int]],
+        single_df: bool,
+        global_test: bool,
+    ) -> tuple[list[list[float]], list[list[float]], ProportionalityTest]: ...
     def partial_residuals(self) -> list[list[float]]: ...
     @property
     def covariates(self) -> list[list[float]]: ...

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -16332,8 +16332,13 @@ def cox_zph(
         raise TypeError("cox_zph requires a fitted Cox model")
     model = _unwrap_formula_fit(fit)
     native_method = getattr(model, "cox_zph_diagnostics", None)
+    surface_method = (
+        getattr(model, "cox_zph_diagnostics_with_surface", None)
+        if isinstance(fit, _FormulaFit) and fit.multi_state is not None
+        else None
+    )
     scaled_method = getattr(fit, "scaled_schoenfeld_residuals", None)
-    if native_method is None and scaled_method is None:
+    if native_method is None and surface_method is None and scaled_method is None:
         raise TypeError("cox_zph requires a fitted Cox model")
     group_terms = _normalize_bool_option(terms, "terms")
     single_df = _normalize_bool_option(singledf, "singledf")
@@ -16384,7 +16389,26 @@ def cox_zph(
         event_times,
         transform,
     )
-    if native_method is not None:
+    grouped_variance: list[list[float]] | None = None
+    if surface_method is not None:
+        grouped_result, raw_grouped_variance, test = surface_method(
+            transformed_time,
+            active_columns,
+            dense_groups,
+            single_df,
+            include_global,
+        )
+        grouped_y = [[float(value) for value in row] for row in grouped_result]
+        grouped_variance = [[float(value) for value in row] for row in raw_grouped_variance]
+        if len(event_indices) != len(grouped_y):
+            raise ValueError("fitted Cox model event times do not match diagnostic residuals")
+        if any(len(row) != len(groups) for row in grouped_y):
+            raise ValueError("Cox zph diagnostic residuals must be rectangular")
+        if len(grouped_variance) != len(groups) or any(
+            len(row) != len(groups) for row in grouped_variance
+        ):
+            raise ValueError("Cox zph diagnostic variance must match diagnostic terms")
+    elif native_method is not None:
         variance = getattr(fit, "information_matrix", None)
         if variance is None:
             raise TypeError("model does not expose coefficient variance")
@@ -16476,7 +16500,17 @@ def cox_zph(
         x=transformed_time,
         time=event_times,
         y=grouped_y,
-        var=_cox_zph_group_variance(fit, groups, active_beta, active_columns, len(event_indices)),
+        var=(
+            grouped_variance
+            if grouped_variance is not None
+            else _cox_zph_group_variance(
+                fit,
+                groups,
+                active_beta,
+                active_columns,
+                len(event_indices),
+            )
+        ),
         transform=transform_name,
         global_chi2=float(test.global_chi2) if include_global else None,
         global_df=global_df if include_global else None,

--- a/python/tests/test_binding_contract.py
+++ b/python/tests/test_binding_contract.py
@@ -864,6 +864,14 @@ def test_coxph_fit_detail_bindings_are_typed_to_runtime_surface():
             "global_test",
             "penalty_matrix",
         ],
+        "cox_zph_diagnostics_with_surface": [
+            "self",
+            "transformed_events",
+            "active_columns",
+            "groups",
+            "single_df",
+            "global_test",
+        ],
         "partial_residuals": ["self"],
     }
     for method_name, args in coxph_fit_methods.items():
@@ -1028,6 +1036,17 @@ def test_coxph_fit_detail_bindings_are_typed_to_runtime_surface():
     )
     for actual, expected in zip(fused_scaled, custom_scaled, strict=True):
         assert actual == pytest.approx(expected)
+    surface, surface_variance, surface_test = fit.cox_zph_diagnostics_with_surface(
+        transformed_events,
+        [0],
+        [[0]],
+        False,
+        True,
+    )
+    assert len(surface) == sum(status)
+    assert all(len(row) == 1 and math.isfinite(row[0]) for row in surface)
+    assert len(surface_variance) == len(surface_variance[0]) == 1
+    assert surface_test.chi2_values == pytest.approx(fused_test.chi2_values)
     beta = fit.coefficients[-1]
     offset = [
         linear_predictor - row[0] * beta[0]

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -13388,6 +13388,24 @@ def test_coxph_multistate_competing_risks_matches_r_reference():
     )
     assert zph.global_chi2 == pytest.approx(1.2674198241708354, abs=1e-12)
     assert zph.strata == [1, 1, 1, 1, 2, 2, 2, 2]
+    expected_zph_y = [
+        [-3.669221667281993, math.nan],
+        [0.0026004251483797702, math.nan],
+        [-3.1442881202041564, math.nan],
+        [1.1532335108846619, math.nan],
+        [math.nan, -0.9929406879072232],
+        [math.nan, 0.40642227808169573],
+        [math.nan, 0.7137814582456097],
+        [math.nan, -2.0073958471233286],
+    ]
+    for actual, expected in zip(zph.y, expected_zph_y, strict=True):
+        assert actual == pytest.approx(expected, abs=1e-12, nan_ok=True)
+    for actual, expected in zip(
+        zph.var,
+        [[5.350013071194888, 0.0], [0.0, 3.997215621198441]],
+        strict=True,
+    ):
+        assert actual == pytest.approx(expected, abs=1e-12)
 
     predicted = survival.predict(fit, type="lp")
     assert predicted[0] == pytest.approx([1.119748345585229, 0.37210961641001666])
@@ -13867,6 +13885,24 @@ def test_cox_zph_multistate_groups_expanded_factor_terms_like_r():
     assert by_column.df == [1, 1, 1, 1, 1, 1]
     assert by_term.global_chi2 == pytest.approx(by_column.global_chi2, abs=1e-12)
     assert by_term.strata == by_column.strata == [1, 1, 1, 1, 2, 2, 2, 2]
+    assert by_term.y[0] == pytest.approx(
+        [-5.633757567751644, 1.8862607213125682, math.nan, math.nan],
+        abs=1e-12,
+        nan_ok=True,
+    )
+    assert by_term.y[-1] == pytest.approx(
+        [math.nan, math.nan, -4.098561984779203, 1.3156632294499375],
+        abs=1e-12,
+        nan_ok=True,
+    )
+    expected_var = [
+        [10.268646785989345, -3.774690061935757, 0.0, 0.0],
+        [-3.774690061935757, 3.2340615532484676, 0.0, 0.0],
+        [0.0, 0.0, 10.902388505769771, -2.723983963059402],
+        [0.0, 0.0, -2.7239839630594016, 1.34103444774544],
+    ]
+    for actual, expected in zip(by_term.var, expected_var, strict=True):
+        assert actual == pytest.approx(expected, abs=1e-12)
 
 
 def test_coxph_multistate_counting_histories_match_r_reference():

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -8460,6 +8460,16 @@ test_that("single-formula multi-state Cox models match survival", {
       expect_equal(bridged_zph$time, reference_zph$time, tolerance = 1e-12)
       expect_equal(as.character(bridged_zph$transform), reference_zph$transform)
       expect_equal(
+        do.call(rbind, bridged_zph$y),
+        unname(reference_zph$y),
+        tolerance = 1e-08
+      )
+      expect_equal(
+        do.call(rbind, bridged_zph$var),
+        unname(reference_zph$var),
+        tolerance = 1e-08
+      )
+      expect_equal(
         as.integer(bridged_zph$strata),
         as.integer(reference_zph$strata)
       )

--- a/src/regression/coxph.rs
+++ b/src/regression/coxph.rs
@@ -574,6 +574,23 @@ impl CoxPHFit {
         )
     }
 
+    pub fn cox_zph_diagnostics_with_surface(
+        &self,
+        transformed_events: Vec<f64>,
+        active_columns: Vec<usize>,
+        groups: Vec<Vec<usize>>,
+        single_df: bool,
+        global_test: bool,
+    ) -> PyResult<crate::regression::coxph_diagnostics::CoxZphSurfaceDiagnostics> {
+        self.cox_zph_diagnostics_with_surface_internal(
+            transformed_events,
+            active_columns,
+            groups,
+            single_df,
+            global_test,
+        )
+    }
+
     pub fn partial_residuals(&self) -> PyResult<Vec<Vec<f64>>> {
         self.partial_residuals_internal()
     }

--- a/src/regression/coxph_diagnostics.rs
+++ b/src/regression/coxph_diagnostics.rs
@@ -15,6 +15,10 @@ use crate::validation::ProportionalityTest;
 use ndarray::{Array1, Array2};
 use pyo3::prelude::*;
 
+pub(crate) type CoxZphMatrix = Vec<Vec<f64>>;
+pub(crate) type CoxZphSurfaceDiagnostics = (CoxZphMatrix, CoxZphMatrix, ProportionalityTest);
+type CoxZphSurface = (CoxZphMatrix, CoxZphMatrix);
+
 fn value_error(message: impl Into<String>) -> PyErr {
     pyo3::exceptions::PyValueError::new_err(message.into())
 }
@@ -77,6 +81,19 @@ fn validate_column_groups(groups: &[Vec<usize>], width: usize) -> PyResult<()> {
         }
     }
     Ok(())
+}
+
+fn invert_square_rows(matrix: &[Vec<f64>], name: &str) -> PyResult<Vec<Vec<f64>>> {
+    let width = matrix.len();
+    validate_square_matrix(matrix, width, name)?;
+    let values = matrix.iter().flatten().copied().collect::<Vec<_>>();
+    let array = Array2::from_shape_vec((width, width), values)
+        .map_err(|_| value_error(format!("failed to construct {name}")))?;
+    let inverse =
+        matrix_inverse(&array).ok_or_else(|| value_error(format!("{name} is singular")))?;
+    Ok((0..width)
+        .map(|row| (0..width).map(|column| inverse[[row, column]]).collect())
+        .collect())
 }
 
 fn validate_cluster_codes(codes: &[usize], nrows: usize, name: &str) -> PyResult<usize> {
@@ -1710,6 +1727,273 @@ impl CoxPHFit {
         Ok((grouped, test))
     }
 
+    pub(crate) fn cox_zph_diagnostics_with_surface_internal(
+        &self,
+        transformed_events: Vec<f64>,
+        active_columns: Vec<usize>,
+        groups: Vec<Vec<usize>>,
+        single_df: bool,
+        global_test: bool,
+    ) -> PyResult<CoxZphSurfaceDiagnostics> {
+        let beta = self.coefficients.first().ok_or_else(|| {
+            pyo3::exceptions::PyValueError::new_err("model has no fitted coefficients")
+        })?;
+        let nvar = beta.len();
+        validate_selected_columns(&active_columns, nvar)?;
+        validate_column_groups(&groups, active_columns.len())?;
+
+        let n = self.event_times.len();
+        if self.status.len() != n
+            || self.covariates.len() != n
+            || self.linear_predictors.len() != n
+            || self.weights.len() != n
+            || self.strata.len() != n
+        {
+            return Err(value_error(
+                "fitted Cox model diagnostic arrays have inconsistent lengths",
+            ));
+        }
+        validate_matrix_width(&self.covariates, nvar, "covariates")?;
+
+        let method = if matches!(self.tie_method(), CoxMethod::Efron) {
+            "efron"
+        } else {
+            "breslow"
+        };
+        let detail = compute_coxph_detail_with_options(CoxphDetailOptions {
+            time: &self.event_times,
+            status: &self.status,
+            covariates: &self.covariates,
+            coefficients: beta,
+            weights: Some(&self.weights),
+            entry_times: self.entry_times.as_deref(),
+            strata: Some(&self.strata),
+            offset: None,
+            linear_predictors: Some(&self.linear_predictors),
+            method,
+            center: 0.0,
+            include_riskmat: false,
+        })?;
+        let active_beta = active_columns
+            .iter()
+            .map(|&column| beta[column])
+            .collect::<Vec<_>>();
+        let raw_full = self.schoenfeld_residuals_internal()?;
+        let (surface, variance) = self.cox_zph_residual_surface(
+            raw_full,
+            &detail,
+            &active_columns,
+            &groups,
+            &active_beta,
+        )?;
+        let test = cox_zph_tests_from_detail(
+            detail,
+            &transformed_events,
+            &active_columns,
+            groups,
+            active_beta,
+            single_df,
+            global_test,
+            None,
+        )?;
+        Ok((surface, variance, test))
+    }
+
+    fn cox_zph_residual_surface(
+        &self,
+        raw_full: Vec<Vec<f64>>,
+        detail: &CoxphDetail,
+        active_columns: &[usize],
+        groups: &[Vec<usize>],
+        active_beta: &[f64],
+    ) -> PyResult<CoxZphSurface> {
+        let nvar = self.coefficients.first().map_or(0, Vec::len);
+        validate_matrix_width(&raw_full, nvar, "Schoenfeld residuals")?;
+        let active_width = active_columns.len();
+        let raw = raw_full
+            .into_iter()
+            .map(|row| active_columns.iter().map(|&column| row[column]).collect())
+            .collect::<Vec<Vec<f64>>>();
+
+        let mut strata_levels = self.strata.clone();
+        strata_levels.sort_unstable();
+        strata_levels.dedup();
+        let mut strata_rows = vec![Vec::new(); strata_levels.len()];
+        for (row, &stratum) in self.strata.iter().enumerate() {
+            let stratum_index = strata_levels
+                .binary_search(&stratum)
+                .expect("fitted stratum must be present in its level set");
+            strata_rows[stratum_index].push(row);
+        }
+
+        let mut used = vec![vec![0usize; active_width]; strata_levels.len()];
+        for (stratum_index, rows) in strata_rows.iter().enumerate() {
+            let event_count = rows.iter().filter(|&&row| self.status[row] == 1).count();
+            if rows.is_empty() || event_count == 0 {
+                continue;
+            }
+            for (dense_column, &column) in active_columns.iter().enumerate() {
+                let first = self.covariates[rows[0]][column];
+                if rows
+                    .iter()
+                    .skip(1)
+                    .any(|&row| self.covariates[row][column] != first)
+                {
+                    used[stratum_index][dense_column] = event_count;
+                }
+            }
+        }
+
+        for columns in groups {
+            if columns.len() > 1
+                && used
+                    .iter()
+                    .any(|row| columns.iter().any(|&column| row[column] == 0))
+            {
+                for row in &mut used {
+                    let maximum = columns.iter().map(|&column| row[column]).max().unwrap_or(0);
+                    for &column in columns {
+                        row[column] = maximum;
+                    }
+                }
+            }
+        }
+
+        let mut information = vec![vec![0.0; active_width]; active_width];
+        for detail_row in &detail.rows {
+            validate_square_matrix(&detail_row.imat, nvar, "Cox detail information matrix")?;
+            for (dense_row, &row) in active_columns.iter().enumerate() {
+                for (dense_column, &column) in active_columns.iter().enumerate() {
+                    information[dense_row][dense_column] += detail_row.imat[row][column];
+                }
+            }
+        }
+
+        let mut weight = vec![vec![0.0; active_width]; active_width];
+        for stratum_used in &used {
+            for row in 0..active_width {
+                for column in 0..active_width {
+                    weight[row][column] += stratum_used[row].min(stratum_used[column]) as f64;
+                }
+            }
+        }
+        let mean_information = (0..active_width)
+            .map(|row| {
+                (0..active_width)
+                    .map(|column| {
+                        information[row][column]
+                            / if weight[row][column] == 0.0 {
+                                1.0
+                            } else {
+                                weight[row][column]
+                            }
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+
+        let group_count = groups.len();
+        let mut loadings = vec![vec![0.0; group_count]; active_width];
+        for (group_index, columns) in groups.iter().enumerate() {
+            if columns.len() == 1 {
+                loadings[columns[0]][group_index] = 1.0;
+            } else {
+                for &column in columns {
+                    loadings[column][group_index] = active_beta[column];
+                }
+            }
+        }
+        let grouped_raw = cox_zph_term_matrix(raw, groups.to_vec(), active_beta.to_vec())?;
+        let grouped_mean_information = (0..group_count)
+            .map(|left_group| {
+                (0..group_count)
+                    .map(|right_group| {
+                        (0..active_width)
+                            .map(|row| {
+                                (0..active_width)
+                                    .map(|column| {
+                                        loadings[row][left_group]
+                                            * mean_information[row][column]
+                                            * loadings[column][right_group]
+                                    })
+                                    .sum::<f64>()
+                            })
+                            .sum::<f64>()
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+        let grouped_used = used
+            .iter()
+            .map(|row| {
+                groups
+                    .iter()
+                    .map(|columns| row[columns[0]])
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+
+        let event_indices = diagnostic_order(&self.strata, &self.event_times)
+            .into_iter()
+            .filter(|&row| self.status[row] == 1)
+            .collect::<Vec<_>>();
+        if event_indices.len() != grouped_raw.len() {
+            return Err(value_error(
+                "fitted Cox model event order does not match Schoenfeld residuals",
+            ));
+        }
+        let mut surface = vec![vec![f64::NAN; group_count]; grouped_raw.len()];
+        for (stratum_index, &stratum) in strata_levels.iter().enumerate() {
+            let active_groups = grouped_used[stratum_index]
+                .iter()
+                .enumerate()
+                .filter_map(|(group, &count)| (count > 0).then_some(group))
+                .collect::<Vec<_>>();
+            if active_groups.is_empty() {
+                continue;
+            }
+            let stratum_mean = active_groups
+                .iter()
+                .map(|&row| {
+                    active_groups
+                        .iter()
+                        .map(|&column| grouped_mean_information[row][column])
+                        .collect::<Vec<_>>()
+                })
+                .collect::<Vec<_>>();
+            let inverse = invert_square_rows(&stratum_mean, "Cox zph stratum information matrix")?;
+            for (event_row, &source_row) in event_indices.iter().enumerate() {
+                if self.strata[source_row] != stratum {
+                    continue;
+                }
+                for (output_column, &group) in active_groups.iter().enumerate() {
+                    surface[event_row][group] = active_groups
+                        .iter()
+                        .enumerate()
+                        .map(|(input_column, &input_group)| {
+                            grouped_raw[event_row][input_group]
+                                * inverse[input_column][output_column]
+                        })
+                        .sum();
+                }
+            }
+        }
+        for row in &mut surface {
+            for (group, columns) in groups.iter().enumerate() {
+                row[group] += if columns.len() == 1 {
+                    active_beta[columns[0]]
+                } else {
+                    1.0
+                };
+            }
+        }
+        let variance = invert_square_rows(
+            &grouped_mean_information,
+            "Cox zph grouped information matrix",
+        )?;
+        Ok((surface, variance))
+    }
+
     pub(crate) fn schoenfeld_residuals_internal(&self) -> PyResult<Vec<Vec<f64>>> {
         let beta = self.coefficients.first().ok_or_else(|| {
             pyo3::exceptions::PyValueError::new_err("model has no fitted coefficients")
@@ -2482,6 +2766,80 @@ mod tests {
         assert_eq!(test.p_values, expected_test.p_values);
         assert_eq!(test.global_chi2, expected_test.global_chi2);
         assert_eq!(test.global_p_value, expected_test.global_p_value);
+    }
+
+    #[test]
+    fn fit_owned_cox_zph_surface_scales_each_stratum_by_active_terms() {
+        let event_times = vec![1.0, 2.0, 3.0, 4.0, 1.0, 2.0, 3.0, 4.0];
+        let status = vec![1, 1, 1, 0, 1, 1, 1, 0];
+        let covariates = vec![
+            vec![0.0, 0.0],
+            vec![1.0, 0.0],
+            vec![2.0, 0.0],
+            vec![3.0, 0.0],
+            vec![0.0, 0.0],
+            vec![0.0, 1.0],
+            vec![0.0, 2.0],
+            vec![0.0, 3.0],
+        ];
+        let coefficients = vec![0.1, -0.2];
+        let linear_predictors = covariates
+            .iter()
+            .map(|row| {
+                row.iter()
+                    .zip(&coefficients)
+                    .map(|(&value, &coefficient)| value * coefficient)
+                    .sum()
+            })
+            .collect::<Vec<f64>>();
+        let fit = CoxPHFit {
+            coefficients: vec![coefficients],
+            means: vec![0.0, 0.0],
+            score_vector: vec![0.0, 0.0],
+            information_matrix: vec![vec![1.0, 0.0], vec![0.0, 1.0]],
+            degrees_of_freedom: 0.0,
+            log_likelihood: vec![0.0, 0.0],
+            score_test: 0.0,
+            convergence_flag: 0,
+            iterations: 0,
+            risk_scores: linear_predictors.iter().map(|value| value.exp()).collect(),
+            event_times,
+            status,
+            linear_predictors,
+            entry_times: None,
+            weights: vec![1.0; 8],
+            covariates,
+            strata: vec![0, 0, 0, 0, 1, 1, 1, 1],
+            method: "efron".to_string(),
+            nocenter: Vec::new(),
+        };
+
+        let (surface, variance, test) = fit
+            .cox_zph_diagnostics_with_surface_internal(
+                vec![1.0, 2.0, 3.0, 1.0, 2.0, 3.0],
+                vec![0, 1],
+                vec![vec![0], vec![1]],
+                false,
+                true,
+            )
+            .expect("stratified Cox zph surface should compute");
+
+        assert_eq!(surface.len(), 6);
+        for row in &surface[..3] {
+            assert!(row[0].is_finite());
+            assert!(row[1].is_nan());
+        }
+        for row in &surface[3..] {
+            assert!(row[0].is_nan());
+            assert!(row[1].is_finite());
+        }
+        assert_eq!(variance.len(), 2);
+        assert!(variance[0][0].is_finite() && variance[0][0] > 0.0);
+        assert!(variance[1][1].is_finite() && variance[1][1] > 0.0);
+        assert!(variance[0][1].abs() < 1e-12);
+        assert!(variance[1][0].abs() < 1e-12);
+        assert_eq!(test.chi2_values.len(), 2);
+        assert!(test.global_chi2.is_finite());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- compute multi-state scaled Schoenfeld residual surfaces from per-stratum term usage and mean information
- preserve transition-inactive cells as missing values and return R-compatible grouped variance matrices
- route multi-state formula diagnostics through the fused native surface API while retaining existing ordinary-model behavior
- add exact Python and R-reference regressions for single, common, selective, and grouped-factor transition formulas

## Testing
- `PYTHONPATH=python .venv/bin/pytest -q python/tests` (996 passed)
- `cargo test --lib --no-default-features` (1525 passed)
- `cargo test --lib --features ml` (1734 passed)
- `cargo test --lib --features python,ml` (1748 passed)
- strict Clippy for no-default, ML, and Python+ML feature sets
- Ruff format/check, mypy, binding manifest, and `git diff --check`
- `R CMD check --no-manual --no-build-vignettes r/survivalr` reached 3569 passing assertions; only the four inherited multi-state curve attribute mismatches remain