### PR TITLE
Support Cox Yates contrasts locally

### DIFF
--- a/python/survival/_binding_manifest.py
+++ b/python/survival/_binding_manifest.py
@@ -1043,6 +1043,7 @@ BINDINGS = (
     "yates",
     "yates_contrast",
     "yates_pairwise",
+    "yates_risk_profiles",
 )
 
 BINDING_NAMES = frozenset(BINDINGS)

--- a/python/survival/_survival.pyi
+++ b/python/survival/_survival.pyi
@@ -6679,6 +6679,13 @@ def yates_contrast(
     predict_type: str | None = None,
 ) -> YatesResult: ...
 def yates_pairwise(yates_result: YatesResult) -> YatesPairwiseResult: ...
+def yates_risk_profiles(
+    x: list[list[float]],
+    beta: list[float],
+    draws: list[list[float]],
+    n_levels: int,
+    center: list[float],
+) -> tuple[list[float], list[list[float]]]: ...
 def create_simple_ratetable(
     age_breaks: list[float],
     year_breaks: list[float],

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -9721,6 +9721,25 @@ def yates_pairwise(result: YatesResult) -> YatesPairwiseResult:
     return _core.yates_pairwise(result)
 
 
+def _yates_risk_profiles(
+    x: Any,
+    beta: Any,
+    draws: Any,
+    n_levels: Any,
+    center: Any,
+) -> dict[str, list[float] | list[list[float]]]:
+    """Aggregate Cox risk profiles for observed and simulated coefficients."""
+
+    estimate, covariance = _core.yates_risk_profiles(
+        _as_rows(x, "x"),
+        _float_vector(beta, "beta"),
+        _as_rows(draws, "draws"),
+        _integer_scalar(n_levels, "n_levels"),
+        _float_vector(center, "center"),
+    )
+    return {"estimate": estimate, "covariance": covariance}
+
+
 def _scalar_or_vector_with_flag(values: Any, name: str) -> tuple[list[Any], bool]:
     try:
         return _materialize_1d(values, name), False
@@ -18044,6 +18063,20 @@ def model_formula(fit: Any) -> str:
     if isinstance(fit, _FormulaFit) and fit.formula is not None:
         return fit.formula
     raise TypeError("model_formula requires a formula-based fitted model")
+
+
+def _model_xlevels(fit: Any) -> dict[str, list[Any]]:
+    """Return categorical formula levels needed to rebuild model profiles."""
+
+    _require_model_fit(fit, "_model_xlevels")
+    design = _formula_design_for_fit(fit)
+    if design is None:
+        return {}
+    return {
+        factor.term.column: list(factor.levels)
+        for term in design.covariates
+        for factor in _categorical_design_factors(term)
+    }
 
 
 def model_term_names(fit: Any, terms: Any | None = None) -> list[str]:

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -4726,6 +4726,43 @@ def test_r_style_yates_direct_helpers_wrap_rust_kernels():
         survival.yates([1.0], ["a"], conf_level=1.0)
 
 
+def test_yates_risk_profiles_and_formula_levels():
+    result = survival.r_api._yates_risk_profiles(
+        [[0.0], [0.0], [1.0], [1.0]],
+        [math.log(2.0)],
+        [[0.0], [math.log(2.0)], [math.log(4.0)]],
+        2,
+        [0.0],
+    )
+
+    assert result["estimate"] == pytest.approx([1.0, 2.0])
+    assert [value for row in result["covariance"] for value in row] == pytest.approx(
+        [0.0, 0.0, 0.0, 7.0 / 3.0]
+    )
+
+    fit = survival.coxph(
+        "Surv(time, status) ~ group + x",
+        data={
+            "time": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+            "status": [1, 1, 0, 1, 0, 1],
+            "group": ["C", "A", "B", "C", "A", "B"],
+            "x": [0.0, 1.0, 0.5, 1.5, 2.0, 2.5],
+        },
+    )
+    assert survival.r_api._model_xlevels(fit) == {"group": ["C", "A", "B"]}
+
+    interaction_fit = survival.coxph(
+        "Surv(time, status) ~ group:x",
+        data={
+            "time": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+            "status": [1, 1, 0, 1, 0, 1],
+            "group": ["C", "A", "B", "C", "A", "B"],
+            "x": [0.0, 1.0, 0.5, 1.5, 2.0, 2.5],
+        },
+    )
+    assert survival.r_api._model_xlevels(interaction_fit) == {"group": ["C", "A", "B"]}
+
+
 def test_r_style_nsk_wraps_native_spline_basis():
     basis = survival.nsk([1.0, 2.0, 3.0, 4.0, 5.0], df=3)
     intercept_basis = survival.nsk(

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -5729,13 +5729,21 @@ Surv2data <- function(formula, data, subset, id) {
   mf2
 }
 
-.yates_factorial_population <- function(model_frame, adjustment_names, fit) {
+.yates_model_xlevels <- function(fit) {
+  values <- tryCatch(fit$xlevels, error = function(condition) NULL)
+  if (is.null(values) && inherits(fit, "survival_py_model")) {
+    values <- .call_r_api("_model_xlevels", fit)
+  }
+  if (is.null(values)) list() else as.list(values)
+}
+
+.yates_factorial_population <- function(model_frame, adjustment_names, xlevels) {
   if (length(adjustment_names) == 0L) {
     out <- model_frame[1L, , drop = FALSE]
     row.names(out) <- NULL
     return(out)
   }
-  grid_values <- fit$xlevels[adjustment_names]
+  grid_values <- xlevels[adjustment_names]
   if (length(grid_values) != length(adjustment_names) ||
       any(vapply(grid_values, is.null, logical(1)))) {
     return(NULL)
@@ -5751,7 +5759,7 @@ Surv2data <- function(formula, data, subset, id) {
     out[[name]] <- if (is.factor(source)) {
       factor(
         grid[[name]],
-        levels = fit$xlevels[[name]],
+        levels = xlevels[[name]],
         ordered = is.ordered(source)
       )
     } else {
@@ -5762,7 +5770,7 @@ Surv2data <- function(formula, data, subset, id) {
 }
 
 .yates_model_population <- function(population, population_value, model_frame,
-                                    Terms, term, fit) {
+                                    Terms, term, xlevels, fit_weights) {
   if (inherits(population, "data.frame")) {
     if (nrow(population) == 0L) {
       return(NULL)
@@ -5770,7 +5778,7 @@ Surv2data <- function(formula, data, subset, id) {
     return(list(frame = population, weights = NULL))
   }
   if (population_value %in% c("data", "empirical")) {
-    weights <- stats::model.weights(model_frame)
+    weights <- fit_weights
     if (!is.null(weights) &&
         (length(weights) != nrow(model_frame) ||
           !is.finite(sum(weights)) || sum(weights) == 0)) {
@@ -5791,14 +5799,14 @@ Surv2data <- function(formula, data, subset, id) {
     if (any(!categorical)) {
       return(NULL)
     }
-    frame <- .yates_factorial_population(model_frame, adjustment_names, fit)
+    frame <- .yates_factorial_population(model_frame, adjustment_names, xlevels)
     return(if (is.null(frame)) NULL else list(frame = frame, weights = NULL))
   }
   if (population_value != "sas") {
     return(NULL)
   }
   if (all(categorical)) {
-    frame <- .yates_factorial_population(model_frame, adjustment_names, fit)
+    frame <- .yates_factorial_population(model_frame, adjustment_names, xlevels)
     return(if (is.null(frame)) NULL else list(frame = frame, weights = NULL))
   }
   if (!any(categorical)) {
@@ -5810,7 +5818,7 @@ Surv2data <- function(formula, data, subset, id) {
   categorical_frame <- .yates_factorial_population(
     model_frame,
     categorical_names,
-    fit
+    xlevels
   )
   if (is.null(categorical_frame)) {
     return(NULL)
@@ -5835,8 +5843,10 @@ Surv2data <- function(formula, data, subset, id) {
 }
 
 .yates_model_term <- function(fit, term, population, levels, levels_missing,
-                              test, predict, method) {
-  if (!inherits(fit, "lm") ||
+                              test, predict, method, nsim) {
+  cox_fit <- inherits(fit, c("coxph", "survival_py_coxph"))
+  linear_fit <- inherits(fit, "lm")
+  if ((!linear_fit && !cox_fit) || .is_multistate_cox_fit(fit) ||
       !is.character(term) || length(term) != 1L ||
       !is.character(test) || length(test) == 0L ||
       !is.character(predict) || length(predict) != 1L ||
@@ -5855,7 +5865,8 @@ Surv2data <- function(formula, data, subset, id) {
   }
   test_value <- match.arg(test[[1L]], c("global", "trend", "pairwise"))
   method_value <- match.arg(tolower(method[[1L]]), c("direct", "sgtt"))
-  if (test_value == "trend" || !(predict %in% c("linear", "link")) ||
+  allowed_predictions <- if (cox_fit) c("linear", "lp", "risk") else c("linear", "link")
+  if (test_value == "trend" || !(predict %in% allowed_predictions) ||
       method_value != "direct") {
     return(NULL)
   }
@@ -5865,13 +5876,18 @@ Surv2data <- function(formula, data, subset, id) {
     return(NULL)
   }
   factor_names <- row.names(attr(Terms, "factors"))
-  model_frame <- fit$model
+  model_frame <- if (inherits(fit, "survival_py_model")) {
+    stats::model.frame(fit)
+  } else {
+    tryCatch(fit$model, error = function(condition) NULL)
+  }
   if (is.null(model_frame)) {
     model_frame <- stats::model.frame(fit)
   }
   if (!(term %in% factor_names) || !(term %in% names(model_frame))) {
     return(NULL)
   }
+  xlevels <- .yates_model_xlevels(fit)
 
   target <- model_frame[[term]]
   categorical_target <- is.factor(target) || is.character(target)
@@ -5882,7 +5898,7 @@ Surv2data <- function(formula, data, subset, id) {
   if (!levels_missing && (!is.atomic(levels) || !is.null(dim(levels)))) {
     return(NULL)
   }
-  fit_levels <- if (categorical_target) fit$xlevels[[term]] else NULL
+  fit_levels <- if (categorical_target) xlevels[[term]] else NULL
   contrast_levels <- if (categorical_target && levels_missing) {
     fit_levels
   } else if (categorical_target) {
@@ -5906,13 +5922,18 @@ Surv2data <- function(formula, data, subset, id) {
   if (!identical(names(beta), colnames(old_matrix))) {
     return(NULL)
   }
+  fit_weights <- stats::model.weights(model_frame)
+  if (is.null(fit_weights) && inherits(fit, "survival_py_model")) {
+    fit_weights <- stats::weights(fit)
+  }
   population_data <- .yates_model_population(
     population,
     population_value,
     model_frame,
     Terms,
     term,
-    fit
+    xlevels,
+    fit_weights
   )
   if (is.null(population_data)) {
     return(NULL)
@@ -5920,7 +5941,8 @@ Surv2data <- function(formula, data, subset, id) {
   averaging_frame <- population_data$frame
   weights <- population_data$weights
 
-  mean_design <- function(level) {
+  fit_contrasts <- tryCatch(fit$contrasts, error = function(condition) NULL)
+  profile_design <- function(level) {
     profile <- averaging_frame
     profile[[term]] <- if (categorical_target) {
       factor(
@@ -5931,31 +5953,83 @@ Surv2data <- function(formula, data, subset, id) {
     } else {
       rep(level, nrow(profile))
     }
-    design <- stats::model.matrix(
-      Terms,
-      profile,
-      contrasts.arg = fit$contrasts,
-      xlev = fit$xlevels
+    design <- tryCatch(
+      stats::model.matrix(
+        Terms,
+        profile,
+        contrasts.arg = fit_contrasts,
+        xlev = xlevels
+      ),
+      error = function(condition) NULL
     )
-    if (!identical(colnames(design), names(beta))) {
+    if (is.null(design)) {
       return(NULL)
     }
+    if (cox_fit) {
+      if (!all(names(beta) %in% colnames(design))) {
+        return(NULL)
+      }
+      design <- design[, names(beta), drop = FALSE]
+    } else if (!identical(colnames(design), names(beta))) {
+      return(NULL)
+    }
+    design
+  }
+  design_matrices <- lapply(contrast_levels, profile_design)
+  if (any(vapply(design_matrices, is.null, logical(1)))) {
+    return(NULL)
+  }
+  mean_design <- function(design) {
     if (is.null(weights)) {
       colMeans(design)
     } else {
       colSums(design * weights) / sum(weights)
     }
   }
-  design_rows <- lapply(contrast_levels, mean_design)
-  if (any(vapply(design_rows, is.null, logical(1)))) {
-    return(NULL)
-  }
+  design_rows <- lapply(design_matrices, mean_design)
   cmat <- do.call(rbind, design_rows)
   colnames(cmat) <- names(beta)
 
   variance <- stats::vcov(fit)
-  estimate_values <- drop(cmat %*% beta)
-  mean_variance <- cmat %*% variance %*% t(cmat)
+  risk_scale <- cox_fit && identical(predict, "risk")
+  center <- if (cox_fit) as.numeric(fit$means) else numeric(length(beta))
+  if (length(center) != length(beta) || any(!is.finite(center))) {
+    return(NULL)
+  }
+  if (risk_scale) {
+    nsim_value <- suppressWarnings(as.integer(nsim))
+    if (length(nsim) != 1L || length(nsim_value) != 1L ||
+        is.na(nsim_value) || nsim_value < 2L || nsim_value != nsim) {
+      return(NULL)
+    }
+    tol <- sqrt(.Machine$double.eps)
+    if (!isSymmetric(variance, tol = tol, check.attributes = FALSE)) {
+      stop("variance matrix of the coefficients is not symmetric", call. = FALSE)
+    }
+    ev <- eigen(variance, symmetric = TRUE)
+    if (!all(ev$values >= -tol * abs(ev$values[[1L]]))) {
+      warning("variance matrix is numerically not positive definite", call. = FALSE)
+    }
+    Rmat <- t(ev$vectors %*% (t(ev$vectors) * sqrt(ev$values)))
+    bmat <- matrix(stats::rnorm(nsim_value * ncol(variance)), nrow = nsim_value) %*% Rmat
+    bmat <- bmat + rep(beta, each = nsim_value)
+    risk_result <- .call_r_api(
+      "_yates_risk_profiles",
+      x = do.call(rbind, design_matrices),
+      beta = beta,
+      draws = bmat,
+      n_levels = length(contrast_levels),
+      center = center
+    )
+    estimate_values <- .as_numeric_vector(.result_field(risk_result, "estimate"))
+    mean_variance <- .as_numeric_matrix(.result_field(risk_result, "covariance"))
+  } else {
+    estimate_values <- drop(cmat %*% beta)
+    if (cox_fit) {
+      estimate_values <- estimate_values - sum(center * beta)
+    }
+    mean_variance <- cmat %*% variance %*% t(cmat)
+  }
   sigma2 <- if (identical(class(fit)[[1L]], "lm")) summary(fit)$sigma^2 else NULL
   evaluate_contrast <- function(contrast) {
     contrast_estimate <- drop(contrast %*% estimate_values)
@@ -5974,7 +6048,7 @@ Surv2data <- function(formula, data, subset, id) {
     test_matrix <- matrix(
       test_values,
       nrow = 1L,
-      dimnames = list("global", names(test_values))
+      dimnames = list(if (risk_scale) term else "global", names(test_values))
     )
   } else {
     pairs <- utils::combn(seq_along(contrast_levels), 2L)
@@ -5995,12 +6069,13 @@ Surv2data <- function(formula, data, subset, id) {
     stringsAsFactors = FALSE
   )
   names(estimate)[[1L]] <- term
-  list(
+  result <- list(
     estimate = estimate,
     test = test_matrix,
-    mvar = mean_variance,
-    cmat = cmat
+    mvar = mean_variance
   )
+  if (!risk_scale) result$cmat <- cmat
+  result
 }
 
 yates <- function(fit, term, population = c("data", "factorial", "sas"),
@@ -6017,7 +6092,8 @@ yates <- function(fit, term, population = c("data", "factorial", "sas"),
       levels_missing = missing(levels),
       test = test,
       predict = predict,
-      method = method
+      method = method,
+      nsim = nsim
     )
     if (!is.null(local_result)) {
       call[[1L]] <- quote(survival::yates)

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -717,6 +717,154 @@ test_that("R formula wrappers delegate to the Python survival package", {
   expect_null(yates_setup(yates_py_cox_fit, predict = "lp"))
   expect_equal(yates_setup(yates_py_cox_fit, predict = "risk")(c(-1, 0, 1), NULL), exp(c(-1, 0, 1)))
 
+  compare_yates <- function(actual, expected, tolerance = 1e-9) {
+    fields <- setdiff(names(expected), "call")
+    expect_setequal(setdiff(names(actual), "call"), fields)
+    for (field in fields) {
+      expect_equal(actual[[field]], expected[[field]], tolerance = tolerance, info = field)
+    }
+    expect_s3_class(actual, "yates")
+  }
+  yates_cox_model_data <- survival::lung[
+    stats::complete.cases(survival::lung[, c("time", "status", "age", "sex", "ph.ecog")]),
+    c("time", "status", "age", "sex", "ph.ecog")
+  ]
+  yates_cox_model_data$status <- as.integer(yates_cox_model_data$status == 2L)
+  yates_cox_model_data$group <- factor(
+    rep(c("A", "B", "C"), length.out = nrow(yates_cox_model_data))
+  )
+  native_yates_cox_fit <- survival::coxph(
+    survival::Surv(time, status) ~ group + age + sex + ph.ecog,
+    data = yates_cox_model_data,
+    model = TRUE,
+    x = TRUE
+  )
+  local_yates_cox_fit <- coxph(
+    Surv(time, status) ~ group + age + sex + ph.ecog,
+    data = yates_cox_model_data,
+    model = TRUE,
+    x = TRUE
+  )
+  for (predict_name in c("linear", "lp")) {
+    for (test_name in c("global", "pairwise")) {
+      expected <- survival::yates(
+        native_yates_cox_fit,
+        "group",
+        predict = predict_name,
+        test = test_name
+      )
+      compare_yates(
+        yates(
+          native_yates_cox_fit,
+          "group",
+          predict = predict_name,
+          test = test_name
+        ),
+        expected,
+        tolerance = 1e-12
+      )
+      compare_yates(
+        yates(
+          local_yates_cox_fit,
+          "group",
+          predict = predict_name,
+          test = test_name
+        ),
+        expected
+      )
+    }
+  }
+  sas_yates_cox_expected <- survival::yates(
+    native_yates_cox_fit,
+    "group",
+    population = "sas"
+  )
+  compare_yates(
+    yates(native_yates_cox_fit, "group", population = "sas"),
+    sas_yates_cox_expected,
+    tolerance = 1e-12
+  )
+  compare_yates(
+    yates(local_yates_cox_fit, "group", population = "sas"),
+    sas_yates_cox_expected
+  )
+  yates_cox_model_data$sex_factor <- factor(
+    yates_cox_model_data$sex,
+    labels = c("male", "female")
+  )
+  native_factorial_cox_fit <- survival::coxph(
+    survival::Surv(time, status) ~ group + sex_factor,
+    data = yates_cox_model_data,
+    model = TRUE,
+    x = TRUE
+  )
+  local_factorial_cox_fit <- coxph(
+    Surv(time, status) ~ group + sex_factor,
+    data = yates_cox_model_data,
+    model = TRUE,
+    x = TRUE
+  )
+  compare_yates(
+    yates(local_factorial_cox_fit, "group", population = "factorial"),
+    survival::yates(native_factorial_cox_fit, "group", population = "factorial")
+  )
+  for (test_name in c("global", "pairwise")) {
+    set.seed(20260822)
+    expected <- survival::yates(
+      native_yates_cox_fit,
+      "group",
+      predict = "risk",
+      test = test_name,
+      nsim = 400
+    )
+    set.seed(20260822)
+    compare_yates(
+      yates(
+        native_yates_cox_fit,
+        "group",
+        predict = "risk",
+        test = test_name,
+        nsim = 400
+      ),
+      expected,
+      tolerance = 1e-10
+    )
+    set.seed(20260822)
+    compare_yates(
+      yates(
+        local_yates_cox_fit,
+        "group",
+        predict = "risk",
+        test = test_name,
+        nsim = 400
+      ),
+      expected,
+      tolerance = 1e-8
+    )
+  }
+  set.seed(20260822)
+  selected_risk_expected <- survival::yates(
+    native_yates_cox_fit,
+    "group",
+    levels = c("C", "A"),
+    test = "pairwise",
+    predict = "risk",
+    nsim = 400
+  )
+  set.seed(20260822)
+  compare_yates(
+    yates(
+      local_yates_cox_fit,
+      "group",
+      levels = c("C", "A"),
+      test = "pairwise",
+      predict = "risk",
+      nsim = 400
+    ),
+    selected_risk_expected,
+    tolerance = 1e-8
+  )
+
   compare_aareg <- function(actual, expected) {
     fields <- setdiff(names(expected), "call")
     expect_setequal(setdiff(names(actual), "call"), fields)

--- a/src/api/python/classical/survival_models.rs
+++ b/src/api/python/classical/survival_models.rs
@@ -67,6 +67,7 @@ pub(super) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(yates, m)?)?;
     m.add_function(wrap_pyfunction!(yates_contrast, m)?)?;
     m.add_function(wrap_pyfunction!(yates_pairwise, m)?)?;
+    m.add_function(wrap_pyfunction!(yates_risk_profiles, m)?)?;
     m.add_function(wrap_pyfunction!(uno_c_index, m)?)?;
     m.add_function(wrap_pyfunction!(compare_uno_c_indices, m)?)?;
     m.add_function(wrap_pyfunction!(c_index_decomposition, m)?)?;

--- a/src/validation/mod.rs
+++ b/src/validation/mod.rs
@@ -137,4 +137,6 @@ pub use uno_c_index_module::{
     CIndexDecompositionResult, ConcordanceComparisonResult, GonenHellerResult, UnoCIndexResult,
     c_index_decomposition, compare_uno_c_indices, gonen_heller_concordance, uno_c_index,
 };
-pub use yates_module::{YatesPairwiseResult, YatesResult, yates, yates_contrast, yates_pairwise};
+pub use yates_module::{
+    YatesPairwiseResult, YatesResult, yates, yates_contrast, yates_pairwise, yates_risk_profiles,
+};

--- a/src/validation/yates.rs
+++ b/src/validation/yates.rs
@@ -4,6 +4,7 @@ use crate::internal::validation::{
     validate_finite, validate_no_nan, validate_non_empty, validate_non_negative,
 };
 use pyo3::prelude::*;
+use rayon::prelude::*;
 use std::collections::HashMap;
 
 #[derive(Debug, Clone)]
@@ -293,6 +294,120 @@ pub fn yates_pairwise(yates_result: &YatesResult) -> PyResult<YatesPairwiseResul
     })
 }
 
+fn risk_profile_means(
+    x: &[Vec<f64>],
+    beta: &[f64],
+    n_levels: usize,
+    center: &[f64],
+) -> Option<Vec<f64>> {
+    let rows_per_level = x.len() / n_levels;
+    let mut means = Vec::with_capacity(n_levels);
+    for level in 0..n_levels {
+        let start = level * rows_per_level;
+        let end = start + rows_per_level;
+        let mut total = 0.0;
+        for row in &x[start..end] {
+            let eta = row
+                .iter()
+                .zip(center)
+                .zip(beta)
+                .map(|((&value, &mean), &coefficient)| (value - mean) * coefficient)
+                .sum::<f64>();
+            let risk = eta.exp();
+            if !risk.is_finite() {
+                return None;
+            }
+            total += risk;
+        }
+        means.push(total / rows_per_level as f64);
+    }
+    Some(means)
+}
+
+#[pyfunction]
+pub fn yates_risk_profiles(
+    x: Vec<Vec<f64>>,
+    beta: Vec<f64>,
+    draws: Vec<Vec<f64>>,
+    n_levels: usize,
+    center: Vec<f64>,
+) -> PyResult<(Vec<f64>, Vec<Vec<f64>>)> {
+    if n_levels < 2 {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "n_levels must be at least 2",
+        ));
+    }
+    if x.is_empty() || !x.len().is_multiple_of(n_levels) {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "x must contain the same positive number of rows for every level",
+        ));
+    }
+    let n_vars = beta.len();
+    if n_vars == 0 || center.len() != n_vars {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "beta and center must have the same positive length",
+        ));
+    }
+    if x.iter().any(|row| row.len() != n_vars) {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "every x row must have one value per coefficient",
+        ));
+    }
+    if draws.len() < 2 || draws.iter().any(|draw| draw.len() != n_vars) {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "draws must contain at least two rows with one value per coefficient",
+        ));
+    }
+    if x.iter()
+        .flatten()
+        .chain(&beta)
+        .chain(&center)
+        .any(|value| !value.is_finite())
+        || draws.iter().flatten().any(|value| !value.is_finite())
+    {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "x, beta, draws, and center must be finite",
+        ));
+    }
+
+    let Some(estimate) = risk_profile_means(&x, &beta, n_levels, &center) else {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "risk profile means are non-finite",
+        ));
+    };
+    let simulated = draws
+        .par_iter()
+        .map(|draw| risk_profile_means(&x, draw, n_levels, &center))
+        .collect::<Vec<_>>();
+    if simulated.iter().any(Option::is_none) {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "simulated risk profile means are non-finite",
+        ));
+    }
+    let simulated = simulated.into_iter().flatten().collect::<Vec<_>>();
+    let draw_means = (0..n_levels)
+        .map(|level| simulated.iter().map(|row| row[level]).sum::<f64>() / simulated.len() as f64)
+        .collect::<Vec<_>>();
+    let denominator = (simulated.len() - 1) as f64;
+    let covariance = (0..n_levels)
+        .map(|left| {
+            (0..n_levels)
+                .map(|right| {
+                    simulated
+                        .iter()
+                        .map(|row| {
+                            (row[left] - draw_means[left]) * (row[right] - draw_means[right])
+                        })
+                        .sum::<f64>()
+                        / denominator
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+
+    Ok((estimate, covariance))
+}
+
 #[derive(Debug, Clone)]
 #[pyclass(from_py_object)]
 pub struct YatesPairwiseResult {
@@ -508,5 +623,35 @@ mod tests {
 
         assert_eq!(pairwise.level1.len(), 3);
         assert_eq!(pairwise.difference[0], -1.0);
+    }
+
+    #[test]
+    fn test_yates_risk_profiles() {
+        let (estimate, covariance) = yates_risk_profiles(
+            vec![vec![0.0], vec![0.0], vec![1.0], vec![1.0]],
+            vec![2.0_f64.ln()],
+            vec![vec![0.0], vec![2.0_f64.ln()], vec![4.0_f64.ln()]],
+            2,
+            vec![0.0],
+        )
+        .unwrap();
+
+        assert_eq!(estimate, vec![1.0, 2.0]);
+        assert_eq!(covariance[0], vec![0.0, 0.0]);
+        assert_eq!(covariance[1][0], 0.0);
+        assert!((covariance[1][1] - 7.0 / 3.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_yates_risk_profiles_rejects_malformed_draws() {
+        let error = yates_risk_profiles(
+            vec![vec![0.0], vec![1.0]],
+            vec![0.0],
+            vec![vec![0.0]],
+            2,
+            vec![0.0],
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("at least two rows"));
     }
 }


### PR DESCRIPTION
## Summary
- add local Cox Yates contrasts on linear predictor and risk scales
- preserve reference centering, population, test naming, and random-stream behavior for native and local fits
- parallelize risk-profile simulation aggregation in Rust and expose fitted categorical levels to the R bridge

## Testing
- cargo test --lib
- cargo test --lib --features ml
- cargo test --lib --features python,ml
- cargo clippy --all-targets --features python,ml -- -D warnings
- python -m pytest python/tests/ -q
- python -m pytest python/tests/test_binding_contract.py -q
- testthat::test_local("r/survivalr")
- ruff format/check and mypy stub checks