### PR TITLE
Honor multi-state Cox survcheck controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,10 +172,11 @@ shapes for ordinary predictions and individual time-dependent trajectories.
 Single-formula multi-state Cox fits support factor-valued right-censored and
 counting-process responses, with transition-specific coefficients and
 baselines, automatic subject-clustered robust covariance, and matrix-valued
-linear-predictor and risk predictions. Model-based state-probability curves
-support direct or matrix-exponential transition updates for one or more
-covariate profiles across unstratified or stratified baselines, optional
-starting-state mixtures, and conditional start times.
+linear-predictor and risk predictions. Their state-history checks honor
+R-compatible `coxph_control(survcheckallow=...)` policy. Model-based
+state-probability curves support direct or matrix-exponential transition
+updates for one or more covariate profiles across unstratified or stratified
+baselines, optional starting-state mixtures, and conditional start times.
 Formula fits support `tt(...)` time-varying coefficient terms for right-censored
 and counting-process responses, including R's default O'Brien rank transform
 and custom `tt(x, time, riskset, weights)` callables.

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -12221,6 +12221,7 @@ def coxph_control(
     toler_inf: Any | None = None,
     outer_max: Any = 10,
     timefix: Any = True,
+    survcheckallow: Any = "gap",
 ) -> dict[str, Any]:
     """Construct validated Cox fit controls using R-compatible names and defaults."""
 
@@ -12256,6 +12257,7 @@ def coxph_control(
         "toler.inf": toler_inf_value,
         "outer.max": outer_max_value,
         "timefix": timefix_value,
+        "survcheckallow": survcheckallow,
     }
 
 
@@ -12353,10 +12355,10 @@ def _apply_coxph_control(
     max_iter: int,
     eps: float | None,
     toler: float | None,
-) -> tuple[int, float | None, float | None, bool, int]:
+) -> tuple[int, float | None, float | None, bool, int, Any]:
     values = _control_mapping(control, "coxph control")
     if not values:
