### PR TITLE
Remove survobrien formula fallback

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -9423,6 +9423,88 @@ def _survobrien_event_sets(
     )
 
 
+def _survobrien_expand_columns(
+    stop: Any,
+    status: Any,
+    continuous: Mapping[str, Any],
+    *,
+    start: Any | None = None,
+    strata: Any | None = None,
+    transform: Any | None = None,
+) -> dict[str, Any]:
+    """Expand evaluated formula columns over O'Brien risk sets."""
+
+    stop_values = _float_vector(stop, "stop")
+    status_values = _integer_code_vector(status, "status", "0/1 event coding")
+    if len(status_values) != len(stop_values):
+        raise ValueError("status must have the same length as stop")
+    if any(value not in {0, 1} for value in status_values):
+        raise ValueError("status must use 0/1 event coding")
+
+    if start is None:
+        response = Surv(stop_values, status_values)
+    else:
+        start_values = _float_vector(start, "start")
+        if len(start_values) != len(stop_values):
+            raise ValueError("start must have the same length as stop")
+        response = Surv(start_values, stop_values, status_values)
+
+    strata_values = None if strata is None else _materialize_labels(strata, "strata")
+    if strata_values is not None and len(strata_values) != len(stop_values):
+        raise ValueError("strata must have the same length as stop")
+
+    continuous_columns: list[tuple[str, list[float]]] = []
+    for name, values in continuous.items():
+        column = _float_vector(values, str(name))
+        if len(column) != len(stop_values):
+            raise ValueError(f"{name} must have the same length as stop")
+        if any(not math.isfinite(value) for value in column):
+            raise ValueError(f"{name} must be finite")
+        continuous_columns.append((str(name), column))
+    if not continuous_columns:
+        raise ValueError("No continuous variables to modify")
+
+    row_indices, group_sizes, event_times, set_numbers = _survobrien_event_sets(
+        response,
+        strata_values,
+    )
+    if transform is None:
+        transformed_values = _core.survobrien_transform_groups(
+            [values for _name, values in continuous_columns],
+            row_indices,
+            group_sizes,
+        )
+    else:
+        transformed_values = []
+        for _name, values in continuous_columns:
+            output: list[float] = []
+            offset = 0
+            for group_size in group_sizes:
+                group_rows = row_indices[offset : offset + group_size]
+                output.extend(
+                    _survobrien_transform_values(
+                        [values[row] for row in group_rows],
+                        transform,
+                    )
+                )
+                offset += group_size
+            transformed_values.append(output)
+
+    return {
+        "row": row_indices,
+        "event_time": event_times,
+        "set": set_numbers,
+        "transformed": {
+            name: values
+            for (name, _source), values in zip(
+                continuous_columns,
+                transformed_values,
+                strict=True,
+            )
+        },
+    }
+
+
 def _survobrien_formula_frame(
     formula: str,
     data: Any,
@@ -9442,10 +9524,16 @@ def _survobrien_formula_frame(
     n = len(response)
     keepers, continuous = _survobrien_formula_terms(data, terms, n)
     strata_values = _combined_columns(data, terms.strata, n) if terms.strata else None
-    row_indices, group_sizes, event_times, set_numbers = _survobrien_event_sets(
-        response,
-        strata_values,
+    expanded = _survobrien_expand_columns(
+        response.time,
+        response.event,
+        dict(continuous),
+        start=response.start,
+        strata=strata_values,
+        transform=transform,
     )
+    row_indices = expanded["row"]
+    event_times = expanded["event_time"]
 
     frame: dict[str, list[Any]] = {}
     if response.type == "counting":
@@ -9464,32 +9552,10 @@ def _survobrien_formula_frame(
     if not terms.clusters:
         frame[".id."] = [idx + 1 for idx in row_indices]
 
-    if transform is None:
-        transformed_columns = _core.survobrien_transform_groups(
-            [values for _name, values in continuous],
-            row_indices,
-            group_sizes,
-        )
-        for (name, _values), output in zip(
-            continuous,
-            transformed_columns,
-            strict=True,
-        ):
-            frame[name] = output
-    else:
-        for name, values in continuous:
-            output = [0.0] * len(row_indices)
-            offset = 0
-            for group_size in group_sizes:
-                positions = range(offset, offset + group_size)
-                transformed = _survobrien_transform_values(
-                    [values[row_indices[pos]] for pos in positions],
-                    transform,
-                )
-                output[offset : offset + group_size] = transformed
-                offset += group_size
-            frame[name] = output
-    frame[".strata."] = set_numbers
+    transformed_columns = expanded["transformed"]
+    for name, _values in continuous:
+        frame[name] = transformed_columns[name]
+    frame[".strata."] = expanded["set"]
     return frame
 
 

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -4511,6 +4511,32 @@ def test_survobrien_group_transform_matches_python_reference():
             assert actual_column == pytest.approx(expected_column)
 
 
+def test_survobrien_expands_evaluated_formula_columns():
+    from survival.r_api import _survobrien_expand_columns
+
+    expanded = _survobrien_expand_columns(
+        [1.0, 2.0, 3.0, 4.0],
+        [1, 0, 1, 1],
+        {"x": [0.1, 0.4, 0.2, 0.8], "log(x)": [-2.0, -1.0, -1.5, -0.2]},
+    )
+
+    assert expanded["row"] == [0, 1, 2, 3, 2, 3, 3]
+    assert expanded["event_time"] == pytest.approx([1, 1, 1, 1, 3, 3, 4])
+    assert expanded["set"] == [1, 1, 1, 1, 2, 2, 3]
+    assert expanded["transformed"]["x"] == pytest.approx(
+        [
+            -1.9459101490553135,
+            0.5108256237659907,
+            -0.5108256237659907,
+            1.9459101490553132,
+            -1.0986122886681098,
+            1.0986122886681098,
+            0.0,
+        ]
+    )
+    assert len(expanded["transformed"]["log(x)"]) == 7
+
+
 def test_survobrien_event_sets_match_python_reference():
     def reference(
         stop: list[float],

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -4885,47 +4885,168 @@ finegray <- function(formula, data, weights, subset, na.action = na.pass,
   )
 }
 
-.survobrien_result_frame <- function(result, data) {
-  frame <- as.data.frame(result, check.names = TRUE, stringsAsFactors = FALSE)
-  if (ncol(frame) > 0L || length(result) == 0L) {
-    return(frame)
+.survobrien_formula_frame <- function(call, formula, data, data_missing,
+                                      transform, transform_missing, enclos) {
+  if (!transform_missing && length(transform(seq_len(10L))) != 10L) {
+    stop("Transform function must be 1 to 1", call. = FALSE)
   }
-  empty_columns <- lapply(names(result), function(column) {
-    if (column %in% names(data)) {
-      return(data[[column]][integer()])
-    }
-    if (column %in% c("status", ".id.", ".strata.")) {
-      return(integer())
-    }
-    numeric()
-  })
-  names(empty_columns) <- names(result)
-  as.data.frame(empty_columns, check.names = TRUE, stringsAsFactors = FALSE)
-}
 
-.survobrien_restore_row_names <- function(frame, call, formula, data, enclos) {
-  if (nrow(frame) <= 1L || !".id." %in% names(frame) ||
-      anyDuplicated(frame[[".id."]])) {
-    return(frame)
-  }
-  model_args <- match(
+  model_indices <- match(
     c("formula", "data", "subset", "na.action"),
     names(call),
     nomatch = 0L
   )
-  model_call <- call[c(1L, model_args[model_args > 0L])]
+  model_call <- call[c(1L, model_indices[model_indices > 0L])]
   model_call[[1L]] <- quote(stats::model.frame)
-  model_call$formula <- stats::terms(
-    formula,
-    c("strata", "cluster", "tt"),
-    data = data
-  )
-  model_rows <- row.names(eval(model_call, enclos))
-  output_rows <- model_rows[as.integer(frame[[".id."]])]
-  if (!identical(output_rows, as.character(seq_len(nrow(frame))))) {
-    row.names(frame) <- output_rows
+  specials <- c("strata", "cluster", "tt")
+  model_call$formula <- if (data_missing) {
+    stats::terms(formula, specials)
+  } else {
+    stats::terms(formula, specials, data = data)
   }
-  frame
+  model <- eval(model_call, enclos)
+  if (nrow(model) == 0L) {
+    stop("No (non-missing) observations", call. = FALSE)
+  }
+
+  terms <- attr(model, "terms")
+  response <- stats::model.response(model)
+  if (!inherits(response, "Surv")) {
+    stop("Response must be a survival object", call. = FALSE)
+  }
+  if (!attr(response, "type") %in% c("right", "counting")) {
+    stop("Response must be right censored or (start, stop] data", call. = FALSE)
+  }
+
+  cluster_terms <- untangle.specials(terms, "cluster")
+  if (length(cluster_terms$terms) > 0L) {
+    if (length(cluster_terms$terms) > 1L) {
+      stop("Can have only 1 cluster term", call. = FALSE)
+    }
+    idvar <- model[[cluster_terms$vars]]
+    terms_without_specials <- terms[-cluster_terms$tvar]
+  } else {
+    idvar <- seq_len(nrow(model))
+    terms_without_specials <- terms
+  }
+
+  strata_keep <- NULL
+  strata_terms <- NULL
+  if (length(attr(terms, "specials")$strata) > 0L) {
+    strata_terms <- untangle.specials(terms_without_specials, "strata", 1L)
+    if (length(strata_terms$terms) > 0L) {
+      terms_without_specials <- terms_without_specials[-strata_terms$terms]
+    }
+    strata_keep <- if (length(strata_terms$vars) == 1L) {
+      model[[strata_terms$vars]]
+    } else {
+      strata(model[, strata_terms$vars], shortlabel = TRUE)
+    }
+  }
+
+  if (any(attr(terms_without_specials, "order") > 1L)) {
+    stop("This function cannot deal with iteraction terms", call. = FALSE)
+  }
+  term_names <- attr(terms_without_specials, "term.labels")
+  factors <- vapply(model[term_names], is.factor, logical(1))
+  protected <- vapply(
+    model[term_names],
+    function(value) inherits(value, "AsIs"),
+    logical(1)
+  )
+  keepers <- factors | protected
+  if (all(keepers)) {
+    stop("No continuous variables to modify", call. = FALSE)
+  }
+
+  continuous_names <- term_names[!keepers]
+  response_columns <- ncol(response)
+  expanded <- .call_r_api(
+    "_survobrien_expand_columns",
+    stop = .as_python_vector(response[, response_columns - 1L]),
+    status = .as_python_vector(response[, response_columns]),
+    continuous = .as_python_data(model[continuous_names]),
+    start = if (response_columns == 3L) {
+      .as_python_vector(response[, 1L])
+    } else {
+      NULL
+    },
+    strata = if (is.null(strata_keep)) NULL else .as_python_vector(strata_keep),
+    transform = if (transform_missing) NULL else transform
+  )
+  row_indices <- as.integer(.result_field(expanded, "row")) + 1L
+  event_times <- as.numeric(.result_field(expanded, "event_time"))
+
+  if (response_columns == 3L) {
+    newdata <- list(response[row_indices, 1L], response[row_indices, 2L])
+    newdata <- c(newdata, list(as.integer(
+      newdata[[2L]] == event_times & response[row_indices, 3L] == 1
+    )))
+  } else {
+    newdata <- list(response[row_indices, 1L])
+    newdata <- c(newdata, list(as.integer(
+      newdata[[1L]] == event_times & response[row_indices, 2L] == 1
+    )))
+  }
+  names(newdata) <- dimnames(response)[[2L]]
+
+  formula_environment <- environment(formula)
+  if (is.null(formula_environment)) {
+    formula_environment <- enclos
+  }
+  keeper_names <- if (any(keepers)) {
+    unlist(lapply(term_names[keepers], function(term) {
+      all.vars(parse(text = term))
+    }))
+  } else {
+    NULL
+  }
+  if (length(strata_keep) > 0L) {
+    keeper_names <- c(keeper_names, unlist(lapply(
+      names(model)[strata_terms$vars],
+      function(term) all.vars(parse(text = term))
+    )))
+  }
+  if (length(keeper_names) > 0L) {
+    source <- if (data_missing) {
+      values <- lapply(keeper_names, function(name) {
+        eval(as.name(name), formula_environment)
+      })
+      names(values) <- keeper_names
+      values
+    } else {
+      data[keeper_names]
+    }
+    newdata <- c(newdata, lapply(source, function(value) value[row_indices]))
+  }
+  if (length(cluster_terms$vars) > 0L) {
+    cluster_names <- all.vars(parse(text = names(model)[cluster_terms$vars]))
+    if (length(cluster_names) > 0L) {
+      source <- if (data_missing) {
+        values <- lapply(cluster_names, function(name) {
+          eval(as.name(name), formula_environment)
+        })
+        names(values) <- cluster_names
+        values
+      } else {
+        data[cluster_names]
+      }
+      newdata <- c(newdata, lapply(source, function(value) value[row_indices]))
+    }
+  } else {
+    newdata <- c(newdata, list(.id. = idvar[row_indices]))
+  }
+
+  transformed <- .result_field(expanded, "transformed")
+  transformed_columns <- lapply(continuous_names, function(name) {
+    as.numeric(transformed[[name]])
+  })
+  names(transformed_columns) <- continuous_names
+  data.frame(c(
+    newdata,
+    transformed_columns,
+    list(.strata. = as.integer(.result_field(expanded, "set")))
+  ))
 }
 
 survobrien <- function(formula, data, subset, na.action, transform,
@@ -4938,27 +5059,18 @@ survobrien <- function(formula, data, subset, na.action, transform,
     direct_time <- formula
   }
   if (is.null(direct_time)) {
-    if (.survobrien_formula_python_eligible(formula, data)) {
-      result <- .call_r_api(
-        "survobrien",
-        .as_formula_string(formula),
-        data = .as_python_data(data),
-        subset = if (missing(subset)) NULL else subset,
-        `na_action` = if (missing(na.action)) NULL else .as_na_action(na.action),
-        transform = if (missing(transform)) NULL else transform
-      )
-      frame <- .survobrien_result_frame(result, data)
-      frame <- .survobrien_restore_row_names(
-        frame,
-        call,
-        formula,
-        data,
-        parent.frame()
-      )
-      return(.restore_r_column_classes(frame, data))
+    if (missing(formula)) {
+      stop("A formula argument is required", call. = FALSE)
     }
-    call[[1L]] <- quote(survival::survobrien)
-    return(eval.parent(call))
+    return(.survobrien_formula_frame(
+      call,
+      formula,
+      if (missing(data)) NULL else data,
+      missing(data),
+      if (missing(transform)) NULL else transform,
+      missing(transform),
+      parent.frame()
+    ))
   }
   if (missing(status) || missing(covariate)) {
     stop("direct survobrien bridge requires time, status, and covariate", call. = FALSE)
@@ -4979,68 +5091,6 @@ survobrien <- function(formula, data, subset, na.action, transform,
     expected = as.numeric(.result_field(result, "expected")),
     variance = as.numeric(.result_field(result, "variance"))
   )
-}
-
-.survobrien_formula_supported_term <- function(label, data) {
-  if (label %in% names(data)) {
-    value <- data[[label]]
-    return(is.factor(value) || (is.numeric(value) && !inherits(value, "AsIs")))
-  }
-  match <- regexec(
-    paste0(
-      "^(log|sqrt|exp|identity|as\\.numeric|factor|as\\.factor)",
-      "\\(([[:space:]]*[^()]+[[:space:]]*)\\)$"
-    ),
-    label
-  )
-  pieces <- regmatches(label, match)[[1L]]
-  if (length(pieces) == 0L) {
-    return(FALSE)
-  }
-  transform <- pieces[[2L]]
-  column <- trimws(pieces[[3L]])
-  if (transform %in% c("factor", "as.factor")) {
-    return(
-      column %in% names(data) &&
-        (is.factor(data[[column]]) ||
-          is.character(data[[column]]) ||
-          is.numeric(data[[column]]) ||
-          is.logical(data[[column]]))
-    )
-  }
-  column %in% names(data) && is.numeric(data[[column]]) && !is.factor(data[[column]])
-}
-
-.survobrien_formula_python_eligible <- function(formula, data) {
-  if (!inherits(formula, "formula") || missing(data) || is.null(data)) {
-    return(FALSE)
-  }
-  terms <- stats::terms(formula, specials = c("strata", "cluster", "tt"), data = data)
-  if (any(attr(terms, "order") > 1L)) {
-    return(FALSE)
-  }
-  specials <- attr(terms, "specials")
-  if (length(specials$cluster) > 1L || length(specials$tt) > 0L) {
-    return(FALSE)
-  }
-  labels <- attr(terms, "term.labels")
-  labels <- labels[!grepl("^(strata|cluster)\\(", labels)]
-  if (length(labels) == 0L) {
-    return(FALSE)
-  }
-  factor_terms <- vapply(
-    labels,
-    function(label) {
-      (label %in% names(data) && is.factor(data[[label]])) ||
-        grepl("^(factor|as\\.factor)\\(", label)
-    },
-    logical(1)
-  )
-  if (any(factor_terms) && length(specials$strata) > 0L &&
-      length(specials$cluster) > 0L) {
-    return(FALSE)
-  }
-  all(vapply(labels, .survobrien_formula_supported_term, logical(1), data = data))
 }
 
 fromtimeline <- function(formula, data, subset, id, repeated = FALSE,

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -5820,7 +5820,6 @@ test_that("data-prep helpers match R survival shapes", {
     keeper = factor(group, levels = c("b", "a"))
   )
   factor_formula <- survival::Surv(time, status) ~ x + keeper
-  expect_true(.survobrien_formula_python_eligible(factor_formula, obrien_factor_data))
   bridged_obrien_factor <- survobrien(factor_formula, data = obrien_factor_data)
   reference_obrien_factor <- survival::survobrien(
     factor_formula,
@@ -5830,10 +5829,6 @@ test_that("data-prep helpers match R survival shapes", {
   expect_equal(levels(bridged_obrien_factor$keeper), c("b", "a"))
   expect_equal(bridged_obrien_factor, reference_obrien_factor)
   factor_strata_formula <- survival::Surv(time, status) ~ x + keeper + strata(group)
-  expect_true(.survobrien_formula_python_eligible(
-    factor_strata_formula,
-    obrien_factor_data
-  ))
   expect_equal(
     survobrien(factor_strata_formula, data = obrien_factor_data),
     survival::survobrien(factor_strata_formula, data = obrien_factor_data)
@@ -5842,7 +5837,6 @@ test_that("data-prep helpers match R survival shapes", {
     wrapper_formula <- stats::as.formula(paste0(
       "survival::Surv(time, status) ~ x + ", wrapper, "(group) + strata(group)"
     ))
-    expect_true(.survobrien_formula_python_eligible(wrapper_formula, obrien_factor_data))
     expect_equal(
       survobrien(wrapper_formula, data = obrien_factor_data),
       survival::survobrien(wrapper_formula, data = obrien_factor_data)
@@ -5885,12 +5879,6 @@ test_that("data-prep helpers match R survival shapes", {
   )
   obrien_counting_data$keeper <- factor(c("a", "a", "b", "b"))
   counting_factor_formula <- survival::Surv(start, stop, status) ~ x + keeper
-  expect_true(
-    .survobrien_formula_python_eligible(
-      counting_factor_formula,
-      obrien_counting_data
-    )
-  )
   expect_equal(
     survobrien(counting_factor_formula, data = obrien_counting_data),
     survival::survobrien(counting_factor_formula, data = obrien_counting_data)
@@ -5918,16 +5906,86 @@ test_that("data-prep helpers match R survival shapes", {
   )
   counting_factor_strata_formula <-
     survival::Surv(start, stop, status) ~ x + keeper + strata(group)
-  expect_true(.survobrien_formula_python_eligible(
-    counting_factor_strata_formula,
-    obrien_counting_strata_data
-  ))
   expect_equal(
     survobrien(counting_factor_strata_formula, data = obrien_counting_strata_data),
     survival::survobrien(
       counting_factor_strata_formula,
       data = obrien_counting_strata_data
     )
+  )
+  obrien_expression_formula <-
+    survival::Surv(time, status) ~ x + I(off^2)
+  expect_equal(
+    survobrien(obrien_expression_formula, data = obrien_factor_data),
+    survival::survobrien(obrien_expression_formula, data = obrien_factor_data)
+  )
+  obrien_combined_formula <-
+    survival::Surv(time, status) ~ x + keeper + strata(group) + cluster(id)
+  expect_equal(
+    survobrien(obrien_combined_formula, data = obrien_factor_data),
+    survival::survobrien(obrien_combined_formula, data = obrien_factor_data)
+  )
+  obrien_na_data <- obrien_factor_data
+  obrien_na_data$off[[3L]] <- NA_real_
+  expect_equal(
+    survobrien(
+      obrien_expression_formula,
+      data = obrien_na_data,
+      subset = time != 2,
+      na.action = stats::na.omit
+    ),
+    survival::survobrien(
+      obrien_expression_formula,
+      data = obrien_na_data,
+      subset = time != 2,
+      na.action = stats::na.omit
+    )
+  )
+  obrien_environment_result <- local({
+    time <- obrien_data$time
+    status <- obrien_data$status
+    x <- obrien_data$x
+    formula <- survival::Surv(time, status) ~ sqrt(x)
+    list(
+      bridged = survobrien(formula),
+      reference = survival::survobrien(formula)
+    )
+  })
+  expect_equal(
+    obrien_environment_result$bridged,
+    obrien_environment_result$reference
+  )
+
+  obrien_error <- function(expression) {
+    tryCatch(force(expression), error = function(condition) conditionMessage(condition))
+  }
+  invalid_obrien_formulas <- list(
+    survival::Surv(time, status) ~ x * off,
+    survival::Surv(time, status) ~ x + cluster(id) + cluster(group),
+    survival::Surv(time, status) ~ keeper,
+    time ~ x,
+    survival::Surv(time, status, type = "left") ~ x
+  )
+  for (invalid_formula in invalid_obrien_formulas) {
+    expect_identical(
+      obrien_error(survobrien(invalid_formula, data = obrien_factor_data)),
+      obrien_error(survival::survobrien(
+        invalid_formula,
+        data = obrien_factor_data
+      ))
+    )
+  }
+  expect_identical(
+    obrien_error(survobrien(
+      survival::Surv(time, status) ~ x,
+      data = obrien_data,
+      transform = function(value) value[[1L]]
+    )),
+    obrien_error(survival::survobrien(
+      survival::Surv(time, status) ~ x,
+      data = obrien_data,
+      transform = function(value) value[[1L]]
+    ))
   )
 
   condense_data <- data.frame(


### PR DESCRIPTION
## Summary
- evaluate survobrien formulas with R model-frame semantics instead of a term whitelist
- reuse the Rust-backed event-set and grouped-transform kernels for both language frontends
- preserve factors, protected expressions, strata, clusters, subsets, row names, and reference error behavior

## Testing
- `.venv/bin/python -m pytest -q python/tests/`
- `.venv/bin/ruff format --check python/survival/r_api.py python/tests/test_r_api.py`
- `.venv/bin/ruff check python/survival/r_api.py python/tests/test_r_api.py`
- `.venv/bin/mypy python/survival`
- `.venv/bin/python scripts/generate_binding_manifest.py --check`
- `cargo fmt --all -- --check` (Rust 1.94.0)
- `R CMD check --no-manual --no-build-vignettes r/survivalr` (standard source-directory NOTE only)
- `git diff --check`