### PR TITLE
Preserve named responses in survSplit

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,8 @@ R-style `coxph.control(...)` and `survreg.control(...)` helpers are available
 in the bridge and pass named control lists through to the Python API.
 `survSplit` handles formula or data-frame inputs, near-tie correction, added-row
 markers, delayed-entry episode numbering, and `Surv2` subject timelines through
-the native split plan.
+the native split plan. Formulas with a prebuilt survival response preserve that
+response as one classed output column.
 Time-dependent start/stop data can be built with the R-compatible `tmerge`
 workflow. Its update builders preserve R's `(tstart, tstop]` boundary rules,
 event placement, cumulative updates, missing-value handling, and classification

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -534,6 +534,41 @@ attrassign <- function(object, tt) {
   }, character(1))
 }
 
+.survsplit_unique_name <- function(reserved, stem) {
+  candidate <- stem
+  while (candidate %in% reserved) candidate <- paste0(candidate, ".")
+  candidate
+}
+
+.survsplit_named_response <- function(start, end, event, counting, source_names) {
+  if (!counting) event <- as.factor(event)
+  if (!is.null(source_names)) names(event) <- source_names
+  if (is.factor(event)) {
+    event_attributes <- attributes(event)
+    attribute_order <- c(
+      intersect(c("names", "levels", "class"), names(event_attributes)),
+      setdiff(names(event_attributes), c("names", "levels", "class"))
+    )
+    attributes(event) <- event_attributes[attribute_order]
+  }
+  if (!counting) return(Surv2(as.numeric(start), event))
+
+  factor_event <- is.factor(event)
+  out <- cbind(
+    start = as.numeric(start),
+    stop = as.numeric(end),
+    status = if (factor_event) as.integer(event) - 1L else as.numeric(event)
+  )
+  attr(out, "type") <- if (factor_event) "mcounting" else "counting"
+  if (factor_event) attr(out, "states") <- levels(event)[-1L]
+  event_attributes <- attributes(event)
+  if (length(event_attributes) > 0L) {
+    attr(out, "inputAttributes") <- list(event = event_attributes)
+  }
+  class(out) <- "Surv"
+  out
+}
+
 .survsplit_minimal_surv <- function(args) {
   surv_type <- args[["type"]]
   origin <- args[["origin"]]
@@ -10235,6 +10270,8 @@ survSplit <- function(formula, data, subset, na.action = na.pass, id, cut,
     stop("not valid for ", attr(response, "type"), " censored survival data", call. = FALSE)
   }
 
+  named_response <- is.name(formula[[2L]])
+  response_name <- if (named_response) as.character(formula[[2L]]) else NULL
   response_names <- .survsplit_response_names(formula, response)
   counting_response <- !is_surv2 && ncol(response) == 3L
   start_name <- if (missing(start) && (counting_response || is_surv2)) {
@@ -10261,6 +10298,23 @@ survSplit <- function(formula, data, subset, na.action = na.pass, id, cut,
     model_frame[[id_name]] <- seq_len(nrow(model_frame))
   }
   covariates <- if (right_dot) data else model_frame[-1L]
+  base_names <- names(covariates)
+  source_column <- NULL
+  split_start_name <- start_name
+  split_end_name <- end_name
+  split_event_name <- event_name
+  if (named_response) {
+    if (response_name %in% names(covariates)) covariates[[response_name]] <- NULL
+    reserved <- c(names(covariates), response_name, episode_name, added_name)
+    source_column <- .survsplit_unique_name(reserved, "..survsplit.source")
+    reserved <- c(reserved, source_column)
+    split_start_name <- .survsplit_unique_name(reserved, "..survsplit.start")
+    reserved <- c(reserved, split_start_name)
+    split_end_name <- .survsplit_unique_name(reserved, "..survsplit.end")
+    reserved <- c(reserved, split_end_name)
+    split_event_name <- .survsplit_unique_name(reserved, "..survsplit.event")
+    covariates[[source_column]] <- seq_len(nrow(model_frame))
+  }
   subject_id <- if (is_surv2) stats::model.extract(model_frame, "id") else NULL
   if (is_surv2 && is.null(subject_id)) {
     stop("an id statement is required", call. = FALSE)
@@ -10271,9 +10325,9 @@ survSplit <- function(formula, data, subset, na.action = na.pass, id, cut,
     response = py_response,
     data = .as_python_data(covariates),
     cut = as.list(as.numeric(cut)),
-    start = start_name,
-    end = end_name,
-    event = event_name,
+    start = split_start_name,
+    end = split_end_name,
+    event = split_event_name,
     episode = episode_name,
     zero = zero,
     added = added_name,
@@ -10286,11 +10340,40 @@ survSplit <- function(formula, data, subset, na.action = na.pass, id, cut,
   )
   states <- attr(response, "states")
   if (!is.null(states)) {
-    output[[event_name]] <- factor(
-      as.integer(output[[event_name]]),
+    output[[split_event_name]] <- factor(
+      as.integer(output[[split_event_name]]),
       levels = 0:length(states),
       labels = c("censor", states)
     )
+  }
+  if (named_response) {
+    source_rows <- as.integer(output[[source_column]])
+    response_row_names <- rownames(response)
+    source_names <- if (is.null(response_row_names)) {
+      NULL
+    } else {
+      response_row_names[source_rows]
+    }
+    response_column <- .survsplit_named_response(
+      output[[split_start_name]],
+      if (is_surv2) NULL else output[[split_end_name]],
+      output[[split_event_name]],
+      counting_response,
+      source_names
+    )
+    episode_values <- if (is.null(episode_name)) NULL else output[[episode_name]]
+    added_values <- if (is.null(added_name)) NULL else output[[added_name]]
+    output <- output[, setdiff(base_names, response_name), drop = FALSE]
+    output[[response_name]] <- response_column
+    response_order <- if (response_name %in% base_names) {
+      base_names
+    } else {
+      c(base_names, response_name)
+    }
+    output <- output[response_order]
+    if (!is.null(episode_name)) output[[episode_name]] <- episode_values
+    if (!is.null(added_name)) output[[added_name]] <- added_values
+    row.names(output) <- NULL
   }
   output
 }

--- a/r/survivalr/man/survivalr.Rd
+++ b/r/survivalr/man/survivalr.Rd
@@ -1035,7 +1035,9 @@ at a split point.}
 \item{tt, special, order}{Term-object inputs for \code{attrassign} and
 special-term inputs for \code{untangle.specials}.}
 \item{formula}{Formula, formula string, bridged \code{Surv} response, or
-bridged fitted Cox model accepted by \code{survival.r_api}.}
+bridged fitted Cox model accepted by \code{survival.r_api}. A named prebuilt
+\code{Surv} or \code{Surv2} response in \code{survSplit} is preserved as one
+classed output column.}
 \item{data, newdata}{Optional data frames or Python-compatible data objects.}
 \item{subset}{Optional row subset.}
 \item{na.action}{Missing-data policy, either a string or one of the common

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -1033,6 +1033,130 @@ test_that("R formula wrappers delegate to the Python survival package", {
   )
   expect_equal(bridged_timeline_split, reference_timeline_split)
 
+  expect_named_survsplit_equal <- function(y, data) {
+    if (inherits(y, "Surv2")) {
+      bridged <- survSplit(
+        y ~ x,
+        data = data,
+        id = data$id,
+        cut = c(1.5, 3.5),
+        episode = "ep",
+        added = "add"
+      )
+      reference <- survival::survSplit(
+        y ~ x,
+        data = data,
+        id = data$id,
+        cut = c(1.5, 3.5),
+        episode = "ep",
+        added = "add"
+      )
+    } else {
+      bridged <- survSplit(
+        y ~ x,
+        data = data,
+        cut = c(1.5, 3.5),
+        episode = "ep",
+        added = "add"
+      )
+      reference <- survival::survSplit(
+        y ~ x,
+        data = data,
+        cut = c(1.5, 3.5),
+        episode = "ep",
+        added = "add"
+      )
+    }
+    expect_equal(bridged, reference)
+  }
+
+  named_right_data <- data.frame(time = c(1, 3, 5), status = c(1, 0, 1), x = 1:3)
+  expect_named_survsplit_equal(
+    survival::Surv(named_right_data$time, named_right_data$status),
+    named_right_data
+  )
+  named_mright_data <- data.frame(
+    time = c(1, 3, 5),
+    state = factor(c("a", "censor", "b"), levels = c("censor", "a", "b")),
+    x = 1:3
+  )
+  expect_named_survsplit_equal(
+    survival::Surv(named_mright_data$time, named_mright_data$state),
+    named_mright_data
+  )
+  named_counting_data <- data.frame(
+    start = c(0, 2, 3),
+    stop = c(3, 5, 6),
+    status = c(1, 0, 1),
+    x = 1:3
+  )
+  expect_named_survsplit_equal(
+    survival::Surv(
+      named_counting_data$start,
+      named_counting_data$stop,
+      named_counting_data$status
+    ),
+    named_counting_data
+  )
+  named_mcounting_data <- data.frame(
+    start = c(0, 2, 3),
+    stop = c(3, 5, 6),
+    state = factor(c("a", "censor", "b"), levels = c("censor", "a", "b")),
+    x = 1:3
+  )
+  expect_named_survsplit_equal(
+    survival::Surv(
+      named_mcounting_data$start,
+      named_mcounting_data$stop,
+      named_mcounting_data$state
+    ),
+    named_mcounting_data
+  )
+  expect_named_survsplit_equal(
+    survival::Surv2(timeline_split_data$time, timeline_split_data$event),
+    timeline_split_data
+  )
+
+  named_na_data <- data.frame(time = c(1, 3, 5), status = c(1, 0, 1), x = c(1, NA, 3))
+  named_na_response <- survival::Surv(named_na_data$time, named_na_data$status)
+  expect_equal(
+    survSplit(
+      named_na_response ~ x,
+      data = named_na_data,
+      na.action = stats::na.omit,
+      cut = c(1.5, 3.5)
+    ),
+    survival::survSplit(
+      named_na_response ~ x,
+      data = named_na_data,
+      na.action = stats::na.omit,
+      cut = c(1.5, 3.5)
+    )
+  )
+
+  named_dot_data <- data.frame(x = 1:3, check.names = FALSE)
+  named_dot_data[["..survsplit.source"]] <- 11:13
+  named_dot_data[["..survsplit.start"]] <- 21:23
+  named_dot_data[["..survsplit.end"]] <- 31:33
+  named_dot_data[["..survsplit.event"]] <- 41:43
+  named_dot_data$y <- survival::Surv(c(1, 3, 5), c(1, 0, 1))
+  expect_equal(
+    survSplit(
+      y ~ .,
+      data = named_dot_data,
+      cut = c(1.5, 3.5),
+      episode = "..survsplit.event",
+      added = "..survsplit.start"
+    ),
+    survival::survSplit(
+      y ~ .,
+      data = named_dot_data,
+      cut = c(1.5, 3.5),
+      episode = "..survsplit.event",
+      added = "..survsplit.start"
+    )
+  )
+
   check_data <- data.frame(
     id = c(1, 1, 2),
     start = c(0, 1, 0),


### PR DESCRIPTION
## Summary
- reconstruct `y ~ x` split results as a single classed survival-response column instead of expanding ordinary time/status columns
- preserve right, counting, multi-state, and `Surv2` response classes and metadata, including source-row names after omission
- use collision-safe temporary columns while retaining dot-form input order and reference overwrite behavior for `episode` and `added`
- add exact differential coverage against survival 3.8-11 across all supported named response types

## Stack
- based on #494

## Testing
- complete R bridge test file
- `R CMD check --no-manual r/survivalr` (1 source-directory NOTE)
- `git diff --check`