### PR TITLE
Normalize stratified concordance diagnostics

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -26690,6 +26690,44 @@ def _multi_score_concordance_result(
     )
 
 
+def _scaled_concordance_variance(
+    variance: float | list[float | None] | list[list[float]] | None,
+) -> float | list[float | None] | list[list[float]] | None:
+    if variance is None:
+        return None
+    if isinstance(variance, int | float):
+        return 4.0 * float(variance)
+    if variance and isinstance(variance[0], list):
+        covariance = cast(list[list[float]], variance)
+        return [[4.0 * float(value) for value in row] for row in covariance]
+    values = cast(list[float | None], variance)
+    return [None if value is None else 4.0 * float(value) for value in values]
+
+
+def _public_concordance_result(
+    result: ConcordanceResult,
+    weights: list[float] | None,
+) -> ConcordanceResult:
+    n_scores = len(result.concordance) if isinstance(result.concordance, list) else 1
+    return ConcordanceResult(
+        concordance=result.concordance,
+        n=result.n,
+        n_event=result.n_event,
+        reverse=result.reverse,
+        concordant=result.concordant,
+        comparable=result.comparable,
+        tied_x=result.tied_x,
+        tied_y=result.tied_y,
+        tied_xy=result.tied_xy,
+        ranks=result.ranks,
+        dfbeta=_concordancefit_dfbeta(result.dfbeta),
+        influence=_concordancefit_influence(result.influence, weights, n_scores),
+        variance=_scaled_concordance_variance(result.variance),
+        conditional_variance=result.conditional_variance,
+        score_names=result.score_names,
+    )
+
+
 def concordance(
     response: Surv | str,
     data: Any | None = None,
@@ -26862,8 +26900,8 @@ def concordance(
             influence_value,
             include_ranks,
         )
-        return (
-            ConcordanceResult(
+        if score_names is not None:
+            result = ConcordanceResult(
                 concordance=result.concordance,
                 n=result.n,
                 n_event=result.n_event,
@@ -26880,24 +26918,25 @@ def concordance(
                 conditional_variance=result.conditional_variance,
                 score_names=score_names,
             )
-            if score_names is not None
-            else result
-        )
+        return _public_concordance_result(result, weight_values)
 
-    return _multi_score_concordance_result(
-        response,
-        score_columns,
-        score_names or [f"score{idx + 1}" for idx in range(len(score_columns))],
+    return _public_concordance_result(
+        _multi_score_concordance_result(
+            response,
+            score_columns,
+            score_names or [f"score{idx + 1}" for idx in range(len(score_columns))],
+            weight_values,
+            strata_values,
+            cluster_values,
+            effective_reverse_scores,
+            fix_time,
+            time_weight,
+            lower_bound,
+            upper_bound,
+            influence_value,
+            include_ranks,
+        ),
         weight_values,
-        strata_values,
-        cluster_values,
-        effective_reverse_scores,
-        fix_time,
-        time_weight,
-        lower_bound,
-        upper_bound,
-        influence_value,
-        include_ranks,
     )
 
 

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -8054,7 +8054,22 @@ def test_concordance_influence_modes_return_r_style_diagnostics():
         influence=3,
         reverse=True,
     )
+    reference = survival.concordancefit(
+        response,
+        data["score"],
+        weights=data["wt"],
+        influence=3,
+        reverse=True,
+    )
+    reversed_reference = survival.concordancefit(
+        response,
+        data["score"],
+        weights=data["wt"],
+        influence=3,
+    )
 
+    assert reference is not None
+    assert reversed_reference is not None
     assert dfbeta_only.dfbeta is not None
     assert dfbeta_only.influence is None
     assert influence_only.dfbeta is None
@@ -8067,15 +8082,20 @@ def test_concordance_influence_modes_return_r_style_diagnostics():
         assert both_row == pytest.approx(influence_row)
     assert both.variance == pytest.approx(sum(value * value for value in both.dfbeta))
     assert both.var == pytest.approx(both.variance)
-    assert [sum(row[col] for row in both.influence) for col in range(5)] == pytest.approx(
-        [both.concordant, both.comparable - both.concordant, 0.0, 0.0, 0.0]
-    )
+    assert both.dfbeta == pytest.approx(reference.dfbeta)
+    assert both.variance == pytest.approx(reference.variance)
+    for actual, expected in zip(both.influence, reference.influence, strict=True):
+        assert actual == pytest.approx(expected)
     assert sum(both.dfbeta) == pytest.approx(0.0)
     assert reversed_both.concordance == pytest.approx(1.0 - both.concordance)
     assert reversed_both.dfbeta == pytest.approx([-value for value in both.dfbeta])
-    assert [sum(row[col] for row in reversed_both.influence) for col in range(5)] == pytest.approx(
-        [both.comparable - both.concordant, both.concordant, 0.0, 0.0, 0.0]
-    )
+    assert reversed_both.variance == pytest.approx(reversed_reference.variance)
+    for actual, expected in zip(
+        reversed_both.influence,
+        reversed_reference.influence,
+        strict=True,
+    ):
+        assert actual == pytest.approx(expected)
 
 
 def test_concordance_cluster_collapses_dfbeta_for_robust_variance():
@@ -8523,17 +8543,17 @@ def test_concordance_formula_accepts_numeric_outcomes_and_forces_rank_weights():
     for actual, reference in zip(
         multi.variance,
         [
-            [0.0028080323121974, -0.00284354488705543],
-            [-0.00284354488705543, 0.0048698240644387],
+            [0.0112321292487896, -0.0113741795482217],
+            [-0.0113741795482217, 0.0194792962577548],
         ],
         strict=True,
     ):
         assert actual == pytest.approx(reference)
     assert survival.as_data_frame(multi)["variance"] == pytest.approx(
-        [0.0028080323121974, 0.0048698240644387]
+        [0.0112321292487896, 0.0194792962577548]
     )
     assert transformed.concordance == pytest.approx(0.769230769230769)
-    assert transformed.variance == pytest.approx(0.00238086901719127)
+    assert transformed.variance == pytest.approx(0.009523476068765096)
     assert forced_rank_weights.concordance == pytest.approx(ordinary_rank_weights.concordance)
     assert forced_rank_weights.count == pytest.approx(ordinary_rank_weights.count)
 
@@ -8756,13 +8776,99 @@ def test_concordance_formula_accepts_strata_wrapper():
         {"time": 4.0, "rank": 0.0, "timewt": 1.0, "casewt": 1.0},
     ]
     assert influential.influence == [
-        [0.0, 0.5, 0.0, 0.0, 0.0],
-        [0.0, 0.5, 0.0, 0.0, 0.0],
-        [0.0, 0.5, 0.0, 0.0, 0.0],
-        [0.0, 0.5, 0.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0, 0.0, 0.0],
     ]
     assert influential.dfbeta == pytest.approx([0.0, 0.0, 0.0, 0.0])
     assert influential.variance == pytest.approx(0.0)
+
+
+def test_weighted_stratified_concordance_diagnostics_match_reference():
+    data = {
+        "y": [1.0, 3.0, 2.0, 4.0, 4.0, 2.0],
+        "x": [0.2, 0.9, 0.4, 0.7, 0.7, 0.1],
+        "w": [1.0, 2.0, 1.5, 0.5, 3.0, 2.5],
+        "group": ["a", "a", "b", "b", "b", "a"],
+    }
+
+    result = survival.concordance(
+        "y ~ x + strata(group)",
+        data=data,
+        weights="w",
+        influence=3,
+    )
+
+    assert result.concordance == pytest.approx(0.830508474576271)
+    assert result.variance == pytest.approx(0.0336706977699187)
+    assert result.conditional_variance == pytest.approx(0.0332845838447677)
+    assert result.dfbeta == pytest.approx(
+        [
+            -0.117782246480896,
+            0.080436656133295,
+            0.0603274920999713,
+            0.00861821315713875,
+            0.0517092789428325,
+            -0.0833093938523413,
+        ]
+    )
+    expected_influence = [
+        [2.0, 2.5, 0.0, 0.0, 0.0],
+        [3.5, 0.0, 0.0, 0.0, 0.0],
+        [3.5, 0.0, 0.0, 0.0, 0.0],
+        [1.5, 0.0, 0.0, 0.0, 3.0],
+        [1.5, 0.0, 0.0, 0.0, 0.5],
+        [2.0, 1.0, 0.0, 0.0, 0.0],
+    ]
+    for actual, expected in zip(result.influence, expected_influence, strict=True):
+        assert actual == pytest.approx(expected)
+
+
+def test_weighted_stratified_counting_concordance_diagnostics_match_reference():
+    data = {
+        "start": [0.0, 0.0, 1.0, 2.5, 0.0, 0.0, 0.5, 2.0],
+        "stop": [2.0, 4.0, 3.0, 5.0, 1.0, 4.0, 3.0, 5.0],
+        "status": [1, 0, 1, 1, 1, 1, 0, 1],
+        "score": [0.8, 0.2, 0.5, 0.1, 0.3, 0.9, 0.4, 0.6],
+        "w": [1.0, 2.0, 1.5, 0.5, 3.0, 1.0, 2.5, 2.0],
+        "group": ["a", "a", "a", "a", "b", "b", "b", "b"],
+    }
+
+    result = survival.concordance(
+        "Surv(start, stop, status) ~ score + strata(group)",
+        data=data,
+        weights="w",
+        influence=3,
+    )
+
+    assert result.concordance == pytest.approx(0.531645569620253)
+    assert result.variance == pytest.approx(0.144203037729241)
+    assert result.conditional_variance == pytest.approx(0.0320040345276686)
+    assert result.dfbeta == pytest.approx(
+        [
+            -0.0942156705656145,
+            -0.134593815093735,
+            -0.141323505848422,
+            -0.0201890722640602,
+            0.24899855792341,
+            0.0173049190834802,
+            0.177856112802436,
+            -0.053837526037494,
+        ]
+    )
+    expected_influence = [
+        [0.0, 3.5, 0.0, 0.0, 0.0],
+        [0.0, 2.5, 0.0, 0.0, 0.0],
+        [0.0, 3.5, 0.0, 0.0, 0.0],
+        [0.0, 1.5, 0.0, 0.0, 0.0],
+        [3.5, 0.0, 0.0, 0.0, 0.0],
+        [3.0, 2.0, 0.0, 0.0, 0.0],
+        [3.0, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0, 0.0, 0.0],
+    ]
+    for actual, expected in zip(result.influence, expected_influence, strict=True):
+        assert actual == pytest.approx(expected)
 
 
 def test_concordance_formula_strata_ranks_support_counting_process_response():
@@ -8790,13 +8896,13 @@ def test_concordance_formula_strata_ranks_support_counting_process_response():
         {"time": 1.0, "rank": 0.5, "timewt": 2.0, "casewt": 1.0},
     ]
     assert influential.influence == [
-        [0.0, 0.5, 0.0, 0.0, 0.0],
-        [0.0, 0.5, 0.0, 0.0, 0.0],
-        [0.5, 0.0, 0.0, 0.0, 0.0],
-        [0.5, 0.0, 0.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0, 0.0, 0.0],
+        [1.0, 0.0, 0.0, 0.0, 0.0],
+        [1.0, 0.0, 0.0, 0.0, 0.0],
     ]
-    assert influential.dfbeta == pytest.approx([0.0, 0.0, 0.0, 0.0])
-    assert influential.variance == pytest.approx(0.0)
+    assert influential.dfbeta == pytest.approx([-0.25, -0.25, 0.25, 0.25])
+    assert influential.variance == pytest.approx(0.25)
 
 
 def test_concordance_counting_process_uses_delayed_entry_risk_sets():
@@ -8901,7 +9007,14 @@ def test_concordance_counting_process_influence_uses_delayed_entry_risk_sets():
         data=data,
         influence=3,
     )
