### PR TITLE
Count same-time censored concordance pairs

### DIFF
--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -2348,9 +2348,13 @@ def _manual_right_concordance_counts(time, status, scores, weights=None, timewt=
     multipliers = _manual_right_time_multipliers(time, status, weights, timewt)
     for left in range(len(time)):
         for right in range(left + 1, len(time)):
-            if status[left] == 1 and time[left] < time[right]:
+            if status[left] == 1 and (
+                time[left] < time[right] or (time[left] == time[right] and status[right] != 1)
+            ):
                 event_idx, risk_idx = left, right
-            elif status[right] == 1 and time[right] < time[left]:
+            elif status[right] == 1 and (
+                time[right] < time[left] or (time[right] == time[left] and status[left] != 1)
+            ):
                 event_idx, risk_idx = right, left
             else:
                 continue
@@ -8498,6 +8502,77 @@ def test_concordance_formula_returns_one_result_per_score_column():
     )
     assert result.n == len(data["time"])
     assert result.n_event == sum(data["status"])
+
+
+def test_concordance_includes_same_time_censors_in_multi_score_diagnostics():
+    data = {
+        "time": [1.0, 3.0, 2.0, 4.0, 4.0, 5.0],
+        "status": [1, 0, 1, 1, 0, 1],
+        "x": [0.2, 0.9, 0.4, 0.7, 0.7, 0.1],
+        "z": [0.8, 0.3, 0.5, 0.2, 0.6, 0.4],
+    }
+    result = survival.concordance(
+        "Surv(time, status) ~ x + z",
+        data=data,
+        influence=3,
+        ranks=True,
+    )
+    low_level = survival.concordancefit(
+        survival.Surv(data["time"], data["status"]),
+        {"x": data["x"], "z": data["z"]},
+        influence=3,
+        ranks=True,
+    )
+
+    assert low_level is not None
+    assert result.concordance == pytest.approx([0.681818181818182, 0.272727272727273])
+    assert result.count[0] == pytest.approx(
+        {"concordant": 7.0, "discordant": 3.0, "tied.x": 1.0, "tied.y": 0.0, "tied.xy": 0.0}
+    )
+    assert result.count[1] == pytest.approx(
+        {"concordant": 3.0, "discordant": 8.0, "tied.x": 0.0, "tied.y": 0.0, "tied.xy": 0.0}
+    )
+    assert result.conditional_variance == pytest.approx([0.0432506887052342, 0.0461432506887052])
+    for actual, expected in zip(
+        result.variance,
+        [
+            [0.0458302028549962, -0.0116453794139745],
+            [-0.0116453794139745, 0.0375657400450789],
+        ],
+        strict=True,
+    ):
+        assert actual == pytest.approx(expected)
+    assert result.dfbeta[0] == pytest.approx(
+        [
+            0.0537190082644628,
+            0.0578512396694215,
+            0.0537190082644628,
+            -0.0206611570247934,
+            0.0413223140495868,
+            -0.18595041322314,
+        ]
+    )
+    assert result.influence[0][3] == pytest.approx([2.0, 1.0, 1.0, 0.0, 0.0])
+    assert result.influence[0][4] == pytest.approx([2.0, 0.0, 1.0, 0.0, 0.0])
+    assert [row["rank"] for row in result.ranks[0]] == pytest.approx([0.5, 0.4, -1.0 / 3.0, 0.0])
+    assert low_level.concordance == pytest.approx(result.concordance)
+    assert low_level.count == result.count
+    for actual, expected in zip(low_level.variance, result.variance, strict=True):
+        assert actual == pytest.approx(expected)
+    for actual, expected in zip(low_level.dfbeta, result.dfbeta, strict=True):
+        assert actual == pytest.approx(expected)
+    assert low_level.influence == result.influence
+    assert low_level.ranks == result.ranks
+
+    tied_summary = survival.core.concordance_summary(
+        [1.0, 1.0],
+        [1, 0],
+        [0.5, 0.5],
+        weights=[2.0, 3.0],
+    )
+    assert tied_summary["concordance"] == pytest.approx(0.5)
+    assert tied_summary["comparable"] == pytest.approx(6.0)
+    assert tied_summary["tied_x"] == pytest.approx(6.0)
 
 
 def test_concordance_formula_accepts_numeric_outcomes_and_forces_rank_weights():

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -11907,15 +11907,9 @@ concordance <- function(object, ..., formula) {
     if (is.null(value) || is.null(attr(value, "row.names"))) {
       return(NULL)
     }
-    if (.row_names_info(value, type = 1L) < 0L) {
-      return(NULL)
-    }
     row.names(value)
   }
   if (inherits(object, "formula") || is.character(object)) {
-    if (is.data.frame(data)) {
-      return(explicit_row_names(data))
-    }
     formula <- if (inherits(object, "formula")) {
       object
     } else {
@@ -11925,6 +11919,10 @@ concordance <- function(object, ..., formula) {
       stats::model.frame(formula, data = data, na.action = stats::na.pass),
       error = function(condition) NULL
     )
+    response <- tryCatch(stats::model.response(frame), error = function(condition) NULL)
+    if (is.null(response) || !inherits(response, "Surv")) {
+      return(NULL)
+    }
     return(explicit_row_names(frame))
   }
   tryCatch(explicit_row_names(.as_native_surv(object)), error = function(condition) NULL)

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -4177,6 +4177,55 @@ test_that("R formula wrappers delegate to the Python survival package", {
   expect_equal(nrow(aft_dfbeta), nrow(data))
 })
 
+test_that("right-censored concordance includes censors at the death time", {
+  data <- data.frame(
+    time = c(1, 3, 2, 4, 4, 5),
+    status = c(1, 0, 1, 1, 0, 1),
+    x = c(0.2, 0.9, 0.4, 0.7, 0.7, 0.1),
+    z = c(0.8, 0.3, 0.5, 0.2, 0.6, 0.4),
+    w = c(1, 2, 0.5, 1.5, 3, 1)
+  )
+  bridged_formula <- concordance(
+    Surv(time, status) ~ x + z,
+    data = data,
+    influence = 3,
+    ranks = TRUE
+  )
+  reference_formula <- survival::concordance(
+    survival::Surv(time, status) ~ x + z,
+    data = data,
+    influence = 3,
+    ranks = TRUE
+  )
+  formula_fields <- setdiff(names(reference_formula), "call")
+  expect_identical(names(bridged_formula), names(reference_formula))
+  expect_equal(
+    unclass(bridged_formula)[formula_fields],
+    unclass(reference_formula)[formula_fields],
+    tolerance = 1e-12
+  )
+
+  score_matrix <- as.matrix(data[c("x", "z")])
+  bridged_fit <- concordancefit(
+    Surv(data$time, data$status),
+    score_matrix,
+    weights = data$w,
+    timewt = "S",
+    influence = 3,
+    ranks = TRUE
+  )
+  reference_fit <- survival::concordancefit(
+    survival::Surv(data$time, data$status),
+    score_matrix,
+    weights = data$w,
+    timewt = "S",
+    influence = 3,
+    ranks = TRUE
+  )
+  expect_identical(names(bridged_fit), names(reference_fit))
+  expect_equal(unclass(bridged_fit), unclass(reference_fit), tolerance = 1e-12)
+})
+
 test_that("stratified concordance results match reference shapes and diagnostics", {
   right_data <- data.frame(
     y = c(1, 3, 2, 4, 4, 2),

--- a/src/concordance/basic.rs
+++ b/src/concordance/basic.rs
@@ -470,6 +470,18 @@ fn right_concordance_tie_counts_for_vectors(
             group_end += 1;
         }
 
+        for &idx in &time_order[group_start..group_end] {
+            if status[idx] != 1 {
+                add_conditional_variance_observation(
+                    &mut at_risk,
+                    &risk_levels,
+                    risk_scores[idx],
+                    concordance_case_weight(weights, idx),
+                    &mut z2,
+                );
+            }
+        }
+
         let multiplier = exact_multiplier_at(&multipliers, event_time);
         if multiplier > 0.0 {
             let event_indices: Vec<usize> = time_order[group_start..group_end]
@@ -500,6 +512,9 @@ fn right_concordance_tie_counts_for_vectors(
 
         let mut death_weight = 0.0;
         for &idx in &time_order[group_start..group_end] {
+            if status[idx] != 1 {
+                continue;
+            }
             let weight = concordance_case_weight(weights, idx);
             add_conditional_variance_observation(
                 &mut at_risk,
@@ -1130,14 +1145,19 @@ fn right_concordance_influence_rows_for_vectors(
                 continue;
             }
 
-            let (event_idx, risk_idx) =
-                if status[left] == 1 && concordance_time_precedes(time[left], time[right]) {
-                    (left, right)
-                } else if status[right] == 1 && concordance_time_precedes(time[right], time[left]) {
-                    (right, left)
-                } else {
-                    continue;
-                };
+            let (event_idx, risk_idx) = if status[left] == 1
+                && (concordance_time_precedes(time[left], time[right])
+                    || (status[right] != 1 && same_time(time[left], time[right])))
+            {
+                (left, right)
+            } else if status[right] == 1
+                && (concordance_time_precedes(time[right], time[left])
+                    || (status[left] != 1 && same_time(time[right], time[left])))
+            {
+                (right, left)
+            } else {
+                continue;
+            };
             let multiplier = multiplier_at(&multipliers, time[event_idx]);
             let pair_weight = concordance_case_weight(case_weights, event_idx)
                 * concordance_case_weight(case_weights, risk_idx)
@@ -2693,6 +2713,53 @@ mod tests {
         assert!((counts.tied_x - 20.0 / 9.0).abs() < 1e-12);
         assert!((counts.tied_xy - 2.0 / 3.0).abs() < 1e-12);
         assert_eq!(counts.tied_y, 0.0);
+    }
+
+    #[test]
+    fn right_concordance_counts_same_time_censored_pairs() {
+        let (counts, numerator, comparable_pair_weight) = right_concordance_tie_counts_for_vectors(
+            &[1.0, 1.0],
+            &[1, 0],
+            &[0.5, 0.5],
+            Some(&[2.0, 3.0]),
+            ConcordanceTimeWeight::N,
+        );
+
+        assert_eq!(counts.tied_x, 6.0);
+        assert_eq!(counts.tied_y, 0.0);
+        assert_eq!(counts.tied_xy, 0.0);
+        assert_eq!(numerator, 0.0);
+        assert_eq!(comparable_pair_weight, 6.0);
+    }
+
+    #[test]
+    fn right_concordance_same_time_censor_influence_matches_pair_counts() {
+        let (influence, dfbeta, variance) = right_concordance_influence_rows_for_vectors(
+            &[1.0, 1.0],
+            &[1, 0],
+            &[0.5, 0.5],
+            Some(&[2.0, 3.0]),
+            ConcordanceTimeWeight::N,
+        );
+
+        assert_eq!(influence[0], vec![0.0, 0.0, 3.0, 0.0, 0.0]);
+        assert_eq!(influence[1], vec![0.0, 0.0, 3.0, 0.0, 0.0]);
+        assert_eq!(dfbeta, vec![0.0, 0.0]);
+        assert_eq!(variance, 0.0);
+    }
+
+    #[test]
+    fn right_concordance_same_time_censor_remains_in_rank_risk_set() {
+        let rows = right_concordance_rank_rows_for_vectors(
+            &[1.0, 1.0],
+            &[1, 0],
+            &[0.2, 0.8],
+            &[0.2, 0.8],
+            Some(&[2.0, 3.0]),
+            ConcordanceTimeWeight::N,
+        );
+
+        assert_eq!(rows, vec![(0, 1.0, -0.6, 5.0, 2.0)]);
     }
 
     #[test]

--- a/src/internal/statistical.rs
+++ b/src/internal/statistical.rs
@@ -415,13 +415,15 @@ fn concordance_summary_quadratic(
     for i in 0..n {
         for j in (i + 1)..n {
             let i_comparable = event[i] == 1
-                && concordance_time_precedes(time[i], time[j])
+                && (concordance_time_precedes(time[i], time[j])
+                    || (event[j] != 1 && same_time(time[i], time[j])))
                 && match horizon {
                     Some(h) => concordance_at_or_before_horizon(time[i], h),
                     None => true,
                 };
             let j_comparable = event[j] == 1
-                && concordance_time_precedes(time[j], time[i])
+                && (concordance_time_precedes(time[j], time[i])
+                    || (event[i] != 1 && same_time(time[j], time[i])))
                 && match horizon {
                     Some(h) => concordance_at_or_before_horizon(time[j], h),
                     None => true,
@@ -518,6 +520,13 @@ fn concordance_summary_ranked(
             group_end += 1;
         }
 
+        for &idx in &time_order[group_start..group_end] {
+            if event[idx] != 1 {
+                let rank = risk_levels.partition_point(|&risk| risk < risk_scores[idx]);
+                at_risk.update(rank, observation_weight(weights, idx));
+            }
+        }
+
         let at_risk_total = at_risk.total();
         let event_time_multiplier = if time_weight == ConcordanceTimeWeight::N {
             1.0
@@ -540,6 +549,9 @@ fn concordance_summary_ranked(
         }
 
         for &idx in &time_order[group_start..group_end] {
+            if event[idx] != 1 {
+                continue;
+            }
             let rank = risk_levels.partition_point(|&risk| risk < risk_scores[idx]);
             at_risk.update(rank, observation_weight(weights, idx));
         }
@@ -1462,6 +1474,33 @@ mod tests {
 
             assert_concordance_summary_close(near, exact);
             assert_concordance_summary_close(near, near_quadratic);
+        }
+    }
+
+    #[test]
+    fn test_right_censored_concordance_compares_same_time_censors() {
+        let exact_time = [1.0, 1.0];
+        let near_time = [1.0, 1.0 + TIME_EPSILON / 2.0];
+        let event = [1, 0];
+
+        for time in [&exact_time, &near_time] {
+            let tied = concordance_summary_with_horizon(&[0.5, 0.5], time, &event, None);
+            assert_eq!(tied.concordant, 0.5);
+            assert_eq!(tied.comparable, 1.0);
+
+            let concordant = concordance_summary_with_horizon(&[0.8, 0.2], time, &event, None);
+            assert_eq!(concordant.concordant, 1.0);
+            assert_eq!(concordant.comparable, 1.0);
+
+            let weighted = concordance_summary_with_horizon_and_weights(
+                &[0.2, 0.8],
+                time,
+                &event,
+                Some(&[2.0, 3.0]),
+                None,
+            );
+            assert_eq!(weighted.concordant, 0.0);
+            assert_eq!(weighted.comparable, 6.0);
         }
     }
 


### PR DESCRIPTION
## Summary
- include censored observations occurring at a death time in right-censored comparable pairs
- carry corrected weighted pairs through tie counts, conditional diagnostics, influence, and multi-score covariance
- preserve original event-row positions for automatically named survival-formula data

## Testing
- `cargo test --all-features` (1,790 passed)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `.venv/bin/python -m pytest python/tests -q` (1,091 passed)
- full R testthat suite
- `R CMD check --no-manual` (`Status: OK`)
- Rust and Python formatting/lint checks