### PR TITLE
Support Cox survival Yates contrasts

### DIFF
--- a/python/survival/_binding_manifest.py
+++ b/python/survival/_binding_manifest.py
@@ -1045,6 +1045,7 @@ BINDINGS = (
     "yates_link_profiles",
     "yates_pairwise",
     "yates_risk_profiles",
+    "yates_survival_profiles",
 )
 
 BINDING_NAMES = frozenset(BINDINGS)

--- a/python/survival/_survival.pyi
+++ b/python/survival/_survival.pyi
@@ -6693,6 +6693,20 @@ def yates_risk_profiles(
     n_levels: int,
     center: list[float],
 ) -> tuple[list[float], list[list[float]]]: ...
+def yates_survival_profiles(
+    x: list[list[float]],
+    beta: list[float],
+    draws: list[list[float]],
+    n_levels: int,
+    center: list[float],
+    cumulative_hazard: list[float],
+    intervals: list[float],
+) -> tuple[
+    list[float],
+    list[list[float]],
+    list[list[float]],
+    list[list[float]],
+]: ...
 def create_simple_ratetable(
     age_breaks: list[float],
     year_breaks: list[float],

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -9759,6 +9759,34 @@ def _yates_link_profiles(
     return {"estimate": estimate, "covariance": covariance}
 
 
+def _yates_survival_profiles(
+    x: Any,
+    beta: Any,
+    draws: Any,
+    n_levels: Any,
+    center: Any,
+    cumulative_hazard: Any,
+    intervals: Any,
+) -> dict[str, list[float] | list[list[float]]]:
+    """Aggregate Cox restricted means and survival curves across coefficient draws."""
+
+    estimate, covariance, profile_mean, profile_variance = _core.yates_survival_profiles(
+        _as_rows(x, "x"),
+        _float_vector(beta, "beta"),
+        _as_rows(draws, "draws"),
+        _integer_scalar(n_levels, "n_levels"),
+        _float_vector(center, "center"),
+        _float_vector(cumulative_hazard, "cumulative_hazard"),
+        _float_vector(intervals, "intervals"),
+    )
+    return {
+        "estimate": estimate,
+        "covariance": covariance,
+        "profile_mean": profile_mean,
+        "profile_variance": profile_variance,
+    }
+
+
 def _scalar_or_vector_with_flag(values: Any, name: str) -> tuple[list[Any], bool]:
     try:
         return _materialize_1d(values, name), False

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -1,5 +1,6 @@
 import math
 import random
+import statistics
 from bisect import bisect_right
 from dataclasses import replace
 from datetime import date
@@ -4785,6 +4786,28 @@ def test_yates_standard_link_profiles():
             2,
             "custom",
         )
+
+
+def test_yates_survival_profiles():
+    log_two = math.log(2.0)
+    result = survival.r_api._yates_survival_profiles(
+        [[0.0], [0.0], [1.0], [1.0]],
+        [log_two],
+        [[0.0], [log_two], [math.log(4.0)]],
+        2,
+        [0.0],
+        [0.0, 1.0],
+        [1.0, 1.0],
+    )
+
+    simulated = [1.0 + math.exp(-risk) for risk in (1.0, 2.0, 4.0)]
+    expected_variance = statistics.variance(simulated)
+    assert result["estimate"] == pytest.approx([1.0 + math.exp(-1.0), 1.0 + math.exp(-2.0)])
+    assert [value for row in result["covariance"] for value in row] == pytest.approx(
+        [0.0, 0.0, 0.0, expected_variance]
+    )
+    assert result["profile_mean"][1][0] == pytest.approx(statistics.mean(simulated))
+    assert result["profile_variance"][1][0] == pytest.approx(expected_variance)
 
 
 def test_r_style_nsk_wraps_native_spline_basis():

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -5842,8 +5842,105 @@ Surv2data <- function(formula, data, subset, id) {
   list(frame = frame, weights = NULL)
 }
 
+.yates_local_cox_survival_baseline <- function(fit, baseline) {
+  time <- .as_numeric_vector(.result_field(baseline, "time"))
+  stop_time <- .as_numeric_vector(.result_field(fit, "event_times"))
+  status <- as.integer(.result_field(fit, "status"))
+  weights <- .as_numeric_vector(.result_field(fit, "weights"))
+  entry_time <- .result_field(fit, "entry_times")
+  if (!is.null(entry_time)) {
+    entry_time <- .as_numeric_vector(entry_time)
+  }
+  if (length(stop_time) != length(status) || length(stop_time) != length(weights) ||
+      (!is.null(entry_time) && length(entry_time) != length(stop_time))) {
+    stop("fitted Cox response is inconsistent", call. = FALSE)
+  }
+  at_risk <- function(point) {
+    keep <- stop_time >= point
+    if (!is.null(entry_time)) {
+      keep <- keep & entry_time < point
+    }
+    sum(weights[keep])
+  }
+  at_event <- function(point) {
+    sum(weights[status != 0L & stop_time == point])
+  }
+  at_censor <- function(point) {
+    sum(weights[status == 0L & stop_time == point])
+  }
+  structure(
+    list(
+      n = length(stop_time),
+      time = time,
+      n.risk = vapply(time, at_risk, numeric(1L)),
+      n.event = vapply(time, at_event, numeric(1L)),
+      n.censor = vapply(time, at_censor, numeric(1L)),
+      surv = .as_numeric_vector(.result_field(baseline, "surv")),
+      cumhaz = .as_numeric_vector(.result_field(baseline, "cumhaz")),
+      std.err = .as_numeric_vector(.result_field(baseline, "std_chaz")),
+      logse = TRUE,
+      std.chaz = .as_numeric_vector(.result_field(baseline, "std_chaz")),
+      lower = .as_numeric_vector(.result_field(baseline, "conf_lower")),
+      upper = .as_numeric_vector(.result_field(baseline, "conf_upper")),
+      conf.type = "log",
+      conf.int = 0.95,
+      call = quote(survfit(formula = fit, censor = FALSE))
+    ),
+    class = c("survfitcox", "survfit")
+  )
+}
+
+.yates_cox_survival_baseline <- function(fit, options = NULL) {
+  suppressWarnings(baseline <- if (inherits(fit, "survival_py_coxph")) {
+    survfit.survival_py_coxph(fit, censor = FALSE)
+  } else {
+    survival::survfit(fit, censor = FALSE)
+  })
+  if ((inherits(baseline, "survival_py_survfit") &&
+        .is_grouped_survival_py_survfit(baseline)) ||
+      !is.null(baseline$strata)) {
+    stop("stratified models not yet supported", call. = FALSE)
+  }
+  time <- .as_numeric_vector(baseline$time)
+  cumulative_hazard <- c(0, .as_numeric_vector(baseline$cumhaz))
+  rmean <- if (is.null(options) || is.null(options$rmean)) {
+    max(time)
+  } else {
+    options$rmean
+  }
+  if (!is.numeric(rmean) || length(rmean) != 1L || !is.finite(rmean)) {
+    stop("options$rmean must be a finite numeric scalar", call. = FALSE)
+  }
+  intervals <- c(diff(c(0, pmin(rmean, time))), 0)
+  if (length(cumulative_hazard) != length(intervals)) {
+    stop("Cox baseline time and cumulative hazard are inconsistent", call. = FALSE)
+  }
+  list(
+    baseline = baseline,
+    cumulative_hazard = cumulative_hazard,
+    intervals = intervals
+  )
+}
+
+.yates_cox_survival_summary <- function(fit, baseline, profile_mean,
+                                        profile_variance) {
+  if (inherits(baseline, "survival_py_survfit")) {
+    baseline <- .yates_local_cox_survival_baseline(fit, baseline)
+  }
+  bsurv <- t(profile_mean[, -1L, drop = FALSE])
+  std <- t(sqrt(profile_variance[, -1L, drop = FALSE]))
+  chaz <- -log(bsurv)
+  confidence <- if (is.null(baseline$conf.int)) 0.95 else baseline$conf.int
+  zstat <- -stats::qnorm((1 - confidence) / 2)
+  baseline$lower <- exp(-(chaz + zstat * std))
+  baseline$upper <- exp(-(chaz - zstat * std))
+  baseline$surv <- bsurv
+  baseline$std.err <- std / bsurv
+  baseline
+}
+
 .yates_model_term <- function(fit, term, population, levels, levels_missing,
-                              test, predict, method, nsim) {
+                              test, predict, method, nsim, options = NULL) {
   cox_fit <- inherits(fit, c("coxph", "survival_py_coxph"))
   linear_fit <- inherits(fit, "lm")
   glm_fit <- inherits(fit, "glm")
@@ -5867,7 +5964,7 @@ Surv2data <- function(formula, data, subset, id) {
   test_value <- match.arg(test[[1L]], c("global", "trend", "pairwise"))
   method_value <- match.arg(tolower(method[[1L]]), c("direct", "sgtt"))
   allowed_predictions <- if (cox_fit) {
-    c("linear", "lp", "risk")
+    c("linear", "lp", "risk", "survival")
   } else if (glm_fit) {
     c("linear", "link", "response")
   } else {
@@ -5999,6 +6096,7 @@ Surv2data <- function(formula, data, subset, id) {
 
   variance <- stats::vcov(fit)
   risk_scale <- cox_fit && identical(predict, "risk")
+  survival_scale <- cox_fit && identical(predict, "survival")
   response_scale <- glm_fit && identical(predict, "response")
   response_link <- if (response_scale) stats::family(fit)$link else NULL
   standard_links <- c(
@@ -6008,7 +6106,7 @@ Surv2data <- function(formula, data, subset, id) {
   if (response_scale && !(response_link %in% standard_links)) {
     return(NULL)
   }
-  nonlinear_scale <- risk_scale || response_scale
+  nonlinear_scale <- risk_scale || survival_scale || response_scale
   center <- if (cox_fit) as.numeric(fit$means) else numeric(length(beta))
   if (length(center) != length(beta) || any(!is.finite(center))) {
     return(NULL)
@@ -6030,6 +6128,11 @@ Surv2data <- function(formula, data, subset, id) {
     Rmat <- t(ev$vectors %*% (t(ev$vectors) * sqrt(ev$values)))
     bmat <- matrix(stats::rnorm(nsim_value * ncol(variance)), nrow = nsim_value) %*% Rmat
     bmat <- bmat + rep(beta, each = nsim_value)
+    survival_baseline <- if (survival_scale) {
+      .yates_cox_survival_baseline(fit, options)
+    } else {
+      NULL
+    }
     profile_result <- if (risk_scale) {
       .call_r_api(
         "_yates_risk_profiles",
@@ -6039,7 +6142,7 @@ Surv2data <- function(formula, data, subset, id) {
         n_levels = length(contrast_levels),
         center = center
       )
-    } else {
+    } else if (response_scale) {
       .call_r_api(
         "_yates_link_profiles",
         x = do.call(rbind, design_matrices),
@@ -6047,6 +6150,17 @@ Surv2data <- function(formula, data, subset, id) {
         draws = bmat,
         n_levels = length(contrast_levels),
         link = response_link
+      )
+    } else {
+      .call_r_api(
+        "_yates_survival_profiles",
+        x = do.call(rbind, design_matrices),
+        beta = beta,
+        draws = bmat,
+        n_levels = length(contrast_levels),
+        center = center,
+        cumulative_hazard = survival_baseline$cumulative_hazard,
+        intervals = survival_baseline$intervals
       )
     }
     estimate_values <- .as_numeric_vector(.result_field(profile_result, "estimate"))
@@ -6103,6 +6217,14 @@ Surv2data <- function(formula, data, subset, id) {
     mvar = mean_variance
   )
   if (!nonlinear_scale) result$cmat <- cmat
+  if (survival_scale) {
+    result$summary <- .yates_cox_survival_summary(
+      fit,
+      survival_baseline$baseline,
+      .as_numeric_matrix(.result_field(profile_result, "profile_mean")),
+      .as_numeric_matrix(.result_field(profile_result, "profile_variance"))
+    )
+  }
   result
 }
 
@@ -6121,7 +6243,8 @@ yates <- function(fit, term, population = c("data", "factorial", "sas"),
       test = test,
       predict = predict,
       method = method,
-      nsim = nsim
+      nsim = nsim,
+      options = if (missing(options)) NULL else options
     )
     if (!is.null(local_result)) {
       call[[1L]] <- quote(survival::yates)
@@ -6175,34 +6298,22 @@ yates_setup.glm <- function(fit, predict = c("link", "response", "terms", "linea
     return(function(eta, X) exp(eta))
   }
   if (type == "survival") {
-    suppressWarnings(baseline <- survfit(fit, censor = FALSE))
-    rmean <- if (missing(options) || is.null(options$rmean)) {
-      max(baseline$time)
-    } else {
-      options$rmean
-    }
-    if (!is.null(baseline$strata)) {
-      stop("stratified models not yet supported", call. = FALSE)
-    }
-    cumhaz <- c(0, baseline$cumhaz)
-    tt <- c(diff(c(0, pmin(rmean, baseline$time))), 0)
+    setup <- .yates_cox_survival_baseline(
+      fit,
+      if (missing(options)) NULL else options
+    )
     predict_fun <- function(eta, ...) {
-      c2 <- outer(exp(drop(eta)), cumhaz)
+      c2 <- outer(exp(drop(eta)), setup$cumulative_hazard)
       surv <- exp(-c2)
-      meansurv <- apply(rep(tt, each = nrow(c2)) * surv, 1L, sum)
+      meansurv <- apply(
+        rep(setup$intervals, each = nrow(c2)) * surv,
+        1L,
+        sum
+      )
       cbind(meansurv, surv)
     }
     summary_fun <- function(surv, var) {
-      bsurv <- t(surv[, -1L])
-      std <- t(sqrt(var[, -1L]))
-      chaz <- -log(bsurv)
-      zstat <- -stats::qnorm((1 - baseline$conf.int) / 2)
-      baseline$lower <- exp(-(chaz + zstat * std))
-      baseline$upper <- exp(-(chaz - zstat * std))
-      baseline$surv <- bsurv
-      baseline$std.err <- std / bsurv
-      baselinecumhaz <- chaz
-      baseline
+      .yates_cox_survival_summary(fit, setup$baseline, surv, var)
     }
     return(list(predict = predict_fun, summary = summary_fun))
   }

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -978,6 +978,145 @@ test_that("R formula wrappers delegate to the Python survival package", {
     tolerance = 1e-8
   )
 
+  native_survival_setup <- yates_setup(
+    yates_cox_fit,
+    predict = "survival",
+    options = list(rmean = 9)
+  )
+  reference_survival_setup <- survival::yates_setup(
+    yates_cox_fit,
+    predict = "survival",
+    options = list(rmean = 9)
+  )
+  expect_equal(
+    native_survival_setup$predict(c(-1, 0, 1)),
+    reference_survival_setup$predict(c(-1, 0, 1)),
+    tolerance = 1e-12
+  )
+  survival_probe <- .yates_model_term(
+    fit = native_yates_cox_fit,
+    term = "group",
+    population = "data",
+    levels = NULL,
+    levels_missing = TRUE,
+    test = "global",
+    predict = "survival",
+    method = "direct",
+    nsim = 20,
+    options = list(rmean = 365)
+  )
+  expect_false(is.null(survival_probe))
+
+  for (test_name in c("global", "pairwise")) {
+    set.seed(20260822)
+    survival_expected <- survival::yates(
+      native_yates_cox_fit,
+      "group",
+      predict = "survival",
+      options = list(rmean = 365),
+      test = test_name,
+      nsim = 200
+    )
+    set.seed(20260822)
+    compare_yates(
+      yates(
+        native_yates_cox_fit,
+        "group",
+        predict = "survival",
+        options = list(rmean = 365),
+        test = test_name,
+        nsim = 200
+      ),
+      survival_expected,
+      tolerance = 2e-10
+    )
+    set.seed(20260822)
+    compare_yates(
+      yates(
+        local_yates_cox_fit,
+        "group",
+        predict = "survival",
+        options = list(rmean = 365),
+        test = test_name,
+        nsim = 200
+      ),
+      survival_expected,
+      tolerance = 2e-8
+    )
+  }
+
+  weighted_survival_data <- transform(
+    yates_cox_model_data,
+    weight = 1 + (seq_len(nrow(yates_cox_model_data)) %% 5L) / 10
+  )
+  weighted_survival_fit <- survival::coxph(
+    survival::Surv(time, status) ~ group + age + sex + ph.ecog,
+    data = weighted_survival_data,
+    weights = weight,
+    model = TRUE,
+    x = TRUE
+  )
+  set.seed(20260823)
+  weighted_survival_expected <- survival::yates(
+    weighted_survival_fit,
+    "group",
+    predict = "survival",
+    options = list(rmean = 400),
+    nsim = 100
+  )
+  set.seed(20260823)
+  compare_yates(
+    yates(
+      weighted_survival_fit,
+      "group",
+      predict = "survival",
+      options = list(rmean = 400),
+      nsim = 100
+    ),
+    weighted_survival_expected,
+    tolerance = 2e-10
+  )
+
+  counting_survival_data <- data.frame(
+    start = c(0, 0, 1, 2, 0, 3, 4, 0),
+    stop = c(2, 3, 4, 5, 6, 7, 8, 9),
+    status = c(1, 0, 1, 1, 0, 1, 1, 0),
+    x = c(0, 0.2, -0.1, 0.5, 0.8, -0.3, 0.1, 0.4),
+    group = factor(rep(c("A", "B"), 4L))
+  )
+  native_counting_survival_fit <- survival::coxph(
+    survival::Surv(start, stop, status) ~ group + x,
+    data = counting_survival_data,
+    model = TRUE,
+    x = TRUE
+  )
+  local_counting_survival_fit <- coxph(
+    Surv(start, stop, status) ~ group + x,
+    data = counting_survival_data,
+    model = TRUE,
+    x = TRUE
+  )
+  set.seed(20260824)
+  counting_survival_expected <- survival::yates(
+    native_counting_survival_fit,
+    "group",
+    predict = "survival",
+    options = list(rmean = 6),
+    nsim = 60
+  )
+  set.seed(20260824)
+  compare_yates(
+    yates(
+      local_counting_survival_fit,
+      "group",
+      predict = "survival",
+      options = list(rmean = 6),
+      nsim = 60
+    ),
+    counting_survival_expected,
+    tolerance = 1e-7
+  )
+
   compare_aareg <- function(actual, expected) {
     fields <- setdiff(names(expected), "call")
     expect_setequal(setdiff(names(actual), "call"), fields)

--- a/src/api/python/classical/survival_models.rs
+++ b/src/api/python/classical/survival_models.rs
@@ -69,6 +69,7 @@ pub(super) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(yates_pairwise, m)?)?;
     m.add_function(wrap_pyfunction!(yates_link_profiles, m)?)?;
     m.add_function(wrap_pyfunction!(yates_risk_profiles, m)?)?;
+    m.add_function(wrap_pyfunction!(yates_survival_profiles, m)?)?;
     m.add_function(wrap_pyfunction!(uno_c_index, m)?)?;
     m.add_function(wrap_pyfunction!(compare_uno_c_indices, m)?)?;
     m.add_function(wrap_pyfunction!(c_index_decomposition, m)?)?;

--- a/src/validation/mod.rs
+++ b/src/validation/mod.rs
@@ -139,5 +139,5 @@ pub use uno_c_index_module::{
 };
 pub use yates_module::{
     YatesPairwiseResult, YatesResult, yates, yates_contrast, yates_link_profiles, yates_pairwise,
-    yates_risk_profiles,
+    yates_risk_profiles, yates_survival_profiles,
 };

--- a/src/validation/yates.rs
+++ b/src/validation/yates.rs
@@ -392,14 +392,13 @@ fn profile_means(
     Some(means)
 }
 
-fn yates_profile_summary(
+fn validate_profile_inputs(
     x: &[Vec<f64>],
     beta: &[f64],
     draws: &[Vec<f64>],
     n_levels: usize,
     center: &[f64],
-    transform: ProfileTransform,
-) -> PyResult<(Vec<f64>, Vec<Vec<f64>>)> {
+) -> PyResult<()> {
     if n_levels < 2 {
         return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
             "n_levels must be at least 2",
@@ -438,6 +437,19 @@ fn yates_profile_summary(
         ));
     }
 
+    Ok(())
+}
+
+fn yates_profile_summary(
+    x: &[Vec<f64>],
+    beta: &[f64],
+    draws: &[Vec<f64>],
+    n_levels: usize,
+    center: &[f64],
+    transform: ProfileTransform,
+) -> PyResult<(Vec<f64>, Vec<Vec<f64>>)> {
+    validate_profile_inputs(x, beta, draws, n_levels, center)?;
+
     let Some(estimate) = profile_means(x, beta, n_levels, center, transform) else {
         return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
             "profile means are non-finite",
@@ -474,6 +486,152 @@ fn yates_profile_summary(
         .collect::<Vec<_>>();
 
     Ok((estimate, covariance))
+}
+
+fn survival_profile_means(
+    x: &[Vec<f64>],
+    beta: &[f64],
+    n_levels: usize,
+    center: &[f64],
+    cumulative_hazard: &[f64],
+    intervals: &[f64],
+) -> Option<Vec<Vec<f64>>> {
+    let rows_per_level = x.len() / n_levels;
+    let mut profiles = vec![vec![0.0; cumulative_hazard.len() + 1]; n_levels];
+    for (level, profile) in profiles.iter_mut().enumerate() {
+        let start = level * rows_per_level;
+        let end = start + rows_per_level;
+        for row in &x[start..end] {
+            let eta = row
+                .iter()
+                .zip(center)
+                .zip(beta)
+                .map(|((&value, &mean), &coefficient)| (value - mean) * coefficient)
+                .sum::<f64>();
+            let risk = eta.exp();
+            let mut restricted_mean = 0.0;
+            for (point, (&hazard, &interval)) in cumulative_hazard.iter().zip(intervals).enumerate()
+            {
+                let survival = (-risk * hazard).exp();
+                if !survival.is_finite() {
+                    return None;
+                }
+                restricted_mean += interval * survival;
+                profile[point + 1] += survival;
+            }
+            if !restricted_mean.is_finite() {
+                return None;
+            }
+            profile[0] += restricted_mean;
+        }
+        for value in profile {
+            *value /= rows_per_level as f64;
+        }
+    }
+    Some(profiles)
+}
+
+type SurvivalProfileSummary = (Vec<f64>, Vec<Vec<f64>>, Vec<Vec<f64>>, Vec<Vec<f64>>);
+
+#[pyfunction]
+pub fn yates_survival_profiles(
+    x: Vec<Vec<f64>>,
+    beta: Vec<f64>,
+    draws: Vec<Vec<f64>>,
+    n_levels: usize,
+    center: Vec<f64>,
+    cumulative_hazard: Vec<f64>,
+    intervals: Vec<f64>,
+) -> PyResult<SurvivalProfileSummary> {
+    validate_profile_inputs(&x, &beta, &draws, n_levels, &center)?;
+    if cumulative_hazard.is_empty() || cumulative_hazard.len() != intervals.len() {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "cumulative_hazard and intervals must have the same positive length",
+        ));
+    }
+    if cumulative_hazard
+        .iter()
+        .chain(&intervals)
+        .any(|value| !value.is_finite())
+    {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "cumulative_hazard and intervals must be finite",
+        ));
+    }
+
+    let Some(observed) =
+        survival_profile_means(&x, &beta, n_levels, &center, &cumulative_hazard, &intervals)
+    else {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "survival profile means are non-finite",
+        ));
+    };
+    let simulated = draws
+        .par_iter()
+        .map(|draw| {
+            survival_profile_means(&x, draw, n_levels, &center, &cumulative_hazard, &intervals)
+        })
+        .collect::<Vec<_>>();
+    if simulated.iter().any(Option::is_none) {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+            "simulated survival profile means are non-finite",
+        ));
+    }
+    let simulated = simulated.into_iter().flatten().collect::<Vec<_>>();
+    let n_draws = simulated.len();
+    let n_outputs = cumulative_hazard.len() + 1;
+    let mut profile_mean = vec![vec![0.0; n_outputs]; n_levels];
+    for profiles in &simulated {
+        for (mean_row, profile_row) in profile_mean.iter_mut().zip(profiles) {
+            for (mean, &value) in mean_row.iter_mut().zip(profile_row) {
+                *mean += value;
+            }
+        }
+    }
+    for row in &mut profile_mean {
+        for value in row {
+            *value /= n_draws as f64;
+        }
+    }
+
+    let denominator = (n_draws - 1) as f64;
+    let mut profile_variance = vec![vec![0.0; n_outputs]; n_levels];
+    for profiles in &simulated {
+        for ((variance_row, mean_row), profile_row) in
+            profile_variance.iter_mut().zip(&profile_mean).zip(profiles)
+        {
+            for ((variance, &mean), &value) in
+                variance_row.iter_mut().zip(mean_row).zip(profile_row)
+            {
+                *variance += (value - mean).powi(2);
+            }
+        }
+    }
+    for row in &mut profile_variance {
+        for value in row {
+            *value /= denominator;
+        }
+    }
+
+    let covariance = (0..n_levels)
+        .map(|left| {
+            (0..n_levels)
+                .map(|right| {
+                    simulated
+                        .iter()
+                        .map(|profiles| {
+                            (profiles[left][0] - profile_mean[left][0])
+                                * (profiles[right][0] - profile_mean[right][0])
+                        })
+                        .sum::<f64>()
+                        / denominator
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    let estimate = observed.into_iter().map(|profile| profile[0]).collect();
+
+    Ok((estimate, covariance, profile_mean, profile_variance))
 }
 
 #[pyfunction]
@@ -811,5 +969,58 @@ mod tests {
         )
         .unwrap_err();
         assert!(error.to_string().contains("link must be one of"));
+    }
+
+    #[test]
+    fn test_yates_survival_profiles() {
+        let log_two = 2.0_f64.ln();
+        let log_four = 4.0_f64.ln();
+        let (estimate, covariance, profile_mean, profile_variance) = yates_survival_profiles(
+            vec![vec![0.0], vec![0.0], vec![1.0], vec![1.0]],
+            vec![log_two],
+            vec![vec![0.0], vec![log_two], vec![log_four]],
+            2,
+            vec![0.0],
+            vec![0.0, 1.0],
+            vec![1.0, 1.0],
+        )
+        .unwrap();
+
+        let simulated = [
+            1.0 + (-1.0_f64).exp(),
+            1.0 + (-2.0_f64).exp(),
+            1.0 + (-4.0_f64).exp(),
+        ];
+        let simulated_mean = simulated.iter().sum::<f64>() / simulated.len() as f64;
+        let simulated_variance = simulated
+            .iter()
+            .map(|value| (value - simulated_mean).powi(2))
+            .sum::<f64>()
+            / (simulated.len() - 1) as f64;
+
+        assert!((estimate[0] - (1.0 + (-1.0_f64).exp())).abs() < 1e-14);
+        assert!((estimate[1] - (1.0 + (-2.0_f64).exp())).abs() < 1e-14);
+        assert!(covariance[0].iter().all(|value| value.abs() < 1e-15));
+        assert!(covariance[1][0].abs() < 1e-15);
+        assert!((covariance[1][1] - simulated_variance).abs() < 1e-14);
+        assert!((profile_mean[1][0] - simulated_mean).abs() < 1e-14);
+        assert_eq!(profile_mean[0][1], 1.0);
+        assert!(profile_variance[0].iter().all(|value| value.abs() < 1e-15));
+        assert!((profile_variance[1][0] - simulated_variance).abs() < 1e-14);
+    }
+
+    #[test]
+    fn test_yates_survival_profiles_rejects_mismatched_grid() {
+        let error = yates_survival_profiles(
+            vec![vec![0.0], vec![1.0]],
+            vec![0.0],
+            vec![vec![0.0], vec![1.0]],
+            2,
+            vec![0.0],
+            vec![0.0, 1.0],
+            vec![1.0],
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("same positive length"));
     }
 }


### PR DESCRIPTION
## Summary
- compute Cox `predict="survival"` Yates contrasts locally for native and locally fitted models
- use a parallel Rust kernel for restricted-mean estimates, coefficient-draw covariance, and pointwise curve summaries
- preserve `options$rmean`, case-weighted and counting-process baseline metadata, and native-shaped `survfit` summaries

## Testing
- `cargo test --lib --no-default-features` (1541 passed)
- `cargo test --lib --features ml` (1750 passed)
- `cargo test --lib --features python,ml` (1764 passed)
- `cargo clippy --all-targets --features python,ml -- -D warnings`
- `python -m pytest --import-mode=importlib python/tests/ -q` (1001 passed, 18 skipped)
- `python -m pytest python/tests/test_binding_contract.py -q` (111 passed)
- `testthat::test_local("r/survivalr")` (3923 passed; 3 pre-existing warnings)
- Rust and Python formatting, Ruff, mypy, binding-manifest, and diff checks