### PR TITLE
Support ordinal concordance formulas

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,9 @@ They support right-censored `Surv(time, event)` data and counting-process
 `Surv(start, stop, event)` data with delayed-entry risk sets. Direct and
 formula `Surv(...)` calls also accept R-style named aliases including `time=`,
 `time1=`, `start=`, `time2=`, `stop=`, `event=`, and `status=`.
+`concordance(...)` formulas additionally accept numeric and logical outcomes,
+ordered factors, and two-level unordered factors, with rank weighting for these
+non-survival responses.
 Left- and interval-censored curves use a native Turnbull EM fit with the
 reference support-point rules, weighted redistribution, robust or Greenwood
 uncertainty, and all supported confidence transformations.

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -304,6 +304,13 @@ class _CovariateTerm:
 
 
 @dataclass(frozen=True)
+class _ConcordanceFormulaResponseSpec:
+    columns: tuple[str, ...]
+    numeric_expression: _NumericFormulaExpression | None = None
+    factor_term: _CovariateTerm | None = None
+
+
+@dataclass(frozen=True)
 class _InteractionTerm:
     factors: tuple[_CovariateTerm, ...]
 
@@ -3509,7 +3516,9 @@ def _parse_numeric_formula_expression(expression: str) -> _NumericFormulaExpress
     if not value:
         raise ValueError("formula numeric expressions must not be empty")
 
-    split = _find_top_level_arithmetic_operator(value, {"+", "-"})
+    split = _find_top_level_comparison_operator(value)
+    if split is None:
+        split = _find_top_level_arithmetic_operator(value, {"+", "-"})
     if split is None:
         split = _find_top_level_arithmetic_operator(value, {"*", "/"})
     if split is not None:
@@ -3599,6 +3608,18 @@ def _numeric_formula_unary_value(function: str, value: float) -> float:
 def _numeric_formula_binary_value(operator: str, left: float, right: float) -> float:
     if math.isnan(left) or math.isnan(right):
         return math.nan
+    if operator == "<":
+        return float(left < right)
+    if operator == "<=":
+        return float(left <= right)
+    if operator == ">":
+        return float(left > right)
+    if operator == ">=":
+        return float(left >= right)
+    if operator == "==":
+        return float(left == right)
+    if operator == "!=":
+        return float(left != right)
     if operator == "+":
         return left + right
     if operator == "-":
@@ -3973,14 +3994,16 @@ def _formula_transform_states(
     formula: str,
     data: Any,
     n: int,
+    response_columns: Sequence[str] | None = None,
 ) -> tuple[
     _ScaleFormulaStates,
     tuple[tuple[_CovariateTerm, tuple[tuple[float, ...], tuple[float, float], int]], ...],
     tuple[tuple[_CovariateTerm, tuple[tuple[float, ...], tuple[float, ...]]], ...],
 ]:
-    response_spec = _formula_response_spec(formula)
+    if response_columns is None:
+        response_columns = _formula_response_spec(formula).columns
     _lhs, _sep, rhs = formula.partition("~")
