### PR TITLE
Match one-event concordance rank shapes

### DIFF
--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -8628,6 +8628,45 @@ def test_concordance_censoring_weights_use_post_death_risk_set(timewt):
     assert [row["casewt"] for row in result.ranks] == pytest.approx([1.0, 2.0, 1.0])
 
 
+def test_concordance_one_event_keeps_complete_python_rank_rows():
+    response = survival.Surv([1, 2, 3], [1, 0, 0])
+    single = survival.concordancefit(
+        response,
+        [0.2, 0.6, 0.4],
+        ranks=True,
+    )
+    multiple = survival.concordancefit(
+        response,
+        {
+            "x": [0.2, 0.6, 0.4],
+            "z": [0.8, 0.1, 0.5],
+        },
+        ranks=True,
+    )
+
+    assert single is not None
+    assert single.ranks == [
+        {"time": 1.0, "rank": 2.0 / 3.0, "timewt": 3.0, "casewt": 1.0}
+    ]
+    assert multiple is not None
+    assert multiple.score_names == ["x", "z"]
+    assert multiple.ranks == [
+        [{"time": 1.0, "rank": 2.0 / 3.0, "timewt": 3.0, "casewt": 1.0}],
+        [{"time": 1.0, "rank": -2.0 / 3.0, "timewt": 3.0, "casewt": 1.0}],
+    ]
+
+    with pytest.raises(
+        ValueError,
+        match="number of items to replace is not a multiple of replacement length",
+    ):
+        survival.concordancefit(
+            survival.Surv([1, 2, 1, 2], [1, 0, 0, 0]),
+            [0.2, 0.6, 0.4, 0.8],
+            strata=["a", "a", "b", "b"],
+            ranks=True,
+        )
+
+
 def test_concordance_formula_accepts_numeric_outcomes_and_forces_rank_weights():
     data = {
         "y": [1.0, 3.0, 2.0, 4.0, 4.0, 2.0],

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -11972,6 +11972,11 @@ concordance <- function(object, ..., formula) {
     value <- .survival_py_concordance_component(result, name)
     if (!is.null(value)) out[[name]] <- value
   }
+  if (!is.null(out$ranks) &&
+      !isTRUE(.result_field(result, "reverse")) &&
+      identical(names(out$ranks), "fit.resid")) {
+    out$ranks[, "rank"] <- -out$ranks[, "rank"]
+  }
   if (length(na.action)) out$na.action <- na.action
   out$call <- Call
   class(out) <- "concordance"
@@ -12252,14 +12257,11 @@ concordance.survival_py_model <- function(object, ..., newdata, cluster, ymin, y
     value <- .result_field(object, name)
     if (is.null(value)) return(NULL)
     rank_names <- .result_field(object, "rank_names")
-    if (multi_score) {
-      frames <- lapply(value, .concordancefit_rows, row_names = rank_names)
-      for (index in seq_along(frames)) {
-        names(frames[[index]]) <- paste0(names(frames[[index]]), ".", score_names[[index]])
-      }
-      return(do.call(cbind, frames))
-    }
-    return(.concordancefit_rows(value, row_names = rank_names))
+    return(.concordancefit_rank_result(
+      value,
+      row_names = rank_names,
+      score_names = if (multi_score) score_names else NULL
+    ))
   }
 
   if (identical(name, "dfbeta")) {
@@ -12498,6 +12500,40 @@ survConcordance.fit <- function(y, x, strata, weight) {
   frame
 }
 
+.concordancefit_rank_result <- function(rows, row_names = NULL, score_names = NULL) {
+  multi_score <- !is.null(score_names) && length(score_names) > 1L
+  if (multi_score) {
+    one_row_per_score <- is.list(rows) &&
+      length(rows) == length(score_names) &&
+      all(vapply(rows, function(value) is.list(value) && length(value) == 1L, logical(1)))
+    if (one_row_per_score) {
+      rank_columns <- c("time", "rank", "timewt", "casewt")
+      flattened <- unlist(lapply(rows, function(value) {
+        vapply(rank_columns, function(name) {
+          as.numeric(value[[1L]][[name]])[[1L]]
+        }, numeric(1))
+      }), use.names = FALSE)
+      values <- flattened[seq_along(score_names)]
+      names(values) <- score_names
+      return(data.frame(fit.resid = values, check.names = FALSE))
+    }
+
+    frames <- lapply(rows, .concordancefit_rows, row_names = row_names)
+    for (index in seq_along(frames)) {
+      names(frames[[index]]) <- paste0(names(frames[[index]]), ".", score_names[[index]])
+    }
+    return(do.call(cbind, frames))
+  }
+
+  frame <- .concordancefit_rows(rows, row_names = row_names)
+  if (!is.null(frame) && nrow(frame) == 1L) {
+    values <- as.numeric(frame[1L, ])
+    names(values) <- names(frame)
+    return(data.frame(fit.resid = values, check.names = FALSE))
+  }
+  frame
+}
+
 concordancefit <- function(y, x, strata, weights, ymin = NULL, ymax = NULL,
                            timewt = c("n", "S", "S/G", "n/G2", "I"),
                            cluster, influence = 0, ranks = FALSE,
@@ -12608,14 +12644,13 @@ concordancefit <- function(y, x, strata, weights, ymin = NULL, ymax = NULL,
   if (isTRUE(ranks)) {
     rank_rows <- .result_field(result, "ranks")
     rank_names <- .result_field(result, "rank_names")
-    out$ranks <- if (multi_score) {
-      frames <- lapply(rank_rows, .concordancefit_rows, row_names = rank_names)
-      for (index in seq_along(frames)) {
-        names(frames[[index]]) <- paste0(names(frames[[index]]), ".", score_names[[index]])
-      }
-      do.call(cbind, frames)
-    } else {
-      .concordancefit_rows(rank_rows, row_names = rank_names)
+    out$ranks <- .concordancefit_rank_result(
+      rank_rows,
+      row_names = rank_names,
+      score_names = if (multi_score) score_names else NULL
+    )
+    if (isTRUE(reverse) && identical(names(out$ranks), "fit.resid")) {
+      out$ranks[, "rank"] <- -out$ranks[, "rank"]
     }
   }
   out

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -4257,6 +4257,103 @@ test_that("concordance censoring weights use the post-death risk set", {
   }
 })
 
+test_that("one-event concordance ranks match reference dimensions", {
+  data <- data.frame(
+    time = c(1, 2, 3),
+    status = c(1, 0, 0),
+    x = c(0.2, 0.6, 0.4),
+    z = c(0.8, 0.1, 0.5),
+    q = c(0.3, 0.4, 0.9)
+  )
+  bridged_response <- Surv(data$time, data$status)
+  reference_response <- survival::Surv(data$time, data$status)
+  score_sets <- list(
+    data$x,
+    as.matrix(data[c("x", "z")]),
+    as.matrix(data[c("x", "z", "q")])
+  )
+
+  for (scores in score_sets) {
+    bridged_fit <- concordancefit(bridged_response, scores, ranks = TRUE)
+    reference_fit <- survival::concordancefit(reference_response, scores, ranks = TRUE)
+    expect_identical(names(bridged_fit), names(reference_fit))
+    expect_equal(unclass(bridged_fit), unclass(reference_fit), tolerance = 1e-12)
+  }
+
+  bridged_formula <- concordance(
+    Surv(time, status) ~ x + z,
+    data = data,
+    ranks = TRUE
+  )
+  reference_formula <- survival::concordance(
+    survival::Surv(time, status) ~ x + z,
+    data = data,
+    ranks = TRUE
+  )
+  formula_fields <- setdiff(names(reference_formula), "call")
+  expect_equal(
+    unclass(bridged_formula)[formula_fields],
+    unclass(reference_formula)[formula_fields],
+    tolerance = 1e-12
+  )
+
+  expect_error(
+    concordancefit(bridged_response, data$x, ranks = TRUE, reverse = TRUE),
+    "undefined columns selected"
+  )
+  expect_error(
+    survival::concordancefit(
+      reference_response,
+      data$x,
+      ranks = TRUE,
+      reverse = TRUE
+    ),
+    "undefined columns selected"
+  )
+  expect_error(
+    concordance(
+      Surv(time, status) ~ x,
+      data = data,
+      ranks = TRUE,
+      reverse = TRUE
+    ),
+    "undefined columns selected"
+  )
+  expect_error(
+    survival::concordance(
+      survival::Surv(time, status) ~ x,
+      data = data,
+      ranks = TRUE,
+      reverse = TRUE
+    ),
+    "undefined columns selected"
+  )
+
+  stratified_response <- Surv(c(1, 2, 1, 2), c(1, 0, 0, 0))
+  reference_stratified_response <- survival::Surv(c(1, 2, 1, 2), c(1, 0, 0, 0))
+  stratified_scores <- c(0.2, 0.6, 0.4, 0.8)
+  stratified_groups <- c("a", "a", "b", "b")
+  replacement_error <- "number of items to replace is not a multiple of replacement length"
+  expect_error(
+    concordancefit(
+      stratified_response,
+      stratified_scores,
+      strata = stratified_groups,
+      ranks = TRUE
+    ),
+    replacement_error
+  )
+  expect_error(
+    survival::concordancefit(
+      reference_stratified_response,
+      stratified_scores,
+      strata = stratified_groups,
+      ranks = TRUE
+    ),
+    replacement_error
+  )
+})
+
 test_that("stratified concordance results match reference shapes and diagnostics", {
   right_data <- data.frame(
     y = c(1, 3, 2, 4, 4, 2),

--- a/src/concordance/basic.rs
+++ b/src/concordance/basic.rs
@@ -981,7 +981,9 @@ fn reassemble_stratified_rank_rows(
     for indices in groups {
         let group_rows = compute_group(&indices);
         if group_rows.is_empty() {
-            return Err(PyValueError::new_err("replacement has length zero"));
+            return Err(PyValueError::new_err(
+                "number of items to replace is not a multiple of replacement length",
+            ));
         }
         let source: Vec<f64> = (0..4)
             .flat_map(|column| {
@@ -2941,6 +2943,28 @@ mod tests {
                 (1.0, 2.0, 1.0, 2.0),
                 (-0.5, 1.0, -0.5, 1.0),
             ]
+        );
+    }
+
+    #[test]
+    fn stratified_concordance_rank_rows_reject_empty_stratum_residuals() {
+        initialize_python();
+
+        let error = stratified_concordance_rank_rows(
+            vec![1.0, 2.0, 1.0, 2.0],
+            vec![1, 0, 0, 0],
+            vec![0.2, 0.6, 0.4, 0.8],
+            vec![0, 0, 1, 1],
+            None,
+            "n".to_string(),
+            None,
+        )
+        .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .ends_with("number of items to replace is not a multiple of replacement length")
         );
     }
 


### PR DESCRIPTION
## Summary
- reproduce survival 3.8.11 single-row rank dimensions for one and multiple score columns in the R conversion layer
- preserve complete one-event rank records for Python callers
- align the stratified no-event residual diagnostic with the reference

## Testing
- cargo test --lib --features python,ml
- cargo test --doc
- cargo clippy --all-targets --all-features -- -D warnings
- python -m pytest -q python/tests
- testthat::test_local("r/survivalr", reporter = "summary")
- R CMD check --no-manual survivalr_0.1.0.tar.gz