### PR TITLE
Correct concordance censoring weights

### DIFF
--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -8564,6 +8564,7 @@ def test_concordance_includes_same_time_censors_in_multi_score_diagnostics():
     assert low_level.influence == result.influence
     assert low_level.ranks == result.ranks
 
+
     tied_summary = survival.core.concordance_summary(
         [1.0, 1.0],
         [1, 0],
@@ -8573,6 +8574,58 @@ def test_concordance_includes_same_time_censors_in_multi_score_diagnostics():
     assert tied_summary["concordance"] == pytest.approx(0.5)
     assert tied_summary["comparable"] == pytest.approx(6.0)
     assert tied_summary["tied_x"] == pytest.approx(6.0)
+
+
+@pytest.mark.parametrize("timewt", ["S/G", "n/G2"])
+def test_concordance_censoring_weights_use_post_death_risk_set(timewt):
+    result = survival.concordancefit(
+        survival.Surv([1, 2, 2, 3, 4], [1, 1, 0, 1, 0]),
+        [0.1, 0.2, 0.2, 0.8, 0.4],
+        weights=[1, 2, 3, 1, 2],
+        timewt=timewt,
+        influence=3,
+        ranks=True,
+    )
+
+    assert result is not None
+    assert result.concordance == pytest.approx(0.607142857142857)
+    assert result.count == pytest.approx(
+        {
+            "concordant": 14.0,
+            "discordant": 8.0,
+            "tied.x": 6.0,
+            "tied.y": 0.0,
+            "tied.xy": 0.0,
+        }
+    )
+    assert result.var == pytest.approx(0.0461689139941691)
+    assert result.cvar == pytest.approx(0.0196109693877551)
+    assert result.dfbeta == pytest.approx(
+        [
+            0.112244897959184,
+            0.0892857142857143,
+            0.0191326530612245,
+            -0.131377551020408,
+            -0.0892857142857143,
+        ]
+    )
+    expected_influence = [
+        [8.0, 0.0, 0.0, 0.0, 0.0],
+        [4.0, 0.0, 3.0, 0.0, 0.0],
+        [1.0, 0.0, 2.0, 0.0, 0.0],
+        [3.0, 8.0, 0.0, 0.0, 0.0],
+        [3.0, 4.0, 0.0, 0.0, 0.0],
+    ]
+    assert result.influence is not None
+    for actual, expected in zip(result.influence, expected_influence, strict=True):
+        assert actual == pytest.approx(expected)
+    assert result.ranks is not None
+    assert [row["time"] for row in result.ranks] == pytest.approx([1.0, 2.0, 3.0])
+    assert [row["rank"] for row in result.ranks] == pytest.approx(
+        [0.888888888888889, 0.375, -0.666666666666667]
+    )
+    assert [row["timewt"] for row in result.ranks] == pytest.approx([9.0, 8.0, 12.0])
+    assert [row["casewt"] for row in result.ranks] == pytest.approx([1.0, 2.0, 1.0])
 
 
 def test_concordance_formula_accepts_numeric_outcomes_and_forces_rank_weights():

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -4226,6 +4226,37 @@ test_that("right-censored concordance includes censors at the death time", {
   expect_equal(unclass(bridged_fit), unclass(reference_fit), tolerance = 1e-12)
 })
 
+test_that("concordance censoring weights use the post-death risk set", {
+  data <- data.frame(
+    time = c(1, 2, 2, 3, 4),
+    status = c(1, 1, 0, 1, 0),
+    x = c(0.1, 0.2, 0.2, 0.8, 0.4),
+    w = c(1, 2, 3, 1, 2)
+  )
+
+  for (time_weight in c("S/G", "n/G2")) {
+    bridged_fit <- concordancefit(
+      Surv(data$time, data$status),
+      data$x,
+      weights = data$w,
+      timewt = time_weight,
+      influence = 3,
+      ranks = TRUE
+    )
+    reference_fit <- survival::concordancefit(
+      survival::Surv(data$time, data$status),
+      data$x,
+      weights = data$w,
+      timewt = time_weight,
+      influence = 3,
+      ranks = TRUE
+    )
+
+    expect_identical(names(bridged_fit), names(reference_fit))
+    expect_equal(unclass(bridged_fit), unclass(reference_fit), tolerance = 1e-12)
+  }
+})
+
 test_that("stratified concordance results match reference shapes and diagnostics", {
   right_data <- data.frame(
     y = c(1, 3, 2, 4, 4, 2),

--- a/src/concordance/basic.rs
+++ b/src/concordance/basic.rs
@@ -351,8 +351,9 @@ fn right_concordance_time_weight_multipliers_by(
                 survival *= ((nrisk - death_weight) / nrisk).max(0.0);
             }
         }
-        if censor_weight > 0.0 && nrisk > 0.0 {
-            censoring_survival *= ((nrisk - censor_weight) / nrisk).max(0.0);
+        let censoring_risk = (nrisk - death_weight).max(0.0);
+        if censor_weight > 0.0 && censoring_risk > 0.0 {
+            censoring_survival *= ((censoring_risk - censor_weight) / censoring_risk).max(0.0);
         }
         nrisk = (nrisk - group_weight).max(0.0);
         group_start = group_end;
@@ -2484,6 +2485,26 @@ mod tests {
         .unwrap();
 
         assert_eq!(unweighted, unit_weighted);
+    }
+
+    #[test]
+    fn right_concordance_censoring_weights_use_post_death_risk_set() {
+        let time = [1.0, 2.0, 2.0, 3.0, 4.0];
+        let status = [1, 1, 0, 1, 0];
+        let weights = [1.0, 2.0, 3.0, 1.0, 2.0];
+
+        for time_weight in [
+            ConcordanceTimeWeight::SOverG,
+            ConcordanceTimeWeight::NOverG2,
+        ] {
+            let multipliers = right_concordance_time_weight_multipliers(
+                &time,
+                &status,
+                Some(&weights),
+                time_weight,
+            );
+            assert_eq!(multipliers, vec![(1.0, 1.0), (2.0, 1.0), (3.0, 4.0)]);
+        }
     }
 
     #[test]

--- a/src/internal/statistical.rs
+++ b/src/internal/statistical.rs
@@ -674,8 +674,9 @@ fn right_censored_time_weight_multipliers(
                 survival *= ((nrisk - death_weight) / nrisk).max(0.0);
             }
         }
-        if censor_weight > 0.0 && nrisk > 0.0 {
-            censoring_survival *= ((nrisk - censor_weight) / nrisk).max(0.0);
+        let censoring_risk = (nrisk - death_weight).max(0.0);
+        if censor_weight > 0.0 && censoring_risk > 0.0 {
+            censoring_survival *= ((censoring_risk - censor_weight) / censoring_risk).max(0.0);
         }
         nrisk -= group_weight;
         group_start = group_end;
@@ -1545,6 +1546,22 @@ mod tests {
 
             assert_concordance_summary_close(near, exact);
             assert_concordance_summary_close(near, near_quadratic);
+        }
+    }
+
+    #[test]
+    fn test_censoring_weights_remove_same_time_deaths_before_censors() {
+        let time = [1.0, 2.0, 2.0, 3.0, 4.0];
+        let event = [1, 1, 0, 1, 0];
+        let weights = [1.0, 2.0, 3.0, 1.0, 2.0];
+
+        for time_weight in [
+            ConcordanceTimeWeight::SOverG,
+            ConcordanceTimeWeight::NOverG2,
+        ] {
+            let multipliers =
+                right_censored_time_weight_multipliers(&time, &event, Some(&weights), time_weight);
+            assert_eq!(multipliers, vec![(1.0, 1.0), (2.0, 1.0), (3.0, 4.0)]);
         }
     }
 


### PR DESCRIPTION
## Summary
- update inverse-censoring survival after removing same-time deaths from the risk set
- align S/G and n/G2 concordance diagnostics with survival 3.8.11
- add Rust, Python, and R regressions for weighted tied death and censor times

## Testing
- cargo test --lib --features python,ml
- cargo test --doc
- cargo clippy --all-targets --all-features -- -D warnings
- python -m pytest -q python/tests
- testthat::test_local("r/survivalr", reporter = "summary")
- R CMD check --no-manual survivalr_0.1.0.tar.gz