### PR TITLE
Support natural spline formula terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,10 @@ multi-column bases through an O(n d) native recurrence and retain the fitted
 orthogonalization coefficients for new-data prediction. Stateful `scale(...)`
 terms use an O(n) native path, accept R's logical or numeric `center=` and
 `scale=` options, fit before row subsetting or missing-data omission, and reuse
-their fitted state for ordinary new-data model reconstruction.
+their fitted state for ordinary new-data model reconstruction. Formula
+`ns(...)` terms use a parallel O(n k) natural-spline basis matching R's
+`splines::ns`, including fitted knots and boundaries, linear extrapolation,
+interactions, nested numeric expressions, and pre-subset transform state.
 Formula calls also accept `subset=` as a boolean mask or zero-based row indices
 and `na_action="omit"` for row-wise missing-data omission across formula
 columns and external row-aligned arrays such as `weights`, `offset`, and

--- a/python/survival/_binding_manifest.py
+++ b/python/survival/_binding_manifest.py
@@ -838,6 +838,7 @@ BINDINGS = (
     "nostutter_str_numeric",
     "nostutter_str_str",
     "npmle_interval",
+    "ns_basis",
     "nsk",
     "number_needed_to_treat",
     "one_calibration",

--- a/python/survival/_survival.pyi
+++ b/python/survival/_survival.pyi
@@ -7720,6 +7720,13 @@ def nsk(
     knots: list[float] | None = None,
     boundary_knots: tuple[float, float] | None = None,
 ) -> SplineBasisResult: ...
+def ns_basis(
+    x: list[float],
+    df: int | None = None,
+    knots: list[float] | None = None,
+    boundary_knots: tuple[float, float] | None = None,
+    intercept: bool = False,
+) -> SplineBasisResult: ...
 def pspline_basis(
     x: list[float],
     nterm: int,

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -229,6 +229,14 @@ class _PolyFormulaOptions:
 
 
 @dataclass(frozen=True)
+class _NSFormulaOptions:
+    df: int | None
+    knots: tuple[float, ...] | None
+    intercept: bool
+    boundary_knots: tuple[float, float] | None
+
+
+@dataclass(frozen=True)
 class _NumericFormulaLiteral:
     value: float
 
@@ -281,6 +289,7 @@ class _CovariateTerm:
     factor_options: _FactorFormulaOptions | None = None
     formula_label: str | None = None
     poly_options: _PolyFormulaOptions | None = None
+    ns_options: _NSFormulaOptions | None = None
 
 
 @dataclass(frozen=True)
@@ -433,6 +442,15 @@ class _PolyDesignTerm:
 
 
 @dataclass(frozen=True)
+class _NSDesignTerm:
+    term: _CovariateTerm
+    knots: tuple[float, ...]
+    boundary_knots: tuple[float, float]
+    width: int
+    scale_states: _ScaleFormulaStates = ()
+
+
+@dataclass(frozen=True)
 class _CategoricalDesignTerm:
     term: _CovariateTerm
     levels: tuple[Any, ...]
@@ -442,7 +460,7 @@ class _CategoricalDesignTerm:
     full: bool = False
 
 
-_SingleDesignTerm = _NumericDesignTerm | _PolyDesignTerm | _CategoricalDesignTerm
+_SingleDesignTerm = _NumericDesignTerm | _PolyDesignTerm | _NSDesignTerm | _CategoricalDesignTerm
 
 
 @dataclass(frozen=True)
@@ -497,6 +515,10 @@ class _FormulaDesign:
 class _FormulaSubsetData:
     data: Any
     scale_states: _ScaleFormulaStates
+    ns_states: tuple[
+        tuple[_CovariateTerm, tuple[tuple[float, ...], tuple[float, float], int]],
+        ...,
+    ]
     poly_states: tuple[
         tuple[_CovariateTerm, tuple[tuple[float, ...], tuple[float, ...]]],
         ...,
@@ -2140,6 +2162,7 @@ def _subset_data(data: Any, indices: list[int]) -> Any:
         return _FormulaSubsetData(
             _subset_data(data.data, indices),
             data.scale_states,
+            data.ns_states,
             data.poly_states,
         )
     if isinstance(data, Mapping):
@@ -3905,12 +3928,32 @@ def _formula_columns(formula: str, data: Any) -> list[str]:
     return list(dict.fromkeys(columns))
 
 
+def _fit_ns_basis(values: list[float], options: _NSFormulaOptions) -> Any:
+    minimum_df = 1 + int(options.intercept)
+    df = options.df
+    if options.knots is None and df is not None and df < minimum_df:
+        warnings.warn(
+            f"'df' was too small; have used {minimum_df}",
+            RuntimeWarning,
+            stacklevel=4,
+        )
+        df = minimum_df
+    return _core.ns_basis(
+        values,
+        df,
+        None if options.knots is None else list(options.knots),
+        options.boundary_knots,
+        options.intercept,
+    )
+
+
 def _formula_transform_states(
     formula: str,
     data: Any,
     n: int,
 ) -> tuple[
     _ScaleFormulaStates,
+    tuple[tuple[_CovariateTerm, tuple[tuple[float, ...], tuple[float, float], int]], ...],
     tuple[tuple[_CovariateTerm, tuple[tuple[float, ...], tuple[float, ...]]], ...],
 ]:
     response_spec = _formula_response_spec(formula)
@@ -3923,6 +3966,7 @@ def _formula_transform_states(
     unique_terms: list[_CovariateTerm] = []
     _append_unique(unique_terms, formula_terms)
     fitted_scale_states: dict[_NumericFormulaCall, _ScaleFormulaState] = {}
+    ns_states: list[tuple[_CovariateTerm, tuple[tuple[float, ...], tuple[float, float], int]]] = []
     poly_states: list[tuple[_CovariateTerm, tuple[tuple[float, ...], tuple[float, ...]]]] = []
     for term in unique_terms:
         expression = term.numeric_expression
@@ -3934,14 +3978,33 @@ def _formula_transform_states(
                 tuple(fitted_scale_states.items()),
             )
             fitted_scale_states.update(scale_states)
-        options = term.poly_options
-        if options is None or options.raw:
-            continue
         scale_states = (
             ()
             if expression is None
             else _expression_scale_states(expression, tuple(fitted_scale_states.items()))
         )
+        if term.ns_options is not None:
+            values = _numeric_term_values(
+                _term_raw_values(data, term, n, scale_states),
+                term,
+            )
+            basis = _fit_ns_basis(values, term.ns_options)
+            ns_states.append(
+                (
+                    term,
+                    (
+                        tuple(float(value) for value in basis.knots),
+                        (
+                            float(basis.boundary_knots[0]),
+                            float(basis.boundary_knots[1]),
+                        ),
+                        int(basis.n_cols),
+                    ),
+                )
+            )
+        options = term.poly_options
+        if options is None or options.raw:
+            continue
         values = _numeric_term_values(
             _term_raw_values(data, term, n, scale_states),
             term,
@@ -3964,16 +4027,16 @@ def _formula_transform_states(
                 ),
             )
         )
-    return tuple(fitted_scale_states.items()), tuple(poly_states)
+    return tuple(fitted_scale_states.items()), tuple(ns_states), tuple(poly_states)
 
 
 def _formula_state_data(formula: str, data: Any, n: int) -> Any:
     if isinstance(data, _FormulaSubsetData):
         return data
-    scale_states, poly_states = _formula_transform_states(formula, data, n)
-    if not scale_states and not poly_states:
+    scale_states, ns_states, poly_states = _formula_transform_states(formula, data, n)
+    if not scale_states and not ns_states and not poly_states:
         return data
-    return _FormulaSubsetData(data, scale_states, poly_states)
+    return _FormulaSubsetData(data, scale_states, ns_states, poly_states)
 
 
 def _subset_formula_inputs(
@@ -4128,7 +4191,15 @@ def _split_top_level(segment: str, separator: str) -> list[str]:
             depth += 1
         elif not in_backtick and char == ")":
             depth = max(0, depth - 1)
-        elif char == separator and not in_backtick and depth == 0:
+        elif (
+            char == separator
+            and not in_backtick
+            and depth == 0
+            and not (
+                separator == ":"
+                and ((idx > 0 and segment[idx - 1] == ":") or segment[idx + 1 :].startswith(":"))
+            )
+        ):
             parts.append(segment[start:idx].strip())
             start = idx + 1
 
@@ -4540,6 +4611,55 @@ def _parse_poly_formula_term(term: str) -> _CovariateTerm | None:
     )
 
 
+def _parse_ns_formula_term(term: str) -> _CovariateTerm | None:
+    local_term = "ns(" + term[len("splines::ns(") :] if term.startswith("splines::ns(") else term
+    if not (local_term.startswith("ns(") and local_term.endswith(")")):
+        return None
+
+    parts = _formula_response_parts(local_term[3:-1])
+    value, df, knots, intercept, boundary_knots = _numeric_formula_bound_arguments(
+        "ns",
+        parts,
+        ("x", "df", "knots", "intercept", "Boundary.knots"),
+    )
+    if value is None:
+        raise ValueError("ns() requires one numeric argument")
+    df_value = (
+        None
+        if df is None or df.strip().lower() == "null"
+        else _numeric_formula_integer_literal(df, "ns df")
+    )
+    knots_value = (
+        None
+        if knots is None or knots.strip().lower() == "null"
+        else _parse_formula_numeric_vector(knots, "ns knots")
+    )
+    intercept_value = (
+        False if intercept is None else _numeric_formula_bool_literal(intercept, "ns intercept")
+    )
+    boundary_value: tuple[float, float] | None = None
+    if boundary_knots is not None:
+        if boundary_knots.strip().lower() == "null":
+            raise ValueError("ns Boundary.knots must contain two numeric values")
+        parsed_boundary = _parse_formula_numeric_vector(boundary_knots, "ns Boundary.knots")
+        if len(parsed_boundary) != 2:
+            raise ValueError("ns Boundary.knots must contain two numeric values")
+        boundary_value = (parsed_boundary[0], parsed_boundary[1])
+    expression = _parse_numeric_formula_expression(value)
+    return _CovariateTerm(
+        value.strip(),
+        transform="ns",
+        numeric_expression=expression,
+        formula_label=term,
+        ns_options=_NSFormulaOptions(
+            df=df_value,
+            knots=knots_value,
+            intercept=intercept_value,
+            boundary_knots=boundary_value,
+        ),
+    )
+
+
 def _parse_covariate_atom(term: str) -> _CovariateTerm:
     if not term:
         raise ValueError("formula interaction terms must not be empty")
@@ -4551,6 +4671,10 @@ def _parse_covariate_atom(term: str) -> _CovariateTerm:
     poly_term = _parse_poly_formula_term(term)
     if poly_term is not None:
         return poly_term
+
+    ns_term = _parse_ns_formula_term(term)
+    if ns_term is not None:
+        return ns_term
 
     for wrapper in ("I", "identity"):
         prefix = f"{wrapper}("
@@ -4569,10 +4693,10 @@ def _parse_covariate_atom(term: str) -> _CovariateTerm:
                 column, quoted = _formula_name(parts[0])
                 if not _unsupported_formula_name(column, quoted):
                     return _CovariateTerm(column, transform=function)
-        expression = _parse_numeric_formula_expression(term)
+        numeric_expression = _parse_numeric_formula_expression(term)
         return _CovariateTerm(
             term,
-            numeric_expression=expression,
+            numeric_expression=numeric_expression,
             formula_label=term,
         )
 
@@ -4615,7 +4739,11 @@ def _parse_offset_term(expression: str) -> _CovariateTerm:
         _arithmetic_expression_columns(expression)
         return _CovariateTerm(expression, arithmetic=expression)
     offset_term = _parse_covariate_atom(expression)
-    if offset_term.categorical or offset_term.poly_options is not None:
+    if (
+        offset_term.categorical
+        or offset_term.poly_options is not None
+        or offset_term.ns_options is not None
+    ):
         raise ValueError("offset() requires a numeric column or transform")
     return offset_term
 
@@ -5597,6 +5725,7 @@ def _apply_numeric_transform(values: list[float], transform: str | None, term: s
         "I",
         "identity",
         "as.numeric",
+        "ns",
         "poly",
         "ridge",
         "pspline",
@@ -5650,6 +5779,7 @@ def _term_prediction_scale_states(
     expression = term.numeric_expression
     if (
         term.poly_options is not None
+        or term.ns_options is not None
         or not isinstance(expression, _NumericFormulaCall)
         or expression.function != "scale"
     ):
@@ -6094,9 +6224,36 @@ def _fit_single_design_term(
     evaluation_scale_states = _term_scale_states(data, term, n)
     prediction_scale_states = _term_prediction_scale_states(term, evaluation_scale_states)
     values = _term_raw_values(data, term, n, evaluation_scale_states)
+    if term.ns_options is not None:
+        numeric = _numeric_term_values(values, term)
+        ns_stored_state = (
+            next(
+                (state for stored_term, state in data.ns_states if stored_term == term),
+                None,
+            )
+            if isinstance(data, _FormulaSubsetData)
+            else None
+        )
+        if ns_stored_state is None:
+            basis = _fit_ns_basis(numeric, term.ns_options)
+            knots = tuple(float(value) for value in basis.knots)
+            boundary_knots = (
+                float(basis.boundary_knots[0]),
+                float(basis.boundary_knots[1]),
+            )
+            width = int(basis.n_cols)
+        else:
+            knots, boundary_knots, width = ns_stored_state
+        return _NSDesignTerm(
+            term=term,
+            knots=knots,
+            boundary_knots=boundary_knots,
+            width=width,
+            scale_states=evaluation_scale_states,
+        )
     if term.poly_options is not None:
         numeric = _numeric_term_values(values, term)
-        stored_state = (
+        poly_stored_state = (
             next(
                 (state for stored_term, state in data.poly_states if stored_term == term),
                 None,
@@ -6104,7 +6261,7 @@ def _fit_single_design_term(
             if isinstance(data, _FormulaSubsetData)
             else None
         )
-        if stored_state is None:
+        if poly_stored_state is None:
             _rows, alpha, norm2 = _core.poly_basis(
                 numeric,
                 term.poly_options.degree,
@@ -6113,7 +6270,7 @@ def _fit_single_design_term(
                 None,
             )
         else:
-            alpha, norm2 = stored_state
+            alpha, norm2 = poly_stored_state
         return _PolyDesignTerm(
             term=term,
             alpha=tuple(float(value) for value in alpha),
@@ -6428,11 +6585,12 @@ def _single_design_columns(
         if len(values) != n:
             raise ValueError("tt transform result must match the expanded risk-set rows")
         return [values]
-    prediction_scale_states = (
-        spec.scale_states
-        if prediction and isinstance(spec, _NumericDesignTerm | _PolyDesignTerm)
-        else None
-    )
+    if isinstance(spec, _NSDesignTerm):
+        prediction_scale_states = () if prediction else spec.scale_states
+    elif prediction and isinstance(spec, _NumericDesignTerm | _PolyDesignTerm):
+        prediction_scale_states = spec.scale_states
+    else:
+        prediction_scale_states = None
     values = _term_raw_values(
         data,
         spec.term,
@@ -6440,22 +6598,40 @@ def _single_design_columns(
         prediction_scale_states,
         fit_scales=prediction,
     )
+    if isinstance(spec, _NSDesignTerm):
+        ns_options = cast(_NSFormulaOptions, spec.term.ns_options)
+        basis = _core.ns_basis(
+            _numeric_term_values(values, spec.term),
+            None,
+            list(spec.knots),
+            spec.boundary_knots,
+            ns_options.intercept,
+        )
+        if int(basis.n_cols) != spec.width:
+            raise ValueError("ns() basis width changed during formula reconstruction")
+        rows = [
+            basis.basis[index : index + spec.width]
+            for index in range(0, len(basis.basis), spec.width)
+        ]
+        if len(rows) != n:
+            raise ValueError("ns() basis row count must match formula data")
+        return [list(column) for column in zip(*rows, strict=True)]
     if isinstance(spec, _PolyDesignTerm):
-        options = cast(_PolyFormulaOptions, spec.term.poly_options)
-        recompute = options.simple and prediction
-        alpha = None if options.raw or recompute else list(spec.alpha)
-        norm2 = None if options.raw or recompute else list(spec.norm2)
+        poly_options = cast(_PolyFormulaOptions, spec.term.poly_options)
+        recompute = poly_options.simple and prediction
+        alpha = None if poly_options.raw or recompute else list(spec.alpha)
+        norm2 = None if poly_options.raw or recompute else list(spec.norm2)
         rows, _alpha, _norm2 = _core.poly_basis(
             _numeric_term_values(values, spec.term),
-            options.degree,
-            options.raw,
+            poly_options.degree,
+            poly_options.raw,
             alpha,
             norm2,
         )
         if len(rows) != n:
             raise ValueError("poly() basis row count must match formula data")
         if not rows:
-            return [[] for _ in range(options.degree)]
+            return [[] for _ in range(poly_options.degree)]
         return [list(column) for column in zip(*rows, strict=True)]
     if isinstance(spec, _NumericDesignTerm):
         return [_numeric_term_values(values, spec.term)]
@@ -7319,6 +7495,9 @@ def _design_term_name(spec: _DesignTerm) -> str:
 
 def _single_design_term_output_names(spec: _SingleDesignTerm) -> list[str]:
     term = spec.term
+    if isinstance(spec, _NSDesignTerm):
+        prefix = _covariate_term_name(term)
+        return [f"{prefix}{index}" for index in range(1, spec.width + 1)]
     if isinstance(spec, _PolyDesignTerm):
         options = cast(_PolyFormulaOptions, term.poly_options)
         prefix = _covariate_term_name(term)

--- a/python/tests/test_binding_contract.py
+++ b/python/tests/test_binding_contract.py
@@ -10012,6 +10012,7 @@ def test_core_utility_bindings_are_typed():
         "SplineBasisResult",
         "PSpline",
         "nsk",
+        "ns_basis",
         "poly_basis",
         "pspline_basis",
         "scale_values",
@@ -10051,6 +10052,7 @@ def test_core_utility_bindings_are_typed():
 
     expected_args = {
         "nsk": ["x", "df", "knots", "boundary_knots"],
+        "ns_basis": ["x", "df", "knots", "boundary_knots", "intercept"],
         "poly_basis": ["x", "degree", "raw", "alpha", "norm2"],
         "pspline_basis": ["x", "nterm", "degree", "boundary_knots"],
         "scale_values": ["x", "center", "scale", "center_value", "scale_value"],
@@ -10189,6 +10191,13 @@ def test_core_utility_bindings_are_typed():
     default_basis = core.nsk([1.0, 2.0, 3.0, 4.0, 5.0], None, None, None)
     basis = core.nsk([1.0, 2.0, 3.0, 4.0, 5.0], 3, None, None)
     explicit_basis = core.nsk([1.0, 2.0, 3.0, 4.0], None, [2.0, 3.0], (1.0, 4.0))
+    natural_basis = core.ns_basis(
+        [-2.0, 0.0, 0.5, 1.5, 3.0, 5.0, 8.0, 13.0],
+        None,
+        [1.0, 4.0, 7.0],
+        (0.0, 8.0),
+        False,
+    )
     spline = core.NaturalSplineKnot([2.0, 3.0], (1.0, 4.0), None, False)
     spline_basis = spline.basis([1.0, 2.0, 3.0])
     pspline = core.PSpline([1.0, 2.0, 3.0, 4.0], 3, 0.1, 1e-6, "GCV", (0.0, 5.0), False, False)
@@ -10219,6 +10228,13 @@ def test_core_utility_bindings_are_typed():
         1.0 if row > 0 and row - 1 == col else 0.0 for row in range(4) for col in range(3)
     ]
     assert explicit_basis.basis == pytest.approx(expected_identity)
+    assert natural_basis.n_cols == 4
+    assert natural_basis.knots == [1.0, 4.0, 7.0]
+    assert natural_basis.boundary_knots == (0.0, 8.0)
+    assert natural_basis.basis[:4] == pytest.approx(
+        [0.0, 0.181568259800641, -0.907841299003203, 0.726273039202563],
+        abs=2e-14,
+    )
     assert spline.df == 3
     assert spline.intercept is False
     assert spline_basis.n_rows == 3

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -17523,6 +17523,190 @@ def test_formula_scale_supports_r_options_and_validation_rules():
             survival.coxph(f"Surv(time,status) ~ {term}", data=data)
 
 
+def test_formula_ns_matches_r_subset_interaction_and_prediction_state():
+    data = {
+        "time": [float(index) for index in range(1, 11)],
+        "status": [1, 0] * 5,
+        "x": [-10.0, -4.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 8.0, 20.0],
+        "z": [0.1, 0.2, 0.3, None, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0],
+    }
+    keep = [False, *([True] * 7), False, False]
+    formula = (
+        "Surv(time,status) ~ ns(x,df=3) + ns(log(x+11),knots=c(2,2.5),Boundary.knots=c(1,4)):z"
+    )
+    fit = survival.coxph(
+        formula,
+        data=data,
+        subset=keep,
+        na_action="omit",
+        max_iter=0,
+    )
+    matrix = survival.model_matrix(fit)
+    expected = [
+        [
+            -0.183357984196436,
+            0.541720076870056,
+            -0.291695426006953,
+            -0.0136720611251965,
+            0.119671036290179,
+            -0.0683834493086738,
+        ],
+        [
+            -0.127040794324088,
+            0.617641885644578,
+            -0.332576399962465,
+            0.0383793121043007,
+            0.170483103349157,
+            -0.096761354798039,
+        ],
+        [
+            0.0267853762660533,
+            0.605986182111382,
+            -0.325893251499128,
+            0.155842438956225,
+            0.250078775172267,
+            -0.133902866173946,
+        ],
+        [
+            0.128829169593671,
+            0.573317222494136,
+            -0.305453270394685,
+            0.227953496260405,
+            0.281497463481944,
+            -0.141309705515239,
+        ],
+        [
+            0.227664092495275,
+            0.535299228164999,
+            -0.277249034945988,
+            0.301087452898934,
+            0.310487704768118,
+            -0.141431881825872,
+        ],
+        [
+            0.310332672003121,
+            0.500172802664608,
+            -0.243750624579545,
+            0.372121095262756,
+            0.338293150890159,
+            -0.134475607563453,
+        ],
+    ]
+    assert matrix["columns"] == [
+        "ns(x,df=3)1",
+        "ns(x,df=3)2",
+        "ns(x,df=3)3",
+        "ns(log(x+11),knots=c(2,2.5),Boundary.knots=c(1,4))1:z",
+        "ns(log(x+11),knots=c(2,2.5),Boundary.knots=c(1,4))2:z",
+        "ns(log(x+11),knots=c(2,2.5),Boundary.knots=c(1,4))3:z",
+    ]
+    assert matrix["assign"] == [1, 1, 1, 2, 2, 2]
+    for actual, expected_row in zip(matrix["data"], expected, strict=True):
+        assert actual == pytest.approx(expected_row, abs=2e-14)
+
+    rows, offsets = survival.r_api._prediction_inputs(
+        fit,
+        {"x": [-6.0, 4.0, 14.0], "z": [0.4, 0.5, 0.9]},
+    )
+    assert offsets is None
+    assert rows is not None
+    expected_new = [
+        [
+            -0.164180269680181,
+            0.398522271549858,
+            -0.214588915449923,
+            -0.0627149571978303,
+            0.193282421240293,
+            -0.110447097851596,
+        ],
+        [
+            0.375086462421965,
+            0.469382035710669,
+            -0.205667792665262,
+            0.244184729358635,
+            0.203043020872657,
+            -0.0670298447362882,
+        ],
+        [
+            0.26914941374946,
+            0.343827063860296,
+            0.367975903342625,
+            0.381259742666009,
+            0.309887834343169,
+            0.16119174268158,
+        ],
+    ]
+    for actual, expected_row in zip(rows, expected_new, strict=True):
+        assert actual == pytest.approx(expected_row, abs=2e-14)
+
+
+def test_formula_ns_fits_before_na_omission_and_recomputes_nested_scale_for_prediction():
+    data = {
+        "time": [float(index) for index in range(1, 9)],
+        "status": [1, 0] * 4,
+        "x": [1.0, 2.0, None, 4.0, 8.0, 9.0, 10.0, 12.0],
+        "z": [0.1, 0.2, 0.3, None, 0.5, 0.6, 0.7, 0.8],
+    }
+    fit = survival.coxph(
+        "Surv(time,status) ~ ns(scale(x),df=3) + z",
+        data=data,
+        na_action="omit",
+        max_iter=0,
+    )
+    expected = [
+        [0.0, 0.0, 0.0, 0.1],
+        [-0.0514858065951185, 0.202670179737657, -0.147396494354659, 0.2],
+        [0.525504836457573, 0.348148932988899, -0.107744678537381, 0.5],
+        [0.528771360259757, 0.311171679047559, 0.0577842334199574, 0.6],
+        [0.396077348438935, 0.325494166835015, 0.248125454423019, 0.7],
+        [-0.123711340206186, 0.45360824742268, 0.670103092783505, 0.8],
+    ]
+    for actual, expected_row in zip(fit.covariates, expected, strict=True):
+        assert actual == pytest.approx(expected_row, abs=2e-14)
+
+    rows, _offsets = survival.r_api._prediction_inputs(
+        fit,
+        {"x": [3.0, 7.0, 14.0], "z": [0.25, 0.55, 0.9]},
+    )
+    assert rows is not None
+    expected_new = [
+        [-0.0715217422198635, 0.338803346357782, -0.24640243371475, 0.25],
+        [0.225269330425255, 0.489285330712898, -0.342357442231141, 0.55],
+        [0.124295234146218, 0.389039194676059, 0.484234193882389, 0.9],
+    ]
+    for actual, expected_row in zip(rows, expected_new, strict=True):
+        assert actual == pytest.approx(expected_row, abs=2e-14)
+
+
+def test_formula_ns_supports_namespace_partial_options_and_validation():
+    data = _numeric_data()
+    fit = survival.coxph(
+        "Surv(time,status) ~ splines::ns(x1,d=4,int=TRUE,B=c(0,2))",
+        data=data,
+        max_iter=0,
+    )
+    matrix = survival.model_matrix(fit)
+    assert len(matrix["columns"]) == 4
+    assert all(
+        name.startswith("splines::ns(x1,d=4,int=TRUE,B=c(0,2))") for name in matrix["columns"]
+    )
+
+    with pytest.warns(RuntimeWarning, match="df.*too small"):
+        small = survival.coxph("Surv(time,status) ~ ns(x1,df=0)", data=data, max_iter=0)
+    assert len(survival.model_matrix(small)["columns"]) == 1
+
+    for term, message in (
+        ("ns()", "requires one numeric argument"),
+        ("ns(x1,df=2.5)", "df must be an integer"),
+        ("ns(x1,knots=c(0.5,Inf))", "must be finite"),
+        ("ns(x1,Boundary.knots=c(0,1,2))", "must contain two"),
+        ("ns(x1,extra=1)", "unsupported ns.*option"),
+        ("offset(ns(x1,df=3))", "offset.*numeric"),
+    ):
+        with pytest.raises(ValueError, match=message):
+            survival.coxph(f"Surv(time,status) ~ {term}", data=data)
+
+
 def test_formula_pmin_na_rm_controls_transformed_row_omission():
     data = _numeric_data()
     data["x1"] = [None, None, *data["x1"][2:]]

--- a/r/survivalr/man/survivalr.Rd
+++ b/r/survivalr/man/survivalr.Rd
@@ -1279,6 +1279,11 @@ accept logical or numeric centering and scaling options, fit before subsetting
 or missing-data omission, and retain their fitted state for ordinary new-data
 model reconstruction. Nested uses follow R's \code{makepredictcall} behavior.
 
+Natural-spline \code{ns(...)} formula terms use a parallel O(nk) Rust basis
+matching \code{splines::ns}, including fitted knots and boundaries, linear
+extrapolation, interactions, nested numeric expressions, and transform state
+computed before subsetting or missing-data omission.
+
 Formula \code{finegray} calls use the Python formula engine and Rust interval
 expansion directly. The bridge supports weights, subsets, missing-data actions,
 strata, counting-process histories, and delayed entry; computes censoring risk

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -5366,6 +5366,124 @@ test_that("survreg scale formula terms match R", {
   )
 })
 
+test_that("coxph natural spline formula terms match R", {
+  skip_if_not_installed("reticulate")
+  skip_if_not_installed("survival")
+  skip_if_not_installed("splines")
+  skip_if_not(reticulate::py_module_available("survival"), "Python survival package is unavailable")
+
+  set.seed(5221)
+  n <- 120L
+  age <- stats::runif(n, 35, 85)
+  marker <- stats::runif(n, 0.4, 4.8)
+  sex <- rep(c(0, 1), length.out = n)
+  event_time <- stats::rexp(n, exp(0.018 * age - 0.12 * log(marker) + 0.15 * sex))
+  censor <- stats::rexp(n, 1.1)
+  data <- data.frame(
+    time = pmax(pmin(event_time, censor), 0.001),
+    status = as.integer(event_time <= censor),
+    age = age,
+    marker = marker,
+    sex = sex
+  )
+  formula <- Surv(time, status) ~ splines::ns(age, df = 3) +
+    sex:splines::ns(log(marker), knots = c(0.5, 1), Boundary.knots = c(-1, 2))
+  bridged <- coxph(
+    formula,
+    data = data,
+    ties = "breslow",
+    max_iter = 150,
+    eps = 1e-10,
+    x = TRUE
+  )
+  reference <- survival::coxph(
+    formula,
+    data = data,
+    ties = "breslow",
+    x = TRUE,
+    control = survival::coxph.control(iter.max = 150, eps = 1e-10)
+  )
+
+  bridged_matrix <- model.matrix(bridged)
+  reference_matrix <- stats::model.matrix(reference)
+  expect_identical(colnames(bridged_matrix), colnames(reference_matrix))
+  expect_identical(attr(bridged_matrix, "assign"), attr(reference_matrix, "assign"))
+  expect_equal(unname(bridged_matrix), unname(reference_matrix), tolerance = 2e-12)
+  expect_identical(attr(terms(bridged), "term.labels"), attr(terms(reference), "term.labels"))
+  expect_equal(unname(coef(bridged)), unname(coef(reference)), tolerance = 3e-08)
+
+  newdata <- transform(
+    data[c(2, 19, 47, 83), ],
+    age = age + c(2, -3, 5, -4),
+    marker = marker + c(0.2, -0.1, 0.4, 0.3)
+  )
+  expect_equal(
+    as.numeric(predict(bridged, newdata = newdata, type = "lp", reference = "zero")),
+    as.numeric(stats::predict(reference, newdata = newdata, type = "lp", reference = "zero")),
+    tolerance = 3e-08
+  )
+})
+
+test_that("survreg natural splines preserve pre-omission state like R", {
+  skip_if_not_installed("reticulate")
+  skip_if_not_installed("survival")
+  skip_if_not_installed("splines")
+  skip_if_not(reticulate::py_module_available("survival"), "Python survival package is unavailable")
+
+  set.seed(5222)
+  n <- 90L
+  x <- stats::runif(n, 0.5, 8)
+  z <- stats::rnorm(n)
+  latent <- exp(1 + 0.08 * x - 0.12 * z + stats::rnorm(n, sd = 0.35))
+  censor <- stats::rexp(n, rate = 1 / 18)
+  data <- data.frame(
+    time = pmax(pmin(latent, censor), 0.01),
+    status = as.integer(latent <= censor),
+    x = x,
+    z = z
+  )
+  data$z[c(7, 61)] <- NA_real_
+  keep <- seq_len(n) %% 8L != 0L
+  formula <- Surv(time, status) ~ splines::ns(scale(x), df = 3) + z
+  bridged <- survreg(
+    formula,
+    data = data,
+    subset = keep,
+    na.action = na.omit,
+    dist = "weibull",
+    max_iter = 150,
+    eps = 1e-10,
+    x = TRUE
+  )
+  reference <- survival::survreg(
+    formula,
+    data = data,
+    subset = keep,
+    na.action = na.omit,
+    dist = "weibull",
+    x = TRUE,
+    control = survival::survreg.control(maxiter = 150, rel.tolerance = 1e-10)
+  )
+
+  bridged_matrix <- model.matrix(bridged)
+  reference_matrix <- stats::model.matrix(reference)
+  expect_identical(colnames(bridged_matrix), colnames(reference_matrix))
+  expect_identical(attr(bridged_matrix, "assign"), attr(reference_matrix, "assign"))
+  expect_equal(unname(bridged_matrix), unname(reference_matrix), tolerance = 2e-12)
+  expect_equal(unname(coef(bridged)), unname(coef(reference)), tolerance = 3e-08)
+
+  newdata <- transform(
+    data[c(3, 21, 44), ],
+    x = x + c(0.3, -0.2, 0.5),
+    z = c(-0.4, 0.2, 0.8)
+  )
+  expect_equal(
+    unname(predict(bridged, newdata = newdata, type = "lp")),
+    unname(stats::predict(reference, newdata = newdata, type = "lp")),
+    tolerance = 3e-08
+  )
+})
+
 test_that("pmin na.rm controls formula row omission like R", {
   skip_if_not_installed("reticulate")
   skip_if_not_installed("survival")

--- a/src/api/python/classical/core.rs
+++ b/src/api/python/classical/core.rs
@@ -86,6 +86,7 @@ pub(super) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(cipoisson, m)?)?;
     m.add_function(wrap_pyfunction!(cipoisson_exact, m)?)?;
     m.add_function(wrap_pyfunction!(cipoisson_anscombe, m)?)?;
+    m.add_function(wrap_pyfunction!(ns_basis, m)?)?;
     m.add_function(wrap_pyfunction!(poly_basis, m)?)?;
     m.add_function(wrap_pyfunction!(pspline_basis, m)?)?;
     m.add_function(wrap_pyfunction!(scale_values, m)?)?;

--- a/src/core/bspline.rs
+++ b/src/core/bspline.rs
@@ -1,0 +1,88 @@
+pub(crate) fn basis_row(knots: &[f64], x: f64, order: usize) -> Vec<f64> {
+    let n_basis = knots.len() - order;
+    let mut values = vec![0.0; knots.len() - 1];
+    for idx in 0..knots.len() - 1 {
+        if (knots[idx] <= x && x < knots[idx + 1])
+            || (x == knots[knots.len() - 1] && knots[idx] <= x && x <= knots[idx + 1])
+        {
+            values[idx] = 1.0;
+        }
+    }
+
+    for current_order in 2..=order {
+        let mut next_values = vec![0.0; knots.len() - current_order];
+        for idx in 0..next_values.len() {
+            let left_denominator = knots[idx + current_order - 1] - knots[idx];
+            let right_denominator = knots[idx + current_order] - knots[idx + 1];
+            let left = if left_denominator == 0.0 {
+                0.0
+            } else {
+                (x - knots[idx]) / left_denominator * values[idx]
+            };
+            let right = if right_denominator == 0.0 {
+                0.0
+            } else {
+                (knots[idx + current_order] - x) / right_denominator * values[idx + 1]
+            };
+            next_values[idx] = left + right;
+        }
+        values = next_values;
+    }
+    values.truncate(n_basis);
+    values
+}
+
+pub(crate) fn derivative_row(knots: &[f64], x: f64, order: usize, derivative: usize) -> Vec<f64> {
+    if derivative == 0 {
+        return basis_row(knots, x, order);
+    }
+    if order <= derivative {
+        return vec![0.0; knots.len().saturating_sub(order)];
+    }
+
+    let lower_order = derivative_row(knots, x, order - 1, derivative - 1);
+    let n_basis = knots.len() - order;
+    (0..n_basis)
+        .map(|idx| {
+            let left_denominator = knots[idx + order - 1] - knots[idx];
+            let right_denominator = knots[idx + order] - knots[idx + 1];
+            let left = if left_denominator == 0.0 {
+                0.0
+            } else {
+                (order - 1) as f64 / left_denominator * lower_order[idx]
+            };
+            let right = if right_denominator == 0.0 {
+                0.0
+            } else {
+                (order - 1) as f64 / right_denominator * lower_order[idx + 1]
+            };
+            left - right
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn repeated_boundary_knots_have_expected_values_and_derivatives() {
+        let knots = [0.0, 0.0, 0.0, 0.0, 1.0, 4.0, 7.0, 8.0, 8.0, 8.0, 8.0];
+        assert_eq!(
+            basis_row(&knots, 0.0, 4),
+            vec![1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        );
+        assert_eq!(
+            basis_row(&knots, 8.0, 4),
+            vec![0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]
+        );
+        assert_eq!(
+            derivative_row(&knots, 0.0, 4, 2),
+            vec![6.0, -7.5, 1.5, 0.0, 0.0, 0.0, 0.0]
+        );
+        assert_eq!(
+            derivative_row(&knots, 8.0, 4, 2),
+            vec![0.0, 0.0, 0.0, 0.0, 1.5, -7.5, 6.0]
+        );
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,6 +1,8 @@
+pub(crate) mod bspline;
 #[path = "coxcount1.rs"]
 pub(crate) mod coxcount1_module;
 pub(crate) mod coxscho;
+pub(crate) mod ns;
 #[path = "nsk.rs"]
 pub(crate) mod nsk_module;
 pub(crate) mod poly;
@@ -9,6 +11,7 @@ pub(crate) mod scale;
 
 pub use coxcount1_module::{CoxCountOutput, coxcount1, coxcount2};
 pub use coxscho::schoenfeld_residuals;
+pub use ns::ns_basis;
 pub use nsk_module::{NaturalSplineKnot, SplineBasisResult, nsk};
 pub use poly::poly_basis;
 pub use pspline::{PSpline, pspline_basis};

--- a/src/core/ns.rs
+++ b/src/core/ns.rs
@@ -1,0 +1,391 @@
+use super::bspline::{basis_row, derivative_row};
+use super::nsk_module::SplineBasisResult;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use rayon::prelude::*;
+
+const ORDER: usize = 4;
+
+fn value_error(message: impl Into<String>) -> PyErr {
+    PyValueError::new_err(message.into())
+}
+
+fn quantile_type7(sorted: &[f64], probability: f64) -> f64 {
+    if sorted.len() == 1 {
+        return sorted[0];
+    }
+    let position = probability * (sorted.len() - 1) as f64;
+    let lower = position.floor() as usize;
+    let upper = position.ceil() as usize;
+    let weight = position - lower as f64;
+    sorted[lower] * (1.0 - weight) + sorted[upper] * weight
+}
+
+fn normalize_boundaries(
+    observed: &[f64],
+    boundary_knots: Option<(f64, f64)>,
+) -> PyResult<(f64, f64)> {
+    let (mut lower, mut upper) = match boundary_knots {
+        Some(bounds) => bounds,
+        None if observed.len() == 1 => (observed[0] * 7.0 / 8.0, observed[0] * 9.0 / 8.0),
+        None => observed.iter().copied().fold(
+            (f64::INFINITY, f64::NEG_INFINITY),
+            |(lower, upper), value| (lower.min(value), upper.max(value)),
+        ),
+    };
+    if lower > upper {
+        std::mem::swap(&mut lower, &mut upper);
+    }
+    if !lower.is_finite() || !upper.is_finite() || lower >= upper {
+        return Err(value_error(
+            "boundary_knots must contain two distinct finite values",
+        ));
+    }
+    Ok((lower, upper))
+}
+
+fn computed_knots(
+    observed: &[f64],
+    n_interior: usize,
+    boundaries: (f64, f64),
+) -> PyResult<Vec<f64>> {
+    if n_interior == 0 {
+        return Ok(Vec::new());
+    }
+    let mut inside: Vec<f64> = observed
+        .iter()
+        .copied()
+        .filter(|value| *value >= boundaries.0 && *value <= boundaries.1)
+        .collect();
+    inside.sort_by(f64::total_cmp);
+    if inside.is_empty() {
+        return Err(value_error(
+            "x must contain values within boundary_knots to compute knots",
+        ));
+    }
+    let mut knots: Vec<f64> = (1..=n_interior)
+        .map(|index| quantile_type7(&inside, index as f64 / (n_interior + 1) as f64))
+        .collect();
+
+    if knots.contains(&boundaries.0) {
+        let next = knots
+            .iter()
+            .copied()
+            .filter(|value| *value > boundaries.0)
+            .reduce(f64::min)
+            .ok_or_else(|| value_error("all interior knots match left boundary knot"))?;
+        let replacement = boundaries.0 + (next - boundaries.0) / 8.0;
+        for knot in &mut knots {
+            if *knot == boundaries.0 {
+                *knot = replacement;
+            }
+        }
+    }
+    if knots.contains(&boundaries.1) {
+        let previous = knots
+            .iter()
+            .copied()
+            .filter(|value| *value < boundaries.1)
+            .reduce(f64::max)
+            .ok_or_else(|| value_error("all interior knots match right boundary knot"))?;
+        let replacement = boundaries.1 - (boundaries.1 - previous) / 8.0;
+        for knot in &mut knots {
+            if *knot == boundaries.1 {
+                *knot = replacement;
+            }
+        }
+    }
+    Ok(knots)
+}
+
+struct HouseholderReflector {
+    pivot: usize,
+    values: Vec<f64>,
+    beta: f64,
+}
+
+fn householder_reflectors(matrix: &[Vec<f64>]) -> PyResult<Vec<HouseholderReflector>> {
+    let rows = matrix.len();
+    let columns = matrix.first().map_or(0, Vec::len);
+    if rows < columns {
+        return Err(value_error("natural spline constraint matrix is malformed"));
+    }
+    let mut factors = matrix.to_vec();
+    let mut reflectors = Vec::with_capacity(columns);
+
+    for pivot in 0..columns {
+        let norm = factors[pivot..]
+            .iter()
+            .map(|row| row[pivot] * row[pivot])
+            .sum::<f64>()
+            .sqrt();
+        if norm == 0.0 || !norm.is_finite() {
+            return Err(value_error("natural spline constraints are rank deficient"));
+        }
+        let alpha = -norm.copysign(factors[pivot][pivot]);
+        let mut reflector: Vec<f64> = factors[pivot..].iter().map(|row| row[pivot]).collect();
+        reflector[0] -= alpha;
+        let squared_norm = reflector.iter().map(|value| value * value).sum::<f64>();
+        if squared_norm == 0.0 || !squared_norm.is_finite() {
+            return Err(value_error("natural spline constraints are rank deficient"));
+        }
+        let beta = 2.0 / squared_norm;
+
+        let mut column = pivot;
+        while column < columns {
+            let projection = reflector
+                .iter()
+                .enumerate()
+                .map(|(offset, value)| value * factors[pivot + offset][column])
+                .sum::<f64>();
+            for (offset, value) in reflector.iter().enumerate() {
+                factors[pivot + offset][column] -= beta * value * projection;
+            }
+            column += 1;
+        }
+        reflectors.push(HouseholderReflector {
+            pivot,
+            values: reflector,
+            beta,
+        });
+    }
+    Ok(reflectors)
+}
+
+fn apply_householder_constraints(
+    mut values: Vec<f64>,
+    reflectors: &[HouseholderReflector],
+) -> Vec<f64> {
+    for reflector in reflectors {
+        let projection = reflector
+            .values
+            .iter()
+            .enumerate()
+            .map(|(offset, value)| values[reflector.pivot + offset] * value)
+            .sum::<f64>();
+        for (offset, value) in reflector.values.iter().enumerate() {
+            values[reflector.pivot + offset] -= reflector.beta * projection * value;
+        }
+    }
+    values
+}
+
+fn raw_basis_row(x: f64, knots: &[f64], boundaries: (f64, f64)) -> Vec<f64> {
+    let pivot = if x < boundaries.0 {
+        Some(boundaries.0)
+    } else if x > boundaries.1 {
+        Some(boundaries.1)
+    } else {
+        None
+    };
+    match pivot {
+        Some(pivot) => basis_row(knots, pivot, ORDER)
+            .into_iter()
+            .zip(derivative_row(knots, pivot, ORDER, 1))
+            .map(|(basis, derivative)| (x - pivot).mul_add(derivative, basis))
+            .collect(),
+        None => basis_row(knots, x, ORDER),
+    }
+}
+
+pub(crate) fn ns_basis_core(
+    x: &[f64],
+    df: Option<usize>,
+    knots: Option<&[f64]>,
+    boundary_knots: Option<(f64, f64)>,
+    intercept: bool,
+) -> PyResult<SplineBasisResult> {
+    if x.iter().any(|value| value.is_infinite()) {
+        return Err(value_error("x must contain only finite or missing values"));
+    }
+    let observed: Vec<f64> = x.iter().copied().filter(|value| !value.is_nan()).collect();
+    if observed.is_empty() {
+        return Err(value_error("x must contain at least one non-missing value"));
+    }
+    let boundaries = normalize_boundaries(&observed, boundary_knots)?;
+    let minimum_df = 1 + usize::from(intercept);
+    let interior = match knots {
+        Some(values) => {
+            if values.iter().any(|value| !value.is_finite()) {
+                return Err(value_error("knots must contain only finite values"));
+            }
+            values.to_vec()
+        }
+        None => computed_knots(
+            &observed,
+            df.unwrap_or(minimum_df).saturating_sub(minimum_df),
+            boundaries,
+        )?,
+    };
+
+    let mut augmented = Vec::with_capacity(interior.len() + 8);
+    augmented.extend([boundaries.0; 4]);
+    augmented.extend(interior.iter().copied());
+    augmented.extend([boundaries.1; 4]);
+    augmented.sort_by(f64::total_cmp);
+    let first_column = usize::from(!intercept);
+    let raw_width = augmented.len() - ORDER - first_column;
+    let output_width = raw_width
+        .checked_sub(2)
+        .ok_or_else(|| value_error("natural spline basis has too few columns"))?;
+
+    let constraints: Vec<Vec<f64>> = [boundaries.0, boundaries.1]
+        .iter()
+        .map(|value| derivative_row(&augmented, *value, ORDER, 2)[first_column..].to_vec())
+        .collect();
+    let constraint_transpose: Vec<Vec<f64>> = (0..raw_width)
+        .map(|column| vec![constraints[0][column], constraints[1][column]])
+        .collect();
+    let reflectors = householder_reflectors(&constraint_transpose)?;
+
+    let basis: Vec<f64> = x
+        .par_iter()
+        .flat_map_iter(|value| {
+            if value.is_nan() {
+                return vec![f64::NAN; output_width];
+            }
+            let raw = raw_basis_row(*value, &augmented, boundaries);
+            apply_householder_constraints(raw[first_column..].to_vec(), &reflectors)[2..].to_vec()
+        })
+        .collect();
+
+    Ok(SplineBasisResult {
+        basis,
+        n_rows: x.len(),
+        n_cols: output_width,
+        knots: interior,
+        boundary_knots: boundaries,
+    })
+}
+
+#[pyfunction]
+#[pyo3(signature = (x, df=None, knots=None, boundary_knots=None, intercept=false))]
+pub fn ns_basis(
+    x: Vec<f64>,
+    df: Option<usize>,
+    knots: Option<Vec<f64>>,
+    boundary_knots: Option<(f64, f64)>,
+    intercept: bool,
+) -> PyResult<SplineBasisResult> {
+    ns_basis_core(&x, df, knots.as_deref(), boundary_knots, intercept)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rows(result: &SplineBasisResult) -> Vec<Vec<f64>> {
+        result
+            .basis
+            .chunks(result.n_cols)
+            .map(<[f64]>::to_vec)
+            .collect()
+    }
+
+    #[test]
+    fn explicit_basis_matches_r_splines_fixture_including_extrapolation() {
+        let result = ns_basis_core(
+            &[-2.0, 0.0, 0.5, 1.5, 3.0, 5.0, 8.0, 13.0],
+            None,
+            Some(&[1.0, 4.0, 7.0]),
+            Some((0.0, 8.0)),
+            false,
+        )
+        .unwrap();
+        let expected = [
+            [
+                0.0,
+                0.181568259800641,
+                -0.907841299003203,
+                0.726273039202563,
+            ],
+            [0.0, 0.0, 0.0, 0.0],
+            [
+                0.00446428571428571,
+                -0.0437709197733687,
+                0.218854598866844,
+                -0.175083679093475,
+            ],
+            [
+                0.112599206349206,
+                -0.0937484650816598,
+                0.473702642868617,
+                -0.378962114294893,
+            ],
+            [
+                0.456349206349206,
+                -0.00814919180508497,
+                0.358206276485742,
+                -0.286565021188594,
+            ],
+            [
+                0.456349206349206,
+                0.441262450350684,
+                0.111148065706897,
+                -0.0722517858988506,
+            ],
+            [
+                0.0,
+                -0.0952380952380952,
+                0.476190476190476,
+                0.619047619047619,
+            ],
+            [0.0, -3.30952380952381, 1.54761904761905, 2.76190476190476],
+        ];
+        assert_eq!(result.n_cols, 4);
+        for (actual, expected) in rows(&result).iter().zip(expected) {
+            for (actual, expected) in actual.iter().zip(expected) {
+                assert!((actual - expected).abs() < 2e-14);
+            }
+        }
+    }
+
+    #[test]
+    fn computed_knots_and_missing_rows_match_r() {
+        let result =
+            ns_basis_core(&[1.0, f64::NAN, 2.0, 5.0, 9.0], Some(3), None, None, false).unwrap();
+        assert_eq!(result.knots, vec![2.0, 5.0]);
+        assert_eq!(result.boundary_knots, (1.0, 9.0));
+        assert_eq!(result.n_cols, 3);
+        assert!(rows(&result)[1].iter().all(|value| value.is_nan()));
+        let expected_last = [-0.150537634408602, 0.413978494623656, 0.736559139784946];
+        for (actual, expected) in rows(&result)[4].iter().zip(expected_last) {
+            assert!((actual - expected).abs() < 2e-14);
+        }
+    }
+
+    #[test]
+    fn intercept_and_duplicate_knots_match_r_dimensions() {
+        let intercept =
+            ns_basis_core(&[1.0, 2.0, 3.0, 4.0, 5.0], Some(4), None, None, true).unwrap();
+        assert_eq!(intercept.n_cols, 4);
+
+        let duplicate = ns_basis_core(
+            &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+            None,
+            Some(&[3.0, 3.0, 6.0]),
+            Some((1.0, 8.0)),
+            false,
+        )
+        .unwrap();
+        assert_eq!(duplicate.n_cols, 4);
+        assert_eq!(duplicate.knots, vec![3.0, 3.0, 6.0]);
+    }
+
+    #[test]
+    fn malformed_inputs_are_rejected() {
+        assert!(ns_basis_core(&[f64::NAN], Some(3), None, None, false).is_err());
+        assert!(ns_basis_core(&[1.0, f64::INFINITY], Some(3), None, None, false).is_err());
+        assert!(ns_basis_core(&[1.0, 2.0], Some(3), None, Some((1.0, 1.0)), false).is_err());
+        assert!(
+            ns_basis_core(
+                &[1.0, 2.0],
+                None,
+                Some(&[f64::NAN]),
+                Some((0.0, 3.0)),
+                false,
+            )
+            .is_err()
+        );
+    }
+}

--- a/src/core/pspline.rs
+++ b/src/core/pspline.rs
@@ -1,4 +1,5 @@
 use crate::constants::STRICT_EPSILON;
+use crate::core::bspline::{basis_row, derivative_row};
 use crate::internal::matrix::lu_solve;
 use ndarray::{Array1, Array2};
 use pyo3::exceptions::PyValueError;
@@ -89,62 +90,6 @@ fn validate_positive_scalar(value: f64, field: &str) -> PyResult<()> {
     Ok(())
 }
 
-fn r_pspline_basis_row(knots: &[f64], x: f64, order: usize) -> Vec<f64> {
-    let n_basis = knots.len() - order;
-    let mut values = vec![0.0; knots.len() - 1];
-    for idx in 0..knots.len() - 1 {
-        if (knots[idx] <= x && x < knots[idx + 1])
-            || (x == knots[knots.len() - 1] && knots[idx] <= x && x <= knots[idx + 1])
-        {
-            values[idx] = 1.0;
-        }
-    }
-
-    for current_order in 2..=order {
-        let mut next_values = vec![0.0; knots.len() - current_order];
-        for idx in 0..next_values.len() {
-            let left_denominator = knots[idx + current_order - 1] - knots[idx];
-            let right_denominator = knots[idx + current_order] - knots[idx + 1];
-            let left = if left_denominator == 0.0 {
-                0.0
-            } else {
-                (x - knots[idx]) / left_denominator * values[idx]
-            };
-            let right = if right_denominator == 0.0 {
-                0.0
-            } else {
-                (knots[idx + current_order] - x) / right_denominator * values[idx + 1]
-            };
-            next_values[idx] = left + right;
-        }
-        values = next_values;
-    }
-    values.truncate(n_basis);
-    values
-}
-
-fn r_pspline_basis_derivative_row(knots: &[f64], x: f64, order: usize) -> Vec<f64> {
-    let lower_order = r_pspline_basis_row(knots, x, order - 1);
-    let n_basis = knots.len() - order;
-    (0..n_basis)
-        .map(|idx| {
-            let left_denominator = knots[idx + order - 1] - knots[idx];
-            let right_denominator = knots[idx + order] - knots[idx + 1];
-            let left = if left_denominator == 0.0 {
-                0.0
-            } else {
-                (order - 1) as f64 / left_denominator * lower_order[idx]
-            };
-            let right = if right_denominator == 0.0 {
-                0.0
-            } else {
-                (order - 1) as f64 / right_denominator * lower_order[idx + 1]
-            };
-            left - right
-        })
-        .collect()
-}
-
 fn r_pspline_knots(boundary_knots: (f64, f64), nterm: usize, degree: usize) -> PyResult<Vec<f64>> {
     let knot_count = nterm
         .checked_add(
@@ -218,10 +163,10 @@ pub(crate) fn pspline_basis_core(
     }
 
     let order = degree + 1;
-    let left_basis = r_pspline_basis_row(&knots, lower, order);
-    let left_derivative = r_pspline_basis_derivative_row(&knots, lower, order);
-    let right_basis = r_pspline_basis_row(&knots, upper, order);
-    let right_derivative = r_pspline_basis_derivative_row(&knots, upper, order);
+    let left_basis = basis_row(&knots, lower, order);
+    let left_derivative = derivative_row(&knots, lower, order, 1);
+    let right_basis = basis_row(&knots, upper, order);
+    let right_derivative = derivative_row(&knots, upper, order, 1);
     let basis = x
         .par_iter()
         .map(|value| {
@@ -240,7 +185,7 @@ pub(crate) fn pspline_basis_core(
                     .map(|(basis, derivative)| basis + (value - upper) * derivative)
                     .collect()
             } else {
-                r_pspline_basis_row(&knots, *value, order)
+                basis_row(&knots, *value, order)
             }
         })
         .collect();


### PR DESCRIPTION
## Summary
- add a parallel native cubic B-spline basis with natural constraints, R-compatible knot selection, and linear extrapolation
- support `ns(...)` and `splines::ns(...)` formula terms with interactions, nested expressions, subset/omission state, and new-data reconstruction
- share the B-spline recurrence with penalized splines and update typing, manifests, documentation, and cross-language coverage

## Validation
- `cargo test --lib --no-default-features` (1,555 passed)
- `cargo test --lib --features ml` (1,764 passed)
- `cargo test --lib --features python,ml` (1,778 passed)
- strict Rust linting across all three feature configurations
- Python suite (1,070 passed)
- full R bridge suite
- 328 randomized and edge basis comparisons against R (maximum absolute error 4.88e-15)
- `R CMD check --no-manual --no-build-vignettes r/survivalr` (pass with the standard source-directory NOTE)
- formatting, Python lint, type stubs, binding manifest, and whitespace checks