### PR TITLE
Preserve formula factor contrasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,8 +248,9 @@ available and falls back to the stable outer-product system otherwise. Formula
 fits retry from weighted transformed-time starts when a zero start exhausts the
 standard iteration budget. The R bridge also routes built-in `survreg.fit`
 matrix calls through this kernel, including fixed or stratified scales and
-interval-censored responses. Formula factors retain their declared level order,
-including unused levels represented by aliased coefficients.
+interval-censored responses. Formula factors retain their declared level order
+and stored contrast matrices, including unused levels represented by aliased
+coefficients.
 Model helpers include `model_formula`, `model_weights`, `df_residual`,
 `loglik`, `aic`, `bic`, `extract_aic`, coefficient, variance-covariance,
 confidence-interval, model-matrix/model-frame, and summary accessors for fitted

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -342,6 +342,8 @@ class _NumericDesignTerm:
 class _CategoricalDesignTerm:
     term: _CovariateTerm
     levels: tuple[Any, ...]
+    contrasts: tuple[tuple[float, ...], ...] | None = None
+    contrast_names: tuple[str, ...] = ()
     full: bool = False
 
 
@@ -1578,9 +1580,19 @@ def _coerce_array_like(values: Any, name: str) -> list[Any]:
 class _RFactorVector:
     """Iterable factor values with level metadata preserved across reticulate."""
 
-    def __init__(self, values: Any, levels: Any):
+    def __init__(
+        self,
+        values: Any,
+        levels: Any,
+        contrasts: Any | None = None,
+        contrast_names: Any | None = None,
+    ):
         self._values = tuple(values)
         self.categories = tuple(levels)
+        self.contrasts = None if contrasts is None else tuple(tuple(row) for row in contrasts)
+        self.contrast_names = (
+            None if contrast_names is None else tuple(str(name) for name in contrast_names)
+        )
 
     def __iter__(self):
         return iter(self._values)
@@ -1592,8 +1604,13 @@ class _RFactorVector:
         return self._values[item]
 
 
-def _r_factor(values: Any, levels: Any) -> _RFactorVector:
-    return _RFactorVector(values, levels)
+def _r_factor(
+    values: Any,
+    levels: Any,
+    contrasts: Any | None = None,
+    contrast_names: Any | None = None,
+) -> _RFactorVector:
+    return _RFactorVector(values, levels, contrasts, contrast_names)
 
 
 def _materialize_1d(values: Any, name: str) -> list[Any]:
@@ -1701,6 +1718,13 @@ def _mstate_categories(values: Any) -> Any | None:
     if categories is not None:
         return categories
     return getattr(getattr(values, "dtype", None), "categories", None)
+
+
+def _factor_contrasts(values: Any) -> tuple[Any | None, Any | None]:
+    return (
+        getattr(values, "contrasts", None),
+        getattr(values, "contrast_names", None),
+    )
 
 
 def _mstate_event_vector(values: Any, name: str) -> tuple[list[int | None], tuple[str, ...]]:
@@ -1908,7 +1932,8 @@ def _subset_sequence(values: Any, indices: list[int], name: str) -> Any:
     subsetted = [materialized[idx] for idx in indices]
     categories = _mstate_categories(values)
     if categories is not None:
-        return _RFactorVector(subsetted, categories)
+        contrasts, contrast_names = _factor_contrasts(values)
+        return _RFactorVector(subsetted, categories, contrasts, contrast_names)
     return subsetted
 
 
