### PR TITLE
Match default concordance score names

### DIFF
--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -12542,7 +12542,16 @@ concordancefit <- function(y, x, strata, weights, ymin = NULL, ymax = NULL,
   if (any(is.na(x)) || any(is.na(y))) {
     return(NULL)
   }
-  input_score_names <- if (is.matrix(x) || is.data.frame(x)) colnames(x) else NULL
+  input_score_names <- if (is.matrix(x) || is.data.frame(x)) {
+    matrix_names <- colnames(x)
+    if (is.null(matrix_names) && ncol(x) > 1L) {
+      paste0("X", seq_len(ncol(x)))
+    } else {
+      matrix_names
+    }
+  } else {
+    NULL
+  }
   timewt <- match.arg(timewt)
   influence <- as.integer(influence)
   if (!isTRUE(std.err)) {

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -4354,6 +4354,35 @@ test_that("one-event concordance ranks match reference dimensions", {
   )
 })
 
+test_that("unnamed concordance score matrices use reference names", {
+  score_matrix <- matrix(
+    c(0.2, 0.6, 0.4, 0.9, 0.3, 0.8, 0.1, 0.5, 0.2, 0.7),
+    ncol = 2
+  )
+  fixtures <- list(
+    list(time = c(1, 2, 3, 4, 5), status = c(1, 1, 0, 1, 0)),
+    list(time = c(1, 2, 3, 4, 5), status = c(1, 0, 0, 0, 0))
+  )
+
+  for (fixture in fixtures) {
+    bridged_fit <- concordancefit(
+      Surv(fixture$time, fixture$status),
+      score_matrix,
+      influence = 3,
+      ranks = TRUE
+    )
+    reference_fit <- survival::concordancefit(
+      survival::Surv(fixture$time, fixture$status),
+      score_matrix,
+      influence = 3,
+      ranks = TRUE
+    )
+
+    expect_identical(names(bridged_fit), names(reference_fit))
+    expect_equal(unclass(bridged_fit), unclass(reference_fit), tolerance = 1e-12)
+  }
+})
+
 test_that("stratified concordance results match reference shapes and diagnostics", {
   right_data <- data.frame(
     y = c(1, 3, 2, 4, 4, 2),


### PR DESCRIPTION
## Summary
- assign R-compatible X1, X2, and subsequent labels to unnamed multi-column score matrices
- align concordance, count, influence, and rank names for ordinary and one-event results
- keep Python-native score labels unchanged

## Testing
- python -m pytest -q python/tests/test_r_api.py::test_concordance_matrix_scores_return_cluster_covariance
- testthat::test_local("r/survivalr", reporter = "summary")
- R CMD check --no-manual survivalr_0.1.0.tar.gz