### PR TITLE
Preserve multi-score concordance covariance

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -22224,7 +22224,23 @@ def _concordance_frame(result: ConcordanceResult) -> dict[str, list[Any]]:
     if isinstance(result.concordance, list):
         n_scores = len(result.concordance)
         score_names = result.score_names or [f"score{idx + 1}" for idx in range(n_scores)]
-        variance = result.variance if isinstance(result.variance, list) else [math.nan] * n_scores
+        if (
+            isinstance(result.variance, list)
+            and result.variance
+            and isinstance(result.variance[0], list)
+        ):
+            covariance = cast(list[list[float]], result.variance)
+            variance = [
+                covariance[idx][idx] if idx < len(covariance[idx]) else math.nan
+                for idx in range(min(n_scores, len(covariance)))
+            ]
+            variance.extend([math.nan] * (n_scores - len(variance)))
+        else:
+            variance = (
+                cast(list[float | None], result.variance)
+                if isinstance(result.variance, list)
+                else [math.nan] * n_scores
+            )
         tied_x = result.tied_x if isinstance(result.tied_x, list) else [result.tied_x] * n_scores
         tied_y = result.tied_y if isinstance(result.tied_y, list) else [result.tied_y] * n_scores
         tied_xy = (
@@ -26623,6 +26639,8 @@ def _multi_score_concordance_result(
     influence_value: int,
     include_ranks: bool,
 ) -> ConcordanceResult:
+    # The reference fit always computes dfbeta values for standard errors,
+    # even when the caller does not request that diagnostic in the result.
     results = [
         _single_score_concordance_result(
             response,
@@ -26635,10 +26653,18 @@ def _multi_score_concordance_result(
             time_weight,
             lower_bound,
             upper_bound,
-            influence_value,
+            3,
             include_ranks,
         )
         for score_values in score_columns
+    ]
+    dfbeta_columns = [cast(list[float], result.dfbeta) for result in results]
+    covariance = [
+        [
+            math.fsum(left * right for left, right in zip(left_column, right_column, strict=True))
+            for right_column in dfbeta_columns
+        ]
+        for left_column in dfbeta_columns
     ]
     return ConcordanceResult(
         concordance=[float(result.concordance) for result in results],
@@ -26651,9 +26677,9 @@ def _multi_score_concordance_result(
         tied_y=[float(result.tied_y) for result in results],
         tied_xy=[float(result.tied_xy) for result in results],
         ranks=[result.ranks for result in results] if include_ranks else None,
-        dfbeta=[result.dfbeta for result in results] if influence_value in {1, 3} else None,
+        dfbeta=dfbeta_columns if influence_value in {1, 3} else None,
         influence=[result.influence for result in results] if influence_value in {2, 3} else None,
-        variance=[result.variance for result in results],
+        variance=covariance,
         conditional_variance=[
             float(result.conditional_variance)
             if isinstance(result.conditional_variance, int | float)

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -8501,7 +8501,7 @@ def test_concordance_formula_accepts_numeric_outcomes_and_forces_rank_weights():
         influence=3,
         ranks=True,
     )
-    multi = survival.concordance("y ~ x + z", data=data, weights="w", influence=3)
+    multi = survival.concordance("y ~ x + z", data=data, weights="w")
     transformed = survival.concordance("log(y + 1) ~ x", data=data)
     forced_rank_weights = survival.concordance("y ~ x", data=data, timewt="S")
     ordinary_rank_weights = survival.concordance("y ~ x", data=data)
@@ -8518,6 +8518,20 @@ def test_concordance_formula_accepts_numeric_outcomes_and_forces_rank_weights():
     assert fitted.n == fitted.n_event == len(data["y"])
     assert multi.score_names == ["x", "z"]
     assert multi.concordance == pytest.approx([0.753246753246753, 0.233766233766234])
+    assert multi.dfbeta is None
+    assert multi.influence is None
+    for actual, reference in zip(
+        multi.variance,
+        [
+            [0.0028080323121974, -0.00284354488705543],
+            [-0.00284354488705543, 0.0048698240644387],
+        ],
+        strict=True,
+    ):
+        assert actual == pytest.approx(reference)
+    assert survival.as_data_frame(multi)["variance"] == pytest.approx(
+        [0.0028080323121974, 0.0048698240644387]
+    )
     assert transformed.concordance == pytest.approx(0.769230769230769)
     assert transformed.variance == pytest.approx(0.00238086901719127)
     assert forced_rank_weights.concordance == pytest.approx(ordinary_rank_weights.concordance)
@@ -8595,7 +8609,7 @@ def test_numeric_concordance_formula_applies_subset_na_action_and_dot_exclusion(
     assert fitted.concordance == pytest.approx([1.0, 0.0])
 
 
-def test_concordance_matrix_scores_return_parallel_cluster_variances():
+def test_concordance_matrix_scores_return_cluster_covariance():
     data = {
         "time": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
         "status": [1, 1, 0, 1, 1, 0],
@@ -8618,12 +8632,14 @@ def test_concordance_matrix_scores_return_parallel_cluster_variances():
         scores=data["x1"],
         weights=data["wt"],
         cluster=data["cluster"],
+        influence=1,
     )
     x2 = survival.concordance(
         response,
         scores=data["x2"],
         weights=data["wt"],
         cluster=data["cluster"],
+        influence=1,
     )
 
     assert result.score_names == ["score1", "score2"]
@@ -8633,7 +8649,22 @@ def test_concordance_matrix_scores_return_parallel_cluster_variances():
     assert result.tied_x == pytest.approx([x1.tied_x, x2.tied_x])
     assert result.tied_y == pytest.approx([x1.tied_y, x2.tied_y])
     assert result.tied_xy == pytest.approx([x1.tied_xy, x2.tied_xy])
-    assert result.variance == pytest.approx([x1.variance, x2.variance])
+    assert result.dfbeta is None
+    assert result.influence is None
+    assert x1.dfbeta is not None
+    assert x2.dfbeta is not None
+    covariance = [
+        [
+            sum(left * right for left, right in zip(x1.dfbeta, x1.dfbeta, strict=True)),
+            sum(left * right for left, right in zip(x1.dfbeta, x2.dfbeta, strict=True)),
+        ],
+        [
+            sum(left * right for left, right in zip(x2.dfbeta, x1.dfbeta, strict=True)),
+            sum(left * right for left, right in zip(x2.dfbeta, x2.dfbeta, strict=True)),
+        ],
+    ]
+    for actual, expected in zip(result.variance, covariance, strict=True):
+        assert actual == pytest.approx(expected)
     assert result.conditional_variance == pytest.approx(
         [x1.conditional_variance, x2.conditional_variance]
     )

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -12088,6 +12088,17 @@ vcov.survival_py_concordance <- function(object, ...) {
   if (nrow(frame) == 1L) {
     return(4 * as.numeric(frame$variance)[[1L]])
   }
+  variance <- .result_field(object, "variance")
+  if (is.matrix(variance) || (
+    is.list(variance) && length(variance) == nrow(frame) &&
+      all(vapply(variance, length, integer(1)) == nrow(frame))
+  )) {
+    covariance <- .as_numeric_matrix(variance)
+    if (!identical(dim(covariance), c(nrow(frame), nrow(frame)))) {
+      stop("concordance covariance must match the score count", call. = FALSE)
+    }
+    return(4 * covariance)
+  }
   dfbeta <- .result_field(object, "dfbeta")
   if (is.null(dfbeta)) {
     values <- 4 * as.numeric(frame$variance)

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -4166,7 +4166,8 @@ test_that("concordance formulas accept numeric and orderable outcomes", {
     y = c(1, 3, 2, 4, 4, 2),
     x = c(0.2, 0.9, 0.4, 0.7, 0.7, 0.1),
     z = c(1, 0.2, 0.5, 0.8, 0.3, 0.6),
-    w = c(1, 2, 1.5, 0.5, 3, 2.5)
+    w = c(1, 2, 1.5, 0.5, 3, 2.5),
+    cluster = c(1, 1, 2, 2, 3, 3)
   )
   data$binary <- factor(data$y >= 3)
   data$ordinal <- ordered(
@@ -4215,7 +4216,8 @@ test_that("concordance formulas accept numeric and orderable outcomes", {
     0.0112321292487896,
     tolerance = 1e-12
   )
-  expect_concordance_equal(y ~ x + z, weights = data$w, influence = 3)
+  expect_concordance_equal(y ~ x + z, weights = data$w)
+  expect_concordance_equal(y ~ x + z, weights = data$w, cluster = data$cluster)
   expect_concordance_equal(I(y >= 3) ~ x)
   expect_concordance_equal(binary ~ x)
   expect_concordance_equal(ordinal ~ x)


### PR DESCRIPTION
## Summary
- retain full multi-score concordance covariance when diagnostic arrays are not requested
- keep tabular variance output on the covariance diagonal
- return complete weighted and clustered covariance matrices through R vcov
- add exact Python and R parity coverage

## Stack
- based on #526

## Testing
- 1087 Python tests
- 1556 Rust tests without default features
- 1765 Rust tests with ML features
- 1779 Rust tests with Python and ML features
- clippy in all three feature configurations
- formatting, lint, type, and diff checks
- R CMD check --no-manual --no-build-vignettes (1 standard source-directory note)