### PR TITLE
Align multi-state Cox se.fit handling

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -15209,6 +15209,8 @@ def survfit(
     if _is_clogit_fit(response):
         raise ValueError("predicted survival curves are not defined for a clogit model")
 
+    is_multistate_cox_fit = isinstance(response, _FormulaFit) and response.multi_state is not None
+
     conf_int = _pop_dotted_keyword(kwargs, "conf.int", "conf_int", conf_int, None)
     conf_type = _pop_dotted_keyword(kwargs, "conf.type", "conf_type", conf_type, "log")
     if "se.fit" in kwargs:
@@ -15216,7 +15218,9 @@ def survfit(
             raise ValueError("use only one of se_fit or se.fit")
         se_fit = kwargs.pop("se.fit")
     if se_fit is _MISSING:
-        se_fit = not (isinstance(response, _FormulaFit) and response.multi_state is not None)
+        se_fit = not is_multistate_cox_fit
+    elif is_multistate_cox_fit:
+        se_fit = False
     start_time = _pop_dotted_keyword(kwargs, "start.time", "start_time", start_time, None)
     na_action = _pop_dotted_keyword(kwargs, "na.action", "na_action", na_action, "fail")
     timefix = _pop_dotted_keyword(kwargs, "time.fix", "timefix", timefix, True)
@@ -15316,7 +15320,6 @@ def survfit(
             group = _combined_formula_groups(data, terms.strata, terms.covariates, len(response))
             formula_group_levels = _r_formula_ordered_levels(group, "survfit formula groups")
 
-    is_multistate_cox_fit = isinstance(response, _FormulaFit) and response.multi_state is not None
     if p0 is not None and not (
         (isinstance(response, Surv) and response.type in {"mright", "mcounting"})
         or is_multistate_cox_fit
@@ -15327,10 +15330,6 @@ def survfit(
         if etype is not None or istate is not None:
             raise ValueError("etype and istate are only supported for Surv or formula inputs")
         if is_multistate_cox_fit:
-            if include_se:
-                raise NotImplementedError(
-                    "standard errors are not implemented for multi-state Cox survival curves"
-                )
             if computation.ctype != 1:
                 raise NotImplementedError(
                     "ctype=2 is not implemented for multi-state Cox survival curves"
@@ -15364,7 +15363,7 @@ def survfit(
                 include_censor=include_censor,
                 stype=curve_style,
                 conf_level=normalized_conf_level,
-                conf_type=normalized_conf_type,
+                conf_type="none",
                 keep_model=keep_model,
             )
         if not computation.is_kaplan_meier:
@@ -18823,6 +18822,7 @@ def _survfit_multistate_structure(
     )
     if grouped:
         structure["strata"] = {str(label): len(curve.time) for label, curve in curves}
+    uncertainty_present = False
     for field_name, attribute in (
         ("std.err", "std_err"),
         ("std.chaz", "std_chaz"),
@@ -18831,7 +18831,9 @@ def _survfit_multistate_structure(
         values = combined_matrix(attribute)
         if values is not None and (field_name != "std.chaz" or first.transitions):
             structure[field_name] = values
-    structure["logse"] = False
+            uncertainty_present = True
+    if uncertainty_present:
+        structure["logse"] = False
 
     if first.transitions:
         target_states = list(dict.fromkeys(target for _source, target in first.transitions))
@@ -18862,10 +18864,11 @@ def _survfit_multistate_structure(
         values = combined_matrix(attribute)
         if values is not None:
             structure[field_name] = values
+    if uncertainty_present:
+        structure["conf.type"] = first.conf_type
+        structure["conf.int"] = first.conf_level
     structure.update(
         {
-            "conf.type": first.conf_type,
-            "conf.int": first.conf_level,
             "states": list(first.states),
             "type": first.surv_type,
             "t0": first.t0,

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -2530,6 +2530,17 @@ def test_survfit_multistate_matches_r_aalen_johansen_fixture():
     assert without_se.std_chaz is None
     assert without_se.conf_lower is None
     assert without_se.conf_upper is None
+    without_se_structure = survival.r_api._survfit_multistate_structure(without_se)
+    assert not {
+        "std.err",
+        "std.chaz",
+        "std.auc",
+        "logse",
+        "lower",
+        "upper",
+        "conf.type",
+        "conf.int",
+    }.intersection(without_se_structure)
 
     zero_weight = survival.survfit(response, weights=[1.0, 0.0, 1.0, 1.0, 1.0, 1.0])
     assert zero_weight.n_risk[0] == pytest.approx([5.0, 0.0, 0.0])
@@ -13655,8 +13666,33 @@ def test_coxph_multistate_competing_risks_matches_r_reference():
         survival.predict(fit, type="terms")
     with pytest.raises(ValueError, match="newdata is required"):
         survival.survfit(fit, se_fit=False)
-    with pytest.raises(NotImplementedError, match="standard errors"):
-        survival.survfit(fit, newdata=pandas.DataFrame({"x": [0.5]}), se_fit=True)
+    explicit_se_curve = survival.survfit(
+        fit,
+        newdata=pandas.DataFrame({"x": [0.5]}),
+        se_fit=True,
+        time0=True,
+    )
+    assert explicit_se_curve.time == pytest.approx(model_curve.time)
+    for actual, expected in zip(explicit_se_curve.pstate, model_curve.pstate, strict=True):
+        assert actual == pytest.approx(expected, abs=1e-12)
+    for actual, expected in zip(explicit_se_curve.cumhaz, model_curve.cumhaz, strict=True):
+        assert actual == pytest.approx(expected, abs=1e-12)
+    assert explicit_se_curve.std_err is None
+    assert explicit_se_curve.std_chaz is None
+    assert explicit_se_curve.conf_lower is None
+    assert explicit_se_curve.conf_upper is None
+    assert explicit_se_curve.conf_type == "none"
+    explicit_se_structure = survival.r_api._survfit_multistate_structure(explicit_se_curve)
+    assert not {
+        "std.err",
+        "std.chaz",
+        "std.auc",
+        "logse",
+        "lower",
+        "upper",
+        "conf.type",
+        "conf.int",
+    }.intersection(explicit_se_structure)
 
 
 def test_coxph_multistate_formula_lists_match_r_reference():

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -8858,7 +8858,7 @@ survfit.survival_py_surv <- function(formula, ..., group = NULL, subset = NULL, 
 }
 
 survfit.survival_py_coxph <- function(formula, newdata = NULL, ..., se.fit = TRUE) {
-  if (missing(se.fit) && .is_multistate_cox_fit(formula)) {
+  if (.is_multistate_cox_fit(formula)) {
     se.fit <- FALSE
   }
   .call_r_api(
@@ -11576,8 +11576,12 @@ summary.survival_py_anova <- function(object, ...) {
   }
   fields[["states"]] <- states
   fields[["type"]] <- as.character(fields[["type"]])[[1L]]
-  fields[["conf.type"]] <- as.character(fields[["conf.type"]])[[1L]]
-  fields[["conf.int"]] <- as.numeric(fields[["conf.int"]])[[1L]]
+  if (!is.null(fields[["conf.type"]])) {
+    fields[["conf.type"]] <- as.character(fields[["conf.type"]])[[1L]]
+  }
+  if (!is.null(fields[["conf.int"]])) {
+    fields[["conf.int"]] <- as.numeric(fields[["conf.int"]])[[1L]]
+  }
   fields[["t0"]] <- as.numeric(fields[["t0"]])[[1L]]
   fields
 }

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -8160,6 +8160,44 @@ test_that("single-formula multi-state Cox models match survival", {
   )
   expect_equal(dim(default_curve), c(data = 1L, states = 3L))
 
+  explicit_se_curve <- expect_warning(
+    survfit(
+      bridged,
+      newdata = data.frame(x = 0.5),
+      se.fit = TRUE,
+      time0 = TRUE
+    ),
+    NA
+  )
+  reference_explicit_se_curve <- expect_warning(
+    survival::survfit(
+      reference,
+      newdata = data.frame(x = 0.5),
+      se.fit = TRUE,
+      time0 = TRUE
+    ),
+    NA
+  )
+  explicit_se_list <- as.list(explicit_se_curve)
+  expect_named(
+    explicit_se_list,
+    setdiff(names(reference_explicit_se_curve), c("start.time", "newdata", "call"))
+  )
+  expect_equal(
+    explicit_se_list$pstate,
+    reference_explicit_se_curve$pstate,
+    tolerance = 1e-12
+  )
+  expect_equal(
+    explicit_se_list$cumhaz,
+    reference_explicit_se_curve$cumhaz,
+    tolerance = 1e-12
+  )
+  expect_false(any(c(
+    "std.err", "std.chaz", "std.auc", "logse", "lower", "upper",
+    "conf.type", "conf.int"
+  ) %in% names(explicit_se_list)))
+
   for (curve_style in 1:2) {
     bridged_curve <- as.list(survfit(
       bridged,


### PR DESCRIPTION
## Summary
- match R by treating `se.fit` as disabled for multi-state Cox curves, including when explicitly requested
- omit empty uncertainty and confidence metadata when multi-state curve uncertainty is unavailable
- cover direct Python behavior and R facade field compatibility with regressions

## Testing
- `.venv/bin/python -m pytest python/tests -q` (996 passed)
- `R CMD check --no-manual r/survivalr` (3,580 passed; source-directory NOTE only)
- `.venv/bin/ruff format python/ test/ --check`
- `.venv/bin/ruff check python/ test/`
- `.venv/bin/mypy python/survival/__init__.pyi python/survival/_survival.pyi --ignore-missing-imports`
- `.venv/bin/python scripts/generate_binding_manifest.py --check`
- `git diff --check`