### PR TITLE
Support transformed Yates profiles

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -18216,6 +18216,23 @@ def model_matrix(fit: Any) -> dict[str, Any]:
     }
 
 
+def _model_matrix_newdata(fit: Any, newdata: Any) -> dict[str, Any]:
+    """Build a fitted model's design matrix for new formula data."""
+
+    _require_model_fit(fit, "_model_matrix_newdata")
+    rows, _offsets = _prediction_inputs(fit, newdata)
+    if rows is None:
+        raise TypeError("newdata is required")
+    width = len(rows[0]) if rows else len(_location_beta(fit))
+    if any(len(row) != width for row in rows):
+        raise ValueError("newdata model matrix must be rectangular")
+    return {
+        "data": rows,
+        "columns": _model_matrix_column_names(fit, width),
+        "assign": _model_matrix_assignments(fit, width),
+    }
+
+
 def _coxph_multistate_transition_names(
     metadata: _MultiStateCoxFitMetadata,
 ) -> list[str]:

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -9949,6 +9949,19 @@ def test_coxph_formula_pspline_matches_fixed_theta_reference():
         [-0.0043472678247675],
         abs=1e-12,
     )
+    profile_data = {"z": [0.3, -0.2], "x": [0.8, 1.6]}
+    profile_matrix = survival.r_api._model_matrix_newdata(fit, profile_data)
+    assert profile_matrix["columns"] == survival.coef_names(fit)
+    assert profile_matrix["assign"] == [1, 2, 2, 2, 2, 2, 2]
+    assert [
+        sum(
+            value * coefficient for value, coefficient in zip(row, fit.coefficients[0], strict=True)
+        )
+        for row in profile_matrix["data"]
+    ] == pytest.approx(
+        survival.predict(fit, profile_data, type="lp", reference="zero"),
+        abs=1e-12,
+    )
 
     intercept_fit = survival.coxph(
         "Surv(time,status) ~ pspline(x,theta=.5,nterm=4,intercept=True)",

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -5778,8 +5778,7 @@ Surv2data <- function(formula, data, subset, id) {
   }, character(1L))
   part_names <- row.names(attr(Terms, "factors"))
   parts <- part_names[match(target_names, variable_keys)]
