### PR TITLE
Match survreg distribution helper semantics

### DIFF
--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -10691,48 +10691,54 @@ survregDtest <- function(dlist, verbose = FALSE) {
   }
 }
 
+.survreg_distribution_helper <- function(distribution) {
+  dist <- survreg.distributions[[casefold(distribution)]]
+  if (is.null(dist)) {
+    stop("Distribution not found", call. = FALSE)
+  }
+  dist
+}
+
 dsurvreg <- function(x, mean, scale = 1, distribution = "weibull", parms) {
-  .as_numeric_vector(.call_r_api(
-    "dsurvreg",
-    x = .as_python_vector(x),
-    mean = .as_python_vector(mean),
-    scale = .as_python_vector(scale),
-    distribution = distribution,
-    parms = if (missing(parms)) NULL else parms
-  ))
+  dist <- .survreg_distribution_helper(distribution)
+  if (!is.null(dist$trans)) {
+    dx <- dist$dtrans(x)
+    x <- (dist$trans(x) - mean) / scale
+    dist <- survreg.distributions[[dist$dist]]
+    return(dist$density(x, parms)[, 3L] * dx / scale)
+  }
+  x <- (x - mean) / scale
+  dist$density(x, parms)[, 3L] / scale
 }
 
 psurvreg <- function(q, mean, scale = 1, distribution = "weibull", parms) {
-  .as_numeric_vector(.call_r_api(
-    "psurvreg",
-    q = .as_python_vector(q),
-    mean = .as_python_vector(mean),
-    scale = .as_python_vector(scale),
-    distribution = distribution,
-    parms = if (missing(parms)) NULL else parms
-  ))
+  dist <- .survreg_distribution_helper(distribution)
+  if (!is.null(dist$trans)) {
+    q <- (dist$trans(q) - mean) / scale
+    dist <- survreg.distributions[[dist$dist]]
+    return(dist$density(q, parms)[, 1L])
+  }
+  q <- (q - mean) / scale
+  dist$density(q, parms)[, 1L]
 }
 
 qsurvreg <- function(p, mean, scale = 1, distribution = "weibull", parms) {
-  .as_numeric_vector(.call_r_api(
-    "qsurvreg",
-    p = .as_python_vector(p),
-    mean = .as_python_vector(mean),
-    scale = .as_python_vector(scale),
-    distribution = distribution,
-    parms = if (missing(parms)) NULL else parms
-  ))
+  dist <- .survreg_distribution_helper(distribution)
+  if (!is.null(dist$trans)) {
+    reference <- survreg.distributions[[dist$dist]]
+    quantiles <- reference$quantile(p, parms)
+    return(dist$itrans(quantiles * scale + mean))
+  }
+  dist$quantile(p, parms) * scale + mean
 }
 
 rsurvreg <- function(n, mean, scale = 1, distribution = "weibull", parms) {
-  args <- .compact_null(list(
-    n = .as_integer_scalar(n, "n", nonnegative = TRUE),
-    mean = .as_python_vector(mean),
-    scale = .as_python_vector(scale),
-    distribution = distribution,
-    parms = if (missing(parms)) NULL else parms
-  ))
-  .as_numeric_vector(do.call(.python_attr("rsurvreg"), args))
+  probabilities <- stats::runif(n)
+  if (missing(parms)) {
+    qsurvreg(probabilities, mean, scale, distribution)
+  } else {
+    qsurvreg(probabilities, mean, scale, distribution, parms)
+  }
 }
 
 .survreg_distribution_name <- function(value) {

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -1932,6 +1932,100 @@ test_that("R formula wrappers delegate to the Python survival package", {
     tolerance = 1e-12
   )
 
+  distributions <- c(
+    "extreme", "logistic", "gaussian", "weibull", "exponential",
+    "rayleigh", "loggaussian", "lognormal", "loglogistic"
+  )
+  values <- setNames(c(0.5, 1.2, 2), c("first", "second", "third"))
+  means <- c(0.1, -0.2, 0.3)
+  scales <- c(0.7, 1.1, 1.4)
+  probabilities <- setNames(c(0.1, 0.5, 0.9), names(values))
+  for (distribution in distributions) {
+    expect_equal(
+      dsurvreg(values, means, scales, distribution),
+      survival::dsurvreg(values, means, scales, distribution),
+      tolerance = 1e-12,
+      info = paste(distribution, "density")
+    )
+    expect_equal(
+      psurvreg(values, means, scales, distribution),
+      survival::psurvreg(values, means, scales, distribution),
+      tolerance = 1e-12,
+      info = paste(distribution, "distribution")
+    )
+    expect_equal(
+      qsurvreg(probabilities, means, scales, distribution),
+      survival::qsurvreg(probabilities, means, scales, distribution),
+      tolerance = 1e-12,
+      info = paste(distribution, "quantile")
+    )
+  }
+
+  expect_warning(
+    recycled_density <- dsurvreg(values, mean = c(0, 1), scale = 1),
+    "longer object length"
+  )
+  expect_equal(
+    recycled_density,
+    suppressWarnings(survival::dsurvreg(values, mean = c(0, 1), scale = 1)),
+    tolerance = 1e-12
+  )
+  expect_warning(
+    recycled_quantiles <- qsurvreg(
+      probabilities,
+      mean = c(0, 1),
+      scale = c(1, 2),
+      distribution = "gaussian"
+    ),
+    "longer object length"
+  )
+  expect_equal(
+    recycled_quantiles,
+    suppressWarnings(
+      survival::qsurvreg(
+        probabilities,
+        mean = c(0, 1),
+        scale = c(1, 2),
+        distribution = "gaussian"
+      )
+    ),
+    tolerance = 1e-12
+  )
+
+  set.seed(20260822)
+  reference_draws <- suppressWarnings(
+    survival::rsurvreg(5, mean = c(0, 1), scale = c(1, 2), distribution = "gaussian")
+  )
+  reference_seed <- .Random.seed
+  set.seed(20260822)
+  expect_warning(
+    bridged_draws <- rsurvreg(
+      5,
+      mean = c(0, 1),
+      scale = c(1, 2),
+      distribution = "gaussian"
+    ),
+    "longer object length"
+  )
+  expect_equal(bridged_draws, reference_draws, tolerance = 1e-12)
+  expect_identical(.Random.seed, reference_seed)
+
+  set.seed(42)
+  reference_t_draws <- survival::rsurvreg(
+    4,
+    mean = 0.5,
+    scale = 1.2,
+    distribution = "t",
+    parms = 5
+  )
+  set.seed(42)
+  expect_equal(
+    rsurvreg(4, mean = 0.5, scale = 1.2, distribution = "t", parms = 5),
+    reference_t_draws,
+    tolerance = 1e-12
+  )
+  expect_error(dsurvreg(1, 0, distribution = "missing"), "Distribution not found")
+
   km <- survfit(Surv(time, status) ~ group, data = data)
   expect_s3_class(km, "survival_py_survfit")
   km_direct <- survfit.formula(Surv(time, status) ~ group, data = data)


### PR DESCRIPTION
## Summary
- evaluate R-facing survreg density, distribution, and quantile helpers with the package's vectorized distribution definitions
- preserve R recycling, names, warnings, boundary behavior, and error messages
- generate random survival times through R's RNG so `set.seed()` controls both draws and resulting RNG state
- add differential coverage for every built-in distribution, recycled inputs, and seeded Gaussian and Student-t draws

## Testing
- `.venv/bin/python -m pytest -q python/tests/` (1014 passed)
- `.venv/bin/ruff format python/ test/ --check`
- `.venv/bin/ruff check python/ test/`
- `.venv/bin/mypy python/survival/__init__.pyi python/survival/_survival.pyi --ignore-missing-imports`
- `.venv/bin/python scripts/generate_binding_manifest.py --check`
- `cargo fmt --all -- --check`
- `R CMD check --no-manual --no-build-vignettes r/survivalr` (standard source-directory NOTE only)
- `git diff --check`