### PR TITLE
Return native Cox anova tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,9 @@ Model helpers include `model_formula`, `model_weights`, `df_residual`,
 confidence-interval, model-matrix/model-frame, and summary accessors for fitted
 Cox and `survreg` models. Analysis-of-deviance comparisons support sequential
 term refits and nested models for both families, including fractional degrees
-of freedom from penalized `survreg` fits.
+of freedom from penalized `survreg` fits. The R bridge returns native Cox and
+accelerated-failure-time analysis tables with their model headings and test
+columns.
 Common result objects can be converted to column-oriented tables with
 `as_data_frame(...)`; the experimental R bridge exposes the same path through
 `as.data.frame(...)`, `summary(...)`, and `print(...)` methods.

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -407,6 +407,7 @@ class _SparseFrailtyFitMetadata:
     formula: _FrailtyFormulaTerm
     levels: tuple[str, ...]
     effects: tuple[float, ...]
+    groups: tuple[int, ...]
 
 
 @dataclass(frozen=True)
@@ -493,6 +494,7 @@ class _FormulaFit:
     n_observations: int | None = None
     sparse_frailty: _SparseFrailtyFitMetadata | None = None
     multi_state: _MultiStateCoxFitMetadata | None = None
+    time_transform_expanded: bool = False
 
     def __getattr__(self, name: str) -> Any:
         if self.conditional_logistic and name in {
@@ -19552,8 +19554,54 @@ def _anova_result(
     return _core.AnovaCoxphResult(rows, test_name)
 
 
-def _cox_design_groups(fit: Any, n_columns: int) -> list[tuple[str, int]]:
-    return [(name, len(columns)) for name, columns in _cox_predict_term_groups(fit, n_columns)]
+def _cox_anova_design(
+    fit: Any,
+    model: Any,
+    n_columns: int,
+) -> tuple[list[list[float]], list[tuple[str, int]]]:
+    rows = _cox_training_rows(model, n_columns)
+    sparse = fit.sparse_frailty if isinstance(fit, _FormulaFit) else None
+    if sparse is None:
+        groups = [
+            (name, len(columns)) for name, columns in _cox_predict_term_groups(fit, n_columns)
+        ]
+        return rows, groups
+
+    if not isinstance(fit, _FormulaFit) or fit.design is None:
+        raise ValueError("sparse frailty anova requires formula design metadata")
+    if len(sparse.groups) != len(rows):
+        raise ValueError("sparse frailty groups do not match the fitted observations")
+
+    expanded_rows = [[] for _row in rows]
+    grouped_columns: dict[int, list[int]] = {}
+    source_column = 0
+    for term, assignment in zip(
+        fit.design.covariates,
+        fit.design.term_assignments,
+        strict=True,
+    ):
+        if isinstance(term, _FrailtyDesignTerm) and term.sparse:
+            target_column = len(expanded_rows[0]) if expanded_rows else 0
+            for row, group in zip(expanded_rows, sparse.groups, strict=True):
+                row.append(float(group + 1))
+            grouped_columns.setdefault(assignment, []).append(target_column)
+            continue
+
+        width = len(_design_term_output_names(term))
+        target_start = len(expanded_rows[0]) if expanded_rows else 0
+        for target, source in zip(expanded_rows, rows, strict=True):
+            target.extend(source[source_column : source_column + width])
+        grouped_columns.setdefault(assignment, []).extend(range(target_start, target_start + width))
+        source_column += width
+    if source_column != n_columns:
+        raise ValueError("sparse frailty design does not match fitted covariates")
+
+    groups = [
+        (label, len(grouped_columns[assignment]))
+        for assignment, label in enumerate(fit.design.term_labels, start=1)
+        if assignment in grouped_columns
+    ]
+    return expanded_rows, groups
 
 
 def _cox_fit_offset(fit: Any, beta: list[float]) -> list[float] | None:
@@ -19580,17 +19628,18 @@ def _cox_fit_offset(fit: Any, beta: list[float]) -> list[float] | None:
 
 def _cox_refit_loglik_and_df(
     fit: Any,
-    width: int,
+    rows: Sequence[Sequence[float]],
     offset: list[float] | None,
+    strata: Sequence[int] | None,
 ) -> tuple[float, float | int]:
-    rows = [[float(value) for value in row[:width]] for row in fit.covariates]
+    refit_rows = [[float(value) for value in row] for row in rows]
     nocenter = getattr(fit, "nocenter", None)
     refit = _core.coxph_fit(
         [float(value) for value in fit.event_times],
         [int(value) for value in fit.status],
-        rows,
-        strata=[int(value) for value in fit.strata] if hasattr(fit, "strata") else None,
-        weights=[float(value) for value in fit.weights] if hasattr(fit, "weights") else None,
+        refit_rows,
+        strata=[int(value) for value in strata] if strata is not None else None,
+        weights=None,
         offset=offset,
         initial_beta=None,
         max_iter=None,
@@ -19607,8 +19656,17 @@ def _cox_refit_loglik_and_df(
     return _cox_full_loglik(refit), _cox_degrees_of_freedom(refit)
 
 
-def _anova_single_coxph(fit: Any, test_name: str, with_tests: bool) -> Any:
+def _require_nonrobust_cox_anova(fit: Any) -> Any:
     model = _require_coxph_fit(fit)
+    if isinstance(fit, _FormulaFit) and fit.multi_state is not None:
+        raise ValueError("anova not yet available for multistate")
+    if isinstance(fit, _FormulaFit) and fit.robust_variance is not None:
+        raise ValueError("cannot create anova tables with robust variances")
+    return model
+
+
+def _anova_single_coxph(fit: Any, test_name: str, with_tests: bool) -> Any:
+    model = _require_nonrobust_cox_anova(fit)
     beta = _cox_beta(model)
     n_columns = len(beta)
     names = ["NULL"]
@@ -19617,8 +19675,20 @@ def _anova_single_coxph(fit: Any, test_name: str, with_tests: bool) -> Any:
     if n_columns == 0:
         return _anova_result(logliks, dfs, names, test_name, with_tests)
 
-    groups = _cox_design_groups(fit, n_columns)
-    offset = _cox_fit_offset(model, beta)
+    rows, groups = _cox_anova_design(fit, model, n_columns)
+    offset = (
+        _cox_fit_offset(model, beta)
+        if not isinstance(fit, _FormulaFit) or fit.x_matrix is not None
+        else None
+    )
+    refit_strata = (
+        None
+        if isinstance(fit, _FormulaFit)
+        and fit.time_transform_expanded
+        and fit.design is not None
+        and not fit.design.strata
+        else getattr(model, "strata", None)
+    )
     width = 0
     for idx, (name, group_width) in enumerate(groups):
         width += group_width
@@ -19627,18 +19697,106 @@ def _anova_single_coxph(fit: Any, test_name: str, with_tests: bool) -> Any:
             logliks.append(_cox_full_loglik(model))
             dfs.append(_cox_degrees_of_freedom(fit))
         else:
-            refit_loglik, refit_df = _cox_refit_loglik_and_df(model, width, offset)
+            refit_rows = [row[:width] for row in rows]
+            refit_loglik, refit_df = _cox_refit_loglik_and_df(
+                model,
+                refit_rows,
+                offset,
+                refit_strata,
+            )
             logliks.append(refit_loglik)
             dfs.append(refit_df)
     return _anova_result(logliks, dfs, names, test_name, with_tests)
 
 
+def _cox_anova_response_name(fit: Any) -> str | None:
+    if not isinstance(fit, _FormulaFit) or fit.formula is None:
+        return None
+    response, separator, _rhs = fit.formula.partition("~")
+    return "".join(response.split()) if separator else None
+
+
+def _same_cox_anova_response(left: Any, right: Any) -> bool:
+    left_name = _cox_anova_response_name(left)
+    right_name = _cox_anova_response_name(right)
+    if left_name is not None and right_name is not None:
+        return left_name == right_name
+
+    left_model = _require_coxph_fit(left)
+    right_model = _require_coxph_fit(right)
+    return (
+        list(left_model.event_times) == list(right_model.event_times)
+        and list(left_model.status) == list(right_model.status)
+        and list(getattr(left_model, "entry_times", []) or [])
+        == list(getattr(right_model, "entry_times", []) or [])
+    )
+
+
+def _cox_anova_strata_terms(fit: Any) -> tuple[str, ...]:
+    if isinstance(fit, _FormulaFit) and fit.design is not None:
+        return fit.design.strata
+    return ()
+
+
+def _anova_multiple_coxph_result(
+    logliks: list[float],
+    dfs: list[float | int],
+    names: list[str],
+    test_name: str,
+    with_tests: bool,
+) -> Any:
+    if not with_tests:
+        return _anova_result(logliks, dfs, names, test_name, False)
+
+    rows = [_core.AnovaRow(names[0], logliks[0], dfs[0], None, None)]
+    for model_index in range(1, len(logliks)):
+        chisq = abs(2.0 * (logliks[model_index] - logliks[model_index - 1]))
+        df = abs(float(dfs[model_index]) - float(dfs[model_index - 1]))
+        if df == 0.0:
+            p_value = 1.0 if chisq <= 0.0 else 0.0
+        else:
+            p_value = float(_core.chi_square_survival(chisq, df))
+        rows.append(
+            _core.AnovaRow(
+                names[model_index],
+                logliks[model_index],
+                dfs[model_index],
+                chisq,
+                p_value,
+            )
+        )
+    return _core.AnovaCoxphResult(rows, test_name)
+
+
 def _anova_multiple_coxph(fits: tuple[Any, ...], test_name: str, with_tests: bool) -> Any:
-    models = [_require_coxph_fit(fit) for fit in fits]
+    models = [_require_nonrobust_cox_anova(fit) for fit in fits]
+    methods = [str(getattr(model, "method", "breslow")) for model in models]
+    if any(method != methods[0] for method in methods[1:]):
+        raise ValueError("all Cox models must use the same ties option")
+    same_response = [True, *[_same_cox_anova_response(fits[0], fit) for fit in fits[1:]]]
+    if not all(same_response):
+        warnings.warn(
+            "Cox models with a different response were removed",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        fits = tuple(fit for fit, keep in zip(fits, same_response, strict=True) if keep)
+        models = [model for model, keep in zip(models, same_response, strict=True) if keep]
+    if len(fits) == 1:
+        return _anova_single_coxph(fits[0], test_name, with_tests)
+    row_counts = [_model_row_count(fit) for fit in fits]
+    if any(count != row_counts[0] for count in row_counts[1:]):
+        raise ValueError("Cox models must use the same size dataset")
+    strata_terms = [_cox_anova_strata_terms(fit) for fit in fits]
+    if any(terms != strata_terms[0] for terms in strata_terms[1:]):
+        raise ValueError("Cox models must use the same strata")
+    strata_values = [list(getattr(model, "strata", [])) for model in models]
+    if any(values != strata_values[0] for values in strata_values[1:]):
+        raise ValueError("Cox models must use the same strata")
     logliks = [_cox_full_loglik(model) for model in models]
     dfs = [_cox_degrees_of_freedom(fit) for fit in fits]
     names = [f"Model {idx + 1}" for idx in range(len(models))]
-    return _anova_result(logliks, dfs, names, test_name, with_tests)
+    return _anova_multiple_coxph_result(logliks, dfs, names, test_name, with_tests)
 
 
 def _survreg_anova_test(test: str | None) -> tuple[str, bool]:
@@ -26842,6 +27000,7 @@ def coxph(
             sparse_design_term.formula,
             native_formula_frailty_block.levels,
             tuple(float(value) for value in fit.frailty),
+            native_formula_frailty_block.groups,
         )
     if (
         formula_design is not None
@@ -26892,6 +27051,7 @@ def coxph(
             ),
             sparse_frailty=sparse_frailty_metadata,
             multi_state=multi_state_metadata,
+            time_transform_expanded=time_transform_expanded,
         )
     return fit
 

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -13044,7 +13044,11 @@ def test_anova_coxph_single_formula_model_refits_terms_sequentially():
 
 def test_anova_coxph_single_formula_model_preserves_offsets():
     data = _toy_data()
-    fit = survival.coxph("Surv(time, status) ~ x1 + x2 + offset(offset)", data=data)
+    fit = survival.coxph(
+        "Surv(time, status) ~ x1 + x2 + offset(offset)",
+        data=data,
+        x=True,
+    )
     first_term = survival.regression.coxph_fit(
         time=data["time"],
         status=data["status"],
@@ -13057,6 +13061,107 @@ def test_anova_coxph_single_formula_model_preserves_offsets():
     assert [row.model_name for row in result.rows] == ["NULL", "x1", "x2"]
     assert result.rows[1].loglik == pytest.approx(first_term.log_likelihood[-1])
     assert result.rows[2].loglik == pytest.approx(fit.log_likelihood[-1])
+
+
+def test_anova_coxph_reduced_refits_match_r_storage_semantics():
+    data = _toy_data()
+    weighted = {**data, "weights": [1, 2, 1, 2, 1, 2, 1, 2]}
+    unweighted_x1 = survival.regression.coxph_fit(
+        time=data["time"],
+        status=data["status"],
+        covariates=[[value] for value in data["x1"]],
+    )
+    weighted_fit = survival.coxph(
+        "Surv(time, status) ~ x1 + x2",
+        data=weighted,
+        weights=weighted["weights"],
+    )
+    offset_fit = survival.coxph(
+        "Surv(time, status) ~ x1 + x2 + offset(offset)",
+        data=data,
+    )
+
+    weighted_result = survival.anova(weighted_fit)
+    offset_result = survival.anova(offset_fit)
+
+    assert weighted_result.rows[1].loglik == pytest.approx(unweighted_x1.log_likelihood[-1])
+    assert offset_result.rows[1].loglik == pytest.approx(unweighted_x1.log_likelihood[-1])
+    assert weighted_result.rows[-1].loglik == pytest.approx(weighted_fit.log_likelihood[-1])
+    assert offset_result.rows[-1].loglik == pytest.approx(offset_fit.log_likelihood[-1])
+
+
+def test_anova_coxph_time_transform_refits_the_expanded_response_without_strata():
+    data = _toy_data()
+    fit = survival.coxph(
+        "Surv(time, status) ~ x1 + tt(x2)",
+        data=data,
+        tt=lambda x, time, riskset, weights: [
+            value * math.log(event_time) for value, event_time in zip(x, time, strict=True)
+        ],
+        x=True,
+    )
+    first_term = survival.regression.coxph_fit(
+        time=fit.event_times,
+        status=fit.status,
+        covariates=[[row[0]] for row in fit.covariates],
+    )
+
+    result = survival.anova(fit)
+
+    assert [row.model_name for row in result.rows] == ["NULL", "x1", "tt(x2)"]
+    assert result.rows[1].loglik == pytest.approx(first_term.log_likelihood[-1])
+    assert result.rows[-1].loglik == pytest.approx(fit.log_likelihood[-1])
+
+
+def test_anova_coxph_includes_sparse_frailty_as_a_sequential_term():
+    data = {
+        "time": [float(value) for value in range(2, 20)],
+        "status": [1, 1, 0, 1, 1, 0, 1, 0, 1, 1, 0, 1, 0, 1, 1, 0, 1, 1],
+        "x": [
+            -1.2,
+            -0.8,
+            -0.4,
+            0.0,
+            0.4,
+            0.8,
+            1.2,
+            -1.0,
+            -0.6,
+            -0.2,
+            0.2,
+            0.6,
+            1.0,
+            1.4,
+            -1.4,
+            -0.9,
+            0.1,
+            0.9,
+        ],
+        "z": [0, 1] * 9,
+        "g": [level for level in "abcdef" for _ in range(3)],
+    }
+    frailty_term = "frailty(g,distribution='gaussian',theta=.5,sparse=True)"
+    fit = survival.coxph(
+        f"Surv(time,status) ~ x + {frailty_term} + z",
+        data=data,
+    )
+
+    result = survival.anova(fit)
+
+    assert [row.model_name for row in result.rows] == [
+        "NULL",
+        "x",
+        frailty_term,
+        "z",
+    ]
+    assert [row.df for row in result.rows] == pytest.approx(
+        [0.0, 1.0, 2.0, 3.9488253265922464],
+        abs=2e-8,
+    )
+    assert [row.loglik for row in result.rows] == pytest.approx(
+        [-23.690198555957362, -23.49662920106851, -7.08886458533118, -18.690207888785487],
+        abs=2e-8,
+    )
 
 
 def test_anova_coxph_compares_nested_models():
@@ -13073,6 +13178,50 @@ def test_anova_coxph_compares_nested_models():
     assert result.rows[1].chisq == pytest.approx(
         2.0 * (fit_full.log_likelihood[-1] - fit_x1.log_likelihood[-1])
     )
+
+    reverse = survival.anova(fit_full, fit_x1)
+    assert reverse.rows[1].chisq == pytest.approx(result.rows[1].chisq)
+    assert reverse.rows[1].p_value == pytest.approx(result.rows[1].p_value)
+
+
+def test_anova_coxph_validates_robust_and_nested_model_inputs():
+    data = _toy_data()
+    fit_x1 = survival.coxph("Surv(time, status) ~ x1", data=data)
+    fit_full = survival.coxph("Surv(time, status) ~ x1 + x2", data=data)
+
+    robust = survival.coxph(
+        "Surv(time, status) ~ x1 + cluster(group)",
+        data=data,
+    )
+    with pytest.raises(ValueError, match="robust variances"):
+        survival.anova(robust)
+    with pytest.raises(ValueError, match="robust variances"):
+        survival.anova(fit_x1, robust)
+
+    exact = survival.coxph("Surv(time, status) ~ x1", data=data, ties="exact")
+    with pytest.raises(ValueError, match="same ties option"):
+        survival.anova(fit_x1, exact)
+
+    response_data = {**data, "other_time": list(data["time"])}
+    other_response = survival.coxph(
+        "Surv(other_time, status) ~ x1",
+        data=response_data,
+    )
+    with pytest.warns(RuntimeWarning, match="different response"):
+        filtered = survival.anova(fit_x1, other_response)
+    assert [row.model_name for row in filtered.rows] == ["NULL", "x1"]
+
+    smaller = {name: values[:-1] for name, values in data.items()}
+    smaller_fit = survival.coxph("Surv(time, status) ~ x1", data=smaller)
+    with pytest.raises(ValueError, match="same size dataset"):
+        survival.anova(fit_x1, smaller_fit)
+
+    stratified = survival.coxph(
+        "Surv(time, status) ~ x1 + strata(group)",
+        data=data,
+    )
+    with pytest.raises(ValueError, match="same strata"):
+        survival.anova(fit_full, stratified)
 
 
 def test_anova_coxph_accepts_r_style_test_aliases_and_prefixes():

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -11692,22 +11692,142 @@ residuals.survival_py_model <- function(object, ..., type = "martingale") {
   table
 }
 
+.coxph_anova_response <- function(object) {
+  as.character(formula(object))[[2L]]
+}
+
+.as_coxph_anova <- function(result, fits, test) {
+  frame <- as.data.frame(result, optional = TRUE)
+  loglik <- as.numeric(frame$loglik)
+  fitted_df <- as.numeric(frame$df)
+  chisq <- c(NA_real_, abs(2 * diff(loglik)))
+  df <- c(NA_real_, abs(diff(fitted_df)))
+
+  if (length(fits) == 1L) {
+    chisq <- c(NA_real_, 2 * diff(loglik))
+    df <- c(NA_real_, diff(fitted_df))
+    table <- data.frame(
+      loglik = loglik,
+      Chisq = chisq,
+      Df = df,
+      row.names = as.character(frame$model),
+      check.names = FALSE
+    )
+    if (length(test) > 0L && identical(test[[1L]], "Chisq")) {
+      table[["Pr(>|Chi|)"]] <- stats::pchisq(chisq, df, lower.tail = FALSE)
+    }
+    heading <- paste0(
+      "Analysis of Deviance Table\n Cox model: response is ",
+      .coxph_anova_response(fits[[1L]]),
+      "\nTerms added sequentially (first to last)\n"
+    )
+    return(structure(table, heading = heading, class = c("anova", "data.frame")))
+  }
+
+  table <- data.frame(
+    loglik = loglik,
+    Chisq = chisq,
+    Df = df,
+    row.names = as.character(seq_along(fits)),
+    check.names = FALSE
+  )
+  if (length(test) > 0L) {
+    table[["Pr(>|Chi|)"]] <- stats::pchisq(chisq, df, lower.tail = FALSE)
+  }
+  variables <- vapply(
+    fits,
+    function(fit) {
+      paste(
+        as.character(stats::delete.response(stats::terms(stats::formula(fit)))),
+        collapse = " "
+      )
+    },
+    character(1L)
+  )
+  title <- paste0(
+    "Analysis of Deviance Table\n Cox model: response is  ",
+    .coxph_anova_response(fits[[1L]])
+  )
+  topnote <- paste(
+    " Model ",
+    format(seq_along(fits)),
+    ": ",
+    variables,
+    sep = "",
+    collapse = "\n"
+  )
+  structure(table, heading = c(title, topnote), class = c("anova", "data.frame"))
+}
+
 anova.survival_py_model <- function(object, ..., test = "Chisq") {
-  fits <- list(object, ...)
+  dots <- list(...)
+  fits <- c(list(object), unname(dots))
   if (inherits(object, "survival_py_survreg")) {
     test <- match.arg(test, c("Chisq", "none"))
-  }
-  result <- .call_r_api(
-    "anova",
-    object,
-    ...,
-    test = test,
-    .wrap = c("survival_py_anova", "survival_py_object")
-  )
-  if (inherits(object, "survival_py_survreg")) {
+    result <- do.call(
+      .call_r_api,
+      c(
+        list(name = "anova"),
+        fits,
+        list(
+          test = test,
+          .wrap = c("survival_py_anova", "survival_py_object")
+        )
+      )
+    )
     return(.as_survreg_anova(result, fits, test))
   }
-  result
+
+  named <- if (is.null(names(dots))) {
+    rep(FALSE, length(dots))
+  } else {
+    names(dots) != ""
+  }
+  if (any(named)) {
+    warning(
+      paste(
+        "The following arguments to anova.coxph(..) are invalid and dropped:",
+        paste(deparse(dots[named]), collapse = ", ")
+      ),
+      call. = FALSE
+    )
+    dots <- dots[!named]
+    fits <- c(list(object), unname(dots))
+  }
+  if (length(fits) > 1L) {
+    responses <- vapply(fits, .coxph_anova_response, character(1L))
+    same_response <- responses == responses[[1L]]
+    if (!all(same_response)) {
+      warning(
+        paste(
+          "Models with response",
+          paste(responses[!same_response], collapse = ", "),
+          "removed because response differs from model 1"
+        ),
+        call. = FALSE
+      )
+      fits <- fits[same_response]
+    }
+  }
+  python_test <- if (length(test) == 0L) {
+    "none"
+  } else if (length(fits) > 1L || identical(test[[1L]], "Chisq")) {
+    "Chisq"
+  } else {
+    "none"
+  }
+  result <- do.call(
+    .call_r_api,
+    c(
+      list(name = "anova"),
+      fits,
+      list(
+        test = python_test,
+        .wrap = c("survival_py_anova", "survival_py_object")
+      )
+    )
+  )
+  .as_coxph_anova(result, fits, test)
 }
 
 summary.survival_py_survfit <- function(object, times, censored = FALSE, scale = 1,

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -6254,7 +6254,7 @@ test_that("Cox time transforms agree with R survival", {
     x = TRUE
   )
   reference_right <- survival::coxph(
-    survival::Surv(time, status) ~ x1 + tt(x2),
+    Surv(time, status) ~ x1 + tt(x2),
     data = right,
     tt = log_transform,
     control = survival::coxph.control(eps = 1e-10, iter.max = 50),
@@ -6267,6 +6267,11 @@ test_that("Cox time transforms agree with R survival", {
   expect_equal(unname(model.matrix(bridged_right)), unname(model.matrix(reference_right)))
   expect_equal(summary(bridged_right)$n, summary(reference_right)$n)
   expect_equal(nobs(bridged_right), nobs(reference_right))
+  expect_equal(
+    anova(bridged_right),
+    survival:::anova.coxph(reference_right),
+    tolerance = 2e-08
+  )
 
   default_bridged <- coxph(
     Surv(time, status) ~ x1 + tt(x2),
@@ -7137,6 +7142,168 @@ test_that("penalized survreg model metadata matches survival", {
   expect_type(df.residual(bridged), "double")
   expect_equal(extractAIC(bridged), extractAIC(reference), tolerance = 1e-08)
   expect_equal(AIC(bridged), AIC(reference), tolerance = 1e-08)
+})
+
+test_that("coxph analysis of deviance matches survival", {
+  skip_if_not_installed("reticulate")
+  skip_if_not_installed("survival")
+  skip_if_not(reticulate::py_module_available("survival"), "Python survival package is unavailable")
+
+  data <- data.frame(
+    time = c(1, 2, 3, 5, 6, 8, 9, 11, 12, 14, 15, 18),
+    status = c(1, 1, 0, 1, 0, 1, 1, 0, 1, 1, 0, 1),
+    x = c(-1, .2, .5, 1.2, -.7, .8, 1.7, -1.3, .4, 1.4, -.2, .9),
+    z = c(0, 1, 1, 0, 1, 0, 1, 0, 0, 1, 0, 1),
+    group = factor(rep(c("a", "b"), 6L)),
+    offset = seq(.1, 1.2, .1),
+    weights = rep(c(1L, 2L), 6L)
+  )
+  formula <- Surv(time, status) ~ x + z
+  bridged <- coxph(formula, data = data)
+  reference <- survival::coxph(formula, data = data)
+
+  expect_equal(
+    anova(bridged),
+    survival:::anova.coxph(reference),
+    tolerance = 2e-08
+  )
+  expect_equal(
+    anova(bridged, test = NULL),
+    survival:::anova.coxph(reference, test = NULL),
+    tolerance = 2e-08
+  )
+  expect_equal(
+    anova(bridged, test = "none"),
+    survival:::anova.coxph(reference, test = "none"),
+    tolerance = 2e-08
+  )
+
+  tied_data <- data
+  tied_data$time <- rep(seq_len(nrow(data) / 2L), each = 2L)
+  bridged_exact <- coxph(formula, data = tied_data, ties = "exact")
+  reference_exact <- survival::coxph(formula, data = tied_data, ties = "exact")
+  expect_equal(
+    anova(bridged_exact),
+    survival:::anova.coxph(reference_exact),
+    tolerance = 2e-07
+  )
+
+  counting_data <- data.frame(
+    start = c(0, 2, 0, 3, 0, 4, 0, 2, 0, 5, 0, 3),
+    stop = c(2, 6, 3, 7, 4, 9, 2, 8, 5, 10, 3, 11),
+    status = rep(c(0, 1), 6L),
+    x = data$x,
+    group = data$group
+  )
+  counting_formula <- Surv(start, stop, status) ~ x + strata(group)
+  bridged_counting <- coxph(counting_formula, data = counting_data)
+  reference_counting <- survival::coxph(counting_formula, data = counting_data)
+  expect_equal(
+    anova(bridged_counting),
+    survival:::anova.coxph(reference_counting),
+    tolerance = 2e-08
+  )
+
+  x_formula <- Surv(time, status) ~ x
+  bridged_x <- coxph(x_formula, data = data)
+  reference_x <- survival::coxph(x_formula, data = data)
+  expect_equal(
+    anova(bridged, bridged_x),
+    survival:::anova.coxph(reference, reference_x),
+    tolerance = 2e-08
+  )
+  expect_equal(
+    anova(bridged_x, bridged),
+    survival:::anova.coxph(reference_x, reference),
+    tolerance = 2e-08
+  )
+  expect_equal(
+    anova(bridged_x, bridged, test = NULL),
+    survival:::anova.coxph(reference_x, reference, test = NULL),
+    tolerance = 2e-08
+  )
+  expect_equal(
+    anova(bridged_x, bridged, test = "none"),
+    survival:::anova.coxph(reference_x, reference, test = "none"),
+    tolerance = 2e-08
+  )
+
+  response_data <- transform(data, other_time = time)
+  other_formula <- Surv(other_time, status) ~ x
+  bridged_other <- coxph(other_formula, data = response_data)
+  reference_other <- survival::coxph(other_formula, data = response_data)
+  expect_warning(
+    bridged_filtered <- anova(bridged, bridged_other),
+    "response.*removed"
+  )
+  reference_filtered <- suppressWarnings(
+    survival:::anova.coxph(reference, reference_other)
+  )
+  expect_equal(bridged_filtered, reference_filtered, tolerance = 2e-08)
+
+  bridged_weighted <- coxph(formula, data = data, weights = weights)
+  reference_weighted <- survival::coxph(formula, data = data, weights = weights)
+  expect_equal(
+    anova(bridged_weighted),
+    survival:::anova.coxph(reference_weighted),
+    tolerance = 2e-08
+  )
+
+  offset_formula <- Surv(time, status) ~ x + z + offset(offset)
+  for (keep_x in c(FALSE, TRUE)) {
+    bridged_offset <- coxph(offset_formula, data = data, x = keep_x)
+    reference_offset <- survival::coxph(offset_formula, data = data, x = keep_x)
+    expect_equal(
+      anova(bridged_offset),
+      survival:::anova.coxph(reference_offset),
+      tolerance = 2e-08
+    )
+  }
+
+  strata_formula <- Surv(time, status) ~ x + strata(group) + z + offset(offset)
+  bridged_strata <- coxph(strata_formula, data = data)
+  reference_strata <- survival::coxph(strata_formula, data = data)
+  expect_equal(
+    anova(bridged_strata),
+    survival:::anova.coxph(reference_strata),
+    tolerance = 2e-08
+  )
+
+  penalty_formula <- Surv(time, status) ~ pspline(x, theta = .5, nterm = 4) + z
+  bridged_penalty <- coxph(penalty_formula, data = data)
+  reference_penalty <- survival::coxph(penalty_formula, data = data)
+  expect_equal(
+    suppressWarnings(anova(bridged_penalty)),
+    suppressWarnings(survival:::anova.coxph(reference_penalty)),
+    tolerance = 2e-08
+  )
+
+  frailty_data <- data.frame(
+    time = 2:19,
+    status = c(1, 1, 0, 1, 1, 0, 1, 0, 1, 1, 0, 1, 0, 1, 1, 0, 1, 1),
+    x = c(-1.2, -.8, -.4, 0, .4, .8, 1.2, -1, -.6, -.2, .2, .6, 1, 1.4, -1.4, -.9, .1, .9),
+    z = rep(c(0, 1), 9L),
+    group = rep(letters[1:6], each = 3L)
+  )
+  frailty_formula <- Surv(time, status) ~ x +
+    frailty(group, distribution = "gaussian", theta = .5, sparse = TRUE) + z
+  bridged_frailty <- coxph(frailty_formula, data = frailty_data)
+  reference_frailty <- survival::coxph(frailty_formula, data = frailty_data)
+  expect_equal(
+    anova(bridged_frailty),
+    survival:::anova.coxph(reference_frailty),
+    tolerance = 2e-08
+  )
+
+  robust <- coxph(
+    Surv(time, status) ~ x + z + cluster(group),
+    data = data
+  )
+  expect_error(anova(robust), "robust variances")
+  expect_warning(
+    anova(bridged, ignored = bridged_x),
+    "invalid and dropped"
+  )
 })
 
 test_that("survreg analysis of deviance matches survival", {
@@ -8546,6 +8713,8 @@ test_that("single-formula multi-state Cox models match survival", {
     model = TRUE,
     control = survival::coxph.control(iter.max = 20L, eps = 1e-9)
   )
+
+  expect_error(anova(bridged), "not yet available for multistate")
 
   expect_equal(coef(bridged), coef(reference), tolerance = 1e-12)
   expect_equal(vcov(bridged), vcov(reference), tolerance = 1e-12)


### PR DESCRIPTION
## Summary
- return native R-shaped Cox analysis-of-deviance tables with matching headings, row labels, and optional test columns
- preserve sequential refit behavior for weights, offsets, strata, time transforms, penalties, and sparse frailty terms
- validate nested-model ties, responses, sample sizes, strata, robust variance, and multi-state limitations

## Testing
- `.venv/bin/python -m pytest -q python/tests/` (1014 passed)
- `.venv/bin/ruff format python/ test/ --check`
- `.venv/bin/ruff check python/ test/`
- `.venv/bin/mypy python/survival/__init__.pyi python/survival/_survival.pyi --ignore-missing-imports`
- `.venv/bin/python scripts/generate_binding_manifest.py --check`
- `cargo fmt --all -- --check`
- `R CMD check --no-manual --no-build-vignettes r/survivalr` (3689 assertions passed; standard source-directory NOTE only)
- `git diff --check`