+    reference = survival.concordancefit(
+        response,
+        data["score"],
+        influence=3,
+        reverse=True,
+    )
 
+    assert reference is not None
     assert result.dfbeta is not None
     assert result.influence is not None
     assert exact.dfbeta is not None
@@ -8911,9 +9024,9 @@ def test_concordance_counting_process_influence_uses_delayed_entry_risk_sets():
     assert result.influence is not None
     for formula_row, result_row in zip(formula.influence, formula_direction.influence, strict=True):
         assert formula_row == pytest.approx(result_row)
-    assert [sum(row[col] for row in result.influence) for col in range(5)] == pytest.approx(
-        [result.concordant, result.comparable - result.concordant, 0.0, 0.0, 0.0]
-    )
+    assert result.dfbeta == pytest.approx(reference.dfbeta)
+    for actual, expected in zip(result.influence, reference.influence, strict=True):
+        assert actual == pytest.approx(expected)
     assert result.variance == pytest.approx(sum(value * value for value in result.dfbeta))
     assert exact.variance == pytest.approx(sum(value * value for value in exact.dfbeta))
 
@@ -9227,7 +9340,16 @@ def test_counting_concordance_duplicate_event_times_share_survival_weight():
         ranks=True,
         influence=3,
     )
+    reference = survival.concordancefit(
+        response,
+        data["score"],
+        weights=data["wt"],
+        timewt="S",
+        influence=3,
+        reverse=True,
+    )
 