-        return max_iter, eps, toler, True, 10
+        return max_iter, eps, toler, True, 10, "gap"
 
     max_iter_value, name = _pop_control_alias(
         values,
@@ -12400,8 +12402,15 @@ def _apply_coxph_control(
     outer_max = 10 if outer_max_value is None else int(outer_max_value)
     if outer_max < 1:
         raise ValueError("control.outer.max must be positive")
+    survcheck_allow, _ = _pop_control_alias(
+        values,
+        ("survcheckallow", "survcheck_allow"),
+        "survcheckallow",
+        "gap",
+        "gap",
+    )
     _reject_unknown_control_options(values, "coxph")
-    return max_iter, eps, toler, fix_time, outer_max
+    return max_iter, eps, toler, fix_time, outer_max, survcheck_allow
 
 
 def _apply_survreg_control(
@@ -14679,6 +14688,8 @@ def _survfit_multistate_state_data(
     id_values: list[Any] | None,
     istate: Any | None,
     timefix: bool,
+    *,
+    survcheck_allow: Any = _MISSING,
 ) -> tuple[Surv, list[int], tuple[str, ...], list[Any]]:
     n = len(response)
     ids = list(range(n)) if id_values is None else id_values
@@ -14719,16 +14730,52 @@ def _survfit_multistate_state_data(
         if any(left >= right for left, right in zip(start, stop, strict=True)):
             raise ValueError("timefix produced an empty multi-state interval")
 
-    current_states = list(
-        _core.survfit_subject_history(
-            start,
-            stop,
-            mapped_events,
-            id_codes,
-            provided_states,
-            _SURVFIT_TIME_EPSILON if timefix else 0.0,
+    if survcheck_allow is _MISSING:
+        current_states = list(
+            _core.survfit_subject_history(
+                start,
+                stop,
+                mapped_events,
+                id_codes,
+                provided_states,
+                _SURVFIT_TIME_EPSILON if timefix else 0.0,
+            )
         )
-    )
+    else:
+        if any(event is None for event in mapped_events):
+            raise ValueError("missing values in multi-state Cox inputs")
+        event_codes = [cast(int, event) for event in mapped_events]
+        check = _core.survcheck(
+            id_codes,
+            [0.0] * n if start is None else start,
+            stop,
+            event_codes,
+            None if provided_states is None else [state + 1 for state in provided_states],
+        )
+        issue_names = ("overlap", "gap", "jump", "teleport")
+        if survcheck_allow is None:
+            candidates: list[Any] = []
+        elif isinstance(survcheck_allow, str):
+            candidates = [survcheck_allow]
+        else:
+            try:
+                candidates = _materialize_1d(survcheck_allow, "control.survcheckallow")
+            except (TypeError, ValueError):
+                candidates = [survcheck_allow]
+        allowed = {
+            candidate
+            for candidate in candidates
+            if isinstance(candidate, str) and candidate in issue_names
+        }
+        # R selects flag[-match(..., nomatch = 0)]; with no matched names,
+        # that selection is empty and no named issue class is rejected.
+        rejected = bool(check.invalid_rows) or (
+            bool(allowed)
+            and any(name not in allowed and getattr(check, f"{name}_rows") for name in issue_names)
+        )
+        if rejected:
+            raise ValueError("data set fails survcheck for one or more subjects")
+        current_states = [0 if state == 0 else int(state) - 1 for state in check.current_states]
 
     normalized = Surv._from_normalized(
         time=stop,
@@ -24422,7 +24469,9 @@ def _cox_low_level_fit(
     if initial is not None and len(initial) != nvar:
         raise ValueError("Wrong length for initial parameters")
 
-    max_iter, eps, toler, _, _outer_max = _apply_coxph_control(control, 20, None, None)
+    max_iter, eps, toler, _, _outer_max, _survcheck_allow = _apply_coxph_control(
+        control, 20, None, None
+    )
     if max_iter < 0:
         raise ValueError("control.iter.max must be non-negative")
     if eps is not None and eps <= 0.0:
@@ -25190,7 +25239,7 @@ def coxph(
     if init is not None and initial_beta is not None:
         raise ValueError("use only one of init or initial_beta")
     max_iter = _integer_scalar(max_iter, "max_iter")
-    max_iter, eps, toler, fix_time, outer_max = _apply_coxph_control(
+    max_iter, eps, toler, fix_time, outer_max, survcheck_allow = _apply_coxph_control(
         control,
         max_iter,
         eps,
@@ -25535,6 +25584,7 @@ def coxph(
             id_values,
             istate_values,
             fix_time,
+            survcheck_allow=survcheck_allow,
         )
         transitions = _cox_multistate_transitions(normalized, current_states)
         formula_maps = (

--- a/python/survival/r_api.pyi
+++ b/python/survival/r_api.pyi
@@ -1005,6 +1005,7 @@ def coxph_control(
     toler_inf: Any | None = None,
     outer_max: Any = 10,
     timefix: Any = True,
+    survcheckallow: Any = "gap",
 ) -> dict[str, Any]: ...
 def survreg_control(
     maxiter: Any = 30,

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -14174,6 +14174,57 @@ def test_coxph_multistate_counting_histories_match_r_reference():
     assert all(sum(row) == pytest.approx(1.0, abs=1e-12) for row in model_curve.pstate)
 
 
+def test_coxph_multistate_honors_survcheckallow_history_policy():
+    pandas = pytest.importorskip("pandas")
+    data = pandas.DataFrame(
+        {
+            "id": [1, 1, 2, 2, 3, 3, 4, 4],
+            "start": [0.0, 2.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
+            "stop": [1.0, 3.0, 1.0, 2.0, 1.0, 2.0, 1.0, 2.0],
+            "event": pandas.Categorical(
+                ["a", "0", "a", "0", "a", "0", "a", "0"],
+                categories=["0", "a", "b"],
+            ),
+            "x": [0.0, 0.0, 1.0, 1.0, 2.0, 2.0, 3.0, 3.0],
+        }
+    )
+
+    gap_fit = survival.coxph(
+        "Surv(start, stop, event) ~ x",
+        data=data,
+        id="id",
+        max_iter=0,
+    )
+    assert gap_fit.n == len(data)
+    assert gap_fit.multi_state.current_states == (0, 1, 0, 1, 0, 1, 0, 1)
+    with pytest.raises(ValueError, match="data set fails survcheck"):
+        survival.coxph(
+            "Surv(start, stop, event) ~ x",
+            data=data,
+            id="id",
+            max_iter=0,
+            control={"survcheckallow": "overlap"},
+        )
+
+    overlapping = data.copy()
+    overlapping.loc[1, "start"] = 0.5
+    with pytest.raises(ValueError, match="data set fails survcheck"):
+        survival.coxph(
+            "Surv(start, stop, event) ~ x",
+            data=overlapping,
+            id="id",
+            max_iter=0,
+        )
+    overlap_fit = survival.coxph(
+        "Surv(start, stop, event) ~ x",
+        data=overlapping,
+        id="id",
+        max_iter=0,
+        control={"survcheck_allow": "overlap"},
+    )
+    assert overlap_fit.n == len(overlapping)
+
+
 def test_survfit_accepts_simple_coxph_model():
     data = _toy_data()
     fit = survival.coxph("Surv(time, status) ~ x1 + x2", data=_toy_data(), max_iter=10)
@@ -16860,6 +16911,7 @@ def test_r_style_control_constructors_match_reference_defaults_and_feed_fits():
         "toler.inf": pytest.approx(math.sqrt(1e-9)),
         "outer.max": 10,
         "timefix": True,
+        "survcheckallow": "gap",
     }
     custom_cox_control = survival.coxph_control(
         eps=1e-8,
@@ -16868,9 +16920,11 @@ def test_r_style_control_constructors_match_reference_defaults_and_feed_fits():
         toler_inf=2e-4,
         outer_max=4.9,
         timefix=False,
+        survcheckallow="overlap",
     )
     assert custom_cox_control["iter.max"] == 3
     assert custom_cox_control["outer.max"] == 4
+    assert custom_cox_control["survcheckallow"] == "overlap"
     fit = survival.coxph(
         "Surv(time, status) ~ x1",
         data=_toy_data(),

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -8371,7 +8371,7 @@ aeqSurv <- function(x, tolerance = sqrt(.Machine$double.eps)) {
 
 coxph.control <- function(eps = 1e-09, toler.chol = .Machine$double.eps^0.75,
                           iter.max = 20, toler.inf = sqrt(eps), outer.max = 10,
-                          timefix = TRUE) {
+                          timefix = TRUE, survcheckallow = "gap") {
   eps <- .as_finite_scalar(eps, "eps", positive = TRUE)
   toler.chol <- .as_finite_scalar(toler.chol, "toler.chol", positive = TRUE)
   iter.max <- .as_integer_scalar(iter.max, "iter.max", nonnegative = TRUE)
@@ -8384,7 +8384,8 @@ coxph.control <- function(eps = 1e-09, toler.chol = .Machine$double.eps^0.75,
     iter.max = iter.max,
     toler.inf = toler.inf,
     outer.max = outer.max,
-    timefix = timefix
+    timefix = timefix,
+    survcheckallow = survcheckallow
   )
 }
 

--- a/r/survivalr/man/survivalr.Rd
+++ b/r/survivalr/man/survivalr.Rd
@@ -722,7 +722,7 @@ coxph(formula, data = NULL, ..., subset = NULL, na.action = "fail")
 
 coxph.control(eps = 1e-09, toler.chol = .Machine$double.eps^0.75,
   iter.max = 20, toler.inf = sqrt(eps), outer.max = 10,
-  timefix = TRUE)
+  timefix = TRUE, survcheckallow = "gap")
 
 coxph.fit(x, y, strata, offset, init, control, weights, method,
   rownames, resid = TRUE, nocenter = NULL)
@@ -1168,11 +1168,13 @@ quantiles and Cox summaries.}
 \item{parms}{Optional distribution parameters. Used for the Student-t
 \code{survreg} helper distribution; ignored by the other built-in helper
 distributions to match R.}
-\item{eps, toler.chol, iter.max, toler.inf, outer.max, timefix}{Control
+\item{eps, toler.chol, iter.max, toler.inf, outer.max, timefix, survcheckallow}{Control
 options passed through \code{coxph.control}. \code{timefix} also controls
 near-tie correction in \code{survdiff}. \code{eps} is also the
 convergence tolerance used when \code{ridge}, \code{frailty.*}, or
-\code{pspline} searches for a penalty matching \code{df}.}
+\code{pspline} searches for a penalty matching \code{df}.
+\code{survcheckallow} names the state-history issue permitted for
+multi-state Cox fits and defaults to \code{"gap"}.}
 \item{maxiter, rel.tolerance, debug}{Control options passed through
 \code{survreg.control}.}
 \item{dlist}{Distribution-list object for \code{survregDtest}.}

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -1455,9 +1455,13 @@ test_that("R formula wrappers delegate to the Python survival package", {
   )
 
   cox_control <- coxph.control(iter.max = 0, eps = 1e-05, toler.chol = 1e-08, timefix = FALSE)
-  expect_named(cox_control, c("eps", "toler.chol", "iter.max", "toler.inf", "outer.max", "timefix"))
+  expect_named(
+    cox_control,
+    c("eps", "toler.chol", "iter.max", "toler.inf", "outer.max", "timefix", "survcheckallow")
+  )
   expect_equal(cox_control[["iter.max"]], 0L)
   expect_false(cox_control[["timefix"]])
+  expect_equal(cox_control[["survcheckallow"]], "gap")
   expect_error(coxph.control(iter.max = -1), "iter.max")
   cox_fit_data <- data.frame(
     time = c(1, 2, 3, 4, 5, 6),
@@ -8758,6 +8762,79 @@ test_that("single-formula multi-state Cox models match survival", {
       info = paste("counting field", field)
     )
   }
+})
+
+test_that("multi-state Cox history controls match survival", {
+  skip_if_not_installed("reticulate")
+  skip_if_not_installed("survival")
+  skip_if_not(reticulate::py_module_available("survival"), "Python survival package is unavailable")
+
+  histories <- data.frame(
+    id = rep(seq_len(4L), each = 2L),
+    start = c(0, 2, 0, 1, 0, 1, 0, 1),
+    stop = c(1, 3, 1, 2, 1, 2, 1, 2),
+    event = factor(
+      c("a", "0", "a", "0", "a", "0", "a", "0"),
+      levels = c("0", "a", "b")
+    ),
+    x = rep(0:3, each = 2L)
+  )
+  bridged_gap <- coxph(
+    Surv(start, stop, event) ~ x,
+    data = histories,
+    id = id,
+    control = coxph.control(iter.max = 0L)
+  )
+  reference_gap <- survival::coxph(
+    survival::Surv(start, stop, event) ~ x,
+    data = histories,
+    id = id,
+    control = survival::coxph.control(iter.max = 0L)
+  )
+  expect_equal(coef(bridged_gap), coef(reference_gap), tolerance = 1e-12)
+  expect_error(
+    coxph(
+      Surv(start, stop, event) ~ x,
+      data = histories,
+      id = id,
+      control = coxph.control(iter.max = 0L, survcheckallow = "overlap")
+    ),
+    "data set fails survcheck"
+  )
+
+  overlapping <- histories
+  overlapping$start[2L] <- 0.5
+  expect_error(
+    coxph(
+      Surv(start, stop, event) ~ x,
+      data = overlapping,
+      id = id,
+      control = coxph.control(iter.max = 0L)
+    ),
+    "data set fails survcheck"
+  )
+  expect_error(
+    survival::coxph(
+      survival::Surv(start, stop, event) ~ x,
+      data = overlapping,
+      id = id,
+      control = survival::coxph.control(iter.max = 0L)
+    ),
+    "data set fails survcheck"
+  )
+  bridged_overlap <- coxph(
+    Surv(start, stop, event) ~ x,
+    data = overlapping,
+    id = id,
+    control = coxph.control(iter.max = 0L, survcheckallow = "overlap")
+  )
+  reference_overlap <- survival::coxph(
+    survival::Surv(start, stop, event) ~ x,
+    data = overlapping,
+    id = id,
+    control = survival::coxph.control(iter.max = 0L, survcheckallow = "overlap")
+  )
+  expect_equal(coef(bridged_overlap), coef(reference_overlap), tolerance = 1e-12)
 })
 
 test_that("multi-state Cox tied curve types match survival", {


### PR DESCRIPTION
## Summary
- add the current R `coxph.control(survcheckallow = "gap")` option to both public layers
- validate multi-state Cox histories through the native issue classifier while permitting the configured issue class
- cover default gap handling, rejected overlaps, and explicit overlap allowances against R survival 3.8-11

## Testing
- `PYTHONPATH=python .venv/bin/python -m pytest -q python/tests` (981 passed, 18 skipped)
- `.venv/bin/python -m ruff format python/ test/ --check`
- `.venv/bin/python -m ruff check python/ test/`
- `.venv/bin/python -m mypy python/survival/__init__.pyi python/survival/_survival.pyi --ignore-missing-imports`
- `.venv/bin/python scripts/generate_binding_manifest.py --check`
- `R CMD check --no-manual r/survivalr` (OK; standard source-directory NOTE only)

Stacked on #491.