### PR TITLE
Complete current survSplit semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,9 @@ covariance sweeps stay in Rust; Python performs only formula preparation and
 result labeling.
 R-style `coxph.control(...)` and `survreg.control(...)` helpers are available
 in the bridge and pass named control lists through to the Python API.
+`survSplit` handles formula or data-frame inputs, near-tie correction, added-row
+markers, delayed-entry episode numbering, and `Surv2` subject timelines through
+the native split plan.
 Time-dependent start/stop data can be built with the R-compatible `tmerge`
 workflow. Its update builders preserve R's `(tstart, tstop]` boundary rules,
 event placement, cumulative updates, missing-value handling, and classification

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -11966,8 +11966,55 @@ def _survsplit_data_columns(data: Any | None, n: int) -> dict[str, list[Any]]:
     return columns
 
 
+def _survsplit_timefix(
+    start: list[float],
+    stop: list[float],
+    cut: list[float],
+    *,
+    counting: bool,
+) -> tuple[list[float], list[float], list[float]]:
+    if not counting:
+        adjusted_cut, adjusted_stop = _aeq_adjust_time_columns((cut, stop), None)
+        return start, adjusted_stop, adjusted_cut
+
+    observed_start = [value for value in start if not math.isnan(value)]
+    synthetic_start = [min(observed_start)] * len(cut) if observed_start else []
+    adjusted_synthetic, adjusted_cut, adjusted_start, adjusted_stop = _aeq_adjust_time_columns(
+        (synthetic_start, cut, start, stop),
+        None,
+    )
+    _raise_if_aeq_zero_interval(
+        synthetic_start,
+        cut,
+        adjusted_synthetic,
+        adjusted_cut,
+    )
+    _raise_if_aeq_zero_interval(start, stop, adjusted_start, adjusted_stop)
+    return adjusted_start, adjusted_stop, adjusted_cut
+
+
+def _survsplit_surv2_intervals(
+    times: Sequence[float],
+    subject_id: Any,
+) -> tuple[list[float], list[float]]:
+    subjects = _materialize_labels(subject_id, "subject_id")
+    if len(subjects) != len(times):
+        raise ValueError("subject_id must have the same length as the Surv2 response")
+    if any(_is_missing_value(value) for value in subjects):
+        raise ValueError("subject_id must not contain missing values")
+
+    subject_codes = _encode_labels(subjects, "subject_id")
+    start = list(times)
+    stop = list(start)
+    order = sorted(range(len(times)), key=lambda idx: (subject_codes[idx], start[idx], idx))
+    for current, following in zip(order, order[1:], strict=False):
+        if subject_codes[current] == subject_codes[following]:
+            stop[current] = start[following]
+    return start, stop
+
+
 def survSplit(
-    response: Surv,
+    response: Surv | Surv2,
     data: Any | None = None,
     *,
     cut: Any,
@@ -11977,38 +12024,83 @@ def survSplit(
     episode: str | None = None,
     id: str | None = None,
     zero: Any = 0,
+    added: str | None = None,
+    timefix: Any = True,
+    subject_id: Any | None = None,
 ) -> dict[str, list[Any]]:
-    """Split right or counting-process survival data at fixed cut points."""
+    """Split survival intervals or ``Surv2`` timelines at fixed cut points."""
 
-    if not isinstance(response, Surv):
-        raise TypeError("survSplit response must be a Surv object")
-    if response.type not in {"right", "mright", "counting", "mcounting"}:
+    if not isinstance(response, Surv | Surv2):
+        raise TypeError("survSplit response must be a Surv or Surv2 object")
+    if isinstance(response, Surv) and response.type not in {
+        "right",
+        "mright",
+        "counting",
+        "mcounting",
+    }:
         raise ValueError(f"not valid for {response.type} censored survival data")
 
     cut_values = _float_vector(cut, "cut")
     if any(not math.isfinite(value) for value in cut_values):
         raise ValueError("cut must be a vector of finite numbers")
+    cut_values = sorted(set(cut_values))
+    timefix_value = _normalize_bool_option(timefix, "timefix")
     start_name = _survsplit_output_name(start, "start")
     end_name = _survsplit_output_name(end, "end")
     event_name = _survsplit_output_name(event, "event")
     episode_name = _survsplit_output_name(episode, "episode") if episode is not None else None
     id_name = _survsplit_output_name(id, "id") if id is not None else None
+    added_name = _survsplit_output_name(added, "added") if added is not None else None
 
     n = len(response)
     frame = _survsplit_data_columns(data, n)
     if id_name is not None and id_name in frame:
         raise ValueError("the suggested id name is already present")
 
-    if response.start is None:
+    is_surv2 = isinstance(response, Surv2)
+    if is_surv2:
+        if subject_id is None:
+            raise ValueError("subject_id is required for a Surv2 response")
+        start_values = list(response.time)
+        if timefix_value:
+            cut_values, start_values = _aeq_adjust_time_columns((cut_values, start_values), None)
+        start_values, stop_values = _survsplit_surv2_intervals(
+            start_values,
+            subject_id,
+        )
+        original_status = list(response.status)
+    elif response.start is None:
         zero_value = _finite_float(zero, "zero")
         stop_values = list(response.time)
         observed_times = [value for value in stop_values if not math.isnan(value)]
         if any(value <= zero_value for value in observed_times):
             raise ValueError("'zero' parameter must be less than any observed times")
         start_values = [zero_value] * n
+        if timefix_value:
+            start_values, stop_values, cut_values = _survsplit_timefix(
+                start_values,
+                stop_values,
+                cut_values,
+                counting=False,
+            )
+        original_status = list(response.event)
     else:
         start_values = list(response.start)
         stop_values = list(response.time)
+        if timefix_value:
+            start_values, stop_values, cut_values = _survsplit_timefix(
+                start_values,
+                stop_values,
+                cut_values,
+                counting=True,
+            )
+        original_status = list(response.event)
+
+    if not is_surv2 and any(
+        not math.isnan(left) and not math.isnan(right) and left >= right
+        for left, right in zip(start_values, stop_values, strict=True)
+    ):
+        raise ValueError("start time must be < stop time")
 
     split = _core.survsplit(start_values, stop_values, cut_values)
     row_indices = [int(row) - 1 for row in split.row]
@@ -12019,15 +12111,36 @@ def survSplit(
     if id_name is not None:
         result[id_name] = [row_idx + 1 for row_idx in row_indices]
 
-    original_status = list(response.event)
     result[start_name] = [float(value) for value in split.start]
-    result[end_name] = [float(value) for value in split.end]
-    result[event_name] = [
-        0 if censor else int(original_status[row_idx])
-        for censor, row_idx in zip(split.censor, row_indices, strict=True)
-    ]
+    if not is_surv2:
+        result[end_name] = [float(value) for value in split.end]
+    if is_surv2:
+        seen_rows: set[int] = set()
+        output_status: list[int | None] = []
+        for row_idx in row_indices:
+            status_value = original_status[row_idx]
+            output_status.append(
+                None
+                if status_value is None
+                else int(status_value)
+                if row_idx not in seen_rows
+                else 0
+            )
+            seen_rows.add(row_idx)
+        result[event_name] = output_status
+    else:
+        result[event_name] = [
+            None
+            if original_status[row_idx] is None
+            else 0
+            if censor
+            else int(original_status[row_idx])
+            for censor, row_idx in zip(split.censor, row_indices, strict=True)
+        ]
     if episode_name is not None:
         result[episode_name] = [int(value) for value in split.interval]
+    if added_name is not None:
+        result[added_name] = [bool(value) for value in split.censor]
     return result
 
 

--- a/python/survival/r_api.pyi
+++ b/python/survival/r_api.pyi
@@ -1248,7 +1248,7 @@ def survcondense(
     **kwargs: Any,
 ) -> Any: ...
 def survSplit(
-    response: Surv,
+    response: Surv | Surv2,
     data: Any | None = None,
     *,
     cut: Any,
@@ -1258,6 +1258,9 @@ def survSplit(
     episode: str | None = None,
     id: str | None = None,
     zero: Any = 0,
+    added: str | None = None,
+    timefix: Any = True,
+    subject_id: Any | None = None,
 ) -> dict[str, list[Any]]: ...
 def lvcf(id: Any, x: Any, time: Any | None = None) -> list[Any]: ...
 def nostutter(id: Any, x: Any, censor: Any = 0, single: bool = False) -> list[Any]: ...

--- a/python/tests/test_binding_contract.py
+++ b/python/tests/test_binding_contract.py
@@ -12788,7 +12788,20 @@ def test_r_api_stub_tracks_survsplit_public_signature():
     survival = importlib.import_module("survival")
     stub_path = PACKAGE_ROOT / "r_api.pyi"
 
-    expected = ["response", "data", "cut", "start", "end", "event", "episode", "id", "zero"]
+    expected = [
+        "response",
+        "data",
+        "cut",
+        "start",
+        "end",
+        "event",
+        "episode",
+        "id",
+        "zero",
+        "added",
+        "timefix",
+        "subject_id",
+    ]
     runtime_params = inspect.signature(survival.r_api.survSplit).parameters
     assert list(runtime_params) == expected
     assert runtime_params["cut"].kind is inspect.Parameter.KEYWORD_ONLY

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -447,6 +447,87 @@ def test_survSplit_splits_right_and_counting_surv_responses_like_r():
         survival.survSplit(right, cut=[math.inf])
 
 
+def test_survSplit_matches_current_timefix_added_episode_and_surv2_semantics():
+    class Factor(list):
+        def __init__(self, values, levels):
+            super().__init__(values)
+            self.categories = levels
+
+    right = survival.Surv([1.0], [1])
+    fixed = survival.survSplit(
+        right,
+        {"x": [9]},
+        cut=[1.0 - 1e-9],
+        end="time",
+        event="status",
+        added="made",
+    )
+    exact = survival.survSplit(
+        right,
+        {"x": [9]},
+        cut=[1.0 - 1e-9],
+        end="time",
+        event="status",
+        added="made",
+        timefix=False,
+    )
+    assert fixed == {
+        "x": [9],
+        "tstart": [0.0],
+        "time": [1.0 - 1e-9],
+        "status": [1],
+        "made": [False],
+    }
+    assert exact["tstart"] == pytest.approx([0.0, 1.0 - 1e-9])
+    assert exact["time"] == pytest.approx([1.0 - 1e-9, 1.0])
+    assert exact["status"] == [0, 1]
+    assert exact["made"] == [True, False]
+
+    delayed = survival.survSplit(
+        survival.Surv([5.0], [10.0], [1]),
+        cut=[3.0, 7.0],
+        start="start",
+        end="stop",
+        event="status",
+        episode="episode",
+    )
+    assert delayed["episode"] == [2, 3]
+
+    with pytest.raises(ValueError, match="effective length 0"):
+        survival.survSplit(
+            survival.Surv([0.0], [1.0], [1]),
+            cut=[1e-9],
+            timefix=True,
+        )
+    with pytest.raises(TypeError, match="timefix"):
+        survival.survSplit(right, cut=[0.5], timefix=1)
+
+    timeline = survival.Surv2(
+        [0.0, 2.0, 5.0, 0.0, 4.0],
+        Factor(["a", "b", "b", "a", "b"], ["a", "b"]),
+    )
+    timeline_split = survival.survSplit(
+        timeline,
+        {"x": [1, 2, 3, 4, 5], "(id)": [1, 1, 1, 2, 2]},
+        cut=[1.0, 3.0],
+        start="time",
+        event="event",
+        episode="ep",
+        added="add",
+        subject_id=[1, 1, 1, 2, 2],
+    )
+    assert timeline_split == {
+        "x": [1, 1, 2, 2, 3, 4, 4, 4, 5],
+        "(id)": [1, 1, 1, 1, 1, 2, 2, 2, 2],
+        "time": [0.0, 1.0, 2.0, 3.0, 5.0, 0.0, 1.0, 3.0, 4.0],
+        "event": [0, 0, 1, 0, 1, 0, 0, 0, 1],
+        "ep": [1, 2, 2, 3, 3, 1, 2, 3, 3],
+        "add": [True, False, True, False, False, True, True, False, False],
+    }
+    with pytest.raises(ValueError, match="subject_id is required"):
+        survival.survSplit(timeline, cut=[1.0])
+
+
 def test_survcheck_accepts_formula_direct_and_legacy_inputs():
     counting = survival.Surv([0.0, 1.0, 0.0], [1.0, 2.0, 2.0], [0, 1, 1])
     direct = survival.survcheck(counting, id=[1, 1, 2])

--- a/python/tests/test_utilities.py
+++ b/python/tests/test_utilities.py
@@ -152,7 +152,7 @@ def test_survsplit_public_api_and_validation():
     assert result.censor == [True, True, False]
 
     assert boundary_result.row == [1, 1]
-    assert boundary_result.interval == [1, 2]
+    assert boundary_result.interval == [2, 3]
     assert boundary_result.start == pytest.approx([0.0, 3.0])
     assert boundary_result.end == pytest.approx([3.0, 10.0])
     assert boundary_result.censor == [True, False]

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -430,7 +430,7 @@ attrassign <- function(object, tt) {
     if (ncol(value) == 2L) {
       return(.wrap_python(
         .python_attr("Surv")(
-          as.numeric(value[, 1L]),
+          as.list(as.numeric(value[, 1L])),
           .as_python_factor(event),
           type = "mstate"
         ),
@@ -440,8 +440,8 @@ attrassign <- function(object, tt) {
     if (ncol(value) == 3L) {
       return(.wrap_python(
         .python_attr("Surv")(
-          as.numeric(value[, 1L]),
-          as.numeric(value[, 2L]),
+          as.list(as.numeric(value[, 1L])),
+          as.list(as.numeric(value[, 2L])),
           .as_python_factor(event),
           type = "mstate"
         ),
@@ -451,22 +451,55 @@ attrassign <- function(object, tt) {
   }
   if (ncol(value) == 2L) {
     return(.wrap_python(
-      .python_attr("Surv")(as.numeric(value[, 1L]), as.numeric(value[, 2L]), type = surv_type),
+      .python_attr("Surv")(
+        as.list(as.numeric(value[, 1L])),
+        as.list(as.numeric(value[, 2L])),
+        type = surv_type
+      ),
       c("survival_py_surv", "survival_py_object")
     ))
   }
   if (ncol(value) == 3L) {
     return(.wrap_python(
       .python_attr("Surv")(
-        as.numeric(value[, 1L]),
-        as.numeric(value[, 2L]),
-        as.numeric(value[, 3L]),
+        as.list(as.numeric(value[, 1L])),
+        as.list(as.numeric(value[, 2L])),
+        as.list(as.numeric(value[, 3L])),
         type = surv_type
       ),
       c("survival_py_surv", "survival_py_object")
     ))
   }
   stop("unsupported Surv matrix shape", call. = FALSE)
+}
+
+.as_python_surv2 <- function(value) {
+  if (inherits(value, "survival_py_surv2")) {
+    return(value)
+  }
+  if (!inherits(value, "Surv2") || !is.matrix(value) || ncol(value) != 2L) {
+    return(value)
+  }
+  event_attributes <- attr(value, "inputAttributes")[["event"]]
+  event_levels <- event_attributes[["levels"]]
+  if (is.null(event_levels)) {
+    event_levels <- c("(s0)", attr(value, "states"))
+  }
+  status <- as.integer(value[, 2L])
+  event_values <- rep(NA_character_, length(status))
+  observed <- !is.na(status)
+  event_values[observed] <- event_levels[status[observed] + 1L]
+  event <- factor(event_values, levels = event_levels)
+  repeated <- attr(value, "repeated")
+  if (is.null(repeated)) repeated <- FALSE
+  .wrap_python(
+    .python_attr("Surv2")(
+      as.list(as.numeric(value[, 1L])),
+      .as_python_factor(event),
+      repeated = repeated
+    ),
+    c("survival_py_surv2", "survival_py_object")
+  )
 }
 
 .survsplit_arg_label <- function(expr, name = "") {
@@ -10083,37 +10116,118 @@ statefig <- function(layout, connect, margin = 0.03, box = TRUE, cex = 1,
   invisible(coords)
 }
 
-survSplit <- function(formula, data, subset, na.action = na.pass, cut,
-                      start = "tstart", id, zero = 0, episode,
-                      end = "tstop", event = "event", added) {
-  if (missing(formula)) {
+survSplit <- function(formula, data, subset, na.action = na.pass, id, cut,
+                      zero = 0, episode, start = "tstart", end = "tstop",
+                      event = "event", added, timefix = TRUE) {
+  call <- match.call()
+  char_id <- FALSE
+  if (missing(formula) || is.data.frame(formula)) {
+    if (!missing(id)) {
+      id_name <- id
+      char_id <- TRUE
+    }
+    if (missing(data)) {
+      if (missing(formula)) {
+        stop("a data frame is required", call. = FALSE)
+      }
+      names(call)[[2L]] <- "data"
+      data <- formula
+    }
+    if (missing(end) || missing(event)) {
+      stop("either a formula or the end and event arguments are required", call. = FALSE)
+    }
+    if (!(is.character(event) && length(event) == 1L && event %in% names(data))) {
+      stop("'event' must be a variable name in the data set", call. = FALSE)
+    }
+    if (!(is.character(end) && length(end) == 1L && end %in% names(data))) {
+      stop("'end' must be a variable name in the data set", call. = FALSE)
+    }
+    if (!(is.character(start) && length(start) == 1L)) {
+      stop("'start' must be a variable name", call. = FALSE)
+    }
+    response_columns <- if (start %in% names(data)) {
+      paste(start, end, event, sep = ",")
+    } else {
+      paste(end, event, sep = ",")
+    }
+    formula <- stats::as.formula(
+      paste0("Surv(", response_columns, ") ~ ."),
+      env = parent.frame()
+    )
+  } else if (!inherits(formula, "formula")) {
     stop("either a formula or the end and event arguments are required", call. = FALSE)
+  }
+  if (!char_id && !missing(id)) {
+    id_name <- try(id, silent = TRUE)
+    if (!inherits(id_name, "try-error") && length(id_name) == 1L) {
+      if (is.character(id_name)) {
+        char_id <- TRUE
+      } else {
+        stop("invalid value for id", call. = FALSE)
+      }
+    }
   }
   if (missing(cut)) {
     stop("cut must be supplied", call. = FALSE)
   }
-  call <- match.call()
-  model_formula <- formula
-  if (inherits(model_formula, "formula")) {
-    model_env <- new.env(parent = environment(model_formula))
-    model_env$Surv <- .survsplit_model_frame_surv
-    environment(model_formula) <- model_env
+  if (!is.numeric(cut) || any(!is.finite(cut))) {
+    stop("cut must be a vector of finite numbers", call. = FALSE)
   }
-  keep <- match(c("data", "subset"), names(call), nomatch = 0L)
+  if (!is.logical(timefix) || length(timefix) != 1L || is.na(timefix)) {
+    stop("invalid value for timefix option", call. = FALSE)
+  }
+  episode_name <- NULL
+  if (!missing(episode)) {
+    if (!is.character(episode)) {
+      stop("episode must be a character string", call. = FALSE)
+    }
+    episode_name <- make.names(episode)
+  }
+  added_name <- NULL
+  if (!missing(added)) {
+    if (!is.character(added)) {
+      stop("added must be a character string", call. = FALSE)
+    }
+    added_name <- make.names(added)
+  }
+  if (match("data", names(call), nomatch = 0L) == 0L) {
+    stop("a data argument is required", call. = FALSE)
+  }
+
+  model_formula <- formula
+  model_env <- new.env(parent = environment(model_formula))
+  model_env$Surv <- .survsplit_model_frame_surv
+  environment(model_formula) <- model_env
+  model_arguments <- if (char_id) {
+    c("data", "subset", "na.action")
+  } else {
+    c("data", "subset", "na.action", "id")
+  }
+  keep <- match(model_arguments, names(call), nomatch = 0L)
   model_call <- call[c(1L, keep)]
   model_call$formula <- model_formula
-  model_call$na.action <- na.action
+  if (missing(na.action)) model_call$na.action <- quote(stats::na.pass)
   model_call[[1L]] <- quote(stats::model.frame)
   model_frame <- eval.parent(model_call)
   response <- stats::model.response(model_frame)
-  py_response <- .as_python_surv(response)
-  if (!is.Surv(py_response)) {
-    stop("the model must have a Surv object as the response", call. = FALSE)
+  is_surv2 <- inherits(response, "Surv2")
+  if (!(inherits(response, "Surv") || is_surv2)) {
+    stop("the model must have a Surv or Surv2 object as the response", call. = FALSE)
   }
+  if (inherits(response, "Surv") && !(attr(response, "type") %in% c(
+    "right", "mright", "counting", "mcounting"
+  ))) {
+    stop("not valid for ", attr(response, "type"), " censored survival data", call. = FALSE)
+  }
+
   response_names <- .survsplit_response_names(formula, response)
-  counting_response <- length(response_names) >= 3L
-  start_name <- if (missing(start) && counting_response) response_names[[1L]] else start
-  end_name <- if (missing(end) && length(response_names) >= 2L) {
+  counting_response <- !is_surv2 && ncol(response) == 3L
+  start_name <- if (missing(start) && (counting_response || is_surv2)) {
+    response_names[[1L]]
+  } else {
+    start
+  }
+  end_name <- if (!is_surv2 && missing(end) && length(response_names) >= 2L) {
     response_names[[if (counting_response) 2L else 1L]]
   } else {
     end
@@ -10123,7 +10237,20 @@ survSplit <- function(formula, data, subset, na.action = na.pass, cut,
   } else {
     event
   }
-  covariates <- model_frame[-1L]
+
+  right_dot <- is.name(formula[[3L]]) && formula[[3L]] == as.name(".") &&
+    nrow(model_frame) == nrow(data)
+  if (char_id && !(id_name %in% names(data)) && inherits(response, "Surv") &&
+      identical(attr(response, "type"), "right")) {
+    data[[id_name]] <- seq_len(nrow(data))
+    model_frame[[id_name]] <- seq_len(nrow(model_frame))
+  }
+  covariates <- if (right_dot) data else model_frame[-1L]
+  subject_id <- if (is_surv2) stats::model.extract(model_frame, "id") else NULL
+  if (is_surv2 && is.null(subject_id)) {
+    stop("an id statement is required", call. = FALSE)
+  }
+  py_response <- if (is_surv2) .as_python_surv2(response) else .as_python_surv(response)
   result <- .call_r_api(
     "survSplit",
     response = py_response,
@@ -10132,9 +10259,11 @@ survSplit <- function(formula, data, subset, na.action = na.pass, cut,
     start = start_name,
     end = end_name,
     event = event_name,
-    episode = if (missing(episode)) NULL else as.character(episode),
-    id = if (missing(id)) NULL else as.character(id),
-    zero = zero
+    episode = episode_name,
+    zero = zero,
+    added = added_name,
+    timefix = timefix,
+    subject_id = if (is.null(subject_id)) NULL else .as_python_vector(subject_id)
   )
   output <- .restore_r_column_classes(
     as.data.frame(result, stringsAsFactors = FALSE, optional = TRUE),
@@ -10142,9 +10271,6 @@ survSplit <- function(formula, data, subset, na.action = na.pass, cut,
   )
   states <- attr(response, "states")
   if (!is.null(states)) {
-    if (!missing(id)) {
-      output[[as.character(id)]] <- NULL
-    }
     output[[event_name]] <- factor(
       as.integer(output[[event_name]]),
       levels = 0:length(states),

--- a/r/survivalr/man/survivalr.Rd
+++ b/r/survivalr/man/survivalr.Rd
@@ -647,9 +647,9 @@ survfit_confint(p, se, logse = TRUE, conf.type, conf.int = 0.95,
 
 pseudo(fit, times, type, collapse = TRUE, data.frame = FALSE, ...)
 
-survSplit(formula, data, subset, na.action = na.pass, cut,
-  start = "tstart", id, zero = 0, episode, end = "tstop",
-  event = "event", added)
+survSplit(formula, data, subset, na.action = na.pass, id, cut,
+  zero = 0, episode, start = "tstart", end = "tstop",
+  event = "event", added, timefix = TRUE)
 
 survcondense(formula, data, subset, weights, na.action = na.pass,
   id, start = "tstart", end = "tstop", event = "event")
@@ -1027,8 +1027,8 @@ input.}
 \code{nostutter}. \code{censor} also controls whether
 \code{points.survival_py_survfit} marks censoring rows instead of event rows.}
 \item{episode, end, added}{Output column controls for
-\code{survSplit} and \code{survcondense}; \code{added} is accepted for R API
-compatibility.}
+\code{survSplit} and \code{survcondense}; \code{added} marks rows introduced
+at a split point.}
 \item{tt, special, order}{Term-object inputs for \code{attrassign} and
 special-term inputs for \code{untangle.specials}.}
 \item{formula}{Formula, formula string, bridged \code{Surv} response, or

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -837,13 +837,27 @@ test_that("R formula wrappers delegate to the Python survival package", {
     episode = "episode",
     id = "rowid"
   )
-  expect_equal(names(counting_split), c("group", "rowid", "start", "stop", "status", "episode"))
+  expect_equal(names(counting_split), c("group", "start", "stop", "status", "episode"))
   expect_equal(counting_split$group, c("a", "a", "b", "b", "b"))
-  expect_equal(as.integer(counting_split$rowid), c(1L, 1L, 2L, 2L, 2L))
   expect_equal(as.numeric(counting_split$start), c(0, 3, 2, 3, 6))
   expect_equal(as.numeric(counting_split$stop), c(3, 5, 3, 6, 8))
   expect_equal(as.integer(counting_split$status), c(0L, 1L, 0L, 0L, 0L))
   expect_equal(as.integer(counting_split$episode), c(1L, 2L, 1L, 2L, 3L))
+  reference_counting_split_formula <- Surv(start, stop, status) ~ group
+  environment(reference_counting_split_formula) <- list2env(
+    list(Surv = survival::Surv),
+    parent = parent.frame()
+  )
+  expect_equal(
+    counting_split,
+    survival::survSplit(
+      reference_counting_split_formula,
+      data = split_counting,
+      cut = c(3, 6),
+      episode = "episode",
+      id = "rowid"
+    )
+  )
 
   split_multistate <- data.frame(
     time = c(1, 3, 4),
@@ -897,6 +911,127 @@ test_that("R formula wrappers delegate to the Python survival package", {
     id = "subject"
   )
   expect_equal(multistate_counting_split, reference_multistate_counting_split)
+
+  expect_identical(names(formals(survSplit)), names(formals(survival::survSplit)))
+  near_tie_split_data <- data.frame(time = 1, status = 1, x = 9)
+  reference_near_tie_formula <- Surv(time, status) ~ x
+  environment(reference_near_tie_formula) <- list2env(
+    list(Surv = survival::Surv),
+    parent = parent.frame()
+  )
+  for (fix_times in c(TRUE, FALSE)) {
+    bridged_near_tie <- survSplit(
+      Surv(time, status) ~ x,
+      data = near_tie_split_data,
+      cut = 1 - 1e-9,
+      added = "made",
+      timefix = fix_times
+    )
+    reference_near_tie <- survival::survSplit(
+      reference_near_tie_formula,
+      data = near_tie_split_data,
+      cut = 1 - 1e-9,
+      added = "made",
+      timefix = fix_times
+    )
+    expect_equal(bridged_near_tie, reference_near_tie, tolerance = 1e-12)
+  }
+
+  bridged_frame_split <- survSplit(
+    near_tie_split_data,
+    cut = 0.5,
+    end = "time",
+    event = "status",
+    id = "rowid",
+    added = "made"
+  )
+  reference_frame_split <- survival::survSplit(
+    near_tie_split_data,
+    cut = 0.5,
+    end = "time",
+    event = "status",
+    id = "rowid",
+    added = "made"
+  )
+  expect_equal(bridged_frame_split, reference_frame_split)
+  sanitized_split <- survSplit(
+    near_tie_split_data,
+    cut = 0.5,
+    end = "time",
+    event = "status",
+    episode = "split index",
+    added = "inserted row"
+  )
+  expect_true(all(c("split.index", "inserted.row") %in% names(sanitized_split)))
+  expect_error(
+    survSplit(
+      near_tie_split_data,
+      cut = 0.5,
+      end = "time",
+      event = "status",
+      episode = 1
+    ),
+    "episode must be a character string"
+  )
+  expect_error(
+    survSplit(
+      near_tie_split_data,
+      cut = 0.5,
+      end = "time",
+      event = "status",
+      added = 1
+    ),
+    "added must be a character string"
+  )
+
+  delayed_split_data <- data.frame(start = 5, stop = 10, status = 1)
+  reference_delayed_split_formula <- Surv(start, stop, status) ~ 1
+  environment(reference_delayed_split_formula) <- list2env(
+    list(Surv = survival::Surv),
+    parent = parent.frame()
+  )
+  bridged_delayed_split <- survSplit(
+    Surv(start, stop, status) ~ 1,
+    data = delayed_split_data,
+    cut = c(3, 7),
+    episode = "episode"
+  )
+  reference_delayed_split <- survival::survSplit(
+    reference_delayed_split_formula,
+    data = delayed_split_data,
+    cut = c(3, 7),
+    episode = "episode"
+  )
+  expect_equal(bridged_delayed_split, reference_delayed_split)
+
+  timeline_split_data <- data.frame(
+    id = c(1, 1, 1, 2, 2),
+    time = c(0, 2, 5, 0, 4),
+    event = factor(c("a", "b", "b", "a", "b"), levels = c("a", "b")),
+    x = 1:5
+  )
+  reference_timeline_split_formula <- Surv2(time, event) ~ x
+  environment(reference_timeline_split_formula) <- list2env(
+    list(Surv2 = survival::Surv2),
+    parent = parent.frame()
+  )
+  bridged_timeline_split <- survSplit(
+    Surv2(time, event) ~ x,
+    data = timeline_split_data,
+    id = id,
+    cut = c(1, 3),
+    episode = "ep",
+    added = "add"
+  )
+  reference_timeline_split <- survival::survSplit(
+    reference_timeline_split_formula,
+    data = timeline_split_data,
+    id = id,
+    cut = c(1, 3),
+    episode = "ep",
+    added = "add"
+  )
+  expect_equal(bridged_timeline_split, reference_timeline_split)
 
   check_data <- data.frame(
     id = c(1, 1, 2),

--- a/src/data_prep/survsplit.rs
+++ b/src/data_prep/survsplit.rs
@@ -16,11 +16,11 @@ pub struct SplitResult {
 }
 
 fn interior_cut_bounds(cutpoints: &[f64], start: f64, stop: f64) -> (usize, usize) {
+    let first = cutpoints.partition_point(|&cutpoint| cutpoint <= start);
     if start >= stop {
-        return (0, 0);
+        return (first, first);
     }
 
-    let first = cutpoints.partition_point(|&cutpoint| cutpoint <= start);
     let last = cutpoints.partition_point(|&cutpoint| cutpoint < stop);
     (first, last)
 }
@@ -86,8 +86,8 @@ pub fn survsplit(tstart: Vec<f64>, tstop: Vec<f64>, cut: Vec<f64>) -> PyResult<S
             continue;
         }
         let mut current = current_start;
-        let mut interval_num = 1;
         let (first, last) = interior_cut_bounds(&cutpoints, current_start, current_stop);
+        let mut interval_num = first + 1;
         for &cutpoint in &cutpoints[first..last] {
             result.row.push(i + 1);
             result.interval.push(interval_num);
@@ -156,10 +156,19 @@ mod tests {
         let result = survsplit(vec![0.0], vec![10.0], vec![0.0, 3.0, 10.0]).unwrap();
 
         assert_eq!(result.row, vec![1, 1]);
-        assert_eq!(result.interval, vec![1, 2]);
+        assert_eq!(result.interval, vec![2, 3]);
         assert_eq!(result.start, vec![0.0, 3.0]);
         assert_eq!(result.end, vec![3.0, 10.0]);
         assert_eq!(result.censor, vec![true, false]);
+    }
+
+    #[test]
+    fn episode_numbers_account_for_cuts_before_interval_entry() {
+        let result = survsplit(vec![5.0], vec![10.0], vec![3.0, 7.0]).unwrap();
+
+        assert_eq!(result.interval, vec![2, 3]);
+        assert_eq!(result.start, vec![5.0, 7.0]);
+        assert_eq!(result.end, vec![7.0, 10.0]);
     }
 
     #[test]
@@ -167,7 +176,7 @@ mod tests {
         let result = survsplit(vec![5.0, 2.0], vec![5.0, 1.0], vec![1.5, 3.0, 4.0]).unwrap();
 
         assert_eq!(result.row, vec![1, 2]);
-        assert_eq!(result.interval, vec![1, 1]);
+        assert_eq!(result.interval, vec![4, 2]);
         assert_eq!(result.start, vec![5.0, 2.0]);
         assert_eq!(result.end, vec![5.0, 1.0]);
         assert_eq!(result.censor, vec![false, false]);


### PR DESCRIPTION
## Summary
- align `survSplit` with the survival 3.8-11 formula and data-frame interface, including `timefix`, `added`, and output-name handling
- support `Surv2` subject timelines and correct near-tie behavior through the Rust-backed Python path
- correct native episode numbering for delayed entry and boundary cut points
- add Python, Rust, and R parity coverage for the expanded behavior

## Stack
- based on #492

## Testing
- `PYTHONPATH=python .venv/bin/python -m pytest -q python/tests` (982 passed, 18 skipped)
- `cargo test --lib` (1,529 passed)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `R CMD check --no-manual r/survivalr` (1 source-directory NOTE)
- `.venv/bin/python -m ruff format python/ test/ --check`
- `.venv/bin/python -m ruff check python/ test/`
- `.venv/bin/python -m mypy python/survival/__init__.pyi python/survival/_survival.pyi --ignore-missing-imports`
- `.venv/bin/python scripts/generate_binding_manifest.py --check`
- `git diff --check`