-    terms = _split_terms(rhs, _dot_terms(data, list(response_spec.columns)))
+    terms = _split_terms(rhs, _dot_terms(data, list(response_columns)))
     formula_terms = [
         *(term for spec in terms.covariates for term in _covariate_factors(spec)),
         *terms.offsets,
@@ -4052,23 +4075,34 @@ def _formula_transform_states(
     return tuple(fitted_scale_states.items()), tuple(ns_states), tuple(poly_states)
 
 
-def _formula_state_data(formula: str, data: Any, n: int) -> Any:
+def _formula_state_data(
+    formula: str,
+    data: Any,
+    n: int,
+    response_columns: Sequence[str] | None = None,
+) -> Any:
     if isinstance(data, _FormulaSubsetData):
         return data
-    scale_states, ns_states, poly_states = _formula_transform_states(formula, data, n)
+    scale_states, ns_states, poly_states = _formula_transform_states(
+        formula,
+        data,
+        n,
+        response_columns,
+    )
     if not scale_states and not ns_states and not poly_states:
         return data
     return _FormulaSubsetData(data, scale_states, ns_states, poly_states)
 
 
-def _subset_formula_inputs(
+def _subset_formula_inputs_for_columns(
     formula: str,
     data: Any,
     subset: Any,
+    response_columns: Sequence[str],
     **row_aligned: Any,
 ) -> tuple[Any, dict[str, Any]]:
-    n = len(_column(data, _formula_response_args(formula)[0]))
-    data = _formula_state_data(formula, data, n)
+    n = len(_column(data, response_columns[0]))
+    data = _formula_state_data(formula, data, n, response_columns)
     indices = _subset_indices(subset, n)
     filtered = {
         name: _subset_optional_sequence(values, indices, name)
@@ -4077,11 +4111,29 @@ def _subset_formula_inputs(
     return _subset_data(data, indices), filtered
 
 
-def _apply_formula_na_action(
+def _subset_formula_inputs(
+    formula: str,
+    data: Any,
+    subset: Any,
+    **row_aligned: Any,
+) -> tuple[Any, dict[str, Any]]:
+    response_columns = _formula_response_spec(formula).columns
+    return _subset_formula_inputs_for_columns(
+        formula,
+        data,
+        subset,
+        response_columns,
+        **row_aligned,
+    )
+
+
+def _apply_formula_na_action_for_columns(
     formula: str,
     data: Any,
     na_action: str | None,
+    response_columns: Sequence[str],
     *,
+    response_values: Sequence[tuple[str, Sequence[Any]]] = (),
     exclude_columns: Sequence[str] = (),
     **row_aligned: Any,
 ) -> tuple[Any, dict[str, Any]]:
@@ -4089,18 +4141,17 @@ def _apply_formula_na_action(
     if action == "pass":
         return data, row_aligned
 
-    response_spec = _formula_response_spec(formula)
-    n = len(_column(data, response_spec.columns[0]))
-    data = _formula_state_data(formula, data, n)
+    n = len(_column(data, response_columns[0]))
+    data = _formula_state_data(formula, data, n, response_columns)
     excluded = set(exclude_columns)
     _lhs, _sep, rhs = formula.partition("~")
-    terms = _split_terms(rhs, _dot_terms(data, list(response_spec.columns)))
+    terms = _split_terms(rhs, _dot_terms(data, list(response_columns)))
     raw_columns = [
-        *response_spec.columns,
+        *response_columns,
         *_offset_columns(terms.offsets),
         *terms.clusters,
     ]
-    transformed_columns: list[tuple[str, Sequence[Any]]] = []
+    transformed_columns: list[tuple[str, Sequence[Any]]] = list(response_values)
     evaluated_strata: set[_CovariateTerm] = set()
     for spec in terms.covariates:
         for term in _covariate_factors(spec):
@@ -4171,6 +4222,27 @@ def _apply_formula_na_action(
         name: _subset_optional_sequence(values, keep, name) for name, values in row_aligned.items()
     }
     return _subset_data(data, keep), filtered
+
+
+def _apply_formula_na_action(
+    formula: str,
+    data: Any,
+    na_action: str | None,
+    *,
+    exclude_columns: Sequence[str] = (),
+    **row_aligned: Any,
+) -> tuple[Any, dict[str, Any]]:
+    if _normalize_na_action(na_action) == "pass":
+        return data, row_aligned
+    response_columns = _formula_response_spec(formula).columns
+    return _apply_formula_na_action_for_columns(
+        formula,
+        data,
+        na_action,
+        response_columns,
+        exclude_columns=exclude_columns,
+        **row_aligned,
+    )
 
 
 def _data_column_names(data: Any) -> list[Any] | None:
@@ -4294,6 +4366,55 @@ def _is_scientific_notation_sign(text: str, idx: int) -> bool:
         saw_digit = saw_digit or text[cursor].isdigit()
         cursor -= 1
     return saw_digit and (cursor < 0 or text[cursor] in "+-*/(^,=")
+
+
+def _find_top_level_comparison_operator(
+    expression: str,
+) -> tuple[str, str, str] | None:
+    depth = 0
+    in_backtick = False
+    match: tuple[int, str] | None = None
+    idx = 0
+    operators = ("<=", ">=", "==", "!=", "<", ">")
+
+    while idx < len(expression):
+        char = expression[idx]
+        if char == "`":
+            in_backtick = not in_backtick
+            idx += 1
+            continue
+        if in_backtick:
+            idx += 1
+            continue
+        if char == "(":
+            depth += 1
+            idx += 1
+            continue
+        if char == ")":
+            depth = max(0, depth - 1)
+            idx += 1
+            continue
+        if depth == 0:
+            operator = next(
+                (candidate for candidate in operators if expression.startswith(candidate, idx)),
+                None,
+            )
+            if operator is not None:
+                match = (idx, operator)
+                idx += len(operator)
+                continue
+        idx += 1
+
+    if in_backtick:
+        raise ValueError("unterminated backtick in formula")
+    if match is None:
+        return None
+    split_idx, operator = match
+    left = expression[:split_idx].strip()
+    right = expression[split_idx + len(operator) :].strip()
+    if not left or not right:
+        raise ValueError("formula comparison terms require both operands")
+    return left, operator, right
 
 
 def _find_top_level_arithmetic_operator(
@@ -25917,6 +26038,116 @@ class _CountingConcordanceData:
     status: list[int]
 
 
+@lru_cache(maxsize=512)
+def _concordance_formula_response_spec(formula: str) -> _ConcordanceFormulaResponseSpec:
+    lhs, separator, _rhs = formula.partition("~")
+    if not separator:
+        raise ValueError("formula must contain '~'")
+    expression_text = _strip_outer_formula_parentheses(lhs.strip())
+    if expression_text.startswith("I(") and expression_text.endswith(")"):
+        expression_text = expression_text[2:-1]
+
+    factor_term = _parse_factor_formula_term(expression_text)
+    if factor_term is not None:
+        return _ConcordanceFormulaResponseSpec(
+            tuple(_covariate_term_columns(factor_term)),
+            factor_term=factor_term,
+        )
+
+    expression = _parse_numeric_formula_expression(expression_text)
+    columns = tuple(_numeric_formula_expression_columns(expression))
+    if not columns:
+        raise ValueError("formula response must contain a data column")
+    return _ConcordanceFormulaResponseSpec(columns, numeric_expression=expression)
+
+
+def _concordance_factor_is_ordered(source: Any) -> bool:
+    if bool(getattr(source, "ordered", False)):
+        return True
+    return bool(getattr(getattr(source, "dtype", None), "ordered", False))
+
+
+def _concordance_factor_codes(
+    values: Sequence[Any],
+    levels: Sequence[Any],
+    ordered: bool,
+) -> list[float]:
+    normalized_levels = [
+        value for value in levels if value is not _FACTOR_NA_LEVEL and not _is_missing_value(value)
+    ]
+    if not ordered and len(normalized_levels) != 2:
+        raise ValueError(
+            "left hand side of the formula must be a numeric vector,\n"
+            " survival object, or an orderable factor"
+        )
+    level_indices = {
+        _factor_value_key(level): float(index + 1) for index, level in enumerate(normalized_levels)
+    }
+    result: list[float] = []
+    for value in values:
+        if value is _FACTOR_NA_LEVEL or _is_missing_value(value):
+            result.append(math.nan)
+            continue
+        try:
+            result.append(level_indices[_factor_value_key(value)])
+        except KeyError as exc:
+            raise ValueError(f"factor response contains undeclared level {value!r}") from exc
+    return result
+
+
+def _concordance_formula_response_values(
+    data: Any,
+    spec: _ConcordanceFormulaResponseSpec,
+) -> list[float]:
+    n = len(_column(data, spec.columns[0]))
+    if spec.factor_term is not None:
+        term = spec.factor_term
+        values = _term_raw_values(data, term, n)
+        encoding = _factor_encoding(data, term, values)
+        source = _column_source(data, term.column)
+        ordered = (
+            False
+            if term.categorical_wrapper == "as.factor"
+            else (
+                _concordance_factor_is_ordered(source)
+                if term.factor_options is None or term.factor_options.ordered is None
+                else term.factor_options.ordered
+            )
+        )
+        return _concordance_factor_codes(encoding.values, encoding.levels, ordered)
+
+    expression = cast(_NumericFormulaExpression, spec.numeric_expression)
+    if isinstance(expression, _NumericFormulaColumn):
+        source = _column_source(data, expression.name)
+        categories = _mstate_categories(source)
+        if categories is not None:
+            values = _factor_normalized_values(source, _column(data, expression.name))
+            levels = _materialize_1d(categories, f"{expression.name} categories")
+            return _concordance_factor_codes(
+                values,
+                levels,
+                _concordance_factor_is_ordered(source),
+            )
+    try:
+        return _numeric_formula_expression_values(data, expression, n)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "left hand side of the formula must be a numeric vector,\n"
+            " survival object, or an orderable factor"
+        ) from exc
+
+
+def _parse_concordance_formula(
+    formula: str,
+    data: Any,
+    spec: _ConcordanceFormulaResponseSpec,
+) -> tuple[Surv, _FormulaTerms]:
+    _lhs, _separator, rhs = formula.partition("~")
+    response = Surv(_concordance_formula_response_values(data, spec))
+    terms = _split_terms(rhs, _dot_terms(data, list(spec.columns)))
+    return response, terms
+
+
 def _unsupported_concordance_response() -> NoReturn:
     raise NotImplementedError(
         "concordance currently supports right-censored and counting Surv responses"
@@ -26347,22 +26578,18 @@ def _single_score_concordance_result(
         if include_ranks
         else None
     )
-    influence_rows = None
-    dfbeta = None
-    variance = None
-    if influence_value or cluster_values is not None:
-        influence_rows, dfbeta, variance = _concordance_influence(
-            response,
-            risk_values,
-            weight_values,
-            strata_values,
-            fix_time,
-            time_weight,
-            lower_bound,
-            upper_bound,
-        )
-        if cluster_values is not None and dfbeta is not None:
-            dfbeta, variance = _clustered_concordance_dfbeta(dfbeta, cluster_values)
+    influence_rows, dfbeta, variance = _concordance_influence(
+        response,
+        risk_values,
+        weight_values,
+        strata_values,
+        fix_time,
+        time_weight,
+        lower_bound,
+        upper_bound,
+    )
+    if cluster_values is not None:
+        dfbeta, variance = _clustered_concordance_dfbeta(dfbeta, cluster_values)
     return ConcordanceResult(
         concordance=float(summary["concordance"]),
         n=len(response),
@@ -26376,7 +26603,7 @@ def _single_score_concordance_result(
         ranks=rank_rows,
         dfbeta=dfbeta if influence_value in {1, 3} else None,
         influence=influence_rows if influence_value in {2, 3} else None,
-        variance=variance if influence_value or cluster_values is not None else None,
+        variance=variance,
         conditional_variance=float(summary["conditional_variance"]),
     )
 
@@ -26426,11 +26653,7 @@ def _multi_score_concordance_result(
         ranks=[result.ranks for result in results] if include_ranks else None,
         dfbeta=[result.dfbeta for result in results] if influence_value in {1, 3} else None,
         influence=[result.influence for result in results] if influence_value in {2, 3} else None,
-        variance=(
-            [result.variance for result in results]
-            if influence_value or cluster_values is not None
-            else None
-        ),
+        variance=[result.variance for result in results],
         conditional_variance=[
             float(result.conditional_variance)
             if isinstance(result.conditional_variance, int | float)
@@ -26490,30 +26713,75 @@ def concordance(
         effective_reverse_scores = not reverse_scores
         if external_scores is not None:
             raise ValueError("concordance formula input cannot be combined with scores")
+        lhs = response.partition("~")[0].strip()
+        surv_formula = lhs.startswith("Surv(") or lhs.startswith("survival::Surv(")
+        concordance_response_spec = (
+            None if surv_formula else _concordance_formula_response_spec(response)
+        )
         weights = _formula_weight_values(data, weights)
         cluster = _formula_cluster_values(data, cluster)
         if subset is not None:
-            data, aligned = _subset_formula_inputs(
-                response,
-                data,
-                subset,
-                weights=weights,
-                cluster=cluster,
-            )
+            if concordance_response_spec is None:
+                data, aligned = _subset_formula_inputs(
+                    response,
+                    data,
+                    subset,
+                    weights=weights,
+                    cluster=cluster,
+                )
+            else:
+                data, aligned = _subset_formula_inputs_for_columns(
+                    response,
+                    data,
+                    subset,
+                    concordance_response_spec.columns,
+                    weights=weights,
+                    cluster=cluster,
+                )
             weights = aligned["weights"]
             cluster = aligned["cluster"]
             subset = None
-        data, aligned = _apply_formula_na_action(
-            response,
-            data,
-            na_action,
-            weights=weights,
-            cluster=cluster,
-        )
+        if concordance_response_spec is None:
+            data, aligned = _apply_formula_na_action(
+                response,
+                data,
+                na_action,
+                weights=weights,
+                cluster=cluster,
+            )
+        else:
+            n = len(_column(data, concordance_response_spec.columns[0]))
+            data = _formula_state_data(
+                response,
+                data,
+                n,
+                concordance_response_spec.columns,
+            )
+            response_values = _concordance_formula_response_values(
+                data,
+                concordance_response_spec,
+            )
+            data, aligned = _apply_formula_na_action_for_columns(
+                response,
+                data,
+                na_action,
+                concordance_response_spec.columns,
+                response_values=(("formula response", response_values),),
+                weights=weights,
+                cluster=cluster,
+            )
         weights = aligned["weights"]
         cluster = aligned["cluster"]
         na_action = "pass"
-        response, terms = _parse_formula(response, data)
+        if concordance_response_spec is None:
+            response, terms = _parse_formula(response, data)
+        else:
+            response, terms = _parse_concordance_formula(
+                response,
+                data,
+                concordance_response_spec,
+            )
+            time_weight = "n"
         if terms.clusters:
             if cluster is not None:
                 raise ValueError("use only one of formula cluster(...) or cluster")

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -8478,6 +8478,123 @@ def test_concordance_formula_returns_one_result_per_score_column():
     assert result.n_event == sum(data["status"])
 
 
+def test_concordance_formula_accepts_numeric_outcomes_and_forces_rank_weights():
+    data = {
+        "y": [1.0, 3.0, 2.0, 4.0, 4.0, 2.0],
+        "x": [0.2, 0.9, 0.4, 0.7, 0.7, 0.1],
+        "z": [1.0, 0.2, 0.5, 0.8, 0.3, 0.6],
+        "w": [1.0, 2.0, 1.5, 0.5, 3.0, 2.5],
+    }
+
+    fitted = survival.concordance(
+        "y ~ x",
+        data=data,
+        weights="w",
+        influence=3,
+        ranks=True,
+    )
+    expected = survival.concordance(
+        survival.Surv(data["y"]),
+        scores=data["x"],
+        weights=data["w"],
+        reverse=True,
+        influence=3,
+        ranks=True,
+    )
+    multi = survival.concordance("y ~ x + z", data=data, weights="w", influence=3)
+    transformed = survival.concordance("log(y + 1) ~ x", data=data)
+    forced_rank_weights = survival.concordance("y ~ x", data=data, timewt="S")
+    ordinary_rank_weights = survival.concordance("y ~ x", data=data)
+
+    assert fitted.concordance == pytest.approx(0.753246753246753)
+    assert fitted.concordance == pytest.approx(expected.concordance)
+    assert fitted.count == pytest.approx(expected.count)
+    assert fitted.conditional_variance == pytest.approx(0.0268217769926587)
+    assert fitted.dfbeta == pytest.approx(expected.dfbeta)
+    for actual, reference in zip(fitted.influence, expected.influence, strict=True):
+        assert actual == pytest.approx(reference)
+    for actual, reference in zip(fitted.ranks, expected.ranks, strict=True):
+        assert actual == pytest.approx(reference)
+    assert fitted.n == fitted.n_event == len(data["y"])
+    assert multi.score_names == ["x", "z"]
+    assert multi.concordance == pytest.approx([0.753246753246753, 0.233766233766234])
+    assert transformed.concordance == pytest.approx(0.769230769230769)
+    assert transformed.variance == pytest.approx(0.00238086901719127)
+    assert forced_rank_weights.concordance == pytest.approx(ordinary_rank_weights.concordance)
+    assert forced_rank_weights.count == pytest.approx(ordinary_rank_weights.count)
+
+
+def test_concordance_formula_accepts_logical_and_orderable_factor_outcomes():
+    x = [0.2, 0.9, 0.4, 0.7, 0.7, 0.1]
+    numeric_y = [1.0, 3.0, 2.0, 4.0, 4.0, 2.0]
+    logical = survival.concordance(
+        "y ~ x",
+        data={"y": [False, True, False, True, True, False], "x": x},
+    )
+    logical_expression = survival.concordance(
+        "I(y >= 3) ~ x",
+        data={"y": numeric_y, "x": x},
+    )
+    binary = survival.r_api._r_factor(
+        ["FALSE", "TRUE", "FALSE", "TRUE", "TRUE", "FALSE"],
+        ["FALSE", "TRUE"],
+        codes=[1, 2, 1, 2, 2, 1],
+    )
+    binary_fit = survival.concordance("y ~ x", data={"y": binary, "x": x})
+    ordered = survival.r_api._r_factor(
+        ["low", "high", "mid", "high", "high", "mid"],
+        ["low", "mid", "high"],
+        ordered=True,
+        codes=[1, 3, 2, 3, 3, 2],
+    )
+    ordered_fit = survival.concordance("y ~ x", data={"y": ordered, "x": x})
+    constructed = survival.concordance(
+        'factor(y, levels=c("low", "mid", "high"), ordered=TRUE) ~ x',
+        data={"y": ["low", "high", "mid", "high", "high", "mid"], "x": x},
+    )
+
+    assert logical.concordance == pytest.approx(1.0)
+    assert logical.variance == pytest.approx(0.0)
+    assert logical.count == pytest.approx(
+        {"concordant": 9.0, "discordant": 0.0, "tied.x": 0.0, "tied.y": 5.0, "tied.xy": 1.0}
+    )
+    assert logical_expression.concordance == pytest.approx(logical.concordance)
+    assert logical_expression.count == pytest.approx(logical.count)
+    assert binary_fit.concordance == pytest.approx(logical.concordance)
+    assert binary_fit.count == pytest.approx(logical.count)
+    assert ordered_fit.concordance == pytest.approx(0.909090909090909)
+    assert ordered_fit.count == pytest.approx(
+        {"concordant": 10.0, "discordant": 1.0, "tied.x": 0.0, "tied.y": 3.0, "tied.xy": 1.0}
+    )
+    assert constructed.concordance == pytest.approx(ordered_fit.concordance)
+
+    unordered = survival.r_api._r_factor(
+        ["a", "b", "c", "a", "b", "c"],
+        ["a", "b", "c"],
+        codes=[1, 2, 3, 1, 2, 3],
+    )
+    with pytest.raises(ValueError, match="orderable factor"):
+        survival.concordance("y ~ x", data={"y": unordered, "x": x})
+
+
+def test_numeric_concordance_formula_applies_subset_na_action_and_dot_exclusion():
+    data = {
+        "y": [1.0, None, 2.0, 4.0, 5.0],
+        "x": [0.2, 0.9, None, 0.7, 0.8],
+        "z": [1.0, 0.2, 0.5, 0.8, 0.3],
+    }
+    fitted = survival.concordance(
+        "y ~ .",
+        data=data,
+        subset=[0, 1, 2, 3],
+        na_action="omit",
+    )
+
+    assert fitted.n == fitted.n_event == 2
+    assert fitted.score_names == ["x", "z"]
+    assert fitted.concordance == pytest.approx([1.0, 0.0])
+
+
 def test_concordance_matrix_scores_return_parallel_cluster_variances():
     data = {
         "time": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -11895,21 +11895,50 @@ concordance.default <- function(object, data = NULL, ..., scores = NULL, risk.sc
                                 weights = NULL, cluster = NULL, subset = NULL, na.action = "fail") {
   formula <- object
   env <- parent.frame()
-  score_values <- .eval_formula_arg(substitute(scores), missing(scores), data, env, vector = TRUE)
-  risk_score_values <- .eval_formula_arg(
-    substitute(risk.scores),
-    missing(risk.scores),
-    data,
+  formula_data <- if (is.null(data) && inherits(formula, "formula")) {
+    .formula_environment_data(formula, env)
+  } else {
+    data
+  }
+  score_values <- .eval_formula_arg(
+    substitute(scores),
+    missing(scores),
+    formula_data,
     env,
     vector = TRUE
   )
-  weight_values <- .eval_formula_arg(substitute(weights), missing(weights), data, env, vector = TRUE)
-  cluster_values <- .eval_formula_arg(substitute(cluster), missing(cluster), data, env, vector = TRUE)
-  subset_values <- .eval_formula_arg(substitute(subset), missing(subset), data, env, vector = TRUE)
+  risk_score_values <- .eval_formula_arg(
+    substitute(risk.scores),
+    missing(risk.scores),
+    formula_data,
+    env,
+    vector = TRUE
+  )
+  weight_values <- .eval_formula_arg(
+    substitute(weights),
+    missing(weights),
+    formula_data,
+    env,
+    vector = TRUE
+  )
+  cluster_values <- .eval_formula_arg(
+    substitute(cluster),
+    missing(cluster),
+    formula_data,
+    env,
+    vector = TRUE
+  )
+  subset_values <- .eval_formula_arg(
+    substitute(subset),
+    missing(subset),
+    formula_data,
+    env,
+    vector = TRUE
+  )
   .call_r_api(
     "concordance",
     response = .as_formula_string(formula),
-    data = .as_python_data(data),
+    data = .as_python_data(formula_data),
     scores = score_values,
     risk_scores = risk_score_values,
     weights = weight_values,

--- a/r/survivalr/README.md
+++ b/r/survivalr/README.md
@@ -12,6 +12,8 @@ Bridged models support standard R generics including `coef`, `vcov`, `confint`,
 Common result objects such as `survfit`, `basehaz`, `survdiff`, `concordance`,
 `cox.zph`, `coxph.detail`, and `anova` outputs can also be converted with
 `as.data.frame`.
+`concordance` formulas accept numeric and logical outcomes as well as ordered
+or two-level factors, matching the upstream rank-weighted interpretation.
 Multi-state `survfit` objects with retained model frames support native-shaped
 influence residuals and pseudo-values for state probabilities, cumulative
 transition hazards, and integrated state occupancy.

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -4154,6 +4154,106 @@ test_that("interval-censored curves match weighted Turnbull reference fits", {
   }
 })
 
+test_that("concordance formulas accept numeric and orderable outcomes", {
+  skip_if_not_installed("reticulate")
+  skip_if_not_installed("survival")
+  skip_if_not(
+    reticulate::py_module_available("survival"),
+    "Python survival package is unavailable"
+  )
+
+  data <- data.frame(
+    y = c(1, 3, 2, 4, 4, 2),
+    x = c(0.2, 0.9, 0.4, 0.7, 0.7, 0.1),
+    z = c(1, 0.2, 0.5, 0.8, 0.3, 0.6),
+    w = c(1, 2, 1.5, 0.5, 3, 2.5)
+  )
+  data$binary <- factor(data$y >= 3)
+  data$ordinal <- ordered(
+    c("low", "high", "mid", "high", "high", "mid"),
+    levels = c("low", "mid", "high")
+  )
+
+  expect_concordance_equal <- function(formula, ...) {
+    args <- c(list(formula, data = data), list(...))
+    bridged <- do.call(concordance, args)
+    reference <- do.call(survival::concordance, args)
+    bridged_frame <- as.data.frame(bridged)
+    strict_concordant <- bridged_frame$concordant - 0.5 * bridged_frame$tied.x
+    bridged_count <- cbind(
+      concordant = strict_concordant,
+      discordant = bridged_frame$comparable - strict_concordant - bridged_frame$tied.x,
+      tied.x = bridged_frame$tied.x,
+      tied.y = bridged_frame$tied.y,
+      tied.xy = bridged_frame$tied.xy
+    )
+    reference_count <- if (is.matrix(reference$count)) {
+      reference$count
+    } else {
+      matrix(as.numeric(reference$count), nrow = 1L)
+    }
+
+    expect_equal(coef(bridged), coef(reference), tolerance = 1e-12)
+    expect_equal(vcov(bridged), vcov(reference), tolerance = 1e-12)
+    expect_equal(
+      unname(bridged_count),
+      unname(reference_count),
+      tolerance = 1e-12
+    )
+    invisible(bridged)
+  }
+
+  numeric_fit <- expect_concordance_equal(
+    y ~ x,
+    weights = data$w,
+    influence = 3,
+    ranks = TRUE
+  )
+  expect_equal(coef(numeric_fit), 0.753246753246753, tolerance = 1e-12)
+  expect_equal(
+    as.numeric(vcov(numeric_fit)),
+    0.0112321292487896,
+    tolerance = 1e-12
+  )
+  expect_concordance_equal(y ~ x + z, weights = data$w, influence = 3)
+  expect_concordance_equal(I(y >= 3) ~ x)
+  expect_concordance_equal(binary ~ x)
+  expect_concordance_equal(ordinal ~ x)
+  expect_concordance_equal(log(y + 1) ~ x)
+
+  forced_rank_weights <- concordance(y ~ x, data = data, timewt = "S")
+  ordinary_rank_weights <- concordance(y ~ x, data = data, timewt = "n")
+  expect_equal(coef(forced_rank_weights), coef(ordinary_rank_weights))
+  expect_equal(vcov(forced_rank_weights), vcov(ordinary_rank_weights))
+
+  bridged_environment_fit <- local({
+    y <- data$y
+    x <- data$x
+    concordance(y ~ x)
+  })
+  reference_environment_fit <- local({
+    y <- data$y
+    x <- data$x
+    survival::concordance(y ~ x)
+  })
+  expect_equal(
+    coef(bridged_environment_fit),
+    coef(reference_environment_fit),
+    tolerance = 1e-12
+  )
+  expect_equal(
+    vcov(bridged_environment_fit),
+    vcov(reference_environment_fit),
+    tolerance = 1e-12
+  )
+
+  data$unordered <- factor(c("a", "b", "c", "a", "b", "c"))
+  expect_error(
+    concordance(unordered ~ x, data = data),
+    "orderable factor"
+  )
+})
+
 test_that("tmerge matches native interval, metadata, and class semantics", {
   skip_if_not_installed("reticulate")
   skip_if_not_installed("survival")


### PR DESCRIPTION
## Summary
- accept numeric, logical, transformed, ordered-factor, and two-level-factor concordance responses
- preserve factor metadata, subset and missing-row semantics, formula environments, and rank-weight behavior
- compute default concordance variance while retaining diagnostic arrays only when requested
- add Python and R parity coverage against the maintained reference implementation

## Stack
- based on #525

## Testing
- 1087 Python tests
- 1556 Rust tests without default features
- 1765 Rust tests with ML features
- 1779 Rust tests with Python and ML features
- clippy in all three feature configurations
- formatting, lint, type, and diff checks
- R CMD check --no-manual --no-build-vignettes (1 standard source-directory note)