+    assert reference is not None
     assert result.concordant == pytest.approx(concordant)
     assert result.comparable == pytest.approx(comparable)
     assert result.concordance == pytest.approx(concordant / comparable)
@@ -9245,13 +9367,9 @@ def test_counting_concordance_duplicate_event_times_share_survival_weight():
         ]
     )
     assert result.influence is not None
-    column_sums = [sum(row[col] for row in result.influence) for col in range(5)]
-    tied_event_weight = data["wt"][0] * data["wt"][1] * multipliers[1.0]
-    assert column_sums[0] == pytest.approx(concordant)
-    assert column_sums[1] == pytest.approx(comparable - concordant)
-    assert column_sums[2] == pytest.approx(0.0)
-    assert column_sums[3] == pytest.approx(tied_event_weight)
-    assert column_sums[4] == pytest.approx(0.0)
+    assert result.dfbeta == pytest.approx(reference.dfbeta)
+    for actual, expected in zip(result.influence, reference.influence, strict=True):
+        assert actual == pytest.approx(expected)
     assert result.variance == pytest.approx(sum(value * value for value in result.dfbeta))
 
 

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -12086,7 +12086,7 @@ coef.survival_py_concordance <- function(object, ...) {
 vcov.survival_py_concordance <- function(object, ...) {
   frame <- as.data.frame(object)
   if (nrow(frame) == 1L) {
-    return(4 * as.numeric(frame$variance)[[1L]])
+    return(as.numeric(frame$variance)[[1L]])
   }
   variance <- .result_field(object, "variance")
   if (is.matrix(variance) || (
@@ -12097,11 +12097,11 @@ vcov.survival_py_concordance <- function(object, ...) {
     if (!identical(dim(covariance), c(nrow(frame), nrow(frame)))) {
       stop("concordance covariance must match the score count", call. = FALSE)
     }
-    return(4 * covariance)
+    return(covariance)
   }
   dfbeta <- .result_field(object, "dfbeta")
   if (is.null(dfbeta)) {
-    values <- 4 * as.numeric(frame$variance)
+    values <- as.numeric(frame$variance)
     return(diag(values, nrow = length(values)))
   }
   dfbeta_columns <- lapply(dfbeta, .as_numeric_vector)
@@ -12110,7 +12110,7 @@ vcov.survival_py_concordance <- function(object, ...) {
     stop("concordance dfbeta values must be rectangular", call. = FALSE)
   }
   dfbeta_matrix <- do.call(cbind, dfbeta_columns)
-  4 * crossprod(dfbeta_matrix)
+  crossprod(dfbeta_matrix)
 }
 
 coef.concordance <- function(object, ...) {
@@ -12313,9 +12313,9 @@ concordancefit <- function(y, x, strata, weights, ymin = NULL, ymax = NULL,
   }
   if (isTRUE(std.err) && !is.null(variance)) {
     if (multi_score && !is.null(dfbeta_matrix)) {
-      out$var <- 4 * crossprod(dfbeta_matrix)
+      out$var <- crossprod(dfbeta_matrix)
     } else {
-      out$var <- 4 * .as_numeric_vector(variance)
+      out$var <- .as_numeric_vector(variance)
     }
     out$cvar <- if (length(conditional_variance) == 1L) {
       conditional_variance[[1L]]
@@ -12326,9 +12326,9 @@ concordancefit <- function(y, x, strata, weights, ymin = NULL, ymax = NULL,
   if (influence %in% c(1L, 3L)) {
     if (!is.null(dfbeta)) {
       out$dfbeta <- if (multi_score && !is.null(dfbeta_matrix)) {
-        2 * dfbeta_matrix
+        dfbeta_matrix
       } else {
-        2 * .as_numeric_vector(dfbeta)
+        .as_numeric_vector(dfbeta)
       }
     }
   }
@@ -12342,7 +12342,7 @@ concordancefit <- function(y, x, strata, weights, ymin = NULL, ymax = NULL,
           stop("concordance influence values must be rectangular", call. = FALSE)
         }
         out$influence <- array(
-          2 * unlist(influence_matrices, use.names = FALSE),
+          unlist(influence_matrices, use.names = FALSE),
           dim = c(matrix_dims[[1L]], length(influence_matrices))
         )
         dimnames(out$influence) <- list(
@@ -12351,7 +12351,7 @@ concordancefit <- function(y, x, strata, weights, ymin = NULL, ymax = NULL,
           score_names
         )
       } else {
-        out$influence <- 2 * .as_numeric_matrix(influence_rows)
+        out$influence <- .as_numeric_matrix(influence_rows)
         colnames(out$influence) <- c("concordant", "discordant", "tied.x", "tied.y", "tied.xy")
       }
     }

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -4174,6 +4174,7 @@ test_that("concordance formulas accept numeric and orderable outcomes", {
     c("low", "high", "mid", "high", "high", "mid"),
     levels = c("low", "mid", "high")
   )
+  data$group <- factor(c("a", "a", "b", "b", "b", "a"))
 
   expect_concordance_equal <- function(formula, ...) {
     args <- c(list(formula, data = data), list(...))
@@ -4216,6 +4217,64 @@ test_that("concordance formulas accept numeric and orderable outcomes", {
     0.0112321292487896,
     tolerance = 1e-12
   )
+
+  expect_diagnostics_equal <- function(bridged, reference) {
+    bridged_dfbeta <- survivalr:::.as_numeric_vector(
+      survivalr:::.result_field(bridged, "dfbeta")
+    )
+    bridged_influence <- survivalr:::.as_numeric_matrix(
+      survivalr:::.result_field(bridged, "influence")
+    )
+    expect_equal(coef(bridged), coef(reference), tolerance = 1e-12)
+    expect_equal(vcov(bridged), vcov(reference), tolerance = 1e-12)
+    expect_equal(bridged_dfbeta, as.numeric(reference$dfbeta), tolerance = 1e-12)
+    expect_equal(
+      unname(bridged_influence),
+      unname(reference$influence),
+      tolerance = 1e-12
+    )
+  }
+
+  stratified_formula <- y ~ x + strata(group)
+  expect_diagnostics_equal(
+    concordance(
+      stratified_formula,
+      data = data,
+      weights = data$w,
+      influence = 3
+    ),
+    survival::concordance(
+      stratified_formula,
+      data = data,
+      weights = data$w,
+      influence = 3
+    )
+  )
+
+  counting_data <- data.frame(
+    start = c(0, 0, 1, 2.5, 0, 0, 0.5, 2),
+    stop = c(2, 4, 3, 5, 1, 4, 3, 5),
+    status = c(1, 0, 1, 1, 1, 1, 0, 1),
+    score = c(0.8, 0.2, 0.5, 0.1, 0.3, 0.9, 0.4, 0.6),
+    w = c(1, 2, 1.5, 0.5, 3, 1, 2.5, 2),
+    group = factor(c("a", "a", "a", "a", "b", "b", "b", "b"))
+  )
+  counting_formula <- Surv(start, stop, status) ~ score + strata(group)
+  expect_diagnostics_equal(
+    concordance(
+      counting_formula,
+      data = counting_data,
+      weights = counting_data$w,
+      influence = 3
+    ),
+    survival::concordance(
+      counting_formula,
+      data = counting_data,
+      weights = counting_data$w,
+      influence = 3
+    )
+  )
+
   expect_concordance_equal(y ~ x + z, weights = data$w)
   expect_concordance_equal(y ~ x + z, weights = data$w, cluster = data$cluster)
   expect_concordance_equal(I(y >= 3) ~ x)

--- a/src/concordance/basic.rs
+++ b/src/concordance/basic.rs
@@ -1145,20 +1145,21 @@ fn remap_stratified_influence(
     groups: Vec<Vec<usize>>,
     mut compute_group: impl FnMut(&[usize]) -> ConcordanceInfluenceOutput,
 ) -> ConcordanceInfluenceOutput {
-    let mut influence_rows = vec![vec![0.0; 5]; n];
-    let mut dfbeta = vec![0.0; n];
-    let mut variance = 0.0;
+    let mut influence_rows = vec![[0.0; 5]; n];
 
     for indices in groups {
-        let (group_influence, group_dfbeta, group_variance) = compute_group(&indices);
+        let (group_influence, _group_dfbeta, _group_variance) = compute_group(&indices);
         for (local_idx, &original_idx) in indices.iter().enumerate() {
-            influence_rows[original_idx] = group_influence[local_idx].clone();
-            dfbeta[original_idx] = group_dfbeta[local_idx];
+            influence_rows[original_idx].copy_from_slice(&group_influence[local_idx]);
         }
-        variance += group_variance;
     }
 
-    (influence_rows, dfbeta, variance)
+    let concordant = influence_rows.iter().map(|row| row[0] + 0.5 * row[2]).sum();
+    let comparable = influence_rows
+        .iter()
+        .map(|row| row[0] + row[1] + row[2])
+        .sum();
+    influence_from_rows(influence_rows, concordant, comparable)
 }
 
 fn stratified_right_concordance_influence_rows(
@@ -2520,8 +2521,8 @@ mod tests {
         assert_eq!(influence[1], vec![0.5, 0.0, 0.0, 0.0, 0.0]);
         assert_eq!(influence[2], vec![0.0, 0.5, 0.0, 0.0, 0.0]);
         assert_eq!(influence[3], vec![0.0, 0.5, 0.0, 0.0, 0.0]);
-        assert_eq!(dfbeta, vec![0.0, 0.0, 0.0, 0.0]);
-        assert_eq!(variance, 0.0);
+        assert_eq!(dfbeta, vec![0.125, 0.125, -0.125, -0.125]);
+        assert_eq!(variance, 0.0625);
     }
 
     #[test]
@@ -2544,8 +2545,72 @@ mod tests {
         assert_eq!(influence[1], vec![0.5, 0.0, 0.0, 0.0, 0.0]);
         assert_eq!(influence[2], vec![0.0, 0.5, 0.0, 0.0, 0.0]);
         assert_eq!(influence[3], vec![0.0, 0.5, 0.0, 0.0, 0.0]);
-        assert_eq!(dfbeta, vec![0.0, 0.0, 0.0, 0.0]);
-        assert_eq!(variance, 0.0);
+        assert_eq!(dfbeta, vec![0.125, 0.125, -0.125, -0.125]);
+        assert_eq!(variance, 0.0625);
+    }
+
+    #[test]
+    fn stratified_concordance_influence_uses_global_ratio() {
+        initialize_python();
+
+        let (influence, dfbeta, variance) = stratified_concordance_influence_rows(
+            vec![1.0, 3.0, 2.0, 4.0, 4.0, 2.0],
+            vec![1, 1, 1, 1, 1, 1],
+            vec![-0.2, -0.9, -0.4, -0.7, -0.7, -0.1],
+            vec![0, 0, 1, 1, 1, 0],
+            Some(vec![1.0, 2.0, 1.5, 0.5, 3.0, 2.5]),
+            "n".to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(influence[0], vec![1.0, 1.25, 0.0, 0.0, 0.0]);
+        assert_eq!(influence[3], vec![0.375, 0.0, 0.0, 0.0, 0.75]);
+        let expected = [
+            -0.058891123240448,
+            0.0402183280666475,
+            0.03016374604998565,
+            0.004309106578569375,
+            0.02585463947141625,
+            -0.04165469692617065,
+        ];
+        for (actual, expected) in dfbeta.iter().zip(expected) {
+            assert!((actual - expected).abs() < 1e-12);
+        }
+        assert!((variance - 0.008417674442479675).abs() < 1e-12);
+    }
+
+    #[test]
+    fn stratified_counting_concordance_influence_uses_global_ratio() {
+        initialize_python();
+
+        let (influence, dfbeta, variance) = stratified_counting_concordance_influence_rows(
+            vec![0.0, 0.0, 1.0, 2.5, 0.0, 0.0, 0.5, 2.0],
+            vec![2.0, 4.0, 3.0, 5.0, 1.0, 4.0, 3.0, 5.0],
+            vec![1, 0, 1, 1, 1, 1, 0, 1],
+            vec![-0.8, -0.2, -0.5, -0.1, -0.3, -0.9, -0.4, -0.6],
+            vec![0, 0, 0, 0, 1, 1, 1, 1],
+            Some(vec![1.0, 2.0, 1.5, 0.5, 3.0, 1.0, 2.5, 2.0]),
+            "n".to_string(),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(influence[0], vec![0.0, 1.75, 0.0, 0.0, 0.0]);
+        assert_eq!(influence[4], vec![5.25, 0.0, 0.0, 0.0, 0.0]);
+        let expected = [
+            -0.04710783528280725,
+            -0.0672969075468675,
+            -0.070661752924211,
+            -0.0100945361320301,
+            0.124499278961705,
+            0.0086524595417401,
+            0.088928056401218,
+            -0.026918763018747,
+        ];
+        for (actual, expected) in dfbeta.iter().zip(expected) {
+            assert!((actual - expected).abs() < 1e-12);
+        }
+        assert!((variance - 0.03605075943231025).abs() < 1e-12);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- derive stratified dfbeta and variance from the global concordance ratio after reassembling observation rows
- expose reference-scaled diagnostics consistently through the Python and R facades
- add weighted right-censored and delayed-entry regression coverage

## Testing
- cargo test --lib --no-default-features
- cargo test --lib --features ml
- cargo test --lib --features python,ml
- python -m pytest python/tests/
- R CMD check --no-manual --no-build-vignettes r/survivalr
- cargo fmt, clippy, ruff, mypy, and diff checks