@@ -4480,7 +4505,8 @@ def _term_columns(
     declared_levels = _formula_declared_factor_levels(data, term)
     if declared_levels is not None:
         levels = _categorical_levels(values, term.column, declared_levels)
-        return [[1.0 if value == level else 0.0 for value in values] for level in levels[1:]]
+        contrasts, _contrast_names = _formula_declared_factor_contrasts(data, term, levels)
+        return _categorical_columns(values, levels, contrasts=contrasts)
     if not term.categorical:
         if term.transform is not None:
             return [_numeric_term_values(values, term)]
@@ -4492,7 +4518,7 @@ def _term_columns(
             return [numeric]
 
     levels = _categorical_levels(values, term.column)
-    return [[1.0 if value == level else 0.0 for value in values] for level in levels[1:]]
+    return _categorical_columns(values, levels)
 
 
 def _formula_declared_factor_levels(
@@ -4502,6 +4528,64 @@ def _formula_declared_factor_levels(
     if term.arithmetic is not None or (term.transform is not None and not term.categorical):
         return None
     return _mstate_categories(_column_source(data, term.column))
+
+
+def _formula_declared_factor_contrasts(
+    data: Any,
+    term: _CovariateTerm,
+    levels: tuple[Any, ...],
+) -> tuple[tuple[tuple[float, ...], ...] | None, tuple[str, ...]]:
+    raw_contrasts, raw_names = _factor_contrasts(_column_source(data, term.column))
+    if raw_contrasts is None:
+        return None, ()
+    try:
+        contrasts = tuple(
+            tuple(float(value) for value in row)
+            for row in _coerce_array_like(raw_contrasts, f"{term.column} contrasts")
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"factor contrasts for {term.column!r} must be numeric") from exc
+    if len(contrasts) != len(levels):
+        raise ValueError(
+            f"factor contrasts for {term.column!r} must have one row per declared level"
+        )
+    width = len(contrasts[0]) if contrasts else 0
+    if width < 1 or width >= len(levels) or any(len(row) != width for row in contrasts):
+        raise ValueError(
+            f"factor contrasts for {term.column!r} must be a rectangular matrix with fewer "
+            "columns than levels"
+        )
+    if any(not math.isfinite(value) for row in contrasts for value in row):
+        raise ValueError(f"factor contrasts for {term.column!r} must contain finite values")
+    names = (
+        tuple(str(index + 1) for index in range(width))
+        if raw_names is None
+        else tuple(
+            str(value) for value in _materialize_1d(raw_names, f"{term.column} contrast names")
+        )
+    )
+    if len(names) != width:
+        raise ValueError(
+            f"factor contrast names for {term.column!r} must match the contrast columns"
+        )
+    return contrasts, names
+
+
+def _categorical_columns(
+    values: Sequence[Any],
+    levels: tuple[Any, ...],
+    *,
+    contrasts: tuple[tuple[float, ...], ...] | None = None,
+    full: bool = False,
+) -> list[list[float]]:
+    if full:
+        return [[1.0 if value == level else 0.0 for value in values] for level in levels]
+    if contrasts is None:
+        return [[1.0 if value == level else 0.0 for value in values] for level in levels[1:]]
+    encoded_rows = dict(zip(levels, contrasts, strict=True))
+    return [
+        [encoded_rows[value][column] for value in values] for column in range(len(contrasts[0]))
+    ]
 
 
 def _categorical_levels(
@@ -4544,9 +4628,13 @@ def _fit_single_design_term(
     values = _term_raw_values(data, term, n)
     declared_levels = _formula_declared_factor_levels(data, term)
     if declared_levels is not None:
+        levels = _categorical_levels(values, term.column, declared_levels)
+        contrasts, contrast_names = _formula_declared_factor_contrasts(data, term, levels)
         return _CategoricalDesignTerm(
             term,
-            _categorical_levels(values, term.column, declared_levels),
+            levels,
+            contrasts=contrasts,
+            contrast_names=contrast_names,
         )
     if not term.categorical:
         if term.transform is not None:
@@ -4692,6 +4780,8 @@ def _set_full_categorical_factors(
         return _CategoricalDesignTerm(
             spec.term,
             spec.levels,
+            contrasts=spec.contrasts,
+            contrast_names=spec.contrast_names,
             full=spec.term in full_factors,
         )
     if isinstance(spec, _InteractionDesignTerm):
@@ -4700,6 +4790,8 @@ def _set_full_categorical_factors(
                 _CategoricalDesignTerm(
                     factor.term,
                     factor.levels,
+                    contrasts=factor.contrasts,
+                    contrast_names=factor.contrast_names,
                     full=factor.term in full_factors,
                 )
                 if isinstance(factor, _CategoricalDesignTerm)
@@ -4833,8 +4925,12 @@ def _single_design_columns(
             raise ValueError(
                 f"newdata column {spec.term.column!r} contains unknown level {value!r}"
             )
-    encoded_levels = levels if spec.full else levels[1:]
-    return [[1.0 if value == level else 0.0 for value in values] for level in encoded_levels]
+    return _categorical_columns(
+        values,
+        levels,
+        contrasts=spec.contrasts,
+        full=spec.full,
+    )
 
 
 def _design_term_columns(
@@ -5659,8 +5755,11 @@ def _single_design_term_output_names(spec: _SingleDesignTerm) -> list[str]:
     term = spec.term
     if isinstance(spec, _CategoricalDesignTerm):
         prefix = _covariate_term_name(term)
-        levels = spec.levels if spec.full else spec.levels[1:]
-        return [f"{prefix}{level}" for level in levels]
+        if spec.full:
+            return [f"{prefix}{level}" for level in spec.levels]
+        if spec.contrasts is not None:
+            return [f"{prefix}{name}" for name in spec.contrast_names]
+        return [f"{prefix}{level}" for level in spec.levels[1:]]
     return [_covariate_term_name(term)]
 
 

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -15937,6 +15937,143 @@ def test_formula_factors_preserve_declared_numeric_levels_and_unused_aliases():
     assert survival.loglik(aft) == pytest.approx(survival.loglik(reduced_aft), abs=1e-10)
 
 
+def test_formula_factors_preserve_declared_contrast_matrices():
+    n = 48
+    index_values = list(range(n))
+    levels = ["low", "medium", "high", "very_high"]
+    groups = [levels[value % len(levels)] for value in index_values]
+    x = [((value * 11) % 43) / 10.0 - 2.1 for value in index_values]
+    noise = [((value * 13) % 11 - 5) / 20.0 for value in index_values]
+    root_twenty = math.sqrt(20.0)
+    contrasts = [
+        [-3.0 / root_twenty, 0.5, -1.0 / root_twenty],
+        [-1.0 / root_twenty, -0.5, 3.0 / root_twenty],
+        [1.0 / root_twenty, -0.5, -3.0 / root_twenty],
+        [3.0 / root_twenty, 0.5, 1.0 / root_twenty],
+    ]
+    encoded = [contrasts[levels.index(value)] for value in groups]
+    data = {
+        "time": [
+            math.exp(2.2 + 0.25 * x_value + 0.18 * row[0] - 0.12 * row[1] + error)
+            for x_value, row, error in zip(x, encoded, noise, strict=True)
+        ],
+        "status": [int(value % 5 != 0) for value in index_values],
+        "x": x,
+        "group": survival.r_api._r_factor(
+            groups,
+            levels,
+            contrasts,
+            [".L", ".Q", ".C"],
+        ),
+        "linear": [row[0] for row in encoded],
+        "quadratic": [row[1] for row in encoded],
+        "cubic": [row[2] for row in encoded],
+    }
+
+    cox = survival.coxph("Surv(time,status) ~ group + x", data=data, ties="breslow")
+    numeric_cox = survival.coxph(
+        "Surv(time,status) ~ linear + quadratic + cubic + x",
+        data=data,
+        ties="breslow",
+    )
+    assert survival.coef_names(cox) == ["group.L", "group.Q", "group.C", "x"]
+    for actual, expected in zip(
+        survival.model_matrix(cox)["data"],
+        [[*row, x_value] for row, x_value in zip(encoded, x, strict=True)],
+        strict=True,
+    ):
+        assert actual == pytest.approx(expected, abs=1e-15)
+    assert survival.coef(cox) == pytest.approx(survival.coef(numeric_cox), abs=1e-12)
+    prediction_levels = ["very_high", "low", "high"]
+    prediction_x = [-0.7, 0.2, 1.1]
+    prediction_contrasts = [contrasts[levels.index(value)] for value in prediction_levels]
+    assert survival.predict(
+        cox,
+        {"group": prediction_levels, "x": prediction_x},
+        type="lp",
+        reference="zero",
+    ) == pytest.approx(
+        survival.predict(
+            numeric_cox,
+            {
+                "linear": [row[0] for row in prediction_contrasts],
+                "quadratic": [row[1] for row in prediction_contrasts],
+                "cubic": [row[2] for row in prediction_contrasts],
+                "x": prediction_x,
+            },
+            type="lp",
+            reference="zero",
+        ),
+        abs=1e-12,
+    )
+
+    aft = survival.survreg(
+        "Surv(time,status) ~ group + x",
+        data=data,
+        distribution="weibull",
+        max_iter=100,
+    )
+    numeric_aft = survival.survreg(
+        "Surv(time,status) ~ linear + quadratic + cubic + x",
+        data=data,
+        distribution="weibull",
+        max_iter=100,
+    )
+    assert survival.coef_names(aft)[:4] == ["(Intercept)", "group.L", "group.Q", "group.C"]
+    assert survival.coef(aft) == pytest.approx(survival.coef(numeric_aft), abs=1e-11)
+    assert survival.predict(
+        aft,
+        {"group": prediction_levels, "x": prediction_x},
+        type="lp",
+    ) == pytest.approx(
+        survival.predict(
+            numeric_aft,
+            {
+                "linear": [row[0] for row in prediction_contrasts],
+                "quadratic": [row[1] for row in prediction_contrasts],
+                "cubic": [row[2] for row in prediction_contrasts],
+                "x": prediction_x,
+            },
+            type="lp",
+        ),
+        abs=1e-11,
+    )
+
+    sum_contrasts = [
+        [1.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [0.0, 0.0, 1.0],
+        [-1.0, -1.0, -1.0],
+    ]
+    custom_data = {
+        **data,
+        "group": survival.r_api._r_factor(groups, levels, sum_contrasts),
+    }
+    custom = survival.coxph("Surv(time,status) ~ group + x", data=custom_data)
+    assert survival.coef_names(custom) == ["group1", "group2", "group3", "x"]
+    for actual, expected in zip(
+        survival.model_matrix(custom)["data"],
+        [
+            [*sum_contrasts[levels.index(value)], x_value]
+            for value, x_value in zip(groups, x, strict=True)
+        ],
+        strict=True,
+    ):
+        assert actual == pytest.approx(expected, abs=1e-15)
+
+    malformed_data = {
+        **data,
+        "group": survival.r_api._r_factor(
+            groups,
+            levels,
+            contrasts[:-1],
+            [".L", ".Q", ".C"],
+        ),
+    }
+    with pytest.raises(ValueError, match="one row per declared level"):
+        survival.coxph("Surv(time,status) ~ group + x", data=malformed_data)
+
+
 def test_cox_zph_drops_aliased_columns_like_explicitly_reduced_fit():
     data = {
         "time": [1.0, 1.0, 2.0, 3.0, 3.0, 4.0, 5.0, 5.0],

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -189,7 +189,28 @@ if (getRversion() >= "2.15.1") {
   } else {
     factor_values <- as.list(factor_values)
   }
-  .python_attr("_r_factor")(factor_values, as.list(levels(value)))
+  contrast_matrix <- tryCatch(
+    stats::contrasts(value),
+    error = function(condition) NULL
+  )
+  contrast_values <- if (is.null(contrast_matrix)) {
+    NULL
+  } else {
+    lapply(seq_len(nrow(contrast_matrix)), function(index) {
+      as.list(as.numeric(contrast_matrix[index, , drop = TRUE]))
+    })
+  }
+  contrast_names <- if (is.null(contrast_matrix) || is.null(colnames(contrast_matrix))) {
+    NULL
+  } else {
+    as.list(colnames(contrast_matrix))
+  }
+  .python_attr("_r_factor")(
+    factor_values,
+    as.list(levels(value)),
+    contrast_values,
+    contrast_names
+  )
 }
 
 .as_python_vector <- function(value) {

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -7819,6 +7819,84 @@ test_that("formula factors retain numeric labels and unused levels", {
   )
 })
 
+test_that("formula factors retain ordered and custom contrasts", {
+  skip_if_not_installed("reticulate")
+  skip_if_not_installed("survival")
+  skip_if_not(reticulate::py_module_available("survival"), "Python survival package is unavailable")
+
+  data <- survival::lung[
+    stats::complete.cases(survival::lung[, c("time", "status", "age", "ph.ecog")]),
+    c("time", "status", "age", "ph.ecog")
+  ]
+  data$status <- as.integer(data$status == 2L)
+  data$ph.ecog <- ordered(data$ph.ecog, levels = 0:3)
+  bridged_cox <- coxph(
+    Surv(time, status) ~ ph.ecog * age,
+    data = data
+  )
+  reference_cox <- survival::coxph(
+    survival::Surv(time, status) ~ ph.ecog * age,
+    data = data
+  )
+
+  expect_equal(names(coef(bridged_cox)), names(coef(reference_cox)))
+  expect_equal(coef(bridged_cox), coef(reference_cox), tolerance = 1e-08)
+  expect_equal(
+    as.vector(model.matrix(bridged_cox)),
+    as.vector(model.matrix(reference_cox)),
+    tolerance = 1e-12
+  )
+
+  bridged_aft <- survreg(
+    Surv(time, status) ~ ph.ecog + age,
+    data = data,
+    dist = "weibull"
+  )
+  reference_aft <- survival::survreg(
+    survival::Surv(time, status) ~ ph.ecog + age,
+    data = data,
+    dist = "weibull"
+  )
+  expect_equal(names(coef(bridged_aft)), names(coef(reference_aft)))
+  expect_equal(coef(bridged_aft), coef(reference_aft), tolerance = 1e-08)
+  expect_equal(vcov(bridged_aft), vcov(reference_aft), tolerance = 1e-08)
+  expect_equal(logLik(bridged_aft), logLik(reference_aft), tolerance = 1e-08)
+
+  bridged_full_factor <- survreg(
+    Surv(time, status) ~ 0 + ph.ecog + age,
+    data = data,
+    dist = "weibull"
+  )
+  reference_full_factor <- survival::survreg(
+    survival::Surv(time, status) ~ 0 + ph.ecog + age,
+    data = data,
+    dist = "weibull"
+  )
+  expect_equal(names(coef(bridged_full_factor)), names(coef(reference_full_factor)))
+  expect_equal(coef(bridged_full_factor), coef(reference_full_factor), tolerance = 1e-08)
+  expect_equal(
+    as.vector(model.matrix(bridged_full_factor)),
+    as.vector(model.matrix(reference_full_factor)),
+    tolerance = 1e-12
+  )
+
+  data$ph.ecog <- factor(as.character(data$ph.ecog), levels = 0:3)
+  contrasts(data$ph.ecog) <- stats::contr.sum(4L)
+  bridged_custom <- coxph(Surv(time, status) ~ ph.ecog + age, data = data)
+  reference_custom <- survival::coxph(
+    survival::Surv(time, status) ~ ph.ecog + age,
+    data = data,
+    x = TRUE
+  )
+  expect_equal(names(coef(bridged_custom)), names(coef(reference_custom)))
+  expect_equal(coef(bridged_custom), coef(reference_custom), tolerance = 1e-08)
+  expect_equal(
+    as.vector(model.matrix(bridged_custom)),
+    as.vector(reference_custom$x),
+    tolerance = 1e-12
+  )
+})
+
 test_that("Cox zph bridge preserves scaled variance, strata, and subsetting", {
   skip_if_not_installed("reticulate")
   skip_if_not_installed("survival")


### PR DESCRIPTION
## Summary
- carry declared factor contrast matrices and column names through the R-to-Python boundary
- use fitted contrasts for Cox and AFT design construction, interactions, subsetting, and new-data prediction
- retain full one-hot coding for no-intercept factor terms
- match ordered polynomial and custom sum contrasts from the current R survival package

## Testing
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- .venv/bin/pytest -q
- .venv/bin/mypy python/survival
- .venv/bin/ruff check python/survival python/tests
- .venv/bin/ruff format --check python/survival python/tests
- .venv/bin/python scripts/generate_binding_manifest.py --check
- R bridge test suite
- R CMD check --no-manual --no-build-vignettes r/survivalr (1 expected source-directory NOTE)