### PR TITLE
Preserve implicit formula factor ordering

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -1577,22 +1577,13 @@ def _coerce_array_like(values: Any, name: str) -> list[Any]:
     return result
 
 
-class _RFactorVector:
-    """Iterable factor values with level metadata preserved across reticulate."""
+class _BridgeVector:
+    """Compact iterable storage for values carrying boundary metadata."""
 
-    def __init__(
-        self,
-        values: Any,
-        levels: Any,
-        contrasts: Any | None = None,
-        contrast_names: Any | None = None,
-    ):
+    __slots__ = ("_values",)
+
+    def __init__(self, values: Any):
         self._values = tuple(values)
-        self.categories = tuple(levels)
-        self.contrasts = None if contrasts is None else tuple(tuple(row) for row in contrasts)
-        self.contrast_names = (
-            None if contrast_names is None else tuple(str(name) for name in contrast_names)
-        )
 
     def __iter__(self):
         return iter(self._values)
@@ -1604,6 +1595,26 @@ class _RFactorVector:
         return self._values[item]
 
 
+class _RFactorVector(_BridgeVector):
+    """Iterable factor values with level metadata preserved across reticulate."""
+
+    __slots__ = ("categories", "contrasts", "contrast_names")
+
+    def __init__(
+        self,
+        values: Any,
+        levels: Any,
+        contrasts: Any | None = None,
+        contrast_names: Any | None = None,
+    ):
+        super().__init__(values)
+        self.categories = tuple(levels)
+        self.contrasts = None if contrasts is None else tuple(tuple(row) for row in contrasts)
+        self.contrast_names = (
+            None if contrast_names is None else tuple(str(name) for name in contrast_names)
+        )
+
+
 def _r_factor(
     values: Any,
     levels: Any,
@@ -1611,6 +1622,30 @@ def _r_factor(
     contrast_names: Any | None = None,
 ) -> _RFactorVector:
     return _RFactorVector(values, levels, contrasts, contrast_names)
+
+
+class _RCharacterVector(_BridgeVector):
+    """Iterable character values whose R origin survives row filtering."""
+
+    __slots__ = ("factor_source",)
+
+    def __init__(self, values: Any, factor_source: Any | None = None):
+        super().__init__(values)
+        self.factor_source = self._values if factor_source is None else factor_source
+
+
+def _r_character(values: Any) -> _RCharacterVector:
+    return _RCharacterVector(values)
+
+
+class _RowSubsetVector(_BridgeVector):
+    """Iterable filtered values that retain pre-filter factor inputs."""
+
+    __slots__ = ("factor_source",)
+
+    def __init__(self, values: Any, factor_source: Any):
+        super().__init__(values)
+        self.factor_source = factor_source
 
 
 def _materialize_1d(values: Any, name: str) -> list[Any]:
@@ -1925,7 +1960,13 @@ def _subset_indices(subset: Any, n: int) -> list[int]:
     return indices
 
 
-def _subset_sequence(values: Any, indices: list[int], name: str) -> Any:
+def _subset_sequence(
+    values: Any,
+    indices: list[int],
+    name: str,
+    *,
+    preserve_factor_source: bool = False,
+) -> Any:
     materialized = _coerce_array_like(values, name)
     if indices and max(indices) >= len(materialized):
         raise ValueError(f"{name} must have enough rows for subset")
@@ -1934,7 +1975,12 @@ def _subset_sequence(values: Any, indices: list[int], name: str) -> Any:
     if categories is not None:
         contrasts, contrast_names = _factor_contrasts(values)
         return _RFactorVector(subsetted, categories, contrasts, contrast_names)
-    return subsetted
+    if isinstance(values, _RCharacterVector):
+        return _RCharacterVector(subsetted, values.factor_source)
+    if not preserve_factor_source:
+        return subsetted
+    factor_source = getattr(values, "factor_source", materialized)
+    return _RowSubsetVector(subsetted, factor_source)
 
 
 def _subset_optional_sequence(
@@ -1949,7 +1995,15 @@ def _subset_optional_sequence(
 
 def _subset_data(data: Any, indices: list[int]) -> Any:
     if isinstance(data, Mapping):
-        return {key: _subset_sequence(value, indices, str(key)) for key, value in data.items()}
+        return {
+            key: _subset_sequence(
+                value,
+                indices,
+                str(key),
+                preserve_factor_source=True,
+            )
+            for key, value in data.items()
+        }
     if hasattr(data, "iloc"):
         return data.iloc[indices]
     if hasattr(data, "take"):
@@ -4517,7 +4571,7 @@ def _term_columns(
         if numeric is not None:
             return [numeric]
 
-    levels = _categorical_levels(values, term.column)
+    levels = _formula_inferred_categorical_levels(data, term, values)
     return _categorical_columns(values, levels)
 
 
@@ -4620,6 +4674,31 @@ def _categorical_levels(
     return levels
 
 
+def _formula_inferred_categorical_levels(
+    data: Any,
+    term: _CovariateTerm,
+    values: Sequence[Any],
+) -> tuple[Any, ...]:
+    source = _column_source(data, term.column)
+    r_style_levels = term.categorical_wrapper is not None or isinstance(
+        source,
+        _RCharacterVector,
+    )
+    if not r_style_levels:
+        return _categorical_levels(values, term.column)
+    factor_values = (
+        getattr(source, "factor_source", values) if term.categorical_wrapper is not None else values
+    )
+    levels = _categorical_levels(
+        [value for value in factor_values if not _is_missing_value(value)],
+        term.column,
+    )
+    try:
+        return tuple(sorted(levels))
+    except TypeError:
+        return tuple(sorted(levels, key=lambda value: (type(value).__name__, str(value))))
+
+
 def _fit_single_design_term(
     data: Any,
     term: _CovariateTerm,
@@ -4646,7 +4725,10 @@ def _fit_single_design_term(
             pass
         else:
             return _NumericDesignTerm(term)
-    return _CategoricalDesignTerm(term, _categorical_levels(values, term.column))
+    return _CategoricalDesignTerm(
+        term,
+        _formula_inferred_categorical_levels(data, term, values),
+    )
 
 
 def _fit_design_term(

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -12844,6 +12844,69 @@ def test_formula_metadata_preserves_categorical_spelling_and_assignments():
     assert aft_matrix["assign"] == [0, 1, 1, 2, 2, 3, 3, 4]
 
 
+@pytest.mark.parametrize("wrapper", ["factor", "as.factor"])
+def test_formula_factor_wrappers_sort_inferred_levels_after_subset(wrapper):
+    data = _factor_data()
+    data["dose"] = [9, None, 3, 1, 2, 3, 1, 2]
+    subset = list(range(1, len(data["time"])))
+    kept = subset[1:]
+    fit = survival.coxph(
+        f"Surv(time, status) ~ {wrapper}(dose) + x1",
+        data=data,
+        subset=subset,
+        na_action="omit",
+        max_iter=0,
+    )
+    matrix = survival.model_matrix(fit)
+    prefix = f"{wrapper}(dose)"
+
+    assert matrix["columns"] == [f"{prefix}2", f"{prefix}3", f"{prefix}9", "x1"]
+    for actual, expected in zip(
+        matrix["data"],
+        (
+            [
+                float(data["dose"][idx] == 2),
+                float(data["dose"][idx] == 3),
+                0.0,
+                data["x1"][idx],
+            ]
+            for idx in kept
+        ),
+        strict=True,
+    ):
+        assert actual == pytest.approx(expected)
+
+
+def test_r_character_formula_terms_sort_levels_after_subset():
+    data = _factor_data()
+    groups = ["zz_unused", "z", "a", "m", "z", "a", "m", "z"]
+    subset = list(range(1, len(data["time"])))
+    r_data = {**data, "group": survival.r_api._r_character(groups)}
+    plain_data = {**data, "group": groups}
+
+    r_fit = survival.coxph(
+        "Surv(time, status) ~ group + x1",
+        data=r_data,
+        subset=subset,
+        max_iter=0,
+    )
+    plain_fit = survival.coxph(
+        "Surv(time, status) ~ group + x1",
+        data=plain_data,
+        subset=subset,
+        max_iter=0,
+    )
+
+    assert survival.coef_names(r_fit) == ["groupm", "groupz", "x1"]
+    assert survival.coef_names(plain_fit) == ["groupa", "groupm", "x1"]
+    for actual, expected in zip(
+        survival.model_matrix(r_fit)["data"],
+        ([float(groups[idx] == "m"), float(groups[idx] == "z"), data["x1"][idx]] for idx in subset),
+        strict=True,
+    ):
+        assert actual == pytest.approx(expected)
+
+
 def test_model_matrix_assignments_keep_strata_term_positions():
     data = _factor_data()
     data["group"] = ["A", "A", "B", "B", "A", "B", "A", "B"]

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -252,6 +252,8 @@ if (getRversion() >= "2.15.1") {
       value <- .as_python_vector(column)
       if (is.factor(column)) {
         value
+      } else if (is.character(column)) {
+        .python_attr("_r_character")(as.list(value))
       } else {
         as.list(value)
       }

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -7897,6 +7897,103 @@ test_that("formula factors retain ordered and custom contrasts", {
   )
 })
 
+test_that("implicit formula factors use R level ordering after subsetting", {
+  skip_if_not_installed("reticulate")
+  skip_if_not_installed("survival")
+  skip_if_not(reticulate::py_module_available("survival"), "Python survival package is unavailable")
+
+  row <- seq_len(48L)
+  x <- ((row * 11L) %% 43L) / 10 - 2.1
+  noise <- ((row * 13L) %% 11L - 5L) / 20
+  group <- c("zz_unused", rep(c("z", "a", "m"), length.out = 47L))
+  code <- c(99L, rep(c(3L, 1L, 2L), length.out = 47L))
+  data <- data.frame(
+    time = exp(
+      2.3 + 0.2 * x + 0.1 * (group == "z") - 0.15 * (code == 3L) + noise
+    ),
+    status = as.integer(row %% 5L != 0L),
+    group = group,
+    code = code,
+    x = x
+  )
+  keep <- row > 1L
+
+  bridged_character <- coxph(
+    Surv(time, status) ~ group + x,
+    data = data,
+    subset = keep,
+    ties = "breslow",
+    max_iter = 50L,
+    eps = 1e-09
+  )
+  reference_character <- survival::coxph(
+    survival::Surv(time, status) ~ group + x,
+    data = data,
+    subset = keep,
+    ties = "breslow",
+    x = TRUE,
+    control = survival::coxph.control(iter.max = 50L, eps = 1e-09)
+  )
+  expect_equal(names(coef(bridged_character)), names(coef(reference_character)))
+  expect_equal(coef(bridged_character), coef(reference_character), tolerance = 1e-08)
+  expect_equal(
+    as.vector(model.matrix(bridged_character)),
+    as.vector(reference_character$x),
+    tolerance = 1e-12
+  )
+
+  prediction_data <- data.frame(group = c("m", "z", "a"), x = c(-0.7, 0.2, 1.1))
+  expect_equal(
+    unname(predict(bridged_character, newdata = prediction_data, type = "lp")),
+    unname(stats::predict(reference_character, newdata = prediction_data, type = "lp")),
+    tolerance = 1e-08
+  )
+
+  bridged_factor <- coxph(
+    Surv(time, status) ~ factor(code) + x,
+    data = data,
+    subset = keep,
+    ties = "breslow",
+    max_iter = 50L,
+    eps = 1e-09
+  )
+  reference_factor <- survival::coxph(
+    survival::Surv(time, status) ~ factor(code) + x,
+    data = data,
+    subset = keep,
+    ties = "breslow",
+    x = TRUE,
+    control = survival::coxph.control(iter.max = 50L, eps = 1e-09)
+  )
+  expect_equal(names(coef(bridged_factor)), names(coef(reference_factor)))
+  expect_equal(coef(bridged_factor), coef(reference_factor), tolerance = 1e-08)
+  expect_equal(
+    as.vector(model.matrix(bridged_factor)),
+    as.vector(reference_factor$x),
+    tolerance = 1e-12
+  )
+
+  bridged_aft <- survreg(
+    Surv(time, status) ~ as.factor(code) + x,
+    data = data,
+    subset = keep,
+    dist = "weibull"
+  )
+  reference_aft <- survival::survreg(
+    survival::Surv(time, status) ~ as.factor(code) + x,
+    data = data,
+    subset = keep,
+    dist = "weibull"
+  )
+  expect_equal(names(coef(bridged_aft)), names(coef(reference_aft)))
+  expect_equal(coef(bridged_aft), coef(reference_aft), tolerance = 1e-08)
+  expect_equal(
+    as.vector(model.matrix(bridged_aft)),
+    as.vector(model.matrix(reference_aft)),
+    tolerance = 1e-12
+  )
+})
+
 test_that("Cox zph bridge preserves scaled variance, strata, and subsetting", {
   skip_if_not_installed("reticulate")
   skip_if_not_installed("survival")


### PR DESCRIPTION
## Summary
- preserve the R character origin across the language boundary so bare character formula terms use R-style factor ordering
- sort inferred levels for `factor()` and `as.factor()` while retaining pre-subset levels and excluding missing values
- keep ordinary Python string columns on their existing encounter-order behavior
- add Cox, AFT, subsetting, missing-value, model-matrix, and prediction regressions against the R reference implementation

## Why
R constructs implicit character factors and explicit factor wrappers with sorted levels. The local formula path previously used encounter order, which could change the baseline level, coefficient names, model matrices, and predictions. It also inferred wrapper levels after row filtering even though R evaluates those wrappers before subsetting.

## Impact
Formula fits now reproduce R's level and alias behavior for implicit character terms and explicit factor wrappers without changing the established Python mapping semantics.

## Validation
- Python: 1007 passed, 18 skipped
- Rust: 1542 tests without default features, 1751 with ML, and 1765 with Python plus ML
- R package check: all tests passed with the expected source-directory note
- strict Rust linting and formatting passed
- Python formatting, linting, stub typing, and binding-manifest checks passed