### PR TITLE
Support scaled formula terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,10 @@ or `*`, and numeric `offset(...)` terms. Numeric expressions support nested
 R math calls, row-wise `pmin(...)` / `pmax(...)`, and arithmetic with `+`, `-`,
 `*`, `/`, and `^`. Univariate `poly(...)` terms provide raw or orthogonal
 multi-column bases through an O(n d) native recurrence and retain the fitted
-orthogonalization coefficients for new-data prediction.
+orthogonalization coefficients for new-data prediction. Stateful `scale(...)`
+terms use an O(n) native path, accept R's logical or numeric `center=` and
+`scale=` options, fit before row subsetting or missing-data omission, and reuse
+their fitted state for ordinary new-data model reconstruction.
 Formula calls also accept `subset=` as a boolean mask or zero-based row indices
 and `na_action="omit"` for row-wise missing-data omission across formula
 columns and external row-aligned arrays such as `weights`, `offset`, and

--- a/python/survival/_binding_manifest.py
+++ b/python/survival/_binding_manifest.py
@@ -923,6 +923,7 @@ BINDINGS = (
     "sample_size_survival",
     "sample_size_survival_freedman",
     "scale_schoenfeld_residuals",
+    "scale_values",
     "schoenfeld_residuals",
     "score_test_py",
     "secure_aggregate",

--- a/python/survival/_survival.pyi
+++ b/python/survival/_survival.pyi
@@ -7733,6 +7733,13 @@ def poly_basis(
     alpha: list[float] | None = None,
     norm2: list[float] | None = None,
 ) -> tuple[list[list[float]], list[float], list[float]]: ...
+def scale_values(
+    x: list[float],
+    center: bool = True,
+    scale: bool = True,
+    center_value: float | None = None,
+    scale_value: float | None = None,
+) -> tuple[list[float], float | None, float | None]: ...
 def cox_score_residuals(
     y: list[float],
     strata: list[int],

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -255,7 +255,7 @@ class _NumericFormulaBinary:
 class _NumericFormulaCall:
     function: str
     arguments: tuple[_NumericFormulaExpression, ...]
-    option: float | int | bool | None = None
+    option: float | int | bool | tuple[bool | float, bool | float] | None = None
 
 
 _NumericFormulaExpression = (
@@ -265,6 +265,9 @@ _NumericFormulaExpression = (
     | _NumericFormulaBinary
     | _NumericFormulaCall
 )
+
+_ScaleFormulaState = tuple[float | None, float | None]
+_ScaleFormulaStates = tuple[tuple[_NumericFormulaCall, _ScaleFormulaState], ...]
 
 
 @dataclass(frozen=True)
@@ -418,6 +421,7 @@ class _CachedFormulaTerms:
 @dataclass(frozen=True)
 class _NumericDesignTerm:
     term: _CovariateTerm
+    scale_states: _ScaleFormulaStates = ()
 
 
 @dataclass(frozen=True)
@@ -425,6 +429,7 @@ class _PolyDesignTerm:
     term: _CovariateTerm
     alpha: tuple[float, ...]
     norm2: tuple[float, ...]
+    scale_states: _ScaleFormulaStates = ()
 
 
 @dataclass(frozen=True)
@@ -491,6 +496,7 @@ class _FormulaDesign:
 @dataclass(frozen=True)
 class _FormulaSubsetData:
     data: Any
+    scale_states: _ScaleFormulaStates
     poly_states: tuple[
         tuple[_CovariateTerm, tuple[tuple[float, ...], tuple[float, ...]]],
         ...,
@@ -2133,6 +2139,7 @@ def _subset_data(data: Any, indices: list[int]) -> Any:
     if isinstance(data, _FormulaSubsetData):
         return _FormulaSubsetData(
             _subset_data(data.data, indices),
+            data.scale_states,
             data.poly_states,
         )
     if isinstance(data, Mapping):
@@ -3219,6 +3226,7 @@ _NUMERIC_FORMULA_CALLS = _NUMERIC_FORMULA_UNARY_CALLS | {
     "pmax",
     "pmin",
     "round",
+    "scale",
     "signif",
 }
 _NUMERIC_FORMULA_UNARY_FUNCTIONS = MappingProxyType(
@@ -3309,6 +3317,24 @@ def _numeric_formula_bool_literal(value: str, name: str) -> bool:
     raise ValueError(f"{name} must be TRUE or FALSE")
 
 
+def _numeric_formula_scale_option(value: str, name: str) -> bool | float:
+    text = value.strip()
+    if text.startswith("c(") and text.endswith(")"):
+        parts = _formula_response_parts(text[2:-1])
+        if len(parts) != 1:
+            raise ValueError(f"{name} must be TRUE, FALSE, or a numeric scalar")
+        return _numeric_formula_scale_option(parts[0], name)
+    normalized = text.lower()
+    if normalized in {"true", "t"}:
+        return True
+    if normalized in {"false", "f"}:
+        return False
+    literal = _numeric_formula_literal(value)
+    if literal is None or math.isnan(literal):
+        raise ValueError(f"{name} must be TRUE, FALSE, or a numeric scalar")
+    return literal
+
+
 def _numeric_formula_integer_literal(value: str, name: str) -> int:
     literal = _arithmetic_literal(value.strip().removesuffix("L").removesuffix("l"))
     if literal is None or not literal.is_integer():
@@ -3341,6 +3367,24 @@ def _numeric_formula_call_expression(
     function: str,
     parts: Sequence[str],
 ) -> _NumericFormulaCall:
+    if function == "scale":
+        value, center, scale = _numeric_formula_bound_arguments(
+            function,
+            parts,
+            ("x", "center", "scale"),
+        )
+        if value is None:
+            raise ValueError("scale() requires one numeric argument")
+        center_value = (
+            True if center is None else _numeric_formula_scale_option(center, "scale center")
+        )
+        scale_value = True if scale is None else _numeric_formula_scale_option(scale, "scale scale")
+        return _NumericFormulaCall(
+            function,
+            (_parse_numeric_formula_expression(value),),
+            (center_value, scale_value),
+        )
+
     if function in _NUMERIC_FORMULA_UNARY_CALLS:
         (argument,) = _numeric_formula_bound_arguments(function, parts, ("x",))
         if argument is None:
@@ -3585,10 +3629,13 @@ def _numeric_formula_call_values(
     raise ValueError(f"unsupported formula numeric call {function!r}")
 
 
-def _numeric_formula_expression_values(
+def _numeric_formula_expression_values_with_state(
     data: Any,
     expression: _NumericFormulaExpression,
     n: int,
+    scale_states: dict[_NumericFormulaCall, _ScaleFormulaState],
+    *,
+    fit_scales: bool,
 ) -> list[float]:
     if isinstance(expression, _NumericFormulaLiteral):
         return [expression.value] * n
@@ -3611,19 +3658,129 @@ def _numeric_formula_expression_values(
     if isinstance(expression, _NumericFormulaUnary):
         return [
             value if expression.operator == "+" else -value
-            for value in _numeric_formula_expression_values(data, expression.operand, n)
+            for value in _numeric_formula_expression_values_with_state(
+                data,
+                expression.operand,
+                n,
+                scale_states,
+                fit_scales=fit_scales,
+            )
         ]
     if isinstance(expression, _NumericFormulaBinary):
-        left = _numeric_formula_expression_values(data, expression.left, n)
-        right = _numeric_formula_expression_values(data, expression.right, n)
+        left = _numeric_formula_expression_values_with_state(
+            data,
+            expression.left,
+            n,
+            scale_states,
+            fit_scales=fit_scales,
+        )
+        right = _numeric_formula_expression_values_with_state(
+            data,
+            expression.right,
+            n,
+            scale_states,
+            fit_scales=fit_scales,
+        )
         return [
             _numeric_formula_binary_value(expression.operator, left_value, right_value)
             for left_value, right_value in zip(left, right, strict=True)
         ]
     arguments = [
-        _numeric_formula_expression_values(data, argument, n) for argument in expression.arguments
+        _numeric_formula_expression_values_with_state(
+            data,
+            argument,
+            n,
+            scale_states,
+            fit_scales=fit_scales,
+        )
+        for argument in expression.arguments
     ]
+    if expression.function == "scale":
+        state = scale_states.get(expression)
+        if state is None:
+            if not fit_scales:
+                raise ValueError("fitted scale() formula state is unavailable")
+            center_option, scale_option = cast(
+                tuple[bool | float, bool | float],
+                expression.option,
+            )
+            fit_center = isinstance(center_option, bool) and center_option
+            fit_scale = isinstance(scale_option, bool) and scale_option
+            center_value = None if isinstance(center_option, bool) else float(center_option)
+            scale_value = None if isinstance(scale_option, bool) else float(scale_option)
+            values, fitted_center, fitted_scale = _core.scale_values(
+                arguments[0],
+                fit_center,
+                fit_scale,
+                center_value,
+                scale_value,
+            )
+            state = (
+                None if fitted_center is None else float(fitted_center),
+                None if fitted_scale is None else float(fitted_scale),
+            )
+            scale_states[expression] = state
+            return list(values)
+        values, _center, _scale = _core.scale_values(
+            arguments[0],
+            False,
+            False,
+            state[0],
+            state[1],
+        )
+        return list(values)
     return _numeric_formula_call_values(expression, arguments, n)
+
+
+def _numeric_formula_expression_values(
+    data: Any,
+    expression: _NumericFormulaExpression,
+    n: int,
+    scale_states: _ScaleFormulaStates = (),
+    *,
+    fit_scales: bool = True,
+) -> list[float]:
+    return _numeric_formula_expression_values_with_state(
+        data,
+        expression,
+        n,
+        dict(scale_states),
+        fit_scales=fit_scales,
+    )
+
+
+def _fit_numeric_formula_expression(
+    data: Any,
+    expression: _NumericFormulaExpression,
+    n: int,
+    scale_states: _ScaleFormulaStates = (),
+) -> tuple[list[float], _ScaleFormulaStates]:
+    fitted_states = dict(scale_states)
+    values = _numeric_formula_expression_values_with_state(
+        data,
+        expression,
+        n,
+        fitted_states,
+        fit_scales=True,
+    )
+    return values, tuple(fitted_states.items())
+
+
+def _numeric_formula_scale_calls(
+    expression: _NumericFormulaExpression,
+) -> tuple[_NumericFormulaCall, ...]:
+    if isinstance(expression, _NumericFormulaLiteral | _NumericFormulaColumn):
+        return ()
+    if isinstance(expression, _NumericFormulaUnary):
+        return _numeric_formula_scale_calls(expression.operand)
+    if isinstance(expression, _NumericFormulaBinary):
+        calls = list(_numeric_formula_scale_calls(expression.left))
+        _append_unique(calls, _numeric_formula_scale_calls(expression.right))
+        return tuple(calls)
+    calls = [expression] if expression.function == "scale" else []
+    for argument in expression.arguments:
+        _append_unique(calls, _numeric_formula_scale_calls(argument))
+    return tuple(calls)
 
 
 def _is_formula_arithmetic_expression(expression: str) -> bool:
@@ -3748,38 +3905,75 @@ def _formula_columns(formula: str, data: Any) -> list[str]:
     return list(dict.fromkeys(columns))
 
 
-def _formula_subset_poly_states(
+def _formula_transform_states(
     formula: str,
     data: Any,
     n: int,
-) -> tuple[tuple[_CovariateTerm, tuple[tuple[float, ...], tuple[float, ...]]], ...]:
+) -> tuple[
+    _ScaleFormulaStates,
+    tuple[tuple[_CovariateTerm, tuple[tuple[float, ...], tuple[float, ...]]], ...],
+]:
     response_spec = _formula_response_spec(formula)
     _lhs, _sep, rhs = formula.partition("~")
     terms = _split_terms(rhs, _dot_terms(data, list(response_spec.columns)))
-    states: list[tuple[_CovariateTerm, tuple[tuple[float, ...], tuple[float, ...]]]] = []
-    for spec in terms.covariates:
-        for term in _covariate_factors(spec):
-            options = term.poly_options
-            if options is None or options.raw or any(existing == term for existing, _ in states):
-                continue
-            values = _numeric_term_values(_term_raw_values(data, term, n), term)
-            _rows, alpha, norm2 = _core.poly_basis(
-                values,
-                options.degree,
-                False,
-                None,
-                None,
+    formula_terms = [
+        *(term for spec in terms.covariates for term in _covariate_factors(spec)),
+        *terms.offsets,
+    ]
+    unique_terms: list[_CovariateTerm] = []
+    _append_unique(unique_terms, formula_terms)
+    fitted_scale_states: dict[_NumericFormulaCall, _ScaleFormulaState] = {}
+    poly_states: list[tuple[_CovariateTerm, tuple[tuple[float, ...], tuple[float, ...]]]] = []
+    for term in unique_terms:
+        expression = term.numeric_expression
+        if expression is not None and _numeric_formula_scale_calls(expression):
+            _values, scale_states = _fit_numeric_formula_expression(
+                data,
+                expression,
+                n,
+                tuple(fitted_scale_states.items()),
             )
-            states.append(
+            fitted_scale_states.update(scale_states)
+        options = term.poly_options
+        if options is None or options.raw:
+            continue
+        scale_states = (
+            ()
+            if expression is None
+            else _expression_scale_states(expression, tuple(fitted_scale_states.items()))
+        )
+        values = _numeric_term_values(
+            _term_raw_values(data, term, n, scale_states),
+            term,
+        )
+        if any(_is_missing_value(value) for value in values):
+            raise ValueError("missing values are not allowed in orthogonal poly")
+        _rows, alpha, norm2 = _core.poly_basis(
+            values,
+            options.degree,
+            False,
+            None,
+            None,
+        )
+        poly_states.append(
+            (
+                term,
                 (
-                    term,
-                    (
-                        tuple(float(value) for value in alpha),
-                        tuple(float(value) for value in norm2),
-                    ),
-                )
+                    tuple(float(value) for value in alpha),
+                    tuple(float(value) for value in norm2),
+                ),
             )
-    return tuple(states)
+        )
+    return tuple(fitted_scale_states.items()), tuple(poly_states)
+
+
+def _formula_state_data(formula: str, data: Any, n: int) -> Any:
+    if isinstance(data, _FormulaSubsetData):
+        return data
+    scale_states, poly_states = _formula_transform_states(formula, data, n)
+    if not scale_states and not poly_states:
+        return data
+    return _FormulaSubsetData(data, scale_states, poly_states)
 
 
 def _subset_formula_inputs(
@@ -3789,16 +3983,13 @@ def _subset_formula_inputs(
     **row_aligned: Any,
 ) -> tuple[Any, dict[str, Any]]:
     n = len(_column(data, _formula_response_args(formula)[0]))
-    poly_states = _formula_subset_poly_states(formula, data, n)
+    data = _formula_state_data(formula, data, n)
     indices = _subset_indices(subset, n)
     filtered = {
         name: _subset_optional_sequence(values, indices, name)
         for name, values in row_aligned.items()
     }
-    subset_data = _subset_data(data, indices)
-    if poly_states:
-        subset_data = _FormulaSubsetData(subset_data, poly_states)
-    return subset_data, filtered
+    return _subset_data(data, indices), filtered
 
 
 def _apply_formula_na_action(
@@ -3813,9 +4004,10 @@ def _apply_formula_na_action(
     if action == "pass":
         return data, row_aligned
 
-    excluded = set(exclude_columns)
     response_spec = _formula_response_spec(formula)
     n = len(_column(data, response_spec.columns[0]))
+    data = _formula_state_data(formula, data, n)
+    excluded = set(exclude_columns)
     _lhs, _sep, rhs = formula.partition("~")
     terms = _split_terms(rhs, _dot_terms(data, list(response_spec.columns)))
     raw_columns = [
@@ -5427,9 +5619,76 @@ def _numeric_term_values(values: list[Any], term: _CovariateTerm) -> list[float]
     return _apply_numeric_transform(numeric, term.transform, term.column)
 
 
-def _term_raw_values(data: Any, term: _CovariateTerm, n: int) -> list[Any]:
+def _expression_scale_states(
+    expression: _NumericFormulaExpression,
+    states: _ScaleFormulaStates,
+) -> _ScaleFormulaStates:
+    calls = _numeric_formula_scale_calls(expression)
+    if not calls:
+        return ()
+    by_call = dict(states)
+    missing = next((call for call in calls if call not in by_call), None)
+    if missing is not None:
+        raise ValueError("fitted scale() formula state is unavailable")
+    return tuple((call, by_call[call]) for call in calls)
+
+
+def _term_scale_states(data: Any, term: _CovariateTerm, n: int) -> _ScaleFormulaStates:
+    expression = term.numeric_expression
+    if expression is None or not _numeric_formula_scale_calls(expression):
+        return ()
+    if isinstance(data, _FormulaSubsetData):
+        return _expression_scale_states(expression, data.scale_states)
+    _values, states = _fit_numeric_formula_expression(data, expression, n)
+    return _expression_scale_states(expression, states)
+
+
+def _term_prediction_scale_states(
+    term: _CovariateTerm,
+    states: _ScaleFormulaStates,
+) -> _ScaleFormulaStates:
+    expression = term.numeric_expression
+    if (
+        term.poly_options is not None
+        or not isinstance(expression, _NumericFormulaCall)
+        or expression.function != "scale"
+    ):
+        return ()
+    by_call = dict(states)
+    if expression not in by_call:
+        raise ValueError("fitted scale() formula state is unavailable")
+    return ((expression, by_call[expression]),)
+
+
+def _term_raw_values(
+    data: Any,
+    term: _CovariateTerm,
+    n: int,
+    scale_states: _ScaleFormulaStates | None = None,
+    *,
+    fit_scales: bool | None = None,
+) -> list[Any]:
     if term.numeric_expression is not None:
-        return _numeric_formula_expression_values(data, term.numeric_expression, n)
+        if scale_states is None:
+            if isinstance(data, _FormulaSubsetData):
+                scale_states = _expression_scale_states(
+                    term.numeric_expression,
+                    data.scale_states,
+                )
+            else:
+                values, _states = _fit_numeric_formula_expression(
+                    data,
+                    term.numeric_expression,
+                    n,
+                )
+                return values
+        return _numeric_formula_expression_values(
+            data,
+            term.numeric_expression,
+            n,
+            scale_states,
+            fit_scales=False if fit_scales is None else fit_scales,
+        )
     if term.arithmetic is not None:
         return _arithmetic_expression_values(data, term.arithmetic, n)
     values = _column(data, term.column)
@@ -5832,7 +6091,9 @@ def _fit_single_design_term(
     term: _CovariateTerm,
     n: int,
 ) -> _SingleDesignTerm:
-    values = _term_raw_values(data, term, n)
+    evaluation_scale_states = _term_scale_states(data, term, n)
+    prediction_scale_states = _term_prediction_scale_states(term, evaluation_scale_states)
+    values = _term_raw_values(data, term, n, evaluation_scale_states)
     if term.poly_options is not None:
         numeric = _numeric_term_values(values, term)
         stored_state = (
@@ -5857,6 +6118,7 @@ def _fit_single_design_term(
             term=term,
             alpha=tuple(float(value) for value in alpha),
             norm2=tuple(float(value) for value in norm2),
+            scale_states=prediction_scale_states,
         )
     declared_levels = _formula_declared_factor_levels(data, term)
     if declared_levels is not None and term.factor_options is None:
@@ -5883,13 +6145,13 @@ def _fit_single_design_term(
     if not term.categorical:
         if term.transform is not None:
             _numeric_term_values(values, term)
-            return _NumericDesignTerm(term)
+            return _NumericDesignTerm(term, prediction_scale_states)
         try:
             _numeric_term_values(values, term)
         except (TypeError, ValueError):
             pass
         else:
-            return _NumericDesignTerm(term)
+            return _NumericDesignTerm(term, prediction_scale_states)
     return _CategoricalDesignTerm(
         term,
         _formula_inferred_categorical_levels(data, term, values),
@@ -6166,7 +6428,18 @@ def _single_design_columns(
         if len(values) != n:
             raise ValueError("tt transform result must match the expanded risk-set rows")
         return [values]
-    values = _term_raw_values(data, spec.term, n)
+    prediction_scale_states = (
+        spec.scale_states
+        if prediction and isinstance(spec, _NumericDesignTerm | _PolyDesignTerm)
+        else None
+    )
+    values = _term_raw_values(
+        data,
+        spec.term,
+        n,
+        prediction_scale_states,
+        fit_scales=prediction,
+    )
     if isinstance(spec, _PolyDesignTerm):
         options = cast(_PolyFormulaOptions, spec.term.poly_options)
         recompute = options.simple and prediction

--- a/python/tests/test_binding_contract.py
+++ b/python/tests/test_binding_contract.py
@@ -10014,6 +10014,7 @@ def test_core_utility_bindings_are_typed():
         "nsk",
         "poly_basis",
         "pspline_basis",
+        "scale_values",
         "cox_score_residuals",
         "schoenfeld_residuals",
         "concordance",
@@ -10052,6 +10053,7 @@ def test_core_utility_bindings_are_typed():
         "nsk": ["x", "df", "knots", "boundary_knots"],
         "poly_basis": ["x", "degree", "raw", "alpha", "norm2"],
         "pspline_basis": ["x", "nterm", "degree", "boundary_knots"],
+        "scale_values": ["x", "center", "scale", "center_value", "scale_value"],
         "cox_score_residuals": ["y", "strata", "covar", "score", "weights", "nvar", "method"],
         "schoenfeld_residuals": ["y", "score", "strata", "covar", "nvar", "method"],
         "concordance": ["y", "x", "wt", "timewt", "sortstart", "sortstop"],
@@ -10090,6 +10092,30 @@ def test_core_utility_bindings_are_typed():
     assert rebuilt_poly[0] == pytest.approx([1.31157847467778, 5.16916222373008, 21.9718311398109])
     assert rebuilt_alpha == pytest.approx(poly_alpha)
     assert rebuilt_norm2 == pytest.approx(poly_norm2)
+
+    scaled, scaled_center, scaled_divisor = core.scale_values([1.0, 2.0, float("nan"), 4.0, 8.0])
+    rebuilt_scale, rebuilt_center, rebuilt_divisor = core.scale_values(
+        [3.0, 6.0],
+        False,
+        False,
+        scaled_center,
+        scaled_divisor,
+    )
+    assert scaled == pytest.approx(
+        [
+            -0.888330138395973,
+            -0.565300997161074,
+            float("nan"),
+            0.0807572853087248,
+            1.37287385024832,
+        ],
+        nan_ok=True,
+    )
+    assert scaled_center == pytest.approx(3.75)
+    assert scaled_divisor == pytest.approx(3.09569593683445)
+    assert rebuilt_scale == pytest.approx([-0.242272, 0.726815], abs=1e-6)
+    assert rebuilt_center == scaled_center
+    assert rebuilt_divisor == scaled_divisor
 
     assert _pyi_class_annotation_names(stub_path, "CovariateMatrix") == {
         "values",

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -17369,6 +17369,160 @@ def test_formula_poly_matches_r_missing_value_and_argument_rules():
             survival.coxph(f"Surv(time, status) ~ {term}", data=_numeric_data())
 
 
+def test_formula_scale_terms_match_r_subset_and_prediction_state():
+    data = {
+        "time": [float(index) for index in range(1, 11)],
+        "status": [1, 0] * 5,
+        "x": [-10.0, -4.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 8.0, 20.0],
+        "z": [float(index * 2) for index in range(1, 11)],
+    }
+    keep = [False, *([True] * 7), False, False]
+    formula = (
+        "Surv(time,status) ~ scale(x) + scale(log(z), center=FALSE) + "
+        "scale(x, scale=FALSE):z + offset(scale(z, center=2, scale=3))"
+    )
+    fit = survival.coxph(formula, data=data, subset=keep, max_iter=0)
+    matrix = survival.model_matrix(fit)
+
+    expected = [
+        [-0.716177363358201, 0.569155246353510, -22.8],
+        [-0.464887060425499, 0.735622484456267, -22.2],
+        [-0.339241908959148, 0.853732869530265, -21.6],
+        [-0.213596757492797, 0.945346401607131, -17.0],
+        [-0.087951606026446, 1.02020010763302, -8.4],
+        [0.037693545439905, 1.08348801430947, 4.2],
+        [0.163338696906256, 1.13831049270702, 20.8],
+    ]
+    assert matrix["columns"] == [
+        "scale(x)",
+        "scale(log(z), center=FALSE)",
+        "scale(x, scale=FALSE):z",
+    ]
+    assert matrix["assign"] == [1, 2, 3]
+    for actual, expected_row in zip(matrix["data"], expected, strict=True):
+        assert actual == pytest.approx(expected_row, abs=1e-13)
+
+    newdata = {"x": [4.0, 9.0], "z": [7.0, 13.0]}
+    rows, offsets = survival.r_api._prediction_inputs(fit, newdata)
+    assert rows is not None
+    assert offsets == pytest.approx([5.0 / 3.0, 11.0 / 3.0], abs=1e-14)
+    assert rows[0] == pytest.approx(
+        [0.288983848372607, 0.798910391132717, 16.1],
+        abs=1e-13,
+    )
+    assert rows[1] == pytest.approx(
+        [0.917209605704362, 1.05306233969745, 94.9],
+        abs=1e-13,
+    )
+    assert survival.predict(fit, newdata, reference="zero") == pytest.approx(
+        [-1.0, 1.0],
+        abs=1e-12,
+    )
+
+
+def test_formula_scale_composes_with_poly_using_r_prediction_state_rules():
+    x = [-10.0, -4.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 8.0, 20.0]
+    keep = [False, *([True] * 7), False, False]
+    data = {
+        "time": [float(index) for index in range(1, 11)],
+        "status": [1, 0] * 5,
+        "x": x,
+        "z": [float(index) for index in range(10)],
+    }
+    scaled, _center, _divisor = survival._survival.scale_values(x)
+    full_poly, alpha, norm2 = survival._survival.poly_basis(scaled, 2)
+    fit = survival.coxph(
+        "Surv(time,status) ~ poly(scale(x), 2) + z",
+        data=data,
+        subset=keep,
+        max_iter=0,
+    )
+
+    expected = [
+        [*row, z] for row, z, retained in zip(full_poly, data["z"], keep, strict=True) if retained
+    ]
+    for actual, expected_row in zip(fit.covariates, expected, strict=True):
+        assert actual == pytest.approx(expected_row, abs=1e-13)
+
+    new_x = [4.0, 9.0]
+    rebuilt_scale, _center, _divisor = survival._survival.scale_values(new_x)
+    rebuilt_poly, _alpha, _norm2 = survival._survival.poly_basis(
+        rebuilt_scale,
+        2,
+        False,
+        alpha,
+        norm2,
+    )
+    expected_rows = [[*row, z] for row, z in zip(rebuilt_poly, [2.5, 7.5], strict=True)]
+    assert survival.predict(
+        fit,
+        {"x": new_x, "z": [2.5, 7.5]},
+        reference="zero",
+    ) == pytest.approx(fit.predict(expected_rows), abs=1e-12)
+
+
+def test_formula_scale_fits_before_na_omission_like_r():
+    data = {
+        "time": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+        "status": [1, 0, 1, 1, 0, 1],
+        "x": [1.0, 2.0, 30.0, 4.0, 8.0, 9.0],
+        "z": [0.2, 0.4, None, 0.8, 1.0, 1.2],
+    }
+    full_scale, _center, _divisor = survival._survival.scale_values(data["x"])
+    fit = survival.coxph(
+        "Surv(time,status) ~ scale(x) + z",
+        data=data,
+        na_action="omit",
+        max_iter=0,
+    )
+    expected = [
+        [scaled, z] for scaled, z in zip(full_scale, data["z"], strict=True) if z is not None
+    ]
+    for actual, expected_row in zip(fit.covariates, expected, strict=True):
+        assert actual == pytest.approx(expected_row, abs=1e-13)
+
+    missing_x = {**data, "x": [1.0, 2.0, None, 4.0, 8.0, 9.0], "z": [0.2] * 6}
+    expected_scale, _center, _divisor = survival._survival.scale_values(
+        [1.0, 2.0, math.nan, 4.0, 8.0, 9.0]
+    )
+    missing_fit = survival.coxph(
+        "Surv(time,status) ~ scale(x)",
+        data=missing_x,
+        na_action="omit",
+        max_iter=0,
+    )
+    assert [row[0] for row in missing_fit.covariates] == pytest.approx(
+        [value for value in expected_scale if not math.isnan(value)],
+        abs=1e-13,
+    )
+
+
+def test_formula_scale_supports_r_options_and_validation_rules():
+    data = _numeric_data()
+    fit = survival.coxph(
+        "Surv(time,status) ~ scale(x1, cen=FALSE, sca=FALSE) + scale(x2, center=c(2), scale=c(-2))",
+        data=data,
+        max_iter=0,
+    )
+    expected = [[x1, (x2 - 2.0) / -2.0] for x1, x2 in zip(data["x1"], data["x2"], strict=True)]
+    for actual, expected_row in zip(
+        survival.model_matrix(fit)["data"],
+        expected,
+        strict=True,
+    ):
+        assert actual == pytest.approx(expected_row)
+
+    for term, message in (
+        ("scale()", "requires one numeric argument"),
+        ("scale(x1, center=x2)", "numeric scalar"),
+        ("scale(x1, center=NA)", "numeric scalar"),
+        ("scale(x1, center=TRUE, scale=TRUE, extra=1)", "unsupported scale.*option"),
+        ("scale(x1, TRUE, TRUE, 1)", "too many arguments"),
+    ):
+        with pytest.raises(ValueError, match=message):
+            survival.coxph(f"Surv(time,status) ~ {term}", data=data)
+
+
 def test_formula_pmin_na_rm_controls_transformed_row_omission():
     data = _numeric_data()
     data["x1"] = [None, None, *data["x1"][2:]]

--- a/r/survivalr/man/survivalr.Rd
+++ b/r/survivalr/man/survivalr.Rd
@@ -1274,6 +1274,11 @@ risk set.
 \code{poly(...)} terms, including interactions. Orthogonal bases retain their
 training coefficients when rebuilding model matrices for new data.
 
+Stateful \code{scale(...)} formula terms use an O(n) Rust implementation,
+accept logical or numeric centering and scaling options, fit before subsetting
+or missing-data omission, and retain their fitted state for ordinary new-data
+model reconstruction. Nested uses follow R's \code{makepredictcall} behavior.
+
 Formula \code{finegray} calls use the Python formula engine and Rust interval
 expansion directly. The bridge supports weights, subsets, missing-data actions,
 strata, counting-process histories, and delayed entry; computes censoring risk

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -5211,6 +5211,161 @@ test_that("survreg polynomial formula terms match R", {
   )
 })
 
+test_that("coxph scale formula terms match R", {
+  skip_if_not_installed("reticulate")
+  skip_if_not_installed("survival")
+  skip_if_not(reticulate::py_module_available("survival"), "Python survival package is unavailable")
+
+  set.seed(5211)
+  n <- 100L
+  x <- stats::runif(n, -4, 7)
+  z <- stats::runif(n, 0.2, 5)
+  w <- stats::rnorm(n, sd = 0.4)
+  event_time <- stats::rexp(n, exp(0.12 * x - 0.08 * log(z) + 0.15 * w))
+  censor <- stats::rexp(n, 0.7)
+  data <- data.frame(
+    time = pmax(pmin(event_time, censor), 0.001),
+    status = as.integer(event_time <= censor),
+    x = x,
+    z = z,
+    w = w
+  )
+  bridged <- coxph(
+    Surv(time, status) ~ scale(x) +
+      scale(log(z), center = FALSE) +
+      scale(x, scale = FALSE):w +
+      offset(scale(w)),
+    data = data,
+    ties = "breslow",
+    max_iter = 150,
+    eps = 1e-10,
+    x = TRUE
+  )
+  reference <- survival::coxph(
+    survival::Surv(time, status) ~ scale(x) +
+      scale(log(z), center = FALSE) +
+      scale(x, scale = FALSE):w +
+      offset(scale(w)),
+    data = data,
+    ties = "breslow",
+    x = TRUE,
+    control = survival::coxph.control(iter.max = 150, eps = 1e-10)
+  )
+
+  bridged_matrix <- model.matrix(bridged)
+  reference_matrix <- stats::model.matrix(reference)
+  expect_identical(colnames(bridged_matrix), colnames(reference_matrix))
+  expect_identical(attr(bridged_matrix, "assign"), attr(reference_matrix, "assign"))
+  expect_equal(unname(bridged_matrix), unname(reference_matrix), tolerance = 1e-12)
+  expect_identical(attr(terms(bridged), "term.labels"), attr(terms(reference), "term.labels"))
+  expect_equal(unname(coef(bridged)), unname(coef(reference)), tolerance = 2e-08)
+
+  newdata <- transform(
+    data[c(2, 8, 17, 31), ],
+    x = x + c(0.7, -0.4, 0.3, -0.8),
+    z = z + c(0.2, 0.4, -0.1, 0.3),
+    w = w + c(-0.2, 0.1, 0.25, -0.15)
+  )
+  expect_equal(
+    as.numeric(predict(bridged, newdata = newdata, type = "lp", reference = "zero")),
+    as.numeric(stats::predict(reference, newdata = newdata, type = "lp", reference = "zero")),
+    tolerance = 2e-08
+  )
+})
+
+test_that("scale and poly state precedes subset and missing omission", {
+  skip_if_not_installed("reticulate")
+  skip_if_not_installed("survival")
+  skip_if_not(reticulate::py_module_available("survival"), "Python survival package is unavailable")
+
+  data <- data.frame(
+    time = seq_len(10),
+    status = rep(c(1L, 0L), 5),
+    x = c(-10, -4, -2, -1, 0, 1, 2, 3, 8, 20),
+    z = c(0.1, 0.2, 0.3, NA, 0.5, 0.6, 0.7, 0.8, 0.9, 1)
+  )
+  keep <- c(FALSE, rep(TRUE, 7), FALSE, FALSE)
+  bridged <- coxph(
+    Surv(time, status) ~ poly(scale(x), 2) + z,
+    data = data,
+    subset = keep,
+    na.action = na.omit,
+    max_iter = 0,
+    x = TRUE
+  )
+  reference <- survival::coxph(
+    survival::Surv(time, status) ~ poly(scale(x), 2) + z,
+    data = data,
+    subset = keep,
+    na.action = na.omit,
+    x = TRUE,
+    control = survival::coxph.control(iter.max = 0)
+  )
+  expect_identical(colnames(model.matrix(bridged)), colnames(stats::model.matrix(reference)))
+  expect_identical(
+    attr(model.matrix(bridged), "assign"),
+    attr(stats::model.matrix(reference), "assign")
+  )
+  expect_equal(
+    unname(model.matrix(bridged)),
+    unname(stats::model.matrix(reference)),
+    tolerance = 1e-12
+  )
+})
+
+test_that("survreg scale formula terms match R", {
+  skip_if_not_installed("reticulate")
+  skip_if_not_installed("survival")
+  skip_if_not(reticulate::py_module_available("survival"), "Python survival package is unavailable")
+
+  set.seed(5212)
+  n <- 90L
+  x <- stats::runif(n, -3, 6)
+  z <- stats::runif(n, 0.3, 5)
+  latent <- exp(1.1 + 0.12 * x - 0.09 * log(z) + stats::rnorm(n, sd = 0.4))
+  censor <- stats::rexp(n, rate = 1 / 15)
+  data <- data.frame(
+    time = pmax(pmin(latent, censor), 0.01),
+    status = as.integer(latent <= censor),
+    x = x,
+    z = z
+  )
+  bridged <- survreg(
+    Surv(time, status) ~ scale(x) + scale(log(z), center = FALSE),
+    data = data,
+    dist = "weibull",
+    max_iter = 150,
+    eps = 1e-10,
+    x = TRUE
+  )
+  reference <- survival::survreg(
+    survival::Surv(time, status) ~ scale(x) +
+      scale(log(z), center = FALSE),
+    data = data,
+    dist = "weibull",
+    x = TRUE,
+    control = survival::survreg.control(maxiter = 150, rel.tolerance = 1e-10)
+  )
+
+  bridged_matrix <- model.matrix(bridged)
+  reference_matrix <- stats::model.matrix(reference)
+  expect_identical(colnames(bridged_matrix), colnames(reference_matrix))
+  expect_identical(attr(bridged_matrix, "assign"), attr(reference_matrix, "assign"))
+  expect_equal(unname(bridged_matrix), unname(reference_matrix), tolerance = 1e-12)
+  expect_equal(unname(coef(bridged)), unname(coef(reference)), tolerance = 2e-08)
+
+  newdata <- transform(
+    data[c(3, 11, 24), ],
+    x = x + c(0.5, -0.3, 0.8),
+    z = z + c(0.2, 0.4, -0.1)
+  )
+  expect_equal(
+    unname(predict(bridged, newdata = newdata, type = "lp")),
+    unname(stats::predict(reference, newdata = newdata, type = "lp")),
+    tolerance = 2e-08
+  )
+})
+
 test_that("pmin na.rm controls formula row omission like R", {
   skip_if_not_installed("reticulate")
   skip_if_not_installed("survival")

--- a/src/api/python/classical/core.rs
+++ b/src/api/python/classical/core.rs
@@ -88,6 +88,7 @@ pub(super) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(cipoisson_anscombe, m)?)?;
     m.add_function(wrap_pyfunction!(poly_basis, m)?)?;
     m.add_function(wrap_pyfunction!(pspline_basis, m)?)?;
+    m.add_function(wrap_pyfunction!(scale_values, m)?)?;
     m.add_function(wrap_pyfunction!(crate::concordance::basic::concordance, m)?)?;
     m.add_function(wrap_pyfunction!(agexact, m)?)?;
     m.add_function(wrap_pyfunction!(compute_baseline_survival_steps, m)?)?;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -5,9 +5,11 @@ pub(crate) mod coxscho;
 pub(crate) mod nsk_module;
 pub(crate) mod poly;
 pub(crate) mod pspline;
+pub(crate) mod scale;
 
 pub use coxcount1_module::{CoxCountOutput, coxcount1, coxcount2};
 pub use coxscho::schoenfeld_residuals;
 pub use nsk_module::{NaturalSplineKnot, SplineBasisResult, nsk};
 pub use poly::poly_basis;
 pub use pspline::{PSpline, pspline_basis};
+pub use scale::scale_values;

--- a/src/core/scale.rs
+++ b/src/core/scale.rs
@@ -1,0 +1,129 @@
+use pyo3::prelude::*;
+use rayon::prelude::*;
+
+type ScaleResult = (Vec<f64>, Option<f64>, Option<f64>);
+
+fn fitted_center(x: &[f64]) -> f64 {
+    let (sum, count) = x
+        .iter()
+        .filter(|value| !value.is_nan())
+        .fold((0.0, 0usize), |(sum, count), value| {
+            (sum + value, count + 1)
+        });
+    sum / count as f64
+}
+
+fn fitted_scale(x: &[f64], center: Option<f64>) -> f64 {
+    let (sum_squares, count) = x.iter().fold((0.0, 0usize), |(sum_squares, count), value| {
+        let centered = center.map_or(*value, |location| *value - location);
+        if centered.is_nan() {
+            (sum_squares, count)
+        } else {
+            (centered.mul_add(centered, sum_squares), count + 1)
+        }
+    });
+    (sum_squares / count.saturating_sub(1).max(1) as f64).sqrt()
+}
+
+pub(crate) fn scale_values_core(
+    x: &[f64],
+    center: bool,
+    scale: bool,
+    center_value: Option<f64>,
+    scale_value: Option<f64>,
+) -> ScaleResult {
+    let effective_center = center_value.or_else(|| center.then(|| fitted_center(x)));
+    let effective_scale = scale_value.or_else(|| scale.then(|| fitted_scale(x, effective_center)));
+    let values = x
+        .par_iter()
+        .map(|value| {
+            let centered = effective_center.map_or(*value, |location| *value - location);
+            effective_scale.map_or(centered, |divisor| centered / divisor)
+        })
+        .collect();
+    (values, effective_center, effective_scale)
+}
+
+#[pyfunction]
+#[pyo3(signature = (x, center=true, scale=true, center_value=None, scale_value=None))]
+pub fn scale_values(
+    x: Vec<f64>,
+    center: bool,
+    scale: bool,
+    center_value: Option<f64>,
+    scale_value: Option<f64>,
+) -> ScaleResult {
+    scale_values_core(&x, center, scale, center_value, scale_value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fitted_values_match_r_scale_fixture() {
+        let x = [1.0, 2.0, f64::NAN, 4.0, 8.0];
+        let (values, center, scale) = scale_values_core(&x, true, true, None, None);
+        let expected = [
+            -0.888330138395973,
+            -0.565300997161074,
+            f64::NAN,
+            0.0807572853087248,
+            1.37287385024832,
+        ];
+
+        assert_eq!(center, Some(3.75));
+        assert!((scale.unwrap() - 3.09569593683445).abs() < 1e-14);
+        for (actual, expected) in values.iter().zip(expected) {
+            if expected.is_nan() {
+                assert!(actual.is_nan());
+            } else {
+                assert!((actual - expected).abs() < 1e-14);
+            }
+        }
+    }
+
+    #[test]
+    fn uncentered_scale_and_center_only_match_r() {
+        let x = [1.0, 2.0, f64::NAN, 4.0, 8.0];
+        let (uncentered, center, scale) = scale_values_core(&x, false, true, None, None);
+        assert_eq!(center, None);
+        assert!((scale.unwrap() - 5.32290647422377).abs() < 1e-14);
+        assert!((uncentered[0] - 0.187867287325545).abs() < 1e-14);
+
+        let (centered, center, scale) = scale_values_core(&x, true, false, None, None);
+        assert_eq!(center, Some(3.75));
+        assert_eq!(scale, None);
+        assert_eq!(centered[0], -2.75);
+        assert!(centered[2].is_nan());
+    }
+
+    #[test]
+    fn supplied_state_rebuilds_new_values() {
+        let (values, center, scale) =
+            scale_values_core(&[3.0, 6.0], false, false, Some(4.8), Some(3.56370593624109));
+        assert_eq!(center, Some(4.8));
+        assert_eq!(scale, Some(3.56370593624109));
+        assert!((values[0] - -0.505092179939682).abs() < 1e-14);
+        assert!((values[1] - 0.336728119959788).abs() < 1e-14);
+    }
+
+    #[test]
+    fn zero_scale_preserves_ieee_results() {
+        let (constant, center, scale) = scale_values_core(&[2.0; 4], true, true, None, None);
+        assert_eq!(center, Some(2.0));
+        assert_eq!(scale, Some(0.0));
+        assert!(constant.iter().all(|value| value.is_nan()));
+
+        let (signed, _, _) =
+            scale_values_core(&[1.0, 2.0, 4.0], false, false, Some(2.0), Some(0.0));
+        assert_eq!(signed[0], f64::NEG_INFINITY);
+        assert!(signed[1].is_nan());
+        assert_eq!(signed[2], f64::INFINITY);
+
+        let (missing_center, _, fitted) =
+            scale_values_core(&[1.0, 2.0], false, true, Some(f64::NAN), None);
+        assert_eq!(fitted, Some(0.0));
+        assert!(missing_center.iter().all(|value| value.is_nan()));
+    }
+}


### PR DESCRIPTION
## Summary

- add an O(n) Rust kernel for R-compatible centering and scaling with parallel row transformation
- integrate stateful `scale()` terms into formula training and new-data reconstruction, including partial and numeric options, interactions, nesting, offsets, subset ordering, and missing values
- preserve full-data polynomial state across unrelated missing-value omission and add Python, R-reference, binding, and documentation coverage

## Validation

- Python: 1,067 passed
- Rust: 1,550 default, 1,759 ML, 1,773 Python + ML
- strict Clippy, Rust formatting, Ruff, stub type checks, binding manifest, and diff checks
- full R bridge suite
- R package check: expected source-tree note only
- randomized R parity: maximum training error 8.88e-16, new-data error 0