-  if (anyNA(parts) || !identical(target_names, unname(parts)) ||
-      any(!(target_names %in% names(model_frame)))) {
+  if (anyNA(parts) || any(!(target_names %in% names(model_frame)))) {
     return(NULL)
   }
   categorical <- vapply(target_names, function(name) {
@@ -5866,6 +5865,7 @@ Surv2data <- function(formula, data, subset, id) {
   }
   list(
     names = target_names,
+    parts = unname(parts),
     levels = level_frame,
     categorical = categorical
   )
@@ -6153,6 +6153,18 @@ Surv2data <- function(formula, data, subset, id) {
   if (!identical(names(beta), colnames(old_matrix))) {
     return(NULL)
   }
+  cmat_names <- names(beta)
+  if (!identical(target_names, term_spec$parts)) {
+    reference_matrix <- try(
+      stats::model.matrix(Terms, model_frame, xlev = xlevels),
+      silent = TRUE
+    )
+    if (!inherits(reference_matrix, "try-error") &&
+        ncol(reference_matrix) >= length(beta) &&
+        !is.null(colnames(reference_matrix))) {
+      cmat_names <- tail(colnames(reference_matrix), length(beta))
+    }
+  }
   fit_weights <- stats::model.weights(model_frame)
   if (is.null(fit_weights) && inherits(fit, "survival_py_model")) {
     fit_weights <- stats::weights(fit)
@@ -6162,7 +6174,7 @@ Surv2data <- function(formula, data, subset, id) {
     population_value,
     model_frame,
     Terms,
-    target_names,
+    term_spec$parts,
     xlevels,
     fit_weights
   )
@@ -6189,15 +6201,20 @@ Surv2data <- function(formula, data, subset, id) {
         rep(level, nrow(profile))
       }
     }
-    design <- tryCatch(
+    design <- tryCatch(if (inherits(fit, "survival_py_model")) {
+      .as_model_matrix(.call_r_api(
+        "_model_matrix_newdata",
+        fit,
+        .as_python_data(profile)
+      ))
+    } else {
       stats::model.matrix(
         Terms,
         profile,
         contrasts.arg = fit_contrasts,
         xlev = xlevels
-      ),
-      error = function(condition) NULL
-    )
+      )
+    }, error = function(condition) NULL)
     if (is.null(design)) {
       return(NULL)
     }
@@ -6224,7 +6241,7 @@ Surv2data <- function(formula, data, subset, id) {
   }
   design_rows <- lapply(design_matrices, mean_design)
   cmat <- do.call(rbind, design_rows)
-  colnames(cmat) <- names(beta)
+  colnames(cmat) <- cmat_names
 
   variance <- stats::vcov(fit)
   risk_scale <- cox_fit && identical(predict, "risk")
@@ -6324,7 +6341,7 @@ Surv2data <- function(formula, data, subset, id) {
       test_values,
       nrow = 1L,
       dimnames = list(
-        if (nonlinear_scale) target_names else "global",
+        if (nonlinear_scale) term_spec$parts else "global",
         names(test_values)
       )
     )

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -933,6 +933,61 @@ test_that("R formula wrappers delegate to the Python survival package", {
       tolerance = 1e-8
     )
   }
+  native_spline_yates_fit <- survival::coxph(
+    survival::Surv(time, status) ~
+      pspline(age, theta = 0.5, nterm = 6) + sex + ph.ecog,
+    data = yates_cox_model_data,
+    model = TRUE,
+    x = TRUE
+  )
+  local_spline_yates_fit <- coxph(
+    Surv(time, status) ~
+      pspline(age, theta = 0.5, nterm = 6) + sex + ph.ecog,
+    data = yates_cox_model_data,
+    model = TRUE,
+    x = TRUE
+  )
+  spline_yates_levels <- c(50, 60, 70)
+  spline_yates_cases <- list(
+    variable = list(term = "age"),
+    formula = list(term = ~age),
+    transformed = list(term = "pspline(age)", test = "pairwise")
+  )
+  for (case_name in names(spline_yates_cases)) {
+    arguments <- c(
+      spline_yates_cases[[case_name]],
+      list(levels = spline_yates_levels)
+    )
+    expected <- do.call(
+      survival::yates,
+      c(list(fit = native_spline_yates_fit), arguments)
+    )
+    compare_yates(
+      do.call(yates, c(list(fit = local_spline_yates_fit), arguments)),
+      expected,
+      tolerance = 1e-7
+    )
+  }
+  set.seed(20260822)
+  spline_risk_expected <- survival::yates(
+    native_spline_yates_fit,
+    "age",
+    levels = spline_yates_levels,
+    predict = "risk",
+    nsim = 100
+  )
+  set.seed(20260822)
+  compare_yates(
+    yates(
+      local_spline_yates_fit,
+      "age",
+      levels = spline_yates_levels,
+      predict = "risk",
+      nsim = 100
+    ),
+    spline_risk_expected,
+    tolerance = 1e-7
+  )
   sas_yates_cox_expected <- survival::yates(
     native_yates_cox_fit,
     "group",


### PR DESCRIPTION
## Summary
- build new-data design matrices from fitted Python formula metadata
- support penalized spline Yates terms selected by raw variable, formula, or transformed call
- preserve reference contrast-matrix and nonlinear-test labels

## Testing
- Python: 1001 passed, 18 environment skips
- R bridge: pass with three established warnings
- R CMD check --no-manual --no-build-vignettes: pass with one standard source-directory note
- ruff format, ruff check, mypy, binding manifest, and git diff checks