### PR TITLE
Support polynomial formula terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,12 +128,14 @@ hazard_times, cumulative_hazard = basehaz(cox_model)
 aft_model = survreg("Surv(time, status) ~ group + age", data=data)
 ```
 
-Formula support is intentionally conservative: `+` terms, `.` expansion,
-`-` exclusions, backtick-quoted column names, categorical treatment coding,
+Formula support includes `+` terms, `.` expansion, `-` exclusions,
+backtick-quoted column names, categorical treatment coding,
 `factor(...)` / `as.factor(...)`, `strata(...)`, interaction terms with `:`
-or `*`, and numeric `offset(...)` terms are supported, along with one-column
-numeric transforms `log(...)`, `sqrt(...)`, and `exp(...)`, plus
-`I(...)`/`identity(...)` arithmetic with `+`, `-`, `*`, `/`, and `^`.
+or `*`, and numeric `offset(...)` terms. Numeric expressions support nested
+R math calls, row-wise `pmin(...)` / `pmax(...)`, and arithmetic with `+`, `-`,
+`*`, `/`, and `^`. Univariate `poly(...)` terms provide raw or orthogonal
+multi-column bases through an O(n d) native recurrence and retain the fitted
+orthogonalization coefficients for new-data prediction.
 Formula calls also accept `subset=` as a boolean mask or zero-based row indices
 and `na_action="omit"` for row-wise missing-data omission across formula
 columns and external row-aligned arrays such as `weights`, `offset`, and

--- a/python/survival/_binding_manifest.py
+++ b/python/survival/_binding_manifest.py
@@ -858,6 +858,7 @@ BINDINGS = (
     "perform_survexp_fit",
     "permutation_importance",
     "ph_test",
+    "poly_basis",
     "power_logrank",
     "power_survival",
     "predict_bounded_cumulative_hazard",

--- a/python/survival/_survival.pyi
+++ b/python/survival/_survival.pyi
@@ -7726,6 +7726,13 @@ def pspline_basis(
     degree: int,
     boundary_knots: tuple[float, float],
 ) -> tuple[list[list[float]], list[float]]: ...
+def poly_basis(
+    x: list[float],
+    degree: int,
+    raw: bool = False,
+    alpha: list[float] | None = None,
+    norm2: list[float] | None = None,
+) -> tuple[list[list[float]], list[float], list[float]]: ...
 def cox_score_residuals(
     y: list[float],
     strata: list[int],

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -222,6 +222,13 @@ class _FactorEncoding:
 
 
 @dataclass(frozen=True)
+class _PolyFormulaOptions:
+    degree: int
+    raw: bool = False
+    simple: bool = False
+
+
+@dataclass(frozen=True)
 class _NumericFormulaLiteral:
     value: float
 
@@ -270,6 +277,7 @@ class _CovariateTerm:
     numeric_expression: _NumericFormulaExpression | None = None
     factor_options: _FactorFormulaOptions | None = None
     formula_label: str | None = None
+    poly_options: _PolyFormulaOptions | None = None
 
 
 @dataclass(frozen=True)
@@ -413,6 +421,13 @@ class _NumericDesignTerm:
 
 
 @dataclass(frozen=True)
+class _PolyDesignTerm:
+    term: _CovariateTerm
+    alpha: tuple[float, ...]
+    norm2: tuple[float, ...]
+
+
+@dataclass(frozen=True)
 class _CategoricalDesignTerm:
     term: _CovariateTerm
     levels: tuple[Any, ...]
@@ -422,7 +437,7 @@ class _CategoricalDesignTerm:
     full: bool = False
 
 
-_SingleDesignTerm = _NumericDesignTerm | _CategoricalDesignTerm
+_SingleDesignTerm = _NumericDesignTerm | _PolyDesignTerm | _CategoricalDesignTerm
 
 
 @dataclass(frozen=True)
@@ -471,6 +486,27 @@ class _FormulaDesign:
     strata_levels: tuple[Any, ...] = ()
     ridge: tuple[_RidgeFormulaTerm, ...] = ()
     intercept: bool = False
+
+
+@dataclass(frozen=True)
+class _FormulaSubsetData:
+    data: Any
+    poly_states: tuple[
+        tuple[_CovariateTerm, tuple[tuple[float, ...], tuple[float, ...]]],
+        ...,
+    ]
+
+    @property
+    def columns(self) -> Sequence[Any]:
+        if isinstance(self.data, Mapping):
+            return tuple(self.data)
+        columns = getattr(self.data, "columns", None)
+        if columns is None:
+            raise AttributeError("formula data does not expose column names")
+        return cast(Sequence[Any], columns)
+
+    def __getitem__(self, name: str) -> Any:
+        return self.data[name]
 
 
 @dataclass(frozen=True)
@@ -2094,6 +2130,11 @@ def _subset_optional_sequence(
 
 
 def _subset_data(data: Any, indices: list[int]) -> Any:
+    if isinstance(data, _FormulaSubsetData):
+        return _FormulaSubsetData(
+            _subset_data(data.data, indices),
+            data.poly_states,
+        )
     if isinstance(data, Mapping):
         return {
             key: _subset_sequence(
@@ -3707,6 +3748,40 @@ def _formula_columns(formula: str, data: Any) -> list[str]:
     return list(dict.fromkeys(columns))
 
 
+def _formula_subset_poly_states(
+    formula: str,
+    data: Any,
+    n: int,
+) -> tuple[tuple[_CovariateTerm, tuple[tuple[float, ...], tuple[float, ...]]], ...]:
+    response_spec = _formula_response_spec(formula)
+    _lhs, _sep, rhs = formula.partition("~")
+    terms = _split_terms(rhs, _dot_terms(data, list(response_spec.columns)))
+    states: list[tuple[_CovariateTerm, tuple[tuple[float, ...], tuple[float, ...]]]] = []
+    for spec in terms.covariates:
+        for term in _covariate_factors(spec):
+            options = term.poly_options
+            if options is None or options.raw or any(existing == term for existing, _ in states):
+                continue
+            values = _numeric_term_values(_term_raw_values(data, term, n), term)
+            _rows, alpha, norm2 = _core.poly_basis(
+                values,
+                options.degree,
+                False,
+                None,
+                None,
+            )
+            states.append(
+                (
+                    term,
+                    (
+                        tuple(float(value) for value in alpha),
+                        tuple(float(value) for value in norm2),
+                    ),
+                )
+            )
+    return tuple(states)
+
+
 def _subset_formula_inputs(
     formula: str,
     data: Any,
@@ -3714,12 +3789,16 @@ def _subset_formula_inputs(
     **row_aligned: Any,
 ) -> tuple[Any, dict[str, Any]]:
     n = len(_column(data, _formula_response_args(formula)[0]))
+    poly_states = _formula_subset_poly_states(formula, data, n)
     indices = _subset_indices(subset, n)
     filtered = {
         name: _subset_optional_sequence(values, indices, name)
         for name, values in row_aligned.items()
     }
-    return _subset_data(data, indices), filtered
+    subset_data = _subset_data(data, indices)
+    if poly_states:
+        subset_data = _FormulaSubsetData(subset_data, poly_states)
+    return subset_data, filtered
 
 
 def _apply_formula_na_action(
@@ -3752,7 +3831,11 @@ def _apply_formula_na_action(
             if any(column in excluded for column in term_columns):
                 continue
             declared_levels = _formula_declared_factor_levels(data, term)
-            if term.numeric_expression is not None:
+            if term.poly_options is not None and not term.poly_options.raw:
+                values = _term_raw_values(data, term, n)
+                if any(_is_missing_value(value) for value in values):
+                    raise ValueError("missing values are not allowed in orthogonal poly")
+            elif term.numeric_expression is not None:
                 transformed_columns.append(
                     (
                         _covariate_term_name(term),
@@ -4232,6 +4315,39 @@ def _dot_covariate_terms(dot_terms: Sequence[str] | None) -> list[_CovariateSpec
     return [_CovariateTerm(column) for column in dot_terms]
 
 
+def _parse_poly_formula_term(term: str) -> _CovariateTerm | None:
+    if not (term.startswith("poly(") and term.endswith(")")):
+        return None
+
+    parts = _formula_response_parts(term[5:-1])
+    value, degree, coefs, raw, simple = _numeric_formula_bound_arguments(
+        "poly",
+        parts,
+        ("x", "degree", "coefs", "raw", "simple"),
+    )
+    if value is None:
+        raise ValueError("poly() requires one numeric argument")
+    degree_value = 1 if degree is None else _numeric_formula_integer_literal(degree, "poly degree")
+    if degree_value < 1:
+        raise ValueError("poly degree must be at least 1")
+    if coefs is not None and coefs.strip().lower() != "null":
+        raise ValueError("poly() formula terms do not accept explicit coefs")
+    raw_value = False if raw is None else _numeric_formula_bool_literal(raw, "poly raw")
+    simple_value = False if simple is None else _numeric_formula_bool_literal(simple, "poly simple")
+    expression = _parse_numeric_formula_expression(value)
+    return _CovariateTerm(
+        value.strip(),
+        transform="poly",
+        numeric_expression=expression,
+        formula_label=term,
+        poly_options=_PolyFormulaOptions(
+            degree=degree_value,
+            raw=raw_value,
+            simple=simple_value,
+        ),
+    )
+
+
 def _parse_covariate_atom(term: str) -> _CovariateTerm:
     if not term:
         raise ValueError("formula interaction terms must not be empty")
@@ -4239,6 +4355,10 @@ def _parse_covariate_atom(term: str) -> _CovariateTerm:
     factor_term = _parse_factor_formula_term(term)
     if factor_term is not None:
         return factor_term
+
+    poly_term = _parse_poly_formula_term(term)
+    if poly_term is not None:
+        return poly_term
 
     for wrapper in ("I", "identity"):
         prefix = f"{wrapper}("
@@ -4303,7 +4423,7 @@ def _parse_offset_term(expression: str) -> _CovariateTerm:
         _arithmetic_expression_columns(expression)
         return _CovariateTerm(expression, arithmetic=expression)
     offset_term = _parse_covariate_atom(expression)
-    if offset_term.categorical:
+    if offset_term.categorical or offset_term.poly_options is not None:
         raise ValueError("offset() requires a numeric column or transform")
     return offset_term
 
@@ -5281,7 +5401,16 @@ def _apply_numeric_transform(values: list[float], transform: str | None, term: s
         return [math.sqrt(value) for value in values]
     if transform == "exp":
         return [math.exp(value) for value in values]
-    if transform in {"I", "identity", "as.numeric", "ridge", "pspline", "nsk", "tt"}:
+    if transform in {
+        "I",
+        "identity",
+        "as.numeric",
+        "poly",
+        "ridge",
+        "pspline",
+        "nsk",
+        "tt",
+    }:
         return values
     raise ValueError(f"unsupported formula transform {transform!r}")
 
@@ -5704,6 +5833,31 @@ def _fit_single_design_term(
     n: int,
 ) -> _SingleDesignTerm:
     values = _term_raw_values(data, term, n)
+    if term.poly_options is not None:
+        numeric = _numeric_term_values(values, term)
+        stored_state = (
+            next(
+                (state for stored_term, state in data.poly_states if stored_term == term),
+                None,
+            )
+            if isinstance(data, _FormulaSubsetData)
+            else None
+        )
+        if stored_state is None:
+            _rows, alpha, norm2 = _core.poly_basis(
+                numeric,
+                term.poly_options.degree,
+                term.poly_options.raw,
+                None,
+                None,
+            )
+        else:
+            alpha, norm2 = stored_state
+        return _PolyDesignTerm(
+            term=term,
+            alpha=tuple(float(value) for value in alpha),
+            norm2=tuple(float(value) for value in norm2),
+        )
     declared_levels = _formula_declared_factor_levels(data, term)
     if declared_levels is not None and term.factor_options is None:
         source = _column_source(data, term.column)
@@ -6000,6 +6154,8 @@ def _single_design_columns(
     spec: _SingleDesignTerm,
     n: int,
     time_transform_values: Mapping[_CovariateTerm, Sequence[float]] | None = None,
+    *,
+    prediction: bool = False,
 ) -> list[list[float]]:
     if (
         isinstance(spec, _NumericDesignTerm)
@@ -6011,6 +6167,23 @@ def _single_design_columns(
             raise ValueError("tt transform result must match the expanded risk-set rows")
         return [values]
     values = _term_raw_values(data, spec.term, n)
+    if isinstance(spec, _PolyDesignTerm):
+        options = cast(_PolyFormulaOptions, spec.term.poly_options)
+        recompute = options.simple and prediction
+        alpha = None if options.raw or recompute else list(spec.alpha)
+        norm2 = None if options.raw or recompute else list(spec.norm2)
+        rows, _alpha, _norm2 = _core.poly_basis(
+            _numeric_term_values(values, spec.term),
+            options.degree,
+            options.raw,
+            alpha,
+            norm2,
+        )
+        if len(rows) != n:
+            raise ValueError("poly() basis row count must match formula data")
+        if not rows:
+            return [[] for _ in range(options.degree)]
+        return [list(column) for column in zip(*rows, strict=True)]
     if isinstance(spec, _NumericDesignTerm):
         return [_numeric_term_values(values, spec.term)]
 
@@ -6035,6 +6208,8 @@ def _design_term_columns(
     spec: _DesignTerm,
     n: int,
     time_transform_values: Mapping[_CovariateTerm, Sequence[float]] | None = None,
+    *,
+    prediction: bool = False,
 ) -> list[list[float]]:
     if isinstance(spec, _FrailtyDesignTerm):
         if spec.sparse:
@@ -6080,7 +6255,13 @@ def _design_term_columns(
         return [list(column) for column in zip(*rows, strict=True)]
     if isinstance(spec, _InteractionDesignTerm):
         factor_columns = [
-            _single_design_columns(data, factor, n, time_transform_values)
+            _single_design_columns(
+                data,
+                factor,
+                n,
+                time_transform_values,
+                prediction=prediction,
+            )
             for factor in spec.factors
         ]
         interaction_columns: list[list[float]] = []
@@ -6090,7 +6271,13 @@ def _design_term_columns(
                 [math.prod(column[idx] for column in column_combo) for idx in range(n)]
             )
         return interaction_columns
-    return _single_design_columns(data, spec, n, time_transform_values)
+    return _single_design_columns(
+        data,
+        spec,
+        n,
+        time_transform_values,
+        prediction=prediction,
+    )
 
 
 def _design_rows_from_spec(
@@ -6099,11 +6286,18 @@ def _design_rows_from_spec(
     n: int,
     *,
     time_transform_values: Mapping[_CovariateTerm, Sequence[float]] | None = None,
+    prediction: bool = False,
 ) -> list[list[float]]:
     columns = [
         column
         for term in design.covariates
-        for column in _design_term_columns(data, term, n, time_transform_values)
+        for column in _design_term_columns(
+            data,
+            term,
+            n,
+            time_transform_values,
+            prediction=prediction,
+        )
     ]
     if design.intercept:
         columns.insert(0, [1.0] * n)
@@ -6852,6 +7046,10 @@ def _design_term_name(spec: _DesignTerm) -> str:
 
 def _single_design_term_output_names(spec: _SingleDesignTerm) -> list[str]:
     term = spec.term
+    if isinstance(spec, _PolyDesignTerm):
+        options = cast(_PolyFormulaOptions, term.poly_options)
+        prefix = _covariate_term_name(term)
+        return [f"{prefix}{index}" for index in range(1, options.degree + 1)]
     if isinstance(spec, _CategoricalDesignTerm):
         prefix = _covariate_term_name(term)
         if spec.full:
@@ -23602,7 +23800,9 @@ def _prediction_inputs(
                     f"newdata column {sparse_frailty.formula.term.column!r} contains unknown level "
                     f"{unknown!r}"
                 )
-        return _design_rows_from_spec(newdata, design, n), (offsets if any(offsets) else None)
+        return _design_rows_from_spec(newdata, design, n, prediction=True), (
+            offsets if any(offsets) else None
+        )
     coefficient_names = getattr(fit, "coefficient_names", None)
     if coefficient_names is not None and (
         isinstance(newdata, Mapping) or hasattr(newdata, "columns")

--- a/python/tests/test_binding_contract.py
+++ b/python/tests/test_binding_contract.py
@@ -10012,6 +10012,7 @@ def test_core_utility_bindings_are_typed():
         "SplineBasisResult",
         "PSpline",
         "nsk",
+        "poly_basis",
         "pspline_basis",
         "cox_score_residuals",
         "schoenfeld_residuals",
@@ -10049,6 +10050,7 @@ def test_core_utility_bindings_are_typed():
 
     expected_args = {
         "nsk": ["x", "df", "knots", "boundary_knots"],
+        "poly_basis": ["x", "degree", "raw", "alpha", "norm2"],
         "pspline_basis": ["x", "nterm", "degree", "boundary_knots"],
         "cox_score_residuals": ["y", "strata", "covar", "score", "weights", "nvar", "method"],
         "schoenfeld_residuals": ["y", "score", "strata", "covar", "nvar", "method"],
@@ -10068,6 +10070,26 @@ def test_core_utility_bindings_are_typed():
     assert all(math.isnan(value) for value in constant_basis[1])
     assert constant_basis[2] == pytest.approx(constant_basis[0])
     assert constant_knots == pytest.approx([2.0] * 12)
+
+    poly_rows, poly_alpha, poly_norm2 = core.poly_basis(
+        [-2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
+        3,
+    )
+    rebuilt_poly, rebuilt_alpha, rebuilt_norm2 = core.poly_basis(
+        [10.0, 11.0, 15.0],
+        3,
+        False,
+        poly_alpha,
+        poly_norm2,
+    )
+    assert poly_rows[0] == pytest.approx(
+        [-0.5400617248673217, 0.5400617248673216, -0.4308202184276644]
+    )
+    assert poly_alpha == pytest.approx([1.5, 1.5, 1.5])
+    assert poly_norm2 == pytest.approx([1.0, 8.0, 42.0, 168.0, 594.0])
+    assert rebuilt_poly[0] == pytest.approx([1.31157847467778, 5.16916222373008, 21.9718311398109])
+    assert rebuilt_alpha == pytest.approx(poly_alpha)
+    assert rebuilt_norm2 == pytest.approx(poly_norm2)
 
     assert _pyi_class_annotation_names(stub_path, "CovariateMatrix") == {
         "values",

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -17234,6 +17234,141 @@ def test_formula_numeric_calls_rebuild_interactions_offsets_and_predictions():
     )
 
 
+def test_formula_poly_terms_build_multicolumn_designs_and_interactions():
+    data = {
+        "time": [float(index) for index in range(1, 9)],
+        "status": [1, 1, 0, 1, 0, 1, 0, 1],
+        "x": [-2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
+        "z": [1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0],
+    }
+    formula = "Surv(time, status) ~ poly(x, 3) + poly(log(z), degree=2, raw=TRUE):x"
+    fit = survival.coxph(formula, data=data, max_iter=0)
+    matrix = survival.model_matrix(fit)
+    expected_orthogonal = [
+        [-0.5400617248673217, 0.5400617248673216, -0.4308202184276644],
+        [-0.3857583749052297, 0.0771516749810460, 0.3077287274483316],
+        [-0.2314550249431379, -0.2314550249431379, 0.4308202184276648],
+        [-0.0771516749810459, -0.3857583749052297, 0.1846372364689991],
+        [0.0771516749810459, -0.3857583749052297, -0.1846372364689989],
+        [0.2314550249431380, -0.2314550249431379, -0.4308202184276646],
+        [0.3857583749052298, 0.0771516749810459, -0.3077287274483319],
+        [0.5400617248673216, 0.5400617248673217, 0.4308202184276646],
+    ]
+    expected_rows = [
+        [
+            *expected_orthogonal[index],
+            math.log(data["z"][index]) * data["x"][index],
+            math.log(data["z"][index]) ** 2 * data["x"][index],
+        ]
+        for index in range(8)
+    ]
+
+    assert matrix["columns"] == [
+        "poly(x, 3)1",
+        "poly(x, 3)2",
+        "poly(x, 3)3",
+        "poly(log(z), degree=2, raw=TRUE)1:x",
+        "poly(log(z), degree=2, raw=TRUE)2:x",
+    ]
+    assert matrix["assign"] == [1, 1, 1, 2, 2]
+    assert survival.model_term_names(fit) == [
+        "poly(x, 3)",
+        "poly(log(z), degree=2, raw=TRUE):x",
+    ]
+    for actual, expected in zip(matrix["data"], expected_rows, strict=True):
+        assert actual == pytest.approx(expected, abs=1e-13)
+
+
+def test_formula_poly_reuses_training_coefficients_for_prediction():
+    data = {
+        "time": [float(index) for index in range(1, 9)],
+        "status": [1, 1, 0, 1, 0, 1, 0, 1],
+        "x": [-2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
+    }
+    fit = survival.coxph("Surv(time, status) ~ poly(x, 3)", data=data, max_iter=0)
+    expected_rows = [
+        [1.31157847467778, 5.16916222373008, 21.9718311398109],
+        [1.46588182463987, 6.55789237338891, 31.5729674361988],
+        [2.08309522448824, 13.6558464716451, 95.8267257274105],
+    ]
+
+    expected = fit.predict(expected_rows)
+    assert survival.predict(
+        fit,
+        {"x": [10.0, 11.0, 15.0]},
+        reference="zero",
+    ) == pytest.approx(expected, abs=1e-12)
+
+    simple_fit = survival.coxph(
+        "Surv(time, status) ~ poly(x, 2, simple=TRUE)",
+        data=data,
+        max_iter=0,
+    )
+    simple_rows, _alpha, _norm2 = survival._survival.poly_basis(
+        [10.0, 11.0, 15.0],
+        2,
+    )
+    assert survival.predict(
+        simple_fit,
+        {"x": [10.0, 11.0, 15.0]},
+        reference="zero",
+    ) == pytest.approx(simple_fit.predict(simple_rows), abs=1e-12)
+
+
+def test_formula_poly_fits_orthogonal_state_before_subset_like_r():
+    x = [-10.0, -4.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 8.0, 20.0]
+    keep = [False, True, True, True, True, True, True, True, False, False]
+    data = {
+        "time": [float(index) for index in range(1, 11)],
+        "status": [1, 0] * 5,
+        "x": x,
+    }
+    full_rows, _alpha, _norm2 = survival._survival.poly_basis(x, 2)
+
+    for simple in (False, True):
+        suffix = ", simple=TRUE" if simple else ""
+        fit = survival.coxph(
+            f"Surv(time, status) ~ poly(x, 2{suffix})",
+            data=data,
+            subset=keep,
+            max_iter=0,
+        )
+        expected = [row for row, retained in zip(full_rows, keep, strict=True) if retained]
+        for actual, expected_row in zip(fit.covariates, expected, strict=True):
+            assert actual == pytest.approx(expected_row, abs=1e-13)
+
+
+def test_formula_poly_matches_r_missing_value_and_argument_rules():
+    data = _numeric_data()
+    data["x1"][2] = None
+
+    with pytest.raises(ValueError, match="missing values are not allowed"):
+        survival.coxph(
+            "Surv(time, status) ~ poly(x1, 2)",
+            data=data,
+            na_action="omit",
+        )
+
+    raw_fit = survival.coxph(
+        "Surv(time, status) ~ poly(x1, 2, raw=TRUE)",
+        data=data,
+        na_action="omit",
+        max_iter=0,
+    )
+    assert len(raw_fit.covariates) == 7
+    assert all(len(row) == 2 for row in raw_fit.covariates)
+
+    for term, message in (
+        ("poly(x1, 0)", "at least 1"),
+        ("poly(x1, raw=x2)", "must be TRUE or FALSE"),
+        ("poly(x1, 8)", "unique points"),
+        ("poly(x1, 2, coefs=1)", "explicit coefs"),
+        ("offset(poly(x1, 2))", "offset"),
+    ):
+        with pytest.raises(ValueError, match=message):
+            survival.coxph(f"Surv(time, status) ~ {term}", data=_numeric_data())
+
+
 def test_formula_pmin_na_rm_controls_transformed_row_omission():
     data = _numeric_data()
     data["x1"] = [None, None, *data["x1"][2:]]

--- a/r/survivalr/man/survivalr.Rd
+++ b/r/survivalr/man/survivalr.Rd
@@ -1270,6 +1270,10 @@ R-compatible names and methods.
 their level ordering, while transforming continuous terms within each event
 risk set.
 
+\code{coxph} and \code{survreg} formulas support raw and orthogonal univariate
+\code{poly(...)} terms, including interactions. Orthogonal bases retain their
+training coefficients when rebuilding model matrices for new data.
+
 Formula \code{finegray} calls use the Python formula engine and Rust interval
 expansion directly. The bridge supports weights, subsets, missing-data actions,
 strata, counting-process histories, and delayed entry; computes censoring risk

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -5036,6 +5036,181 @@ test_that("numeric formula calls match R designs and prediction rebuilding", {
   )
 })
 
+test_that("polynomial formula terms match R designs and prediction rebuilding", {
+  skip_if_not_installed("reticulate")
+  skip_if_not_installed("survival")
+  skip_if_not(reticulate::py_module_available("survival"), "Python survival package is unavailable")
+
+  set.seed(5110)
+  n <- 100L
+  x <- stats::runif(n, -2, 5)
+  z <- stats::runif(n, 0.2, 4)
+  w <- stats::runif(n, 0.5, 1.5)
+  eta <- 0.2 * x - 0.1 * x^2 + 0.3 * log(z) + 0.08 * w * log(z)^2
+  event_time <- stats::rexp(n, rate = exp(eta) / 10)
+  censor_time <- stats::rexp(n, rate = 1 / 14)
+  data <- data.frame(
+    time = pmax(pmin(event_time, censor_time), 0.01),
+    status = as.integer(event_time <= censor_time),
+    x = x,
+    z = z,
+    w = w
+  )
+  bridged <- coxph(
+    Surv(time, status) ~ poly(x, 3) +
+      poly(log(z), degree = 2, raw = TRUE):w,
+    data = data,
+    max_iter = 150,
+    eps = 1e-09,
+    toler = 1e-10,
+    x = TRUE
+  )
+  reference <- survival::coxph(
+    survival::Surv(time, status) ~ poly(x, 3) +
+      poly(log(z), degree = 2, raw = TRUE):w,
+    data = data,
+    x = TRUE,
+    control = survival::coxph.control(
+      iter.max = 150,
+      eps = 1e-09,
+      toler.chol = 1e-10
+    )
+  )
+
+  bridged_matrix <- model.matrix(bridged)
+  reference_matrix <- stats::model.matrix(reference)
+  expect_identical(colnames(bridged_matrix), colnames(reference_matrix))
+  expect_identical(attr(bridged_matrix, "assign"), attr(reference_matrix, "assign"))
+  expect_equal(unname(bridged_matrix), unname(reference_matrix), tolerance = 1e-12)
+  expect_identical(attr(terms(bridged), "term.labels"), attr(terms(reference), "term.labels"))
+  expect_equal(unname(coef(bridged)), unname(coef(reference)), tolerance = 2e-08)
+
+  newdata <- transform(
+    data[c(2, 7, 15, 22), ],
+    x = x + c(0.5, -0.3, 0.8, -0.6),
+    z = z + c(0.2, 0.5, -0.1, 0.4),
+    w = w + c(-0.1, 0.15, 0.05, -0.08)
+  )
+  expect_equal(
+    unname(predict(bridged, newdata = newdata, type = "lp", reference = "zero")),
+    unname(stats::predict(reference, newdata = newdata, type = "lp", reference = "zero")),
+    tolerance = 2e-08
+  )
+
+  missing_data <- data[seq_len(8), ]
+  missing_data$x[3] <- NA_real_
+  expect_error(
+    coxph(
+      Surv(time, status) ~ poly(x, 2),
+      data = missing_data,
+      na.action = na.omit
+    ),
+    "missing values are not allowed"
+  )
+  bridged_raw <- coxph(
+    Surv(time, status) ~ poly(x, 2, raw = TRUE),
+    data = missing_data,
+    na.action = na.omit,
+    max_iter = 0,
+    x = TRUE
+  )
+  reference_raw <- survival::coxph(
+    survival::Surv(time, status) ~ poly(x, 2, raw = TRUE),
+    data = missing_data,
+    na.action = na.omit,
+    x = TRUE,
+    control = survival::coxph.control(iter.max = 0)
+  )
+  expect_equal(
+    unname(model.matrix(bridged_raw)),
+    unname(stats::model.matrix(reference_raw)),
+    tolerance = 1e-12
+  )
+
+  subset_data <- data.frame(
+    time = seq_len(10),
+    status = rep(c(1L, 0L), 5),
+    x = c(-10, -4, -2, -1, 0, 1, 2, 3, 8, 20),
+    keep = c(FALSE, rep(TRUE, 7), FALSE, FALSE)
+  )
+  keep <- subset_data$keep
+  bridged_subset <- coxph(
+    Surv(time, status) ~ poly(x, 2),
+    data = subset_data,
+    subset = keep,
+    max_iter = 0,
+    x = TRUE
+  )
+  reference_subset <- survival::coxph(
+    survival::Surv(time, status) ~ poly(x, 2),
+    data = subset_data,
+    subset = keep,
+    x = TRUE,
+    control = survival::coxph.control(iter.max = 0)
+  )
+  expect_equal(
+    unname(model.matrix(bridged_subset)),
+    unname(stats::model.matrix(reference_subset)),
+    tolerance = 1e-12
+  )
+})
+
+test_that("survreg polynomial formula terms match R", {
+  skip_if_not_installed("reticulate")
+  skip_if_not_installed("survival")
+  skip_if_not(reticulate::py_module_available("survival"), "Python survival package is unavailable")
+
+  set.seed(5112)
+  n <- 90L
+  x <- stats::runif(n, -2, 5)
+  z <- stats::runif(n, 0.2, 4)
+  latent <- exp(1.2 + 0.2 * x - 0.03 * x^2 + stats::rnorm(n, sd = 0.45))
+  censor <- stats::rexp(n, rate = 1 / 20)
+  data <- data.frame(
+    time = pmax(pmin(latent, censor), 0.01),
+    status = as.integer(latent <= censor),
+    x = x,
+    z = z
+  )
+  bridged <- survreg(
+    Surv(time, status) ~ poly(x, 3) + poly(log(z), 2, raw = TRUE),
+    data = data,
+    dist = "weibull",
+    max_iter = 150,
+    eps = 1e-10,
+    x = TRUE
+  )
+  reference <- survival::survreg(
+    survival::Surv(time, status) ~ poly(x, 3) + poly(log(z), 2, raw = TRUE),
+    data = data,
+    dist = "weibull",
+    x = TRUE,
+    control = survival::survreg.control(
+      maxiter = 150,
+      rel.tolerance = 1e-10
+    )
+  )
+
+  bridged_matrix <- model.matrix(bridged)
+  reference_matrix <- stats::model.matrix(reference)
+  expect_identical(colnames(bridged_matrix), colnames(reference_matrix))
+  expect_identical(attr(bridged_matrix, "assign"), attr(reference_matrix, "assign"))
+  expect_equal(unname(bridged_matrix), unname(reference_matrix), tolerance = 1e-12)
+  expect_identical(attr(terms(bridged), "term.labels"), attr(terms(reference), "term.labels"))
+  expect_equal(unname(coef(bridged)), unname(coef(reference)), tolerance = 2e-08)
+
+  newdata <- transform(
+    data[c(1, 4, 9), ],
+    x = x + c(0.4, -0.2, 0.7),
+    z = z + c(0.2, 0.3, -0.1)
+  )
+  expect_equal(
+    unname(predict(bridged, newdata = newdata, type = "lp")),
+    unname(stats::predict(reference, newdata = newdata, type = "lp")),
+    tolerance = 2e-08
+  )
+})
+
 test_that("pmin na.rm controls formula row omission like R", {
   skip_if_not_installed("reticulate")
   skip_if_not_installed("survival")

--- a/src/api/python/classical/core.rs
+++ b/src/api/python/classical/core.rs
@@ -86,6 +86,7 @@ pub(super) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(cipoisson, m)?)?;
     m.add_function(wrap_pyfunction!(cipoisson_exact, m)?)?;
     m.add_function(wrap_pyfunction!(cipoisson_anscombe, m)?)?;
+    m.add_function(wrap_pyfunction!(poly_basis, m)?)?;
     m.add_function(wrap_pyfunction!(pspline_basis, m)?)?;
     m.add_function(wrap_pyfunction!(crate::concordance::basic::concordance, m)?)?;
     m.add_function(wrap_pyfunction!(agexact, m)?)?;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -3,9 +3,11 @@ pub(crate) mod coxcount1_module;
 pub(crate) mod coxscho;
 #[path = "nsk.rs"]
 pub(crate) mod nsk_module;
+pub(crate) mod poly;
 pub(crate) mod pspline;
 
 pub use coxcount1_module::{CoxCountOutput, coxcount1, coxcount2};
 pub use coxscho::schoenfeld_residuals;
 pub use nsk_module::{NaturalSplineKnot, SplineBasisResult, nsk};
+pub use poly::poly_basis;
 pub use pspline::{PSpline, pspline_basis};

--- a/src/core/poly.rs
+++ b/src/core/poly.rs
@@ -1,0 +1,278 @@
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use rayon::prelude::*;
+
+type PolyBasis = (Vec<Vec<f64>>, Vec<f64>, Vec<f64>);
+
+fn value_error(message: impl Into<String>) -> PyErr {
+    PyValueError::new_err(message.into())
+}
+
+fn validate_degree(degree: usize) -> PyResult<()> {
+    if degree == 0 {
+        return Err(value_error("degree must be at least 1"));
+    }
+    Ok(())
+}
+
+fn validate_orthogonal_coefficients(degree: usize, alpha: &[f64], norm2: &[f64]) -> PyResult<()> {
+    if alpha.len() != degree {
+        return Err(value_error(format!(
+            "alpha length ({}) must match degree ({degree})",
+            alpha.len()
+        )));
+    }
+    if norm2.len() != degree + 2 {
+        return Err(value_error(format!(
+            "norm2 length ({}) must equal degree + 2 ({})",
+            norm2.len(),
+            degree + 2
+        )));
+    }
+    if alpha.iter().any(|value| !value.is_finite()) {
+        return Err(value_error("alpha must contain only finite values"));
+    }
+    if norm2
+        .iter()
+        .any(|value| !value.is_finite() || *value <= 0.0)
+    {
+        return Err(value_error(
+            "norm2 must contain only finite positive values",
+        ));
+    }
+    Ok(())
+}
+
+fn raw_polynomial_rows(x: &[f64], degree: usize) -> PyResult<Vec<Vec<f64>>> {
+    x.len()
+        .checked_mul(degree)
+        .ok_or_else(|| value_error("polynomial basis dimensions are too large"))?;
+    Ok(x.par_iter()
+        .map(|&value| {
+            let mut row = Vec::with_capacity(degree);
+            let mut power = value;
+            for _ in 0..degree {
+                row.push(power);
+                power *= value;
+            }
+            row
+        })
+        .collect())
+}
+
+fn unique_value_count(x: &[f64]) -> usize {
+    let mut values = x.to_vec();
+    values.sort_by(f64::total_cmp);
+    values.dedup_by(|left, right| *left == *right);
+    values.len()
+}
+
+fn fit_orthogonal_coefficients(x: &[f64], degree: usize) -> PyResult<(Vec<f64>, Vec<f64>)> {
+    if x.iter().any(|value| !value.is_finite()) {
+        return Err(value_error(
+            "missing or infinite values are not allowed in orthogonal poly",
+        ));
+    }
+    if degree >= unique_value_count(x) {
+        return Err(value_error(
+            "degree must be less than the number of unique points",
+        ));
+    }
+
+    let mut alpha = Vec::with_capacity(degree);
+    let mut norm2 = Vec::with_capacity(degree + 2);
+    norm2.push(1.0);
+    norm2.push(x.len() as f64);
+
+    let mut previous_previous = vec![0.0; x.len()];
+    let mut previous = vec![1.0; x.len()];
+    for column in 0..degree {
+        let previous_norm = norm2[column + 1];
+        let weighted_sum = x
+            .iter()
+            .zip(&previous)
+            .map(|(&value, &basis)| value * basis * basis)
+            .sum::<f64>();
+        let center = weighted_sum / previous_norm;
+        if !center.is_finite() {
+            return Err(value_error(
+                "orthogonal polynomial coefficients are not finite",
+            ));
+        }
+        alpha.push(center);
+
+        let ratio = if column == 0 {
+            0.0
+        } else {
+            norm2[column + 1] / norm2[column]
+        };
+        let current: Vec<f64> = x
+            .iter()
+            .zip(&previous)
+            .zip(&previous_previous)
+            .map(|((&value, &prior), &older)| (value - center) * prior - ratio * older)
+            .collect();
+        let current_norm = current.iter().map(|value| value * value).sum::<f64>();
+        if !current_norm.is_finite() || current_norm <= 0.0 {
+            return Err(value_error(
+                "degree must be less than the numerical rank of the input",
+            ));
+        }
+        norm2.push(current_norm);
+        previous_previous = previous;
+        previous = current;
+    }
+    Ok((alpha, norm2))
+}
+
+fn orthogonal_polynomial_rows(
+    x: &[f64],
+    degree: usize,
+    alpha: &[f64],
+    norm2: &[f64],
+) -> PyResult<Vec<Vec<f64>>> {
+    validate_orthogonal_coefficients(degree, alpha, norm2)?;
+    x.len()
+        .checked_mul(degree)
+        .ok_or_else(|| value_error("polynomial basis dimensions are too large"))?;
+
+    Ok(x.par_iter()
+        .map(|&value| {
+            if value.is_nan() {
+                return vec![f64::NAN; degree];
+            }
+            let mut row = Vec::with_capacity(degree);
+            let mut previous_previous = 0.0;
+            let mut previous = 1.0;
+            for column in 0..degree {
+                let ratio = if column == 0 {
+                    0.0
+                } else {
+                    norm2[column + 1] / norm2[column]
+                };
+                let current = (value - alpha[column]) * previous - ratio * previous_previous;
+                row.push(current / norm2[column + 2].sqrt());
+                previous_previous = previous;
+                previous = current;
+            }
+            row
+        })
+        .collect())
+}
+
+pub(crate) fn poly_basis_core(
+    x: &[f64],
+    degree: usize,
+    raw: bool,
+    alpha: Option<&[f64]>,
+    norm2: Option<&[f64]>,
+) -> PyResult<PolyBasis> {
+    validate_degree(degree)?;
+    if raw {
+        return Ok((raw_polynomial_rows(x, degree)?, Vec::new(), Vec::new()));
+    }
+
+    let (fitted_alpha, fitted_norm2) = match (alpha, norm2) {
+        (None, None) => fit_orthogonal_coefficients(x, degree)?,
+        (Some(alpha), Some(norm2)) => {
+            validate_orthogonal_coefficients(degree, alpha, norm2)?;
+            (alpha.to_vec(), norm2.to_vec())
+        }
+        _ => {
+            return Err(value_error(
+                "alpha and norm2 must either both be supplied or both be omitted",
+            ));
+        }
+    };
+    let rows = orthogonal_polynomial_rows(x, degree, &fitted_alpha, &fitted_norm2)?;
+    Ok((rows, fitted_alpha, fitted_norm2))
+}
+
+#[pyfunction]
+#[pyo3(signature = (x, degree, raw=false, alpha=None, norm2=None))]
+pub fn poly_basis(
+    x: Vec<f64>,
+    degree: usize,
+    raw: bool,
+    alpha: Option<Vec<f64>>,
+    norm2: Option<Vec<f64>>,
+) -> PyResult<PolyBasis> {
+    poly_basis_core(&x, degree, raw, alpha.as_deref(), norm2.as_deref())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn orthogonal_basis_matches_r_stats_poly_fixture() {
+        let x = vec![-2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0];
+        let (rows, alpha, norm2) = poly_basis_core(&x, 3, false, None, None).unwrap();
+        let expected = [
+            [-0.5400617248673217, 0.5400617248673216, -0.4308202184276644],
+            [-0.3857583749052297, 0.0771516749810460, 0.3077287274483316],
+            [-0.2314550249431379, -0.2314550249431379, 0.4308202184276648],
+            [-0.0771516749810459, -0.3857583749052297, 0.1846372364689991],
+            [0.0771516749810459, -0.3857583749052297, -0.1846372364689989],
+            [
+                0.231_455_024_943_138,
+                -0.2314550249431379,
+                -0.4308202184276646,
+            ],
+            [0.3857583749052298, 0.0771516749810459, -0.3077287274483319],
+            [0.5400617248673216, 0.5400617248673217, 0.4308202184276646],
+        ];
+
+        assert_eq!(alpha.len(), 3);
+        for value in alpha {
+            assert!((value - 1.5).abs() < 1e-14);
+        }
+        assert_eq!(norm2, vec![1.0, 8.0, 42.0, 168.0, 594.0]);
+        for (actual_row, expected_row) in rows.iter().zip(expected) {
+            for (&actual, expected) in actual_row.iter().zip(expected_row) {
+                assert!((actual - expected).abs() < 1e-14);
+            }
+        }
+    }
+
+    #[test]
+    fn stored_coefficients_rebuild_new_rows() {
+        let training = vec![-2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0];
+        let (_rows, alpha, norm2) = poly_basis_core(&training, 3, false, None, None).unwrap();
+        let (predicted, predicted_alpha, predicted_norm2) =
+            poly_basis_core(&[10.0, 11.0, 15.0], 3, false, Some(&alpha), Some(&norm2)).unwrap();
+        let expected = [
+            [1.31157847467778, 5.16916222373008, 21.9718311398109],
+            [1.46588182463987, 6.55789237338891, 31.5729674361988],
+            [2.08309522448824, 13.6558464716451, 95.8267257274105],
+        ];
+
+        assert_eq!(predicted_alpha, alpha);
+        assert_eq!(predicted_norm2, norm2);
+        for (actual_row, expected_row) in predicted.iter().zip(expected) {
+            for (&actual, expected) in actual_row.iter().zip(expected_row) {
+                assert!((actual - expected).abs() < 1e-12);
+            }
+        }
+    }
+
+    #[test]
+    fn raw_basis_preserves_missing_rows() {
+        let (rows, alpha, norm2) =
+            poly_basis_core(&[-2.0, f64::NAN, 3.0], 3, true, None, None).unwrap();
+        assert_eq!(rows[0], vec![-2.0, 4.0, -8.0]);
+        assert!(rows[1].iter().all(|value| value.is_nan()));
+        assert_eq!(rows[2], vec![3.0, 9.0, 27.0]);
+        assert!(alpha.is_empty());
+        assert!(norm2.is_empty());
+    }
+
+    #[test]
+    fn orthogonal_basis_validates_state_and_rank() {
+        assert!(poly_basis_core(&[1.0, 2.0], 0, false, None, None).is_err());
+        assert!(poly_basis_core(&[1.0, 1.0, 2.0], 2, false, None, None).is_err());
+        assert!(poly_basis_core(&[1.0, f64::NAN, 3.0], 1, false, None, None).is_err());
+        assert!(poly_basis_core(&[1.0], 1, false, Some(&[0.0]), None).is_err());
+        assert!(poly_basis_core(&[1.0], 1, false, Some(&[0.0]), Some(&[1.0, 1.0])).is_err());
+    }
+}


### PR DESCRIPTION
## Summary
- add an O(n d) Rust kernel for raw and orthogonal univariate polynomial bases with R-compatible `alpha` and `norm2` state
- integrate multi-column `poly()` terms and interactions into `coxph` and `survreg` formula designs and new-data reconstruction, including `simple`, subset-ordering, and missing-value rules
- add Rust, Python, and R-reference coverage plus binding types and documentation

## Validation
- Python: 1045 passed, 18 skipped
- binding contract: 111 passed
- Rust: 1546 default, 1755 ML, 1769 Python + ML
- strict clippy, Rust formatting, Ruff, stub type checks, binding manifest, and diff checks
- full R bridge suite
- R package check: expected source-tree NOTE only
- randomized training and extrapolated new-data comparisons against R