### PR TITLE
Support penalized survreg formulas

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,10 @@ baselines, optional starting-state mixtures, and conditional start times.
 Formula fits support `tt(...)` time-varying coefficient terms for right-censored
 and counting-process responses, including R's default O'Brien rank transform
 and custom `tt(x, time, riskset, weights)` callables.
+Both `coxph` and `survreg` formula fits accept `ridge(...)` and `pspline(...)`
+penalties, including fixed smoothing, target degrees of freedom, and AIC-based
+P-spline selection. The native optimizers expose the fitted quadratic penalty,
+penalized likelihood, smoothing history, and effective degrees of freedom.
 `clogit("case ~ exposure + strata(set)", data=...)` fits matched case-control
 models through the exact stratified Cox likelihood; `method="approximate"`
 maps to Breslow handling as it does in R.

--- a/benches/survival_benchmarks.rs
+++ b/benches/survival_benchmarks.rs
@@ -1223,6 +1223,7 @@ mod survreg_bench {
                 None,
                 None,
                 None,
+                None,
             )
             .expect("benchmark Weibull survreg fit should converge");
             black_box(fit);
@@ -1252,6 +1253,7 @@ mod survreg_bench {
                 Some(30),
                 Some(1e-7),
                 Some(1e-9),
+                None,
                 None,
                 None,
                 None,

--- a/python/survival/_survival.pyi
+++ b/python/survival/_survival.pyi
@@ -3744,6 +3744,9 @@ class SurvivalFit:
     log_likelihood: float
     convergence_flag: int
     score_vector: list[float]
+    penalty_matrix: list[list[float]]
+    penalty: float
+    penalized_log_likelihood: float
     def predict(
         self,
         covariates: list[list[float]] | None = None,
@@ -7547,6 +7550,7 @@ def survreg(
     time2: list[float] | None = None,
     fixed_scale: float | None = None,
     distribution_parameter: float | None = None,
+    penalty_matrix: list[list[float]] | None = None,
 ) -> SurvivalFit: ...
 def predict_survreg(
     covariates: list[list[float]],

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -3656,6 +3656,8 @@ def _parse_pspline_formula_term(term: str) -> _PSplineFormulaTerm:
         raise ValueError("pspline fixed theta cannot be combined with df=0 or method='aic'")
     if aic_selection:
         nterm = 15
+        if "eps" not in seen_options:
+            eps = 1e-5
     else:
         if df <= 0.0:
             raise ValueError("pspline df must be positive")
@@ -4495,7 +4497,9 @@ def _fit_formula_design(
     allow_frailty: bool = False,
 ) -> _FormulaDesign:
     if terms.pspline and not allow_pspline:
-        raise NotImplementedError("pspline() formula terms are currently supported only by coxph")
+        raise NotImplementedError(
+            "pspline() formula terms are currently supported only by coxph and survreg"
+        )
     if terms.frailty and not allow_frailty:
         raise NotImplementedError("frailty() formula terms are currently supported only by coxph")
     strata_values = _combined_columns(data, terms.strata, n) if terms.strata else []
@@ -4868,15 +4872,17 @@ def _quadratic_term_degrees_of_freedom(
     penalty: Sequence[Sequence[float]],
     columns: Sequence[int],
 ) -> float:
-    variance = [[float(value) for value in row] for row in fit.information_matrix]
-    width = len(variance)
+    matrix = getattr(fit, "information_matrix", None)
+    if matrix is None:
+        matrix = getattr(fit, "variance_matrix", None)
+    if matrix is None:
+        raise ValueError("quadratic fit does not expose a covariance matrix")
+    width = len(penalty)
+    full_variance = [[float(value) for value in row] for row in matrix]
+    variance = [row[:width] for row in full_variance[:width]]
     if not columns:
         return 0.0
-    if (
-        len(penalty) != width
-        or any(len(row) != width for row in penalty)
-        or any(len(row) != width for row in variance)
-    ):
+    if any(len(row) != width for row in penalty) or any(len(row) != width for row in variance):
         raise ValueError("quadratic fit returned inconsistent covariance dimensions")
     if list(columns) == list(range(width)):
         trace = math.fsum(
@@ -4928,7 +4934,7 @@ def _quadratic_formula_term_degrees_of_freedom(
         output_count = len(_design_term_output_names(term))
         grouped_columns.setdefault(assignment, []).extend(range(cursor, cursor + output_count))
         cursor += output_count
-    if cursor != width:
+    if cursor > width:
         raise ValueError("formula metadata does not match the fitted covariance matrix")
     return {
         (
@@ -5062,7 +5068,7 @@ def _ridge_control_next_theta(
     x = [value[0] for value in ordered]
     y = [value[1] for value in ordered]
     adjusted_target = target
-    if (x[0] - x[1]) * (y[0] - y[1]) <= 0.0:
+    if (history[0][0] - history[1][0]) * (history[0][1] - history[1][1]) <= 0.0:
         y = [-value for value in y]
         adjusted_target = -target
 
@@ -12553,10 +12559,10 @@ def _apply_survreg_control(
     max_iter: int | None,
     eps: float | None,
     tol_chol: float | None,
-) -> tuple[int | None, float | None, float | None]:
+) -> tuple[int | None, float | None, float | None, int]:
     values = _control_mapping(control, "survreg control")
     if not values:
-        return max_iter, eps, tol_chol
+        return max_iter, eps, tol_chol, 10
 
     max_iter_value, name = _pop_control_alias(
         values,
@@ -12589,9 +12595,16 @@ def _apply_survreg_control(
         tol_chol = _finite_float(tol_chol_value, f"control.{name}")
 
     _pop_finite_control_value(values, ("debug",), positive=False)
-    _pop_finite_control_value(values, ("outer.max", "outer_max"), positive=True)
+    outer_max_value = _pop_finite_control_value(
+        values,
+        ("outer.max", "outer_max"),
+        positive=True,
+    )
+    outer_max = 10 if outer_max_value is None else int(outer_max_value)
+    if outer_max < 1:
+        raise ValueError("control.outer.max must be positive")
     _reject_unknown_control_options(values, "survreg")
-    return max_iter, eps, tol_chol
+    return max_iter, eps, tol_chol, outer_max
 
 
 def _normalize_survfit_type(
@@ -21028,7 +21041,7 @@ def survreg_fit(
         strata_values = [value - 1 for value in raw_strata]
 
     distribution, distribution_parameter = _survreg_fit_distribution(dist, parms)
-    max_iter, eps, tol_chol = _apply_survreg_control(
+    max_iter, eps, tol_chol, _outer_max = _apply_survreg_control(
         survreg_control() if controlvals is None else controlvals,
         None,
         None,
@@ -26706,7 +26719,12 @@ def survreg(
     robust_requested = None if robust is None else _normalize_bool_option(robust, "robust")
     if max_iter is not None:
         max_iter = _integer_scalar(max_iter, "max_iter")
-    max_iter, eps, tol_chol = _apply_survreg_control(control, max_iter, eps, tol_chol)
+    max_iter, eps, tol_chol, outer_max = _apply_survreg_control(
+        control,
+        max_iter,
+        eps,
+        tol_chol,
+    )
 
     formula_rows: list[list[float]] | None = None
     formula_design: _FormulaDesign | None = None
@@ -26714,6 +26732,8 @@ def survreg(
     formula_x_matrix: list[list[float]] | None = None
     formula_model_data: Any | None = None
     formula_cluster_columns: tuple[str, ...] = ()
+    formula_ridge_blocks: list[_RidgePenaltyBlock] = []
+    formula_pspline_blocks: list[_PSplinePenaltyBlock] = []
     direct_coefficient_names: tuple[str, ...] | None = None
     matrix_input = response is None and time is not None and status is not None
     if matrix_input:
@@ -26840,7 +26860,14 @@ def survreg(
                 terms,
                 len(response),
                 include_intercept=True,
+                allow_pspline=True,
             )
+            formula_ridge_blocks = _ridge_formula_blocks(
+                data,
+                formula_design,
+                len(response),
+            )
+            formula_pspline_blocks = _pspline_formula_blocks(formula_design)
             formula_rows = (
                 _design_rows_from_spec(data, formula_design, len(response))
                 if terms.covariates or formula_design.intercept
@@ -27010,22 +27037,248 @@ def survreg(
         if exponential_fixed_scale
         else (scale_value if scale_value > 0.0 else None)
     )
-    fit = _core.survreg(
-        response_time,
-        response_status,
-        rows,
-        weights=weight_values,
-        offsets=offset_values,
-        initial_beta=initial_values,
-        strata=strata_values,
-        distribution=distribution_name,
-        max_iter=max_iter,
-        eps=eps,
-        tol_chol=tol_chol,
-        time2=response_time2,
-        fixed_scale=fixed_scale,
-        distribution_parameter=distribution_parameter,
-    )
+
+    def run_fit(
+        penalty: list[list[float]] | None,
+        start: list[float] | None,
+    ) -> Any:
+        return _core.survreg(
+            response_time,
+            response_status,
+            rows,
+            weights=weight_values,
+            offsets=offset_values,
+            initial_beta=start,
+            strata=strata_values,
+            distribution=distribution_name,
+            max_iter=max_iter,
+            eps=eps,
+            tol_chol=tol_chol,
+            time2=response_time2,
+            fixed_scale=fixed_scale,
+            distribution_parameter=distribution_parameter,
+            penalty_matrix=penalty,
+        )
+
+    fit_penalty_matrix: list[list[float]] | None = None
+    penalty_history: dict[str, dict[str, Any]] | None = None
+    term_degrees_of_freedom: dict[str, float] | None = None
+    effective_degrees_of_freedom: float | None = None
+    if formula_ridge_blocks or formula_pspline_blocks:
+        width = len(rows[0]) if rows else 0
+        ridge_thetas = [
+            block.theta if block.theta is not None else 1.0 for block in formula_ridge_blocks
+        ]
+        pspline_thetas = [block.initial_theta for block in formula_pspline_blocks]
+        reported_ridge_thetas = list(ridge_thetas)
+        reported_pspline_thetas = list(pspline_thetas)
+        target_ridge_blocks = [
+            index for index, block in enumerate(formula_ridge_blocks) if block.target_df is not None
+        ]
+        target_pspline_blocks = [
+            index
+            for index, block in enumerate(formula_pspline_blocks)
+            if block.target_df is not None
+        ]
+        aic_pspline_blocks = [
+            index for index, block in enumerate(formula_pspline_blocks) if block.selection == "aic"
+        ]
+        ridge_histories = [
+            [(0.0, float(len(block.columns)))] if block.target_df is not None else []
+            for block in formula_ridge_blocks
+        ]
+        pspline_histories = [
+            [(1.0, 1.0), (0.0, block.maximum_df)] if block.target_df is not None else []
+            for block in formula_pspline_blocks
+        ]
+        pspline_aic_histories: list[list[dict[str, float]]] = [
+            [] for _block in formula_pspline_blocks
+        ]
+        ridge_halves = [0] * len(formula_ridge_blocks)
+        pspline_halves = [0] * len(formula_pspline_blocks)
+        ridge_done = [block.target_df is None for block in formula_ridge_blocks]
+        pspline_done = [block.selection == "fixed" for block in formula_pspline_blocks]
+        start = initial_values
+        adaptive = bool(target_ridge_blocks or target_pspline_blocks or aic_pspline_blocks)
+        fit = None
+        fit_count = outer_max if adaptive else 1
+        for outer_iteration in range(1, fit_count + 1):
+            fitted_ridge_thetas = list(ridge_thetas)
+            fitted_pspline_thetas = list(pspline_thetas)
+            fit_penalty_matrix = _formula_penalty_matrix(
+                width,
+                formula_ridge_blocks,
+                fitted_ridge_thetas,
+                formula_pspline_blocks,
+                fitted_pspline_thetas,
+                (),
+                (),
+            )
+            fit = run_fit(fit_penalty_matrix, start)
+            full_width = len(fit.variance_matrix)
+            full_penalty = [
+                [
+                    fit_penalty_matrix[row][column] if row < width and column < width else 0.0
+                    for column in range(full_width)
+                ]
+                for row in range(full_width)
+            ]
+            next_ridge_thetas = list(fitted_ridge_thetas)
+            next_pspline_thetas = list(fitted_pspline_thetas)
+            next_reported_pspline_thetas = list(fitted_pspline_thetas)
+            for block_index in target_ridge_blocks:
+                block = formula_ridge_blocks[block_index]
+                target = block.target_df
+                if target is None:
+                    raise AssertionError("ridge smoothing target is missing")
+                term_df = _quadratic_term_degrees_of_freedom(
+                    fit,
+                    full_penalty,
+                    block.columns,
+                )
+                ridge_histories[block_index].append((fitted_ridge_thetas[block_index], term_df))
+                next_theta, converged, half = _ridge_control_next_theta(
+                    target,
+                    block.eps,
+                    outer_iteration,
+                    ridge_histories[block_index],
+                    ridge_halves[block_index],
+                )
+                next_ridge_thetas[block_index] = next_theta
+                reported_ridge_thetas[block_index] = next_theta
+                ridge_done[block_index] = converged
+                ridge_halves[block_index] = half
+            for block_index in target_pspline_blocks:
+                block = formula_pspline_blocks[block_index]
+                target = block.target_df
+                if target is None:
+                    raise AssertionError("P-spline smoothing target is missing")
+                term_df = _quadratic_term_degrees_of_freedom(
+                    fit,
+                    full_penalty,
+                    block.columns,
+                )
+                pspline_histories[block_index].append((fitted_pspline_thetas[block_index], term_df))
+                next_theta, converged, half = _ridge_control_next_theta(
+                    target,
+                    block.eps,
+                    outer_iteration,
+                    pspline_histories[block_index],
+                    pspline_halves[block_index],
+                )
+                next_reported_pspline_thetas[block_index] = next_theta
+                next_pspline_thetas[block_index] = min(max(next_theta, 0.0), 1.0 - 1e-12)
+                pspline_done[block_index] = converged
+                pspline_halves[block_index] = half
+            event_count = sum(value == 1.0 for value in response_status)
+            for block_index in aic_pspline_blocks:
+                block = formula_pspline_blocks[block_index]
+                term_df = _quadratic_term_degrees_of_freedom(
+                    fit,
+                    full_penalty,
+                    block.columns,
+                )
+                pspline_aic_histories[block_index].append(
+                    _penalty_aic_history_row(
+                        fitted_pspline_thetas[block_index],
+                        float(fit.log_likelihood),
+                        term_df,
+                        event_count,
+                    )
+                )
+                next_theta, converged = _pspline_aic_next_theta(
+                    block.eps,
+                    outer_iteration,
+                    pspline_aic_histories[block_index],
+                )
+                next_reported_pspline_thetas[block_index] = next_theta
+                next_pspline_thetas[block_index] = min(max(next_theta, 0.0), 1.0 - 1e-12)
+                pspline_done[block_index] = converged
+            reported_pspline_thetas = next_reported_pspline_thetas
+            ridge_thetas = fitted_ridge_thetas
+            pspline_thetas = fitted_pspline_thetas
+            if all(ridge_done) and all(pspline_done):
+                break
+            if outer_iteration == outer_max:
+                warnings.warn(
+                    "penalty smoothing did not converge within control.outer.max iterations",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+                break
+            ridge_thetas = next_ridge_thetas
+            pspline_thetas = next_pspline_thetas
+            start = [float(value) for value in fit.coefficients]
+        if fit is None or fit_penalty_matrix is None:
+            raise AssertionError("penalized survreg fit did not run")
+        penalty_history = {
+            block.label: (
+                {
+                    "theta": reported_ridge_thetas[index],
+                    "done": ridge_done[index],
+                    "history": [{"theta": theta, "df": df} for theta, df in ridge_histories[index]],
+                    "half": ridge_halves[index],
+                }
+                if block.target_df is not None
+                else {"theta": ridge_thetas[index], "done": True}
+            )
+            for index, block in enumerate(formula_ridge_blocks)
+        }
+        penalty_history.update(
+            {
+                block.label: (
+                    {
+                        "theta": reported_pspline_thetas[index],
+                        "done": pspline_done[index],
+                        "history": [
+                            {"theta": theta, "df": df} for theta, df in pspline_histories[index]
+                        ],
+                        "half": pspline_halves[index],
+                    }
+                    if block.target_df is not None
+                    else (
+                        {
+                            "theta": reported_pspline_thetas[index],
+                            "done": pspline_done[index],
+                            "history": pspline_aic_histories[index],
+                        }
+                        if block.selection == "aic"
+                        else {"theta": pspline_thetas[index], "done": True}
+                    )
+                )
+                for index, block in enumerate(formula_pspline_blocks)
+            }
+        )
+        full_width = len(fit.variance_matrix)
+        full_penalty = [
+            [
+                fit_penalty_matrix[row][column] if row < width and column < width else 0.0
+                for column in range(full_width)
+            ]
+            for row in range(full_width)
+        ]
+        if formula_design is None:
+            raise AssertionError("formula penalties require design metadata")
+        term_degrees_of_freedom = _quadratic_formula_term_degrees_of_freedom(
+            fit,
+            full_penalty,
+            formula_design,
+        )
+        effective_degrees_of_freedom = math.fsum(term_degrees_of_freedom.values())
+        if formula_design.intercept:
+            effective_degrees_of_freedom += _quadratic_term_degrees_of_freedom(
+                fit,
+                full_penalty,
+                (0,),
+            )
+        if full_width > width:
+            effective_degrees_of_freedom += _quadratic_term_degrees_of_freedom(
+                fit,
+                full_penalty,
+                tuple(range(width, full_width)),
+            )
+    else:
+        fit = run_fit(None, initial_values)
     robust_cluster = cluster_values_for_validation
     if robust_value and robust_cluster is None:
         robust_cluster = list(range(n))
@@ -27052,6 +27305,10 @@ def survreg(
             y_response=response if keep_y else None,
             model_frame=model_frame,
             score_values=score_values,
+            history=penalty_history,
+            effective_degrees_of_freedom=effective_degrees_of_freedom,
+            term_degrees_of_freedom=term_degrees_of_freedom,
+            penalty_matrix=fit_penalty_matrix,
         )
         if (
             formula_design is not None

--- a/python/tests/test_binding_contract.py
+++ b/python/tests/test_binding_contract.py
@@ -515,6 +515,7 @@ def test_survreg_prediction_bindings_are_typed_to_runtime_surface():
             "time2",
             "fixed_scale",
             "distribution_parameter",
+            "penalty_matrix",
         ],
         "predict_survreg": [
             "covariates",
@@ -615,6 +616,9 @@ def test_survreg_prediction_bindings_are_typed_to_runtime_surface():
         "log_likelihood",
         "convergence_flag",
         "score_vector",
+        "penalty_matrix",
+        "penalty",
+        "penalized_log_likelihood",
     }
     assert _pyi_class_property_names(stub_path, "SurvregPrediction") == {
         "predictions",

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -11641,8 +11641,6 @@ def test_coxph_formula_pspline_rejects_unsupported_or_invalid_options():
             data=data,
             penalty_matrix=[[1.0] * 5 for _ in range(5)],
         )
-    with pytest.raises(NotImplementedError, match="supported only by coxph"):
-        survival.survreg("Surv(time,status) ~ pspline(x,theta=.5)", data=data)
 
 
 def test_coxph_formula_ridge_defaults_to_half_the_term_width():
@@ -18728,6 +18726,201 @@ def test_low_level_survreg_omitted_distribution_matches_explicit_weibull():
     assert default.iterations == explicit.iterations
     assert extreme.distribution == "extreme_value"
     assert extreme.log_likelihood != pytest.approx(default.log_likelihood)
+
+
+def test_low_level_survreg_quadratic_penalty_validates_and_reports_objective():
+    fit = survival.regression.survreg(
+        time=[2.0, 3.0, 5.0, 7.0, 11.0, 13.0],
+        status=[1.0, 1.0, 0.0, 1.0, 1.0, 0.0],
+        covariates=[[1.0, value] for value in (-1.0, -0.5, 0.0, 0.5, 1.0, 1.5)],
+        distribution="weibull",
+        penalty_matrix=[[0.0, 0.0], [0.0, 0.4]],
+        max_iter=100,
+        eps=1e-9,
+    )
+
+    assert fit.penalty_matrix == [[0.0, 0.0], [0.0, 0.4]]
+    assert fit.penalty >= 0.0
+    assert fit.penalized_log_likelihood == pytest.approx(fit.log_likelihood - fit.penalty)
+    with pytest.raises(ValueError, match="shape"):
+        survival.regression.survreg(
+            time=[2.0, 3.0],
+            status=[1.0, 1.0],
+            covariates=[[1.0, 0.0], [1.0, 1.0]],
+            penalty_matrix=[[1.0]],
+        )
+    with pytest.raises(ValueError, match="symmetric"):
+        survival.regression.survreg(
+            time=[2.0, 3.0],
+            status=[1.0, 1.0],
+            covariates=[[1.0, 0.0], [1.0, 1.0]],
+            penalty_matrix=[[1.0, 0.0], [1.0, 1.0]],
+        )
+    with pytest.raises(ValueError, match="positive semidefinite"):
+        survival.regression.survreg(
+            time=[2.0, 3.0],
+            status=[1.0, 1.0],
+            covariates=[[1.0, 0.0], [1.0, 1.0]],
+            penalty_matrix=[[1.0, 2.0], [2.0, 1.0]],
+        )
+
+
+def test_survreg_formula_pspline_fixed_and_target_df_match_reference():
+    n = 48
+    index = list(range(n))
+    x = [((value * 17) % 49) / 10.0 - 2.4 for value in index]
+    noise = [((value * 13) % 11 - 5) / 20.0 for value in index]
+    data = {
+        "time": [
+            math.exp(2.4 + 0.22 * value - 0.08 * value**2 + error)
+            for value, error in zip(x, noise, strict=True)
+        ],
+        "status": [int(value % 5 != 0) for value in index],
+        "x": x,
+    }
+    control = survival.survreg_control(maxiter=100, outer_max=25)
+
+    fixed_term = "pspline(x,theta=.5,nterm=6)"
+    fixed = survival.survreg(
+        f"Surv(time,status) ~ {fixed_term}",
+        data=data,
+        control=control,
+    )
+    assert fixed.location_coefficients == pytest.approx(
+        [
+            1.08304865326958,
+            0.387946072216282,
+            0.93040175850637,
+            1.19521771943437,
+            1.46264285628329,
+            1.54983598150699,
+            1.58166222783296,
+            1.49071735256442,
+            0.999190737033382,
+        ],
+        abs=1e-11,
+    )
+    assert fixed.scale == pytest.approx(0.146830072700599, abs=1e-12)
+    assert fixed.penalty == pytest.approx(0.156025696981009, abs=1e-12)
+    assert fixed.term_degrees_of_freedom[fixed_term] == pytest.approx(
+        5.46884963424033,
+        abs=1e-10,
+    )
+    assert fixed.effective_degrees_of_freedom == pytest.approx(
+        6.711146188830356,
+        abs=1e-9,
+    )
+
+    target_term = "pspline(x,df=4,nterm=6)"
+    target = survival.survreg(
+        f"Surv(time,status) ~ {target_term}",
+        data=data,
+        control=control,
+    )
+    assert target.location_coefficients == pytest.approx(
+        [
+            1.04258547960487,
+            0.468979824921562,
+            0.938339035911159,
+            1.25715933735649,
+            1.48789879771544,
+            1.60333064954198,
+            1.61117384007867,
+            1.51417159595924,
+            1.35035439653465,
+        ],
+        abs=1e-9,
+    )
+    assert target.scale == pytest.approx(0.147868917301435, abs=1e-10)
+    assert target.penalty == pytest.approx(0.286013905524226, abs=5e-9)
+    assert target.term_degrees_of_freedom[target_term] == pytest.approx(
+        4.07556514426807,
+        abs=2e-8,
+    )
+    assert target.history[target_term]["theta"] == pytest.approx(
+        0.896143433527726,
+        abs=2e-9,
+    )
+    assert target.history[target_term]["done"] is True
+
+
+def test_survreg_formula_pspline_aic_and_ridge_match_reference():
+    n = 48
+    index = list(range(n))
+    x = [((value * 17) % 49) / 10.0 - 2.4 for value in index]
+    z = [((value * 7) % 47) / 13.0 - 1.8 for value in index]
+    noise = [((value * 13) % 11 - 5) / 20.0 for value in index]
+    data = {
+        "time": [
+            math.exp(2.4 + 0.22 * xv - 0.08 * xv**2 + 0.15 * zv + error)
+            for xv, zv, error in zip(x, z, noise, strict=True)
+        ],
+        "status": [int(value % 5 != 0) for value in index],
+        "x": x,
+        "z": z,
+    }
+    aic_data = {
+        **data,
+        "time": [
+            math.exp(2.4 + 0.22 * value - 0.08 * value**2 + error)
+            for value, error in zip(x, noise, strict=True)
+        ],
+    }
+    control = survival.survreg_control(maxiter=100, outer_max=25)
+
+    aic_term = "pspline(x,df=0)"
+    aic = survival.survreg(
+        f"Surv(time,status) ~ {aic_term}",
+        data=aic_data,
+        control=control,
+    )
+    assert aic.location_coefficients == pytest.approx(
+        [
+            1.42894200078435,
+            0.151416279731373,
+            0.302847228855692,
+            0.452809683205717,
+            0.595717814216171,
+            0.726995331998452,
+            0.846037366231281,
+            0.950146304877149,
+            1.03608721905761,
+            1.10355200003575,
+            1.15305916845205,
+            1.18597733575767,
+            1.20401249199607,
+            1.20793866347867,
+            1.20259661012098,
+            1.19194773834792,
+            1.17793516545864,
+            1.1632510297958,
+        ],
+        abs=2e-7,
+    )
+    assert aic.history[aic_term]["done"] is True
+    assert len(aic.history[aic_term]["history"]) >= 10
+    assert survival.r_api._parse_pspline_formula_term(aic_term).eps == pytest.approx(1e-5)
+
+    ridge_term = "ridge(x,z,df=1,eps=1e-8)"
+    ridge = survival.survreg(
+        f"Surv(time,status) ~ {ridge_term}",
+        data=data,
+        control=control,
+    )
+    assert ridge.location_coefficients == pytest.approx(
+        [2.39654910462346, 0.116111125071113, 0.0965659135801235],
+        abs=1e-10,
+    )
+    assert ridge.scale == pytest.approx(0.225385567723961, abs=1e-12)
+    assert ridge.penalty == pytest.approx(7.22143350217532, abs=1e-10)
+    assert ridge.term_degrees_of_freedom[ridge_term] == pytest.approx(
+        1.00000000010252,
+        abs=1e-9,
+    )
+    assert ridge.history[ridge_term]["theta"] == pytest.approx(
+        373.352124962237,
+        abs=1e-8,
+    )
 
 
 def test_survreg_formula_matches_low_level_binding():

--- a/src/regression/parametric_survival.rs
+++ b/src/regression/parametric_survival.rs
@@ -125,6 +125,12 @@ pub struct SurvivalFit {
     pub convergence_flag: i32,
     #[pyo3(get)]
     pub score_vector: Vec<f64>,
+    #[pyo3(get)]
+    pub penalty_matrix: Vec<Vec<f64>>,
+    #[pyo3(get)]
+    pub penalty: f64,
+    #[pyo3(get)]
+    pub penalized_log_likelihood: f64,
 }
 
 impl DistributionType {
@@ -795,6 +801,79 @@ fn validate_covariate_values(covariates: &[Vec<f64>], nvar: usize) -> PyResult<(
     Ok(())
 }
 
+fn validate_penalty_matrix(values: &[Vec<f64>], nvar: usize) -> PyResult<Array2<f64>> {
+    if values.len() != nvar || values.iter().any(|row| row.len() != nvar) {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+            "penalty_matrix must have shape ({nvar}, {nvar})"
+        )));
+    }
+    for (row_index, row) in values.iter().enumerate() {
+        validate_finite_values(&format!("penalty_matrix[{row_index}]"), row)?;
+    }
+
+    let scale = values
+        .iter()
+        .flatten()
+        .map(|value| value.abs())
+        .fold(0.0_f64, f64::max);
+    let tolerance = 1e-10 * scale.max(f64::MIN_POSITIVE);
+    let mut matrix = Array2::zeros((nvar, nvar));
+    for row in 0..nvar {
+        for column in 0..nvar {
+            let left = values[row][column];
+            let right = values[column][row];
+            if (left - right).abs() > tolerance {
+                return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                    "penalty_matrix must be symmetric",
+                ));
+            }
+            matrix[(row, column)] = 0.5 * (left + right);
+        }
+    }
+
+    // A diagonally pivoted LDL decomposition admits rank-deficient difference
+    // penalties while still rejecting indefinite quadratic forms.
+    let mut factor = matrix.clone();
+    for pivot_index in 0..nvar {
+        let largest_diagonal = (pivot_index..nvar)
+            .max_by(|&left, &right| factor[(left, left)].total_cmp(&factor[(right, right)]))
+            .unwrap_or(pivot_index);
+        if largest_diagonal != pivot_index {
+            for column in 0..nvar {
+                factor.swap((pivot_index, column), (largest_diagonal, column));
+            }
+            for row in 0..nvar {
+                factor.swap((row, pivot_index), (row, largest_diagonal));
+            }
+        }
+        let pivot = factor[(pivot_index, pivot_index)];
+        if pivot < -tolerance {
+            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                "penalty_matrix must be positive semidefinite",
+            ));
+        }
+        if pivot <= tolerance {
+            if (pivot_index..nvar).any(|row| {
+                (pivot_index..nvar).any(|column| factor[(row, column)].abs() > tolerance)
+            }) {
+                return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                    "penalty_matrix must be positive semidefinite",
+                ));
+            }
+            continue;
+        }
+        for row in (pivot_index + 1)..nvar {
+            for column in row..nvar {
+                let updated = factor[(row, column)]
+                    - factor[(row, pivot_index)] * factor[(column, pivot_index)] / pivot;
+                factor[(row, column)] = updated;
+                factor[(column, row)] = updated;
+            }
+        }
+    }
+    Ok(matrix)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[pyclass(from_py_object)]
 pub enum DistributionType {
@@ -817,7 +896,7 @@ pub enum DistributionType {
 const DEFAULT_SURVREG_DISTRIBUTION: DistributionType = DistributionType::Weibull;
 
 #[pyfunction]
-#[pyo3(signature = (time, status, covariates, weights=None, offsets=None, initial_beta=None, strata=None, distribution=None, max_iter=None, eps=None, tol_chol=None, time2=None, fixed_scale=None, distribution_parameter=None))]
+#[pyo3(signature = (time, status, covariates, weights=None, offsets=None, initial_beta=None, strata=None, distribution=None, max_iter=None, eps=None, tol_chol=None, time2=None, fixed_scale=None, distribution_parameter=None, penalty_matrix=None))]
 #[allow(clippy::too_many_arguments)]
 pub fn survreg(
     time: Vec<f64>,
@@ -834,6 +913,7 @@ pub fn survreg(
     time2: Option<Vec<f64>>,
     fixed_scale: Option<f64>,
     distribution_parameter: Option<f64>,
+    penalty_matrix: Option<Vec<Vec<f64>>>,
 ) -> PyResult<SurvivalFit> {
     let requested_distribution_key = distribution.map(|name| name.to_lowercase().replace('-', "_"));
     let dist_type = parse_distribution_type(distribution)?;
@@ -884,6 +964,10 @@ pub fn survreg(
         )));
     }
     validate_covariate_values(&covariate_rows, nvar)?;
+    let penalty_matrix = penalty_matrix
+        .as_deref()
+        .map(|values| validate_penalty_matrix(values, nvar))
+        .transpose()?;
     let weights_vec = weights.unwrap_or_else(|| vec![1.0; n]);
     let offsets_vec = offsets.unwrap_or_else(|| vec![0.0; n]);
     let has_strata = strata.is_some();
@@ -976,6 +1060,7 @@ pub fn survreg(
         distribution: distribution_type,
         distribution_parameter,
         fixed_scale,
+        penalty_matrix: penalty_matrix.as_ref(),
     })
     .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("{}", e)))?;
     let variance_matrix = result
@@ -1025,8 +1110,44 @@ pub fn survreg(
         log_likelihood: result.log_likelihood,
         convergence_flag: result.convergence_flag,
         score_vector: result.score_vector,
+        penalty_matrix: penalty_matrix
+            .as_ref()
+            .map(|matrix| {
+                matrix
+                    .outer_iter()
+                    .map(|row| row.iter().copied().collect())
+                    .collect()
+            })
+            .unwrap_or_default(),
+        penalty: result.penalty,
+        penalized_log_likelihood: result.penalized_log_likelihood,
     })
 }
+
+fn apply_quadratic_penalty(
+    likelihood: &mut SurvivalLikelihood,
+    beta: &[f64],
+    penalty: Option<&Array2<f64>>,
+) -> f64 {
+    let Some(penalty) = penalty else {
+        return 0.0;
+    };
+    let width = penalty.nrows();
+    let mut quadratic = 0.0;
+    for row in 0..width {
+        let penalty_score = (0..width)
+            .map(|column| penalty[(row, column)] * beta[column])
+            .sum::<f64>();
+        likelihood.u[row] -= penalty_score;
+        quadratic += beta[row] * penalty_score;
+        for column in 0..width {
+            likelihood.imat[(row, column)] += penalty[(row, column)];
+            likelihood.jj[(row, column)] += penalty[(row, column)];
+        }
+    }
+    0.5 * quadratic
+}
+
 fn compute_survreg(
     input: ComputeSurvregInput<'_>,
 ) -> Result<SurvivalFitComputed, Box<dyn std::error::Error>> {
@@ -1045,6 +1166,7 @@ fn compute_survreg(
         distribution,
         distribution_parameter,
         fixed_scale,
+        penalty_matrix,
     } = input;
     let n = y.nrows();
     let ny = y.ncols();
@@ -1097,8 +1219,10 @@ fn compute_survreg(
         covariates,
         frailty: &frailty,
     };
-    let initial_likelihood = calculate_likelihood(&input)?;
+    let mut initial_likelihood = calculate_likelihood(&input)?;
     let mut loglik = initial_likelihood.loglik;
+    let mut penalty_value = apply_quadratic_penalty(&mut initial_likelihood, &beta, penalty_matrix);
+    let mut penalized_loglik = loglik - penalty_value;
     let mut imat = initial_likelihood.imat;
     let mut jj = initial_likelihood.jj;
     let mut u = initial_likelihood.u;
@@ -1106,7 +1230,7 @@ fn compute_survreg(
     let mut iter = 0;
     let mut converged = false;
     while iter < max_iter {
-        let old_loglik = loglik;
+        let old_penalized_loglik = penalized_loglik;
         let mut accepted = None;
         let observed_delta = is_positive_definite(&imat, tol_chol)
             .then(|| regularized_lu_solve(&imat, &u).ok())
@@ -1144,15 +1268,21 @@ fn compute_survreg(
                     covariates,
                     frailty: &frailty,
                 };
-                let candidate = calculate_likelihood(&candidate_input)?;
-                if candidate.loglik.is_finite()
-                    && candidate.loglik >= old_loglik
+                let mut candidate = calculate_likelihood(&candidate_input)?;
+                let candidate_loglik = candidate.loglik;
+                let candidate_penalty =
+                    apply_quadratic_penalty(&mut candidate, &candidate_beta, penalty_matrix);
+                let candidate_penalized_loglik = candidate_loglik - candidate_penalty;
+                if candidate_penalized_loglik.is_finite()
+                    && candidate_penalized_loglik >= old_penalized_loglik
                     && (!uses_observed_information
                         || is_positive_definite(&candidate.imat, tol_chol))
                 {
                     accepted = Some((
                         candidate_beta,
-                        candidate.loglik,
+                        candidate_loglik,
+                        candidate_penalty,
+                        candidate_penalized_loglik,
                         candidate.imat,
                         candidate.jj,
                         candidate.u,
@@ -1166,18 +1296,27 @@ fn compute_survreg(
             }
         }
 
-        if let Some((candidate_beta, candidate_loglik, candidate_imat, candidate_jj, candidate_u)) =
-            accepted
+        if let Some((
+            candidate_beta,
+            candidate_loglik,
+            candidate_penalty,
+            candidate_penalized_loglik,
+            candidate_imat,
+            candidate_jj,
+            candidate_u,
+        )) = accepted
         {
             beta = candidate_beta;
             loglik = candidate_loglik;
+            penalty_value = candidate_penalty;
+            penalized_loglik = candidate_penalized_loglik;
             imat = candidate_imat;
             jj = candidate_jj;
             u = candidate_u;
             usave.assign(&u);
             iter += 1;
 
-            if check_convergence(old_loglik, loglik, eps) {
+            if check_convergence(old_penalized_loglik, penalized_loglik, eps) {
                 converged = true;
                 break;
             }
@@ -1192,6 +1331,8 @@ fn compute_survreg(
         iterations: iter,
         variance_matrix: variance,
         log_likelihood: loglik,
+        penalty: penalty_value,
+        penalized_log_likelihood: penalized_loglik,
         convergence_flag,
         score_vector: usave.to_vec(),
     })
@@ -1201,6 +1342,8 @@ pub(crate) struct SurvivalFitComputed {
     iterations: usize,
     variance_matrix: Array2<f64>,
     log_likelihood: f64,
+    penalty: f64,
+    penalized_log_likelihood: f64,
     convergence_flag: i32,
     score_vector: Vec<f64>,
 }
@@ -1220,6 +1363,7 @@ struct ComputeSurvregInput<'a> {
     distribution: DistributionType,
     distribution_parameter: Option<f64>,
     fixed_scale: Option<f64>,
+    penalty_matrix: Option<&'a Array2<f64>>,
 }
 
 #[cfg(test)]
@@ -1343,6 +1487,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         assert!(gaussian.is_ok());
 
@@ -1362,8 +1507,94 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         assert!(weibull.is_err());
+    }
+
+    #[test]
+    fn quadratic_penalty_matches_reference_pspline_survreg_fit() {
+        let time = vec![
+            4.0, 7.0, 9.0, 12.0, 15.0, 18.0, 22.0, 25.0, 30.0, 36.0, 43.0, 51.0,
+        ];
+        let status = vec![1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0, 0.0];
+        let x = vec![
+            -2.0, -1.5, -1.0, -0.5, 0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5,
+        ];
+        let (basis, _) = crate::core::pspline::pspline_basis_core(&x, 4, 3, (-2.0, 3.5))
+            .expect("P-spline basis should be valid");
+        let covariates = basis
+            .into_iter()
+            .map(|row| {
+                std::iter::once(1.0)
+                    .chain(row.into_iter().skip(1))
+                    .collect()
+            })
+            .collect();
+        let difference_penalty = [
+            [5.0, -4.0, 1.0, 0.0, 0.0, 0.0],
+            [-4.0, 6.0, -4.0, 1.0, 0.0, 0.0],
+            [1.0, -4.0, 6.0, -4.0, 1.0, 0.0],
+            [0.0, 1.0, -4.0, 6.0, -4.0, 1.0],
+            [0.0, 0.0, 1.0, -4.0, 5.0, -2.0],
+            [0.0, 0.0, 0.0, 1.0, -2.0, 1.0],
+        ];
+        let penalty = (0..7)
+            .map(|row| {
+                (0..7)
+                    .map(|column| {
+                        if row == 0 || column == 0 {
+                            0.0
+                        } else {
+                            difference_penalty[row - 1][column - 1]
+                        }
+                    })
+                    .collect()
+            })
+            .collect();
+
+        let fit = survreg(
+            time,
+            status,
+            covariates,
+            None,
+            None,
+            None,
+            None,
+            Some("weibull"),
+            Some(100),
+            Some(1e-9),
+            Some(1e-10),
+            None,
+            None,
+            None,
+            Some(penalty),
+        )
+        .expect("quadratic-penalized survreg fit should succeed");
+
+        let expected = [
+            -1.531_895_335_731_6,
+            3.388_173_860_008_563_6,
+            3.961_988_359_190_023,
+            4.574_463_494_434_461,
+            4.950_961_917_375_609,
+            5.505_539_175_918_376,
+            5.867_096_525_333_904,
+        ];
+        for (actual, expected) in fit.location_coefficients.iter().zip(expected) {
+            assert!((actual - expected).abs() < 1e-8);
+        }
+        assert!((fit.scale - 0.004_673_727_601_541_054).abs() < 1e-10);
+        assert!((fit.penalty - 4.023_383_511_207_064).abs() < 1e-8);
+        assert!((fit.log_likelihood - fit.penalized_log_likelihood - fit.penalty).abs() < 1e-12);
+    }
+
+    #[test]
+    fn quadratic_penalty_validation_rejects_invalid_matrices() {
+        assert!(validate_penalty_matrix(&[vec![1.0, -1.0], vec![-1.0, 1.0]], 2).is_ok());
+        assert!(validate_penalty_matrix(&[vec![1.0], vec![0.0]], 2).is_err());
+        assert!(validate_penalty_matrix(&[vec![1.0, 0.0], vec![1.0, 1.0]], 2).is_err());
+        assert!(validate_penalty_matrix(&[vec![1.0, 2.0], vec![2.0, 1.0]], 2).is_err());
     }
 
     #[test]
@@ -1425,6 +1656,7 @@ mod tests {
             distribution: DistributionType::Weibull,
             distribution_parameter: None,
             fixed_scale: None,
+            penalty_matrix: None,
         });
 
         assert!(result.is_ok());
@@ -1461,6 +1693,7 @@ mod tests {
             distribution: DistributionType::Weibull,
             distribution_parameter: None,
             fixed_scale: None,
+            penalty_matrix: None,
         });
 
         assert!(result.is_ok());
@@ -1497,6 +1730,7 @@ mod tests {
             distribution: DistributionType::LogNormal,
             distribution_parameter: None,
             fixed_scale: None,
+            penalty_matrix: None,
         });
 
         assert!(result.is_ok());
@@ -1532,6 +1766,7 @@ mod tests {
             distribution: DistributionType::LogLogistic,
             distribution_parameter: None,
             fixed_scale: None,
+            penalty_matrix: None,
         });
 
         assert!(result.is_ok());
@@ -1572,6 +1807,7 @@ mod tests {
             distribution: DistributionType::Weibull,
             distribution_parameter: None,
             fixed_scale: None,
+            penalty_matrix: None,
         });
 
         assert!(result.is_ok());
@@ -1607,6 +1843,7 @@ mod tests {
             distribution: DistributionType::Gaussian,
             distribution_parameter: None,
             fixed_scale: None,
+            penalty_matrix: None,
         })
         .unwrap();
 
@@ -1647,6 +1884,7 @@ mod tests {
             distribution: DistributionType::Weibull,
             distribution_parameter: None,
             fixed_scale: None,
+            penalty_matrix: None,
         });
 
         assert!(result.is_ok());
@@ -1682,6 +1920,7 @@ mod tests {
             distribution: DistributionType::Weibull,
             distribution_parameter: None,
             fixed_scale: Some(1.25),
+            penalty_matrix: None,
         });
 
         assert!(result.is_ok());
@@ -1700,6 +1939,8 @@ mod tests {
             iterations: 10,
             variance_matrix: Array2::zeros((2, 2)),
             log_likelihood: -50.0,
+            penalty: 0.25,
+            penalized_log_likelihood: -50.25,
             convergence_flag: 0,
             score_vector: vec![0.001, 0.002],
         };

--- a/src/validation/bootstrap.rs
+++ b/src/validation/bootstrap.rs
@@ -424,6 +424,7 @@ pub(crate) fn bootstrap_survreg(
         None,
         None,
         None,
+        None,
     )?;
     let seed = config.seed.unwrap_or(crate::constants::DEFAULT_RANDOM_SEED);
     let bootstrap_coefs: Vec<Vec<f64>> = (0..config.n_bootstrap)
@@ -446,6 +447,7 @@ pub(crate) fn bootstrap_survreg(
                 Some(DEFAULT_MAX_ITER),
                 Some(1e-5),
                 Some(1e-9),
+                None,
                 None,
                 None,
                 None,

--- a/src/validation/crossval.rs
+++ b/src/validation/crossval.rs
@@ -383,6 +383,7 @@ pub(crate) fn cv_survreg(
                 None,
                 None,
                 None,
+                None,
             )
             .ok()?;
             let test_time: Vec<f64> = test_indices.iter().map(|&i| time[i]).collect();
@@ -400,6 +401,7 @@ pub(crate) fn cv_survreg(
                 Some(1),
                 Some(1e-5),
                 Some(1e-9),
+                None,
                 None,
                 None,
                 None,


### PR DESCRIPTION
## Summary
- add validated native quadratic penalties to parametric survival fitting
- support fixed, target-DF, and AIC P-splines plus ridge penalties in `survreg` formulas
- expose penalty metadata and match reference smoothing histories and effective degrees of freedom

## Testing
- `cargo test`
- `cargo test --lib --features ml`
- `cargo test --lib --features python,ml`
- `.venv/bin/python -m pytest python/tests -q`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo bench -- --test`
- Ruff formatting and lint checks
- mypy stub validation
- binding manifest validation
- `R CMD check --no-manual --no-build-vignettes r/survivalr` (standard source-directory NOTE only)