### PR TITLE
Preserve multi-state Cox curve attributes

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -1348,6 +1348,7 @@ class SurvfitMultiStateResult:
     influence_chaz: list[list[float]] | None = None
     influence_auc: list[list[float]] | None = None
     cox_model: bool = False
+    cox_source: bool = False
 
     def __iter__(self):
         yield self.time
@@ -1390,10 +1391,13 @@ class SurvfitMultiStateCoxResult:
 
     curves: tuple[SurvfitMultiStateResult, ...]
     model: dict[str, Any] | None = None
+    curve_labels: tuple[str, ...] | None = None
 
     def __post_init__(self) -> None:
         if not self.curves:
             raise ValueError("multi-state Cox curves require at least one covariate profile")
+        if self.curve_labels is not None and len(self.curve_labels) != len(self.curves):
+            raise ValueError("multi-state Cox curve labels must match covariate profiles")
         first = self.curves[0]
         for curve in self.curves:
             if not curve.cox_model:
@@ -13971,6 +13975,7 @@ def _survfit0_multistate_result(
         influence_chaz=result.influence_chaz,
         influence_auc=result.influence_auc,
         cox_model=result.cox_model,
+        cox_source=result.cox_source or result.cox_model,
     )
 
 
@@ -13979,7 +13984,11 @@ def _survfit0_multistate_cox_result(
     t0: float | None = None,
 ) -> SurvfitMultiStateCoxResult:
     curves = tuple(_survfit0_multistate_result(curve, t0) for curve in result.curves)
-    return result if curves == result.curves else SurvfitMultiStateCoxResult(curves, result.model)
+    return (
+        result
+        if curves == result.curves
+        else SurvfitMultiStateCoxResult(curves, result.model, result.curve_labels)
+    )
 
 
 def _survfit0_cox_result(
@@ -14323,11 +14332,16 @@ def aggregate_survfit_result(
                     influence_chaz=None,
                     influence_auc=None,
                     cox_model=aggregate_count > 1,
+                    cox_source=True,
                 )
             )
         if aggregate_count == 1:
             return aggregate_curves[0]
-        return SurvfitMultiStateCoxResult(tuple(aggregate_curves), result.model)
+        return SurvfitMultiStateCoxResult(
+            tuple(aggregate_curves),
+            result.model,
+            tuple(str(index + 1) for index in range(aggregate_count)),
+        )
 
     if not isinstance(result, CoxSurvfitResult):
         raise TypeError("survfit object does not have a 'data' margin")
@@ -18672,10 +18686,12 @@ def _subset_survfit_multistate(
             p0_fixed=curve.p0_fixed,
             timefix=curve.timefix,
             cox_model=curve.cox_model,
+            cox_source=curve.cox_source or curve.cox_model,
         )
 
     source_curves = result.curves if isinstance(result, SurvfitMultiStateCoxResult) else (result,)
     if curve_indices is None:
+        selected_curve_indices = list(range(len(source_curves)))
         selected_curves = list(source_curves)
     else:
         selected_curve_indices = [
@@ -18691,7 +18707,16 @@ def _subset_survfit_multistate(
     subset_curves = tuple(subset_curve(curve) for curve in selected_curves)
     if len(subset_curves) == 1:
         return subset_curves[0]
-    return SurvfitMultiStateCoxResult(curves=subset_curves, model=result.model)
+    curve_labels = (
+        None
+        if not isinstance(result, SurvfitMultiStateCoxResult) or result.curve_labels is None
+        else tuple(result.curve_labels[index] for index in selected_curve_indices)
+    )
+    return SurvfitMultiStateCoxResult(
+        curves=subset_curves,
+        model=result.model,
+        curve_labels=curve_labels,
+    )
 
 
 def _survfit_multistate_structure(
@@ -18700,9 +18725,11 @@ def _survfit_multistate_structure(
     batch_curves: tuple[SurvfitMultiStateResult, ...] | None = None
     grouped_batches: list[tuple[Any, SurvfitMultiStateCoxResult]] | None = None
     cox_curve_count = 1
+    cox_curve_names: tuple[str, ...] | None = None
     if isinstance(result, SurvfitMultiStateCoxResult):
         batch_curves = result.curves
         cox_curve_count = result.curve_count
+        cox_curve_names = result.curve_labels
         curves = [(None, result.curves[0])]
         grouped = False
     elif isinstance(result, SurvfitMultiStateResult):
@@ -18724,6 +18751,9 @@ def _survfit_multistate_structure(
         cox_curve_count = grouped_batches[0][1].curve_count
         if any(batch.curve_count != cox_curve_count for _label, batch in grouped_batches):
             raise ValueError("stratified multi-state Cox results must share a data dimension")
+        cox_curve_names = grouped_batches[0][1].curve_labels
+        if any(batch.curve_labels != cox_curve_names for _label, batch in grouped_batches):
+            raise ValueError("stratified multi-state Cox results must share data labels")
         curves = [(label, batch.curves[0]) for label, batch in grouped_batches]
         grouped = True
     else:
@@ -18841,9 +18871,12 @@ def _survfit_multistate_structure(
             "t0": first.t0,
             "_transition_names": transition_names,
             "_cox_model": first.cox_model,
+            "_cox_source": first.cox_source or first.cox_model,
             "_cox_curve_count": cox_curve_count,
         }
     )
+    if cox_curve_names is not None:
+        structure["_cox_curve_names"] = list(cox_curve_names)
     if first.oldstate is not None:
         structure["oldstate"] = list(first.oldstate)
     return structure
@@ -22295,6 +22328,7 @@ def _cox_multistate_survfit_result(
                 cumhaz=[[float(value) for value in row] for row in profile_cumhaz],
                 model=model_frame,
                 cox_model=True,
+                cox_source=True,
             )
             for profile_pstate, profile_cumhaz in profile_curves
         )

--- a/python/survival/r_api.pyi
+++ b/python/survival/r_api.pyi
@@ -711,6 +711,7 @@ class SurvfitMultiStateResult:
     influence_chaz: list[list[float]] | None
     influence_auc: list[list[float]] | None
     cox_model: bool
+    cox_source: bool
     def __iter__(self): ...
     @property
     def curve_count(self) -> int: ...
@@ -730,6 +731,7 @@ class SurvfitMultiStateResult:
 class SurvfitMultiStateCoxResult:
     curves: tuple[SurvfitMultiStateResult, ...]
     model: dict[str, Any] | None
+    curve_labels: tuple[str, ...] | None
     def __iter__(self): ...
     def __getattr__(self, name: str) -> Any: ...
     @property

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -13484,6 +13484,8 @@ def test_coxph_multistate_competing_risks_matches_r_reference():
     )
     assert isinstance(batched_curve, survival.SurvfitMultiStateCoxResult)
     assert batched_curve.curve_count == 2
+    assert batched_curve.curve_labels is None
+    assert all(curve.cox_source for curve in batched_curve.curves)
     assert batched_curve.time == pytest.approx(list(range(13)))
     assert batched_curve.pstate[0][-1] == pytest.approx(expected_pstate[-1], abs=1e-12)
     assert batched_curve.pstate[1][-1] == pytest.approx(
@@ -13514,6 +13516,7 @@ def test_coxph_multistate_competing_risks_matches_r_reference():
     averaged_curve = survival.r_api.aggregate_survfit_result(aggregate_source)
     assert isinstance(averaged_curve, survival.SurvfitMultiStateResult)
     assert averaged_curve.cox_model is False
+    assert averaged_curve.cox_source is True
     assert averaged_curve.pstate[-1] == pytest.approx(
         [0.22713617194521979, 0.36661942336069081, 0.4062444046940894],
         abs=1e-12,
@@ -13526,6 +13529,7 @@ def test_coxph_multistate_competing_risks_matches_r_reference():
     )
     assert isinstance(grouped_curve, survival.SurvfitMultiStateCoxResult)
     assert grouped_curve.curve_count == 2
+    assert grouped_curve.curve_labels == ("1", "2")
     assert grouped_curve.pstate[0][-1] == pytest.approx(
         [0.21304991590588035, 0.40057642090756906, 0.38637366318655059],
         abs=1e-12,
@@ -13534,6 +13538,19 @@ def test_coxph_multistate_competing_risks_matches_r_reference():
         [0.25530868402389867, 0.29870542826693436, 0.44598588770916708],
         abs=1e-12,
     )
+    assert survival.r_api._survfit_multistate_structure(grouped_curve)["_cox_curve_names"] == [
+        "1",
+        "2",
+    ]
+    relabeled_subset = survival.r_api._subset_survfit_multistate(
+        grouped_curve,
+        [0, 2],
+        [1, 0],
+    )
+    assert isinstance(relabeled_subset, survival.SurvfitMultiStateCoxResult)
+    assert relabeled_subset.curve_labels == ("2", "1")
+    with pytest.raises(ValueError, match="labels must match"):
+        survival.SurvfitMultiStateCoxResult(grouped_curve.curves, curve_labels=("1",))
     with pytest.raises(ValueError, match="same length"):
         survival.r_api.aggregate_survfit_result(aggregate_source, groups=[1])
     with pytest.raises(ValueError, match="positive integer"):
@@ -13584,10 +13601,12 @@ def test_coxph_multistate_competing_risks_matches_r_reference():
     stratified_structure = survival.r_api._survfit_multistate_structure(stratified_curves)
     assert stratified_structure["strata"] == {"g1": 7, "g2": 7}
     assert stratified_structure["_cox_curve_count"] == 2
+    assert stratified_structure["_cox_source"] is True
     assert len(stratified_structure["pstate"]) == 28
     stratified_average = survival.r_api.aggregate_survfit_result(stratified_curves)
     assert list(stratified_average) == ["g1", "g2"]
     for label in stratified_curves:
+        assert stratified_average[label].cox_source is True
         assert stratified_average[label].pstate[-1] == pytest.approx(
             [
                 sum(values) / 2.0

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -11450,9 +11450,16 @@ summary.survival_py_anova <- function(object, ...) {
 .as_survival_py_multistate_list <- function(x) {
   fields <- .call_r_api("_survfit_multistate_structure", x)
   cox_model <- isTRUE(as.logical(fields[["_cox_model"]])[[1L]])
+  cox_source <- isTRUE(as.logical(fields[["_cox_source"]])[[1L]])
   cox_curve_count <- as.integer(fields[["_cox_curve_count"]])[[1L]]
+  cox_curve_names <- fields[["_cox_curve_names"]]
+  if (!is.null(cox_curve_names)) {
+    cox_curve_names <- as.character(cox_curve_names)
+  }
   fields[["_cox_model"]] <- NULL
+  fields[["_cox_source"]] <- NULL
   fields[["_cox_curve_count"]] <- NULL
+  fields[["_cox_curve_names"]] <- NULL
   states <- as.character(fields[["states"]])
   transition_names <- as.character(fields[["_transition_names"]])
   fields[["_transition_names"]] <- NULL
@@ -11511,10 +11518,13 @@ summary.survival_py_anova <- function(object, ...) {
     if (cox_curve_count < 1L || nrow(pstate) %% cox_curve_count != 0L) {
       stop("multi-state Cox curve dimensions are inconsistent", call. = FALSE)
     }
+    if (!is.null(cox_curve_names) && length(cox_curve_names) != cox_curve_count) {
+      stop("multi-state Cox curve labels are inconsistent", call. = FALSE)
+    }
     fields[["pstate"]] <- array(
       as.numeric(pstate),
       dim = c(nrow(pstate) %/% cox_curve_count, cox_curve_count, ncol(pstate)),
-      dimnames = list(NULL, NULL, states)
+      dimnames = list(NULL, cox_curve_names, states)
     )
     if (!is.null(fields[["cumhaz"]])) {
       cumhaz <- .as_numeric_matrix(fields[["cumhaz"]])
@@ -11524,7 +11534,7 @@ summary.survival_py_anova <- function(object, ...) {
       fields[["cumhaz"]] <- array(
         as.numeric(cumhaz),
         dim = c(nrow(cumhaz) %/% cox_curve_count, cox_curve_count, ncol(cumhaz)),
-        dimnames = list(NULL, NULL, transition_names)
+        dimnames = list(NULL, cox_curve_names, transition_names)
       )
     }
   }
@@ -11558,7 +11568,7 @@ summary.survival_py_anova <- function(object, ...) {
       unlist(fields[["n.id"]], recursive = TRUE, use.names = FALSE)
     )
   }
-  if (!is.null(strata_names)) {
+  if (!is.null(strata_names) && !cox_source) {
     names(fields[["n"]]) <- strata_names
     if (!is.null(fields[["n.id"]])) {
       names(fields[["n.id"]]) <- strata_names

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -8420,7 +8420,9 @@ test_that("single-formula multi-state Cox models match survival", {
     )
   )
   expect_equal(nrow(stratified_frame), 84L)
-  expect_equal(table(stratified_frame$strata), c(g1 = 42L, g2 = 42L))
+  stratified_counts <- table(stratified_frame$strata)
+  expect_equal(as.integer(stratified_counts), c(42L, 42L))
+  expect_equal(names(stratified_counts), c("g1", "g2"))
 
   formula_data <- transform(
     competing,


### PR DESCRIPTION
## Summary
- preserve numeric group labels on aggregated multi-state Cox prediction margins without naming ordinary batched predictions
- retain Cox provenance through averaging, padding, and subsetting so stratified `n` and `n.id` attributes match R
- validate grouped curve-label consistency across strata and propagate labels through data-margin subsets
- make the stratified frame count regression compare values and names without conflating table-only attributes

## Testing
- `PYTHONPATH=python .venv/bin/pytest -q python/tests` (996 passed)
- focused multi-state curve and runtime/stub contract tests (2 passed)
- Ruff format/check, mypy, binding manifest, and `git diff --check`
- `R CMD check --no-manual --no-build-vignettes r/survivalr` (3574 passed; 0 failures, warnings, or skips; source-directory NOTE only)