### PR TITLE
Support pyears environment formulas

### DIFF
--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -4057,7 +4057,7 @@ survexp <- function(formula, data, weights, subset, na.action, rmap, times,
 }
 
 .pyears_formula_python_eligible <- function(formula, data, rmap, ratetable) {
-  if (!inherits(formula, "formula") || missing(data) || is.null(data)) {
+  if (!inherits(formula, "formula")) {
     return(FALSE)
   }
   if (!missing(ratetable)) {
@@ -4283,13 +4283,22 @@ pyears <- function(formula, data, weights, subset, na.action, rmap, ratetable,
   expect <- match.arg(expect)
   if (is.null(direct_time) && missing(start) && missing(stop)) {
     if (!missing(formula) && .pyears_formula_python_eligible(formula, data, rmap, ratetable)) {
-      output_terms <- stats::terms(formula, data = data)
+      environment_data <- missing(data) || is.null(data)
+      output_terms <- if (environment_data) {
+        stats::terms(formula)
+      } else {
+        stats::terms(formula, data = data)
+      }
       has_ratetable <- !missing(ratetable)
       model_formula <- formula
       model_env <- new.env(parent = environment(model_formula))
       model_env$Surv <- .survsplit_model_frame_surv
       environment(model_formula) <- model_env
-      formula_terms <- stats::terms(model_formula, data = data)
+      formula_terms <- if (environment_data) {
+        stats::terms(model_formula)
+      } else {
+        stats::terms(model_formula, data = data)
+      }
       if (any(attr(formula_terms, "order") > 1L)) {
         stop("Pyears cannot have interaction terms", call. = FALSE)
       }
@@ -4332,10 +4341,15 @@ pyears <- function(formula, data, weights, subset, na.action, rmap, ratetable,
             paste(new_variables, collapse = "+"),
             sep = "+"
           )
-          formula_terms <- stats::terms(
-            stats::as.formula(expanded_formula, environment(formula_terms)),
-            data = data
+          expanded_formula <- stats::as.formula(
+            expanded_formula,
+            environment(formula_terms)
           )
+          formula_terms <- if (environment_data) {
+            stats::terms(expanded_formula)
+          } else {
+            stats::terms(expanded_formula, data = data)
+          }
         }
       }
       model_call <- match.call()[c(1L, match(

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -4936,6 +4936,36 @@ test_that("data-prep helpers match R survival shapes", {
   expect_equal(bridged_pyears_formula$n, reference_pyears_formula$n)
   expect_equal(bridged_pyears_formula$event, reference_pyears_formula$event)
   expect_s3_class(bridged_pyears_formula$terms, "terms")
+  pyears_environment_fixture <- local({
+    time <- c(10, 20, 30, 40)
+    status <- c(1, 0, 1, 1)
+    group <- factor(c("treated", "treated", "control", "control"))
+    wt <- c(1, 2, 3, 4)
+    list(
+      formula = Surv(time, status) ~ group,
+      weights = wt
+    )
+  })
+  bridged_pyears_environment <- pyears(
+    pyears_environment_fixture$formula,
+    weights = pyears_environment_fixture$weights,
+    scale = 1,
+    data.frame = TRUE
+  )
+  reference_pyears_environment <- survival::pyears(
+    pyears_environment_fixture$formula,
+    weights = pyears_environment_fixture$weights,
+    scale = 1,
+    data.frame = TRUE
+  )
+  expect_equal(
+    bridged_pyears_environment$data,
+    reference_pyears_environment$data
+  )
+  expect_equal(
+    bridged_pyears_environment$offtable,
+    reference_pyears_environment$offtable
+  )
   pyears_order_data <- data.frame(
     time = c(10, 20, 30, 40),
     status = c(1, 0, 1, 1),
@@ -5341,6 +5371,39 @@ test_that("data-prep helpers match R survival shapes", {
     age = c(45, 55, 65, 75) * 365.25,
     sex = factor(c("male", "female", "male", "female")),
     year = as.Date(c("1995-03-01", "2000-07-01", "2005-11-01", "2010-01-01"))
+  )
+  pyears_ratetable_environment <- local({
+    time <- pyears_ratetable_data$time
+    status <- pyears_ratetable_data$status
+    group <- pyears_ratetable_data$group
+    age <- pyears_ratetable_data$age
+    sex <- pyears_ratetable_data$sex
+    year <- pyears_ratetable_data$year
+    survival::Surv(time, status) ~ group
+  })
+  bridged_pyears_ratetable_environment <- pyears(
+    pyears_ratetable_environment,
+    ratetable = survival::survexp.us,
+    scale = 365.25
+  )
+  reference_pyears_ratetable_environment <- survival::pyears(
+    pyears_ratetable_environment,
+    ratetable = survival::survexp.us,
+    scale = 365.25
+  )
+  expect_equal(
+    bridged_pyears_ratetable_environment$pyears,
+    reference_pyears_ratetable_environment$pyears,
+    tolerance = 1e-12
+  )
+  expect_equal(
+    bridged_pyears_ratetable_environment$expected,
+    reference_pyears_ratetable_environment$expected,
+    tolerance = 1e-12
+  )
+  expect_equal(
+    bridged_pyears_ratetable_environment$event,
+    reference_pyears_ratetable_environment$event
   )
   for (expected_scale in c("event", "pyears")) {
     bridged_ratetable <- pyears(


### PR DESCRIPTION
## Summary
- evaluate pyears formulas from their captured environment when `data` is omitted or `NULL`
- keep ordinary grouped calculations on the existing accelerated path
- support environment-backed R rate-table mappings without delegating the calculation

## Testing
- `.venv/bin/python -m pytest -q python/tests/`
- `.venv/bin/ruff format --check python`
- `.venv/bin/ruff check python`
- `.venv/bin/mypy python/survival`
- `.venv/bin/python scripts/generate_binding_manifest.py --check`
- `cargo fmt --all -- --check` (Rust 1.94.0)
- `R CMD check --no-manual --no-build-vignettes r/survivalr` (standard source-directory NOTE only)
- `git diff --check`