### PR TITLE
Support Cox rate models in survexp

### DIFF
--- a/python/survival/_binding_manifest.py
+++ b/python/survival/_binding_manifest.py
@@ -966,6 +966,7 @@ BINDINGS = (
     "survcondense_plan",
     "survdiff2",
     "survexp",
+    "survexp_cox_aggregate",
     "survexp_from_coords",
     "survexp_individual",
     "survexp_individual_from_coords",

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -8268,6 +8268,85 @@ def survexp_individual(
     ]
 
 
+def _survexp_cox_fit(
+    fit: Any,
+    data: Any,
+    followup: Any,
+    group: Any,
+    method: str,
+    weights: Any,
+) -> dict[str, Any]:
+    """Aggregate expected-survival curves from a fitted Cox model."""
+
+    followup_values = _float_vector(followup, "followup")
+    group_values = _int_vector(group, "group")
+    weight_values = _float_vector(weights, "weights")
+    n = len(followup_values)
+    if len(group_values) != n or len(weight_values) != n:
+        raise ValueError("followup, group, and weights must have the same length")
+    if any(value < 1 for value in group_values):
+        raise ValueError("group values must be positive integers")
+    if any(not math.isfinite(value) for value in weight_values):
+        raise ValueError("weights must be finite")
+    if method not in {"ederer", "hakulinen", "conditional", "individual"}:
+        raise ValueError("unsupported Cox survexp method")
+
+    rows, offsets = _prediction_inputs(fit, data)
+    if rows is None or len(rows) != n:
+        raise ValueError("Cox survexp data must match followup rows")
+    result = _cox_survfit_result(
+        fit,
+        rows,
+        offsets,
+        True,
+        data,
+        include_censor=False,
+        compute_confidence=False,
+    )
+    if len(result.surv) != n or len(result.cumhaz) != n:
+        raise ValueError("Cox survival curves do not match followup rows")
+
+    if method == "individual":
+        survival = [
+            _core.step_values_at(result.time, curve, [time], 1.0)[0]
+            for curve, time in zip(result.surv, followup_values, strict=True)
+        ]
+        cumulative_hazard = [
+            _core.step_values_at(result.time, curve, [time], 0.0)[0]
+            for curve, time in zip(result.cumhaz, followup_values, strict=True)
+        ]
+        return {
+            "time": [],
+            "surv": survival,
+            "cumhaz": cumulative_hazard,
+            "n": None,
+        }
+
+    if n == 1:
+        return {
+            "time": list(result.time),
+            "surv": [list(result.surv[0])],
+            "cumhaz": None,
+            "n": _model_row_count(fit),
+        }
+
+    survival_by_group, group_sizes = _core.survexp_cox_aggregate(
+        result.time,
+        result.surv,
+        result.cumhaz,
+        followup_values,
+        group_values,
+        weight_values,
+        method,
+    )
+    return {
+        "time": list(result.time),
+        "surv": survival_by_group,
+        "cumhaz": None,
+        "n": group_sizes,
+    }
+
+
 def _pyears_response_from_direct(
     response: Any,
     *,

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -3798,6 +3798,74 @@ def test_survexp_ederer_keeps_the_full_reference_cohort():
     assert ederer.surv == pytest.approx(expected_ederer)
 
 
+def test_survexp_cox_fit_aggregates_profile_curves():
+    survexp_cox_fit = survival.r_api._survexp_cox_fit
+
+    training = {
+        "time": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+        "status": [1, 1, 0, 1, 0, 1, 1, 0],
+        "x": [-1.0, -0.7, -0.3, 0.0, 0.3, 0.6, 0.9, 1.2],
+    }
+    fit = survival.coxph("Surv(time, status) ~ x", data=training)
+    profiles = {"x": [-0.5, 0.25, 1.0]}
+    curves = survival.survfit(fit, newdata=profiles, se_fit=False, censor=False)
+    ederer = survexp_cox_fit(
+        fit,
+        profiles,
+        [10.0, 10.0, 10.0],
+        [1, 1, 2],
+        "ederer",
+        [1.0, 3.0, 2.0],
+    )
+    individual = survexp_cox_fit(
+        fit,
+        profiles,
+        [2.5, 4.5, 7.5],
+        [1, 1, 2],
+        "individual",
+        [1.0, 1.0, 1.0],
+    )
+
+    assert ederer["time"] == curves.time
+    assert ederer["n"] == [2, 1]
+    assert ederer["surv"][0] == pytest.approx(
+        [
+            0.25 * left + 0.75 * right
+            for left, right in zip(curves.surv[0], curves.surv[1], strict=True)
+        ]
+    )
+    assert ederer["surv"][1] == pytest.approx(curves.surv[2])
+    assert individual["surv"] == pytest.approx(
+        [
+            survival._survival.step_values_at(curves.time, curve, [time], 1.0)[0]
+            for curve, time in zip(curves.surv, [2.5, 4.5, 7.5], strict=True)
+        ]
+    )
+    single = survexp_cox_fit(
+        fit,
+        {"x": [-0.5]},
+        [0.5],
+        [1],
+        "conditional",
+        [0.0],
+    )
+    assert single["time"] == curves.time
+    assert single["surv"][0] == pytest.approx(curves.surv[0])
+    assert single["n"] == len(training["time"])
+    for method in ("hakulinen", "conditional"):
+        result = survexp_cox_fit(
+            fit,
+            profiles,
+            [10.0, 10.0, 10.0],
+            [1, 1, 2],
+            method,
+            [1.0, 3.0, 2.0],
+        )
+        assert result["time"] == curves.time
+        assert result["n"] is None
+        assert all(math.isfinite(value) for curve in result["surv"] for value in curve)
+
+
 def test_r_style_cipoisson_uses_rust_scalar_kernel_with_r_recycling():
     scalar = survival.cipoisson(5, time=10.0)
     vector = survival.cipoisson([0, 5, 20], time=[1.0, 10.0, 4.0])

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -3701,6 +3701,225 @@ blog <- function(edge = 0.05) {
   }
 }
 
+.survexp_formula_cox <- function(Call, evaluation_env, fit,
+                                 times_missing, method_missing,
+                                 cohort_missing, conditional_missing,
+                                 se_fit_missing, method, cohort,
+                                 conditional, scale, se_fit, model, x, y) {
+  model_args <- match(
+    c("formula", "data", "weights", "subset", "na.action"),
+    names(Call),
+    nomatch = 0L
+  )
+  if (model_args[[1L]] == 0L) {
+    stop("A formula argument is required", call. = FALSE)
+  }
+  model_call <- Call[c(1L, model_args)]
+  model_call[[1L]] <- quote(stats::model.frame)
+  formula_value <- eval(Call$formula, evaluation_env)
+  Terms <- if ("data" %in% names(Call)) {
+    stats::terms(formula_value, data = eval(Call$data, evaluation_env))
+  } else {
+    stats::terms(formula_value)
+  }
+
+  rate_call <- if ("rmap" %in% names(Call)) Call$rmap else NULL
+  if (!is.null(rate_call) && (!is.call(rate_call) || rate_call[[1L]] != as.name("list"))) {
+    stop("Invalid rate-call argument", call. = FALSE)
+  }
+  rate_terms <- stats::delete.response(stats::terms(fit))
+  varlist <- all.vars(rate_terms)
+  mapped <- match(names(rate_call)[-1L], varlist)
+  if (any(is.na(mapped))) {
+    stop(
+      "Variable not found in the ratetable: ",
+      names(rate_call)[-1L][is.na(mapped)],
+      call. = FALSE
+    )
+  }
+  if (any(!(varlist %in% names(rate_call)))) {
+    missing_vars <- varlist[!(varlist %in% names(rate_call))]
+    additions <- paste(paste(missing_vars, missing_vars, sep = "="), collapse = ",")
+    if (is.null(rate_call)) {
+      rate_call <- parse(text = paste0("list(", additions, ")"))[[1L]]
+    } else {
+      rate_call <- parse(text = paste0(
+        "c(", paste(deparse(rate_call), collapse = ""),
+        ",list(", additions, "))"
+      ))[[1L]]
+    }
+  }
+  new_variables <- all.vars(rate_call)
+  if (length(new_variables) > 0L) {
+    expanded_formula <- paste(
+      paste(deparse(Terms), collapse = ""),
+      paste(new_variables, collapse = "+"),
+      sep = "+"
+    )
+    model_call$formula <- stats::as.formula(
+      expanded_formula,
+      environment(Terms)
+    )
+  }
+
+  model_frame <- eval(model_call, evaluation_env)
+  n <- nrow(model_frame)
+  if (n == 0L) {
+    stop("Data set has 0 rows", call. = FALSE)
+  }
+  if (!se_fit_missing && isTRUE(se_fit)) {
+    warning("se.fit value ignored")
+  }
+  weights <- stats::model.weights(model_frame)
+  if (length(weights) == 0L) {
+    weights <- rep(1, n)
+  }
+  if (any(attr(Terms, "order") > 1L)) {
+    stop("Survexp cannot have interaction terms", call. = FALSE)
+  }
+
+  requested_times <- if (times_missing) NULL else as.numeric(eval(Call$times, evaluation_env))
+  if (!times_missing) {
+    if (any(requested_times < 0)) {
+      stop("Invalid time point requested", call. = FALSE)
+    }
+    if (length(requested_times) > 1L && any(diff(requested_times) < 0)) {
+      stop("Times must be in increasing order", call. = FALSE)
+    }
+  }
+  response <- stats::model.response(model_frame)
+  no_response <- is.null(response)
+  if (!no_response) {
+    if (is.matrix(response)) {
+      if (inherits(response, "Surv") && attr(response, "type") == "right") {
+        response <- response[, 1L]
+      } else {
+        stop("Illegal response value", call. = FALSE)
+      }
+    }
+    if (any(response < 0)) {
+      stop("Negative follow up time", call. = FALSE)
+    }
+  }
+
+  if (!method_missing) {
+    method <- match.arg(method, c(
+      "ederer", "hakulinen", "conditional", "individual.h", "individual.s"
+    ))
+  } else {
+    method <- if (!conditional_missing && isTRUE(conditional)) {
+      "conditional"
+    } else if (no_response) {
+      "ederer"
+    } else {
+      "hakulinen"
+    }
+    if (!cohort_missing && !isTRUE(cohort)) {
+      method <- "individual.s"
+    }
+  }
+  if (no_response && method != "ederer") {
+    stop("a response is required in the formula unless method='ederer'", call. = FALSE)
+  }
+
+  output_variables <- attr(Terms, "term.labels")
+  rate_data <- data.frame(eval(rate_call, model_frame), stringsAsFactors = TRUE)
+  groups <- if (length(output_variables) == 0L) {
+    rep(1L, n)
+  } else {
+    for (variable in output_variables) {
+      if (inherits(model_frame[[variable]], "tcut")) {
+        stop("Can't use tcut variables in expected survival", call. = FALSE)
+      }
+    }
+    strata(model_frame[output_variables])
+  }
+  raw <- .call_r_api(
+    "_survexp_cox_fit",
+    fit,
+    .as_python_data(rate_data),
+    followup = as.list(.as_python_vector(
+      if (no_response) rep(Inf, n) else response
+    )),
+    group = as.list(as.integer(groups)),
+    method = if (startsWith(method, "individual")) "individual" else method,
+    weights = as.list(.as_python_vector(weights))
+  )
+
+  if (startsWith(method, "individual")) {
+    values <- if (method == "individual.s") {
+      .as_numeric_vector(.result_field(raw, "surv"))
+    } else {
+      .as_numeric_vector(.result_field(raw, "cumhaz"))
+    }
+    names(values) <- row.names(model_frame)
+    omitted <- attr(model_frame, "na.action")
+    return(if (length(omitted)) stats::naresid(omitted, values) else values)
+  }
+
+  raw_time <- .as_numeric_vector(.result_field(raw, "time"))
+  raw_survival <- lapply(.result_field(raw, "surv"), .as_numeric_vector)
+  survival <- do.call(cbind, raw_survival)
+  n_risk <- .result_field(raw, "n")
+  if (!is.null(n_risk)) {
+    n_risk <- if (n == 1L) {
+      as.integer(n_risk)
+    } else {
+      matrix(
+        rep(as.integer(.as_numeric_vector(n_risk)), each = length(raw_time)),
+        nrow = length(raw_time)
+      )
+    }
+  }
+  if (times_missing) {
+    new_time <- raw_time
+  } else {
+    keep <- stats::approx(
+      raw_time,
+      seq_along(raw_time),
+      xout = requested_times,
+      yleft = 0,
+      method = "constant",
+      f = 0,
+      rule = 2
+    )$y
+    survival <- rbind(1, survival)[keep + 1L, , drop = FALSE]
+    if (!is.null(n_risk)) {
+      n_risk <- if (is.matrix(n_risk)) {
+        n_risk[pmax(1L, keep), , drop = FALSE]
+      } else {
+        n_risk[pmax(1L, keep)]
+      }
+    }
+    new_time <- requested_times
+  }
+  new_time <- new_time / scale
+  if (length(output_variables) > 0L) {
+    dimnames(survival) <- list(NULL, levels(groups))
+  }
+  out <- list(
+    call = Call,
+    surv = drop(survival),
+    n.risk = if (is.null(n_risk)) NULL else drop(n_risk),
+    time = new_time
+  )
+  if (model) {
+    out$model <- model_frame
+  } else {
+    if (x) out$x <- groups
+    if (y) out$y <- if (no_response) rep(Inf, n) else response
+  }
+  out$method <- if (no_response) {
+    "Ederer"
+  } else if (isTRUE(conditional)) {
+    "conditional"
+  } else {
+    "cohort"
+  }
+  class(out) <- c("survexp", "survfit")
+  out
+}
+
 survexp <- function(formula, data, weights, subset, na.action, rmap, times,
                     method = c(
                       "ederer", "hakulinen", "conditional", "individual.h",
@@ -3726,6 +3945,27 @@ survexp <- function(formula, data, weights, subset, na.action, rmap, times,
         Call = match.call(),
         evaluation_env = parent.frame(),
         ratetable = formula_ratetable,
+        times_missing = missing(times),
+        method_missing = missing(method),
+        cohort_missing = missing(cohort),
+        conditional_missing = missing(conditional),
+        se_fit_missing = missing(se.fit),
+        method = method,
+        cohort = cohort,
+        conditional = conditional,
+        scale = scale,
+        se_fit = if (missing(se.fit)) NULL else se.fit,
+        model = model,
+        x = x,
+        y = y
+      ))
+    }
+    if (inherits(formula_ratetable, "survival_py_coxph") &&
+        !.is_multistate_cox_fit(formula_ratetable)) {
+      return(.survexp_formula_cox(
+        Call = match.call(),
+        evaluation_env = parent.frame(),
+        fit = formula_ratetable,
         times_missing = missing(times),
         method_missing = missing(method),
         cohort_missing = missing(cohort),

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -4896,6 +4896,146 @@ test_that("data-prep helpers match R survival shapes", {
     tolerance = 1e-12
   )
 
+  survexp_cox_data <- stats::na.omit(
+    survival::lung[, c("time", "status", "age", "sex", "ph.ecog")]
+  )
+  survexp_cox_data$case_weight <- seq_len(nrow(survexp_cox_data)) %% 4L + 1L
+  bridged_survexp_cox_fit <- coxph(
+    Surv(time, status) ~ age + sex,
+    data = survexp_cox_data,
+    x = TRUE,
+    model = TRUE
+  )
+  reference_survexp_cox_fit <- survival::coxph(
+    survival::Surv(time, status) ~ age + sex,
+    data = survexp_cox_data,
+    x = TRUE,
+    model = TRUE
+  )
+  survexp_cox_formula <- Surv(time, status) ~ factor(ph.ecog)
+  for (cox_method in c(
+    "ederer", "hakulinen", "conditional", "individual.s", "individual.h"
+  )) {
+    bridged_survexp_cox <- survexp(
+      survexp_cox_formula,
+      data = survexp_cox_data,
+      weights = case_weight,
+      ratetable = bridged_survexp_cox_fit,
+      rmap = list(age = age, sex = sex),
+      method = cox_method,
+      times = c(100, 300, 500)
+    )
+    reference_survexp_cox <- survival::survexp(
+      survexp_cox_formula,
+      data = survexp_cox_data,
+      weights = case_weight,
+      ratetable = reference_survexp_cox_fit,
+      rmap = list(age = age, sex = sex),
+      method = cox_method,
+      times = c(100, 300, 500)
+    )
+    if (is.list(bridged_survexp_cox)) {
+      expect_equal(
+        bridged_survexp_cox$surv,
+        reference_survexp_cox$surv,
+        tolerance = 1e-12
+      )
+      expect_equal(bridged_survexp_cox$n.risk, reference_survexp_cox$n.risk)
+      expect_equal(bridged_survexp_cox$time, reference_survexp_cox$time)
+      expect_equal(bridged_survexp_cox$method, reference_survexp_cox$method)
+    } else {
+      expect_equal(
+        bridged_survexp_cox,
+        reference_survexp_cox,
+        tolerance = 1e-12
+      )
+    }
+  }
+  bridged_survexp_cox_no_response <- survexp(
+    ~factor(ph.ecog),
+    data = survexp_cox_data,
+    ratetable = bridged_survexp_cox_fit,
+    rmap = list(age = age, sex = sex),
+    method = "ederer",
+    times = c(100, 300, 500),
+    x = TRUE
+  )
+  reference_survexp_cox_no_response <- survival::survexp(
+    ~factor(ph.ecog),
+    data = survexp_cox_data,
+    ratetable = reference_survexp_cox_fit,
+    rmap = list(age = age, sex = sex),
+    method = "ederer",
+    times = c(100, 300, 500),
+    x = TRUE
+  )
+  expect_equal(
+    bridged_survexp_cox_no_response$surv,
+    reference_survexp_cox_no_response$surv,
+    tolerance = 1e-12
+  )
+  expect_equal(
+    bridged_survexp_cox_no_response$n.risk,
+    reference_survexp_cox_no_response$n.risk
+  )
+  expect_equal(
+    bridged_survexp_cox_no_response$x,
+    reference_survexp_cox_no_response$x
+  )
+  single_survexp_cox_data <- survexp_cox_data[1L, , drop = FALSE]
+  bridged_survexp_cox_single <- survexp(
+    Surv(time, status) ~ 1,
+    data = single_survexp_cox_data,
+    weights = 0,
+    ratetable = bridged_survexp_cox_fit,
+    rmap = list(age = age, sex = sex),
+    method = "conditional",
+    times = c(100, 300, 500)
+  )
+  reference_survexp_cox_single <- survival::survexp(
+    Surv(time, status) ~ 1,
+    data = single_survexp_cox_data,
+    weights = 0,
+    ratetable = reference_survexp_cox_fit,
+    rmap = list(age = age, sex = sex),
+    method = "conditional",
+    times = c(100, 300, 500)
+  )
+  expect_equal(
+    bridged_survexp_cox_single$surv,
+    reference_survexp_cox_single$surv,
+    tolerance = 1e-12
+  )
+  expect_equal(
+    bridged_survexp_cox_single$n.risk,
+    reference_survexp_cox_single$n.risk
+  )
+  signed_survexp_weights <- rep(1, nrow(survexp_cox_data))
+  signed_survexp_weights[[1L]] <- -0.5
+  bridged_survexp_cox_signed <- survexp(
+    survexp_cox_formula,
+    data = survexp_cox_data,
+    weights = signed_survexp_weights,
+    ratetable = bridged_survexp_cox_fit,
+    rmap = list(age = age, sex = sex),
+    method = "ederer",
+    times = c(100, 300, 500)
+  )
+  reference_survexp_cox_signed <- survival::survexp(
+    survexp_cox_formula,
+    data = survexp_cox_data,
+    weights = signed_survexp_weights,
+    ratetable = reference_survexp_cox_fit,
+    rmap = list(age = age, sex = sex),
+    method = "ederer",
+    times = c(100, 300, 500)
+  )
+  expect_equal(
+    bridged_survexp_cox_signed$surv,
+    reference_survexp_cox_signed$surv,
+    tolerance = 1e-12
+  )
+
   bridged_pyears <- pyears(
     c(10, 20, 30),
     event = c(1, 0, 1),

--- a/src/api/python/classical/population.rs
+++ b/src/api/python/classical/population.rs
@@ -3,6 +3,7 @@ use super::*;
 pub(super) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(survexp, m)?)?;
     m.add_function(wrap_pyfunction!(survexp_individual, m)?)?;
+    m.add_function(wrap_pyfunction!(survexp_cox_aggregate, m)?)?;
     m.add_function(wrap_pyfunction!(survexp_from_coords, m)?)?;
     m.add_function(wrap_pyfunction!(survexp_individual_from_coords, m)?)?;
     m.add_function(wrap_pyfunction!(create_simple_ratetable, m)?)?;

--- a/src/population/mod.rs
+++ b/src/population/mod.rs
@@ -11,7 +11,8 @@ pub use ratetable::{
     is_ratetable, ratetable_date,
 };
 pub use survexp_module::{
-    SurvExpResult, survexp, survexp_from_coords, survexp_individual, survexp_individual_from_coords,
+    SurvExpResult, survexp, survexp_cox_aggregate, survexp_from_coords, survexp_individual,
+    survexp_individual_from_coords,
 };
 pub use survexp_us_module::{
     ExpectedSurvivalResult, compute_expected_survival, survexp_mn, survexp_us, survexp_usr,

--- a/src/population/survexp.rs
+++ b/src/population/survexp.rs
@@ -730,6 +730,168 @@ pub fn survexp_individual(
     Ok(expected)
 }
 
+#[derive(Clone, Copy)]
+enum CoxRateMethod {
+    Ederer,
+    Hakulinen,
+    Conditional,
+}
+
+impl CoxRateMethod {
+    fn parse(method: &str) -> PyResult<Self> {
+        match method {
+            "ederer" => Ok(Self::Ederer),
+            "hakulinen" => Ok(Self::Hakulinen),
+            "conditional" => Ok(Self::Conditional),
+            _ => Err(value_error(
+                "method must be 'ederer', 'hakulinen', or 'conditional'",
+            )),
+        }
+    }
+}
+
+type CoxAggregateOutput = (Vec<Vec<f64>>, Option<Vec<usize>>);
+
+fn validate_cox_curves(time: &[f64], surv: &[Vec<f64>], cumhaz: &[Vec<f64>]) -> PyResult<()> {
+    validate_eval_times(time)?;
+    if surv.len() != cumhaz.len() {
+        return Err(value_error(
+            "surv and cumhaz must contain the same number of curves",
+        ));
+    }
+    for (row, (survival_curve, hazard_curve)) in surv.iter().zip(cumhaz).enumerate() {
+        if survival_curve.len() != time.len() || hazard_curve.len() != time.len() {
+            return Err(value_error(format!(
+                "surv[{row}] and cumhaz[{row}] must have the same length as time"
+            )));
+        }
+        for (index, &value) in survival_curve.iter().enumerate() {
+            if !value.is_finite() || !(0.0..=1.0).contains(&value) {
+                return Err(value_error(format!(
+                    "surv[{row}] must contain finite probabilities; got {value} at index {index}"
+                )));
+            }
+        }
+        for (index, &value) in hazard_curve.iter().enumerate() {
+            if !value.is_finite() || value < 0.0 {
+                return Err(value_error(format!(
+                    "cumhaz[{row}] must contain finite non-negative values; got {value} at index {index}"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+#[pyfunction]
+pub fn survexp_cox_aggregate(
+    time: Vec<f64>,
+    surv: Vec<Vec<f64>>,
+    cumhaz: Vec<Vec<f64>>,
+    followup: Vec<f64>,
+    group: Vec<usize>,
+    weights: Vec<f64>,
+    method: &str,
+) -> PyResult<CoxAggregateOutput> {
+    let calculation = CoxRateMethod::parse(method)?;
+    validate_cox_curves(&time, &surv, &cumhaz)?;
+
+    let row_count = followup.len();
+    if surv.len() != row_count || group.len() != row_count || weights.len() != row_count {
+        return Err(value_error(
+            "surv, cumhaz, followup, group, and weights must have the same row count",
+        ));
+    }
+    for (index, &value) in followup.iter().enumerate() {
+        if value.is_nan() || value < 0.0 {
+            return Err(value_error(format!(
+                "followup values must be non-negative and not NaN; got {value} at index {index}"
+            )));
+        }
+    }
+    for (index, &value) in group.iter().enumerate() {
+        if value == 0 {
+            return Err(value_error(format!(
+                "group values must be positive integers; got 0 at index {index}"
+            )));
+        }
+    }
+    validate_finite(&weights, "weights")?;
+
+    let group_count = group.iter().copied().max().unwrap_or(0);
+    let mut group_rows = vec![Vec::new(); group_count];
+    let mut group_weight_totals = vec![0.0; group_count];
+    for (row, (&group_value, &weight)) in group.iter().zip(&weights).enumerate() {
+        let group_index = group_value - 1;
+        group_rows[group_index].push(row);
+        group_weight_totals[group_index] += weight;
+    }
+    let aggregate_group = |group_index: usize| {
+        let rows = &group_rows[group_index];
+        if rows.is_empty() {
+            return if matches!(calculation, CoxRateMethod::Ederer) {
+                vec![0.0; time.len()]
+            } else {
+                vec![f64::NAN; time.len()]
+            };
+        }
+        let total_weight = group_weight_totals[group_index];
+
+        if matches!(calculation, CoxRateMethod::Ederer) {
+            let mut curve = vec![0.0; time.len()];
+            for &row in rows {
+                let normalized_weight = weights[row] / total_weight;
+                for (aggregate, &subject_survival) in curve.iter_mut().zip(&surv[row]) {
+                    *aggregate += normalized_weight * subject_survival;
+                }
+            }
+            return curve;
+        }
+
+        let mut curve = Vec::with_capacity(time.len());
+        let mut cumulative_hazard = 0.0;
+        for (time_index, &eval_time) in time.iter().enumerate() {
+            let mut numerator = 0.0;
+            let mut denominator = 0.0;
+            for &row in rows {
+                if followup[row] < eval_time {
+                    continue;
+                }
+                let previous_survival =
+                    if matches!(calculation, CoxRateMethod::Conditional) || time_index == 0 {
+                        1.0
+                    } else {
+                        surv[row][time_index - 1]
+                    };
+                let contribution = previous_survival * weights[row] / total_weight;
+                let previous_hazard = if time_index == 0 {
+                    0.0
+                } else {
+                    cumhaz[row][time_index - 1]
+                };
+                numerator += (cumhaz[row][time_index] - previous_hazard) * contribution;
+                denominator += contribution;
+            }
+            let increment = numerator / denominator;
+            cumulative_hazard += increment;
+            curve.push((-cumulative_hazard).exp());
+        }
+        curve
+    };
+
+    let survival_by_group = if group_count > PARALLEL_THRESHOLD_XLARGE {
+        (0..group_count)
+            .into_par_iter()
+            .map(aggregate_group)
+            .collect()
+    } else {
+        (0..group_count).map(aggregate_group).collect()
+    };
+    let group_sizes = matches!(calculation, CoxRateMethod::Ederer)
+        .then(|| group_rows.iter().map(Vec::len).collect());
+    Ok((survival_by_group, group_sizes))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -771,6 +933,96 @@ mod tests {
 
         assert_eq!(result.n, 0);
         assert!(result.time.is_empty());
+    }
+
+    #[test]
+    fn cox_aggregate_computes_weighted_ederer_curves_and_group_sizes() {
+        let result = survexp_cox_aggregate(
+            vec![1.0, 2.0],
+            vec![vec![0.9, 0.8], vec![0.8, 0.6], vec![0.7, 0.5]],
+            vec![vec![0.1, 0.2], vec![0.2, 0.4], vec![0.3, 0.6]],
+            vec![2.0, 2.0, 2.0],
+            vec![1, 1, 3],
+            vec![1.0, 3.0, 2.0],
+            "ederer",
+        )
+        .unwrap();
+
+        assert_eq!(result.1, Some(vec![2, 0, 1]));
+        assert!((result.0[0][0] - 0.825).abs() < 1e-12);
+        assert!((result.0[0][1] - 0.65).abs() < 1e-12);
+        assert_eq!(result.0[1], vec![0.0, 0.0]);
+        assert_eq!(result.0[2], vec![0.7, 0.5]);
+    }
+
+    #[test]
+    fn cox_aggregate_computes_hakulinen_and_conditional_hazards() {
+        let time = vec![1.0, 2.0];
+        let cumhaz: Vec<Vec<f64>> = vec![vec![0.1, 0.3], vec![0.2, 0.5]];
+        let surv = cumhaz
+            .iter()
+            .map(|curve| curve.iter().map(|&value| (-value).exp()).collect())
+            .collect::<Vec<Vec<f64>>>();
+        let call = |method| {
+            survexp_cox_aggregate(
+                time.clone(),
+                surv.clone(),
+                cumhaz.clone(),
+                vec![2.0, 2.0],
+                vec![1, 1],
+                vec![1.0, 1.0],
+                method,
+            )
+            .unwrap()
+            .0
+        };
+
+        let conditional = call("conditional");
+        assert!((conditional[0][0] - (-0.15_f64).exp()).abs() < 1e-12);
+        assert!((conditional[0][1] - (-0.4_f64).exp()).abs() < 1e-12);
+
+        let weighted_increment = (0.2 * (-0.1_f64).exp() + 0.3 * (-0.2_f64).exp())
+            / ((-0.1_f64).exp() + (-0.2_f64).exp());
+        let hakulinen = call("hakulinen");
+        assert!((hakulinen[0][0] - (-0.15_f64).exp()).abs() < 1e-12);
+        assert!((hakulinen[0][1] - (-0.15 - weighted_increment).exp()).abs() < 1e-12);
+
+        let signed = survexp_cox_aggregate(
+            time,
+            surv,
+            cumhaz,
+            vec![2.0, 1.0],
+            vec![1, 1],
+            vec![1.0, -2.0],
+            "conditional",
+        )
+        .unwrap()
+        .0;
+        assert!((signed[0][0] - (-0.3_f64).exp()).abs() < 1e-12);
+        assert!((signed[0][1] - (-0.5_f64).exp()).abs() < 1e-12);
+    }
+
+    #[test]
+    fn cox_aggregate_validates_groups_finite_weights_and_curve_shapes() {
+        Python::initialize();
+        let call = |group, weights, surv| {
+            survexp_cox_aggregate(
+                vec![1.0],
+                surv,
+                vec![vec![0.1]],
+                vec![1.0],
+                group,
+                weights,
+                "ederer",
+            )
+        };
+
+        assert!(call(vec![0], vec![1.0], vec![vec![0.9]]).is_err());
+        assert!(call(vec![1], vec![f64::NAN], vec![vec![0.9]]).is_err());
+        assert!(call(vec![1], vec![1.0], vec![vec![0.9, 0.8]]).is_err());
+
+        let zero_weight = call(vec![1], vec![0.0], vec![vec![0.9]]).unwrap();
+        assert!(zero_weight.0[0][0].is_nan());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- route survexp formulas backed by package Cox fits through the local prediction path
- aggregate Ederer, Hakulinen, and conditional curves in Rust while supporting individual survival and cumulative hazard
- preserve R mapping, grouping, weighting, requested-time, and single-profile semantics with differential coverage

## Testing
- cargo test --lib (1534 passed)
- cargo clippy --all-targets --all-features -- -D warnings
- python tests (998 passed, 18 skipped)
- Ruff format and lint
- mypy stub checks
- binding manifest check
- R CMD check (standard source-directory note only)