### PR TITLE
Support finegray environment formulas

### DIFF
--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -239,6 +239,24 @@ if (getRversion() >= "2.15.1") {
   data
 }
 
+.formula_environment_data <- function(formula, enclos) {
+  formula_environment <- environment(formula)
+  if (is.null(formula_environment)) {
+    formula_environment <- enclos
+  }
+  variables <- unique(all.vars(formula))
+  values <- lapply(variables, function(name) {
+    eval(as.name(name), formula_environment)
+  })
+  names(values) <- variables
+  as.data.frame(
+    values,
+    optional = TRUE,
+    check.names = FALSE,
+    stringsAsFactors = FALSE
+  )
+}
+
 .eval_formula_dots <- function(dots, data, env, vector_args = character()) {
   if (is.null(dots) || length(dots) == 0L) {
     return(list())
@@ -4815,26 +4833,29 @@ finegray <- function(formula, data, weights, subset, na.action = na.pass,
     direct_start <- formula
   }
   if (is.null(direct_start)) {
-    if (missing(formula) || missing(data) || is.null(data) || !inherits(formula, "formula")) {
-      call <- match.call()
-      call[[1L]] <- quote(survival::finegray)
-      return(eval.parent(call))
+    if (missing(formula)) {
+      stop("A formula argument is required", call. = FALSE)
     }
     env <- parent.frame()
+    formula_data <- if (missing(data) || is.null(data)) {
+      .formula_environment_data(formula, env)
+    } else {
+      data
+    }
     weight_values <- .eval_formula_arg(
-      substitute(weights), missing(weights), data, env, vector = TRUE
+      substitute(weights), missing(weights), formula_data, env, vector = TRUE
     )
     subset_values <- .as_python_formula_subset(
-      .eval_formula_arg(substitute(subset), missing(subset), data, env),
-      data
+      .eval_formula_arg(substitute(subset), missing(subset), formula_data, env),
+      formula_data
     )
     id_values <- .eval_formula_arg(
-      substitute(id), missing(id), data, env, vector = TRUE
+      substitute(id), missing(id), formula_data, env, vector = TRUE
     )
     result <- .call_r_api(
       "finegray",
       .as_formula_string(formula),
-      data = .as_python_data(data),
+      data = .as_python_data(formula_data),
       weights = weight_values,
       subset = subset_values,
       `na_action` = .as_na_action(na.action),

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -5558,6 +5558,57 @@ test_that("data-prep helpers match R survival shapes", {
     etype = "a"
   ))
   expect_equal(bridged_finegray_formula, reference_finegray_formula)
+  finegray_environment_fixture <- local({
+    time <- seq_len(8L)
+    status <- factor(
+      c("a", "censored", "b", "a", "censored", "b", "a", "censored"),
+      levels = c("censored", "a", "b")
+    )
+    keeper <- ordered(
+      c("z", "a", "z", "a", "z", "a", "z", "a"),
+      levels = c("z", "a")
+    )
+    x <- c(1, 2, 3, 4, NA, 6, 7, 8)
+    wt <- c(1, 2, 1, 3, 1, 2, 1, 4)
+    list(
+      formula = Surv(time, status) ~ keeper + I(x^2),
+      weights = wt
+    )
+  })
+  bridged_finegray_environment <- finegray(
+    finegray_environment_fixture$formula,
+    weights = finegray_environment_fixture$weights,
+    subset = seq_len(7L),
+    na.action = stats::na.omit,
+    etype = "a",
+    count = "extra rows"
+  )
+  reference_finegray_environment <- survival::finegray(
+    finegray_environment_fixture$formula,
+    weights = finegray_environment_fixture$weights,
+    subset = seq_len(7L),
+    na.action = stats::na.omit,
+    etype = "a",
+    count = "extra rows"
+  )
+  expect_s3_class(bridged_finegray_environment$keeper, "ordered")
+  expect_s3_class(bridged_finegray_environment[["I(x^2)"]], "AsIs")
+  expect_equal(bridged_finegray_environment, reference_finegray_environment)
+  expect_equal(
+    finegray(
+      finegray_environment_fixture$formula,
+      data = NULL,
+      na.action = stats::na.omit,
+      etype = "b"
+    ),
+    survival::finegray(
+      finegray_environment_fixture$formula,
+      data = NULL,
+      na.action = stats::na.omit,
+      etype = "b"
+    )
+  )
+  expect_error(finegray(), "A formula argument is required")
   finegray_extended_data <- data.frame(
     time = c(5, 8, 10, 12, 7, 11),
     status = factor(


### PR DESCRIPTION
## Summary
- materialize formula variables from the formula environment when `data` is omitted or `NULL`
- route those inputs through the existing Rust-backed Fine-Gray expansion path
- preserve ordered factors, protected expressions, weights, subsets, missing-value handling, endpoints, and count columns

## Testing
- `.venv/bin/python -m pytest -q python/tests/`
- `.venv/bin/ruff format --check python`
- `.venv/bin/ruff check python`
- `.venv/bin/mypy python/survival`
- `.venv/bin/python scripts/generate_binding_manifest.py --check`
- `cargo fmt --all -- --check` (Rust 1.94.0)
- `R CMD check --no-manual --no-build-vignettes r/survivalr` (standard source-directory NOTE only)
- `git diff --check`