### PR TITLE
Match reversed multi-score rank behavior

### DIFF
--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -8667,6 +8667,26 @@ def test_concordance_one_event_keeps_complete_python_rank_rows():
         )
 
 
+def test_concordance_reversed_multi_score_ranks_remain_available_in_python():
+    result = survival.concordancefit(
+        survival.Surv([1, 2, 3, 4, 5], [1, 1, 0, 1, 0]),
+        {
+            "x": [0.2, 0.6, 0.4, 0.9, 0.3],
+            "z": [0.8, 0.1, 0.5, 0.2, 0.7],
+        },
+        ranks=True,
+        reverse=True,
+    )
+
+    assert result is not None
+    assert result.score_names == ["x", "z"]
+    assert result.ranks is not None
+    assert [row["rank"] for row in result.ranks[0]] == pytest.approx([-0.8, 0.25, 0.5])
+    assert [row["rank"] for row in result.ranks[1]] == pytest.approx(
+        [0.8, -0.75, -0.5]
+    )
+
+
 def test_concordance_formula_accepts_numeric_outcomes_and_forces_rank_weights():
     data = {
         "y": [1.0, 3.0, 2.0, 4.0, 4.0, 2.0],

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -11974,7 +11974,7 @@ concordance <- function(object, ..., formula) {
   }
   if (!is.null(out$ranks) &&
       !isTRUE(.result_field(result, "reverse")) &&
-      identical(names(out$ranks), "fit.resid")) {
+      !("rank" %in% names(out$ranks))) {
     out$ranks[, "rank"] <- -out$ranks[, "rank"]
   }
   if (length(na.action)) out$na.action <- na.action
@@ -12204,7 +12204,10 @@ concordance.survival_py_model <- function(object, ..., newdata, cluster, ymin, y
   if (!missing(ymax)) {
     fit_args$ymax <- ymax
   }
-  result <- do.call(concordancefit, fit_args)
+  result <- do.call(
+    .concordancefit_impl,
+    c(fit_args, list(.allow_multi_rank_reverse = nfit > 1L))
+  )
   if (isTRUE(ranks) && nfit > 1L && !is.null(result$ranks)) {
     rank_columns <- c("time", "rank", "timewt", "casewt")
     rank_frames <- lapply(seq_len(nfit), function(index) {
@@ -12539,6 +12542,16 @@ concordancefit <- function(y, x, strata, weights, ymin = NULL, ymax = NULL,
                            cluster, influence = 0, ranks = FALSE,
                            reverse = FALSE, timefix = TRUE, keepstrata = 10,
                            std.err = TRUE) {
+  Call <- match.call()
+  Call[[1L]] <- .concordancefit_impl
+  eval(Call, parent.frame())
+}
+
+.concordancefit_impl <- function(y, x, strata, weights, ymin = NULL, ymax = NULL,
+                                 timewt = c("n", "S", "S/G", "n/G2", "I"),
+                                 cluster, influence = 0, ranks = FALSE,
+                                 reverse = FALSE, timefix = TRUE, keepstrata = 10,
+                                 std.err = TRUE, .allow_multi_rank_reverse = FALSE) {
   if (any(is.na(x)) || any(is.na(y))) {
     return(NULL)
   }
@@ -12658,7 +12671,9 @@ concordancefit <- function(y, x, strata, weights, ymin = NULL, ymax = NULL,
       row_names = rank_names,
       score_names = if (multi_score) score_names else NULL
     )
-    if (isTRUE(reverse) && identical(names(out$ranks), "fit.resid")) {
+    if (isTRUE(reverse) &&
+        !isTRUE(.allow_multi_rank_reverse) &&
+        !("rank" %in% names(out$ranks))) {
       out$ranks[, "rank"] <- -out$ranks[, "rank"]
     }
   }

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -4383,6 +4383,53 @@ test_that("unnamed concordance score matrices use reference names", {
   }
 })
 
+test_that("reversed multi-score concordance ranks match reference errors", {
+  data <- data.frame(
+    time = c(1, 2, 3, 4, 5),
+    status = c(1, 1, 0, 1, 0),
+    x = c(0.2, 0.6, 0.4, 0.9, 0.3),
+    z = c(0.8, 0.1, 0.5, 0.2, 0.7)
+  )
+  score_matrix <- as.matrix(data[c("x", "z")])
+
+  expect_error(
+    concordancefit(
+      Surv(data$time, data$status),
+      score_matrix,
+      ranks = TRUE,
+      reverse = TRUE
+    ),
+    "undefined columns selected"
+  )
+  expect_error(
+    survival::concordancefit(
+      survival::Surv(data$time, data$status),
+      score_matrix,
+      ranks = TRUE,
+      reverse = TRUE
+    ),
+    "undefined columns selected"
+  )
+  expect_error(
+    concordance(
+      Surv(time, status) ~ x + z,
+      data = data,
+      ranks = TRUE,
+      reverse = TRUE
+    ),
+    "undefined columns selected"
+  )
+  expect_error(
+    survival::concordance(
+      survival::Surv(time, status) ~ x + z,
+      data = data,
+      ranks = TRUE,
+      reverse = TRUE
+    ),
+    "undefined columns selected"
+  )
+})
+
 test_that("stratified concordance results match reference shapes and diagnostics", {
   right_data <- data.frame(
     y = c(1, 3, 2, 4, 4, 2),


### PR DESCRIPTION
## Summary
- reproduce survival 3.8.11 behavior for reversed multi-score rank tables in low-level and formula calls
- preserve complete reversed multi-score rank rows for Python callers
- keep joint fitted-model concordance working through its distinct reference path

## Testing
- python -m pytest -q python/tests
- testthat::test_local("r/survivalr", reporter = "summary")
- R CMD check --no-manual survivalr_0.1.0.tar.gz