### PR TITLE
Support response-scale GLM Yates contrasts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1229,6 +1229,7 @@ version = "1.3.0"
 dependencies = [
  "burn",
  "divan",
+ "libm",
  "ndarray",
  "numpy",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ crate-type = ["cdylib", "rlib"]
 pyo3 = { version = "0.29.0", optional = true }
 numpy = { version = "0.29.0", optional = true }
 ndarray = "0.17.2"
+libm = "0.2.16"
 rayon = "1.12.0"
 burn = { version = "0.21.0", default-features = false, features = ["autodiff", "ndarray"], optional = true }
 survival-pyo3-macros-shim = { version = "0.1.0", path = "survival-pyo3-macros-shim" }

--- a/python/survival/_binding_manifest.py
+++ b/python/survival/_binding_manifest.py
@@ -1042,6 +1042,7 @@ BINDINGS = (
     "wlw_model",
     "yates",
     "yates_contrast",
+    "yates_link_profiles",
     "yates_pairwise",
     "yates_risk_profiles",
 )

--- a/python/survival/_survival.pyi
+++ b/python/survival/_survival.pyi
@@ -6679,6 +6679,13 @@ def yates_contrast(
     predict_type: str | None = None,
 ) -> YatesResult: ...
 def yates_pairwise(yates_result: YatesResult) -> YatesPairwiseResult: ...
+def yates_link_profiles(
+    x: list[list[float]],
+    beta: list[float],
+    draws: list[list[float]],
+    n_levels: int,
+    link: str,
+) -> tuple[list[float], list[list[float]]]: ...
 def yates_risk_profiles(
     x: list[list[float]],
     beta: list[float],

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -9740,6 +9740,25 @@ def _yates_risk_profiles(
     return {"estimate": estimate, "covariance": covariance}
 
 
+def _yates_link_profiles(
+    x: Any,
+    beta: Any,
+    draws: Any,
+    n_levels: Any,
+    link: str,
+) -> dict[str, list[float] | list[list[float]]]:
+    """Aggregate standard-link GLM profiles for observed and simulated coefficients."""
+
+    estimate, covariance = _core.yates_link_profiles(
+        _as_rows(x, "x"),
+        _float_vector(beta, "beta"),
+        _as_rows(draws, "draws"),
+        _integer_scalar(n_levels, "n_levels"),
+        str(link),
+    )
+    return {"estimate": estimate, "covariance": covariance}
+
+
 def _scalar_or_vector_with_flag(values: Any, name: str) -> tuple[list[Any], bool]:
     try:
         return _materialize_1d(values, name), False

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -4763,6 +4763,30 @@ def test_yates_risk_profiles_and_formula_levels():
     assert survival.r_api._model_xlevels(interaction_fit) == {"group": ["C", "A", "B"]}
 
 
+def test_yates_standard_link_profiles():
+    log_three = math.log(3.0)
+    result = survival.r_api._yates_link_profiles(
+        [[0.0], [0.0], [1.0], [1.0]],
+        [log_three],
+        [[-log_three], [0.0], [log_three]],
+        2,
+        "logit",
+    )
+
+    assert result["estimate"] == pytest.approx([0.5, 0.75])
+    assert [value for row in result["covariance"] for value in row] == pytest.approx(
+        [0.0, 0.0, 0.0, 0.0625]
+    )
+    with pytest.raises(ValueError, match="link must be one of"):
+        survival.r_api._yates_link_profiles(
+            [[0.0], [1.0]],
+            [0.0],
+            [[0.0], [1.0]],
+            2,
+            "custom",
+        )
+
+
 def test_r_style_nsk_wraps_native_spline_basis():
     basis = survival.nsk([1.0, 2.0, 3.0, 4.0, 5.0], df=3)
     intercept_basis = survival.nsk(

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -5846,6 +5846,7 @@ Surv2data <- function(formula, data, subset, id) {
                               test, predict, method, nsim) {
   cox_fit <- inherits(fit, c("coxph", "survival_py_coxph"))
   linear_fit <- inherits(fit, "lm")
+  glm_fit <- inherits(fit, "glm")
   if ((!linear_fit && !cox_fit) || .is_multistate_cox_fit(fit) ||
       !is.character(term) || length(term) != 1L ||
       !is.character(test) || length(test) == 0L ||
@@ -5865,7 +5866,13 @@ Surv2data <- function(formula, data, subset, id) {
   }
   test_value <- match.arg(test[[1L]], c("global", "trend", "pairwise"))
   method_value <- match.arg(tolower(method[[1L]]), c("direct", "sgtt"))
-  allowed_predictions <- if (cox_fit) c("linear", "lp", "risk") else c("linear", "link")
+  allowed_predictions <- if (cox_fit) {
+    c("linear", "lp", "risk")
+  } else if (glm_fit) {
+    c("linear", "link", "response")
+  } else {
+    c("linear", "link")
+  }
   if (test_value == "trend" || !(predict %in% allowed_predictions) ||
       method_value != "direct") {
     return(NULL)
@@ -5992,11 +5999,21 @@ Surv2data <- function(formula, data, subset, id) {
 
   variance <- stats::vcov(fit)
   risk_scale <- cox_fit && identical(predict, "risk")
+  response_scale <- glm_fit && identical(predict, "response")
+  response_link <- if (response_scale) stats::family(fit)$link else NULL
+  standard_links <- c(
+    "identity", "log", "inverse", "sqrt", "1/mu^2",
+    "logit", "probit", "cauchit", "cloglog"
+  )
+  if (response_scale && !(response_link %in% standard_links)) {
+    return(NULL)
+  }
+  nonlinear_scale <- risk_scale || response_scale
   center <- if (cox_fit) as.numeric(fit$means) else numeric(length(beta))
   if (length(center) != length(beta) || any(!is.finite(center))) {
     return(NULL)
   }
-  if (risk_scale) {
+  if (nonlinear_scale) {
     nsim_value <- suppressWarnings(as.integer(nsim))
     if (length(nsim) != 1L || length(nsim_value) != 1L ||
         is.na(nsim_value) || nsim_value < 2L || nsim_value != nsim) {
@@ -6013,16 +6030,27 @@ Surv2data <- function(formula, data, subset, id) {
     Rmat <- t(ev$vectors %*% (t(ev$vectors) * sqrt(ev$values)))
     bmat <- matrix(stats::rnorm(nsim_value * ncol(variance)), nrow = nsim_value) %*% Rmat
     bmat <- bmat + rep(beta, each = nsim_value)
-    risk_result <- .call_r_api(
-      "_yates_risk_profiles",
-      x = do.call(rbind, design_matrices),
-      beta = beta,
-      draws = bmat,
-      n_levels = length(contrast_levels),
-      center = center
-    )
-    estimate_values <- .as_numeric_vector(.result_field(risk_result, "estimate"))
-    mean_variance <- .as_numeric_matrix(.result_field(risk_result, "covariance"))
+    profile_result <- if (risk_scale) {
+      .call_r_api(
+        "_yates_risk_profiles",
+        x = do.call(rbind, design_matrices),
+        beta = beta,
+        draws = bmat,
+        n_levels = length(contrast_levels),
+        center = center
+      )
+    } else {
+      .call_r_api(
+        "_yates_link_profiles",
+        x = do.call(rbind, design_matrices),
+        beta = beta,
+        draws = bmat,
+        n_levels = length(contrast_levels),
+        link = response_link
+      )
+    }
+    estimate_values <- .as_numeric_vector(.result_field(profile_result, "estimate"))
+    mean_variance <- .as_numeric_matrix(.result_field(profile_result, "covariance"))
   } else {
     estimate_values <- drop(cmat %*% beta)
     if (cox_fit) {
@@ -6048,7 +6076,7 @@ Surv2data <- function(formula, data, subset, id) {
     test_matrix <- matrix(
       test_values,
       nrow = 1L,
-      dimnames = list(if (risk_scale) term else "global", names(test_values))
+      dimnames = list(if (nonlinear_scale) term else "global", names(test_values))
     )
   } else {
     pairs <- utils::combn(seq_along(contrast_levels), 2L)
@@ -6074,7 +6102,7 @@ Surv2data <- function(formula, data, subset, id) {
     test = test_matrix,
     mvar = mean_variance
   )
-  if (!risk_scale) result$cmat <- cmat
+  if (!nonlinear_scale) result$cmat <- cmat
   result
 }
 

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -626,7 +626,12 @@ test_that("R formula wrappers delegate to the Python survival package", {
   glm_yates_data <- transform(
     yates_population_data,
     outcome = c(0, 1, 0, 1, 1, 0, 1, 0, 1, 0, 1, 1, 0, 1, 0, 1, 0, 1),
-    count = c(1, 2, 1, 3, 2, 4, 1, 3, 5, 2, 4, 6, 3, 5, 4, 7, 6, 8)
+    count = c(1, 2, 1, 3, 2, 4, 1, 3, 5, 2, 4, 6, 3, 5, 4, 7, 6, 8),
+    positive = c(
+      0.7, 1.4, 0.9, 1.8, 1.2, 2.1,
+      1.1, 2.0, 2.8, 1.5, 2.4, 3.2,
+      1.9, 3.0, 2.6, 3.8, 3.4, 4.2
+    )
   )
   binomial_yates_fit <- stats::glm(
     outcome ~ group + x,
@@ -677,6 +682,114 @@ test_that("R formula wrappers delegate to the Python survival package", {
       ),
       tolerance = 1e-12
     )
+  }
+  inverse_gaussian_n <- 90L
+  inverse_gaussian_data <- data.frame(
+    group = factor(rep(c("A", "B", "C"), each = inverse_gaussian_n / 3L)),
+    x = rep(seq(-1, 1, length.out = inverse_gaussian_n / 3L), 3L)
+  )
+  inverse_gaussian_eta <- 0.7 +
+    c(A = 0.05, B = 0.1, C = 0.15)[inverse_gaussian_data$group] +
+    0.05 * inverse_gaussian_data$x
+  inverse_gaussian_data$positive <-
+    1 / sqrt(inverse_gaussian_eta) + 0.02 * sin(seq_len(inverse_gaussian_n))
+  response_yates_fits <- suppressWarnings(list(
+    logit = stats::glm(
+      outcome ~ group + x,
+      data = glm_yates_data,
+      family = stats::binomial("logit"),
+      model = TRUE
+    ),
+    probit = stats::glm(
+      outcome ~ group + x,
+      data = glm_yates_data,
+      family = stats::binomial("probit"),
+      model = TRUE
+    ),
+    cauchit = stats::glm(
+      outcome ~ group + x,
+      data = glm_yates_data,
+      family = stats::binomial("cauchit"),
+      model = TRUE
+    ),
+    cloglog = stats::glm(
+      outcome ~ group + x,
+      data = glm_yates_data,
+      family = stats::binomial("cloglog"),
+      model = TRUE
+    ),
+    log = stats::glm(
+      count ~ group + x,
+      data = glm_yates_data,
+      weights = wt,
+      family = stats::poisson("log"),
+      model = TRUE
+    ),
+    sqrt = stats::glm(
+      count ~ group + x,
+      data = glm_yates_data,
+      family = stats::poisson("sqrt"),
+      model = TRUE
+    ),
+    identity = stats::glm(
+      positive ~ group + x,
+      data = glm_yates_data,
+      family = stats::gaussian("identity"),
+      model = TRUE
+    ),
+    inverse = stats::glm(
+      positive ~ group + x,
+      data = glm_yates_data,
+      family = stats::Gamma("inverse"),
+      model = TRUE
+    ),
+    `1/mu^2` = stats::glm(
+      positive ~ group + x,
+      data = inverse_gaussian_data,
+      family = stats::inverse.gaussian("1/mu^2"),
+      model = TRUE
+    )
+  ))
+  set.seed(20260822)
+  response_probe <- .yates_model_term(
+    fit = response_yates_fits$logit,
+    term = "group",
+    population = "data",
+    levels = NULL,
+    levels_missing = TRUE,
+    test = "global",
+    predict = "response",
+    method = "direct",
+    nsim = 40
+  )
+  expect_type(response_probe, "list")
+  expect_false("cmat" %in% names(response_probe))
+  for (fit_name in names(response_yates_fits)) {
+    test_names <- if (fit_name == "logit") c("global", "pairwise") else "global"
+    for (test_name in test_names) {
+      set.seed(20260822)
+      expected <- suppressWarnings(survival::yates(
+        response_yates_fits[[fit_name]],
+        "group",
+        predict = "response",
+        test = test_name,
+        nsim = 200
+      ))
+      set.seed(20260822)
+      actual <- suppressWarnings(yates(
+        response_yates_fits[[fit_name]],
+        "group",
+        predict = "response",
+        test = test_name,
+        nsim = 200
+      ))
+      expect_equal(
+        actual,
+        expected,
+        tolerance = 2e-10,
+        info = paste(fit_name, test_name)
+      )
+    }
   }
 
   yates_cox_data <- data.frame(

--- a/src/api/python/classical/survival_models.rs
+++ b/src/api/python/classical/survival_models.rs
@@ -67,6 +67,7 @@ pub(super) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(yates, m)?)?;
     m.add_function(wrap_pyfunction!(yates_contrast, m)?)?;
     m.add_function(wrap_pyfunction!(yates_pairwise, m)?)?;
+    m.add_function(wrap_pyfunction!(yates_link_profiles, m)?)?;
     m.add_function(wrap_pyfunction!(yates_risk_profiles, m)?)?;
     m.add_function(wrap_pyfunction!(uno_c_index, m)?)?;
     m.add_function(wrap_pyfunction!(compare_uno_c_indices, m)?)?;

--- a/src/validation/mod.rs
+++ b/src/validation/mod.rs
@@ -138,5 +138,6 @@ pub use uno_c_index_module::{
     c_index_decomposition, compare_uno_c_indices, gonen_heller_concordance, uno_c_index,
 };
 pub use yates_module::{
-    YatesPairwiseResult, YatesResult, yates, yates_contrast, yates_pairwise, yates_risk_profiles,
+    YatesPairwiseResult, YatesResult, yates, yates_contrast, yates_link_profiles, yates_pairwise,
+    yates_risk_profiles,
 };

--- a/src/validation/yates.rs
+++ b/src/validation/yates.rs
@@ -294,11 +294,79 @@ pub fn yates_pairwise(yates_result: &YatesResult) -> PyResult<YatesPairwiseResul
     })
 }
 
-fn risk_profile_means(
+#[derive(Clone, Copy)]
+enum ProfileTransform {
+    CoxRisk,
+    Identity,
+    Log,
+    Inverse,
+    Sqrt,
+    InverseSquare,
+    Logit,
+    Probit,
+    Cauchit,
+    Cloglog,
+}
+
+impl ProfileTransform {
+    fn from_link(link: &str) -> PyResult<Self> {
+        match link {
+            "identity" => Ok(Self::Identity),
+            "log" => Ok(Self::Log),
+            "inverse" => Ok(Self::Inverse),
+            "sqrt" => Ok(Self::Sqrt),
+            "1/mu^2" => Ok(Self::InverseSquare),
+            "logit" => Ok(Self::Logit),
+            "probit" => Ok(Self::Probit),
+            "cauchit" => Ok(Self::Cauchit),
+            "cloglog" => Ok(Self::Cloglog),
+            _ => Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                "link must be one of 'identity', 'log', 'inverse', 'sqrt', '1/mu^2', 'logit', 'probit', 'cauchit', or 'cloglog'",
+            )),
+        }
+    }
+
+    fn apply(self, eta: f64) -> f64 {
+        const LOWER: f64 = f64::EPSILON;
+        const UPPER: f64 = 1.0 - f64::EPSILON;
+        match self {
+            Self::CoxRisk => eta.exp(),
+            Self::Identity => eta,
+            Self::Log => eta.exp().max(LOWER),
+            Self::Inverse => eta.recip(),
+            Self::Sqrt => eta * eta,
+            Self::InverseSquare => eta.sqrt().recip(),
+            Self::Logit => {
+                let value = if eta >= 0.0 {
+                    1.0 / (1.0 + (-eta).exp())
+                } else {
+                    let exp_eta = eta.exp();
+                    exp_eta / (1.0 + exp_eta)
+                };
+                value.clamp(LOWER, UPPER)
+            }
+            Self::Probit => {
+                let value = 0.5 * (1.0 + libm::erf(eta / std::f64::consts::SQRT_2));
+                value.clamp(LOWER, UPPER)
+            }
+            Self::Cauchit => {
+                let value = 0.5 + eta.atan() / std::f64::consts::PI;
+                value.clamp(LOWER, UPPER)
+            }
+            Self::Cloglog => {
+                let value = -(-eta.exp()).exp_m1();
+                value.clamp(LOWER, UPPER)
+            }
+        }
+    }
+}
+
+fn profile_means(
     x: &[Vec<f64>],
     beta: &[f64],
     n_levels: usize,
     center: &[f64],
+    transform: ProfileTransform,
 ) -> Option<Vec<f64>> {
     let rows_per_level = x.len() / n_levels;
     let mut means = Vec::with_capacity(n_levels);
@@ -313,24 +381,24 @@ fn risk_profile_means(
                 .zip(beta)
                 .map(|((&value, &mean), &coefficient)| (value - mean) * coefficient)
                 .sum::<f64>();
-            let risk = eta.exp();
-            if !risk.is_finite() {
+            let prediction = transform.apply(eta);
+            if !prediction.is_finite() {
                 return None;
             }
-            total += risk;
+            total += prediction;
         }
         means.push(total / rows_per_level as f64);
     }
     Some(means)
 }
 
-#[pyfunction]
-pub fn yates_risk_profiles(
-    x: Vec<Vec<f64>>,
-    beta: Vec<f64>,
-    draws: Vec<Vec<f64>>,
+fn yates_profile_summary(
+    x: &[Vec<f64>],
+    beta: &[f64],
+    draws: &[Vec<f64>],
     n_levels: usize,
-    center: Vec<f64>,
+    center: &[f64],
+    transform: ProfileTransform,
 ) -> PyResult<(Vec<f64>, Vec<Vec<f64>>)> {
     if n_levels < 2 {
         return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
@@ -360,8 +428,8 @@ pub fn yates_risk_profiles(
     }
     if x.iter()
         .flatten()
-        .chain(&beta)
-        .chain(&center)
+        .chain(beta)
+        .chain(center)
         .any(|value| !value.is_finite())
         || draws.iter().flatten().any(|value| !value.is_finite())
     {
@@ -370,18 +438,18 @@ pub fn yates_risk_profiles(
         ));
     }
 
-    let Some(estimate) = risk_profile_means(&x, &beta, n_levels, &center) else {
+    let Some(estimate) = profile_means(x, beta, n_levels, center, transform) else {
         return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-            "risk profile means are non-finite",
+            "profile means are non-finite",
         ));
     };
     let simulated = draws
         .par_iter()
-        .map(|draw| risk_profile_means(&x, draw, n_levels, &center))
+        .map(|draw| profile_means(x, draw, n_levels, center, transform))
         .collect::<Vec<_>>();
     if simulated.iter().any(Option::is_none) {
         return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-            "simulated risk profile means are non-finite",
+            "simulated profile means are non-finite",
         ));
     }
     let simulated = simulated.into_iter().flatten().collect::<Vec<_>>();
@@ -406,6 +474,37 @@ pub fn yates_risk_profiles(
         .collect::<Vec<_>>();
 
     Ok((estimate, covariance))
+}
+
+#[pyfunction]
+pub fn yates_risk_profiles(
+    x: Vec<Vec<f64>>,
+    beta: Vec<f64>,
+    draws: Vec<Vec<f64>>,
+    n_levels: usize,
+    center: Vec<f64>,
+) -> PyResult<(Vec<f64>, Vec<Vec<f64>>)> {
+    yates_profile_summary(
+        &x,
+        &beta,
+        &draws,
+        n_levels,
+        &center,
+        ProfileTransform::CoxRisk,
+    )
+}
+
+#[pyfunction]
+pub fn yates_link_profiles(
+    x: Vec<Vec<f64>>,
+    beta: Vec<f64>,
+    draws: Vec<Vec<f64>>,
+    n_levels: usize,
+    link: &str,
+) -> PyResult<(Vec<f64>, Vec<Vec<f64>>)> {
+    let transform = ProfileTransform::from_link(link)?;
+    let center = vec![0.0; beta.len()];
+    yates_profile_summary(&x, &beta, &draws, n_levels, &center, transform)
 }
 
 #[derive(Debug, Clone)]
@@ -653,5 +752,64 @@ mod tests {
         )
         .unwrap_err();
         assert!(error.to_string().contains("at least two rows"));
+    }
+
+    #[test]
+    fn test_yates_link_profiles() {
+        let log_three = 3.0_f64.ln();
+        let (estimate, covariance) = yates_link_profiles(
+            vec![vec![0.0], vec![0.0], vec![1.0], vec![1.0]],
+            vec![log_three],
+            vec![vec![-log_three], vec![0.0], vec![log_three]],
+            2,
+            "logit",
+        )
+        .unwrap();
+
+        assert_eq!(estimate, vec![0.5, 0.75]);
+        assert_eq!(covariance[0], vec![0.0, 0.0]);
+        assert_eq!(covariance[1][0], 0.0);
+        assert!((covariance[1][1] - 0.0625).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_standard_glm_inverse_links() {
+        let cases = [
+            ("identity", -2.0, -2.0),
+            ("log", 0.0, 1.0),
+            ("inverse", 2.0, 0.5),
+            ("sqrt", -2.0, 4.0),
+            ("1/mu^2", 4.0, 0.5),
+            ("logit", 0.0, 0.5),
+            ("probit", 1.0, 0.841_344_746_068_542_9),
+            ("cauchit", 1.0, 0.75),
+            ("cloglog", 0.0, 1.0 - (-1.0_f64).exp()),
+        ];
+
+        for (link, eta, expected) in cases {
+            let transform = ProfileTransform::from_link(link).unwrap();
+            assert!((transform.apply(eta) - expected).abs() < 1e-14, "{link}");
+        }
+        assert_eq!(
+            ProfileTransform::from_link("logit").unwrap().apply(-1e3),
+            f64::EPSILON
+        );
+        assert_eq!(
+            ProfileTransform::from_link("cloglog").unwrap().apply(1e3),
+            1.0 - f64::EPSILON
+        );
+    }
+
+    #[test]
+    fn test_yates_link_profiles_rejects_unknown_link() {
+        let error = yates_link_profiles(
+            vec![vec![0.0], vec![1.0]],
+            vec![0.0],
+            vec![vec![0.0], vec![1.0]],
+            2,
+            "custom",
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("link must be one of"));
     }
 }


### PR DESCRIPTION
## Summary
- compute response-scale Yates contrasts locally for all standard GLM inverse links
- share the parallel Rust profile-simulation and covariance path with Cox risk contrasts
- preserve reference boundary clamping, unweighted nonlinear profile means, random-stream behavior, and result shaping

## Testing
- cargo test --lib
- cargo test --lib --features ml
- cargo test --lib --features python,ml
- cargo clippy --all-targets --features python,ml -- -D warnings
- python -m pytest python/tests/ -q
- python -m pytest python/tests/test_binding_contract.py -q
- testthat::test_local("r/survivalr")
- ruff format/check, binding-manifest check, and mypy stub checks