### PR TITLE
Match collapsed concordance strata behavior

### DIFF
--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -8687,6 +8687,33 @@ def test_concordance_reversed_multi_score_ranks_remain_available_in_python():
     )
 
 
+def test_concordance_collapsed_single_score_strata_remain_available_in_python():
+    result = survival.concordancefit(
+        survival.Surv([1, 2, 1, 2], [1, 0, 1, 0]),
+        [0.2, 0.6, 0.4, 0.8],
+        strata=["a", "a", "b", "b"],
+        keepstrata=False,
+        influence=3,
+        ranks=True,
+    )
+
+    assert result is not None
+    assert result.concordance == pytest.approx(1.0)
+    assert result.count == pytest.approx(
+        {
+            "concordant": 2.0,
+            "discordant": 0.0,
+            "tied.x": 0.0,
+            "tied.y": 0.0,
+            "tied.xy": 0.0,
+        }
+    )
+    assert result.strata_counts is None
+    assert result.dfbeta == pytest.approx([0.0, 0.0, 0.0, 0.0])
+    assert result.ranks is not None
+    assert [row["time"] for row in result.ranks] == pytest.approx([1.0, 0.5, 1.0, 0.5])
+
+
 def test_concordance_formula_accepts_numeric_outcomes_and_forces_rank_weights():
     data = {
         "y": [1.0, 3.0, 2.0, 4.0, 4.0, 2.0],

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -11946,6 +11946,38 @@ concordance <- function(object, ..., formula) {
   do.call(stats::model.frame, args)
 }
 
+.concordance_formula_strata_count <- function(formula, frame) {
+  Terms <- stats::terms(formula, specials = c("strata", "cluster"))
+  strata_terms <- untangle.specials(Terms, "strata", 1L)
+  if (length(strata_terms$vars) == 0L) {
+    return(1L)
+  }
+  values <- if (length(strata_terms$vars) == 1L) {
+    frame[[strata_terms$vars]]
+  } else {
+    strata(frame[, strata_terms$vars, drop = FALSE], shortlabel = TRUE)
+  }
+  length(unique(values))
+}
+
+.concordance_collapsed_strata_check <- function(n_scores, n_strata, keepstrata, timewt) {
+  if (n_scores != 1L || n_strata <= 1L) {
+    return(invisible(NULL))
+  }
+  retain_strata <- if (is.logical(keepstrata) && length(keepstrata) == 1L) {
+    isTRUE(keepstrata)
+  } else if (is.numeric(keepstrata) && length(keepstrata) == 1L) {
+    n_strata <= keepstrata
+  } else {
+    return(invisible(NULL))
+  }
+  time_weight <- match.arg(timewt, c("n", "S", "S/G", "n/G2", "I"))
+  if (!retain_strata && !(n_strata > 10L && time_weight %in% c("n", "I"))) {
+    colSums(numeric())
+  }
+  invisible(NULL)
+}
+
 .as_native_concordance <- function(result, Call, na.action = NULL) {
   concordance <- .as_numeric_vector(.result_field(result, "concordance"))
   score_names <- as.character(.result_field(result, "score_names"))
@@ -11986,6 +12018,7 @@ concordance <- function(object, ..., formula) {
 concordance.default <- function(object, data = NULL, ..., scores = NULL, risk.scores = NULL,
                                 weights = NULL, cluster = NULL, subset = NULL, na.action = "fail") {
   Call <- match.call()
+  dots <- list(...)
   formula <- object
   formula_input <- inherits(formula, "formula")
   env <- parent.frame()
@@ -12064,6 +12097,25 @@ concordance.default <- function(object, data = NULL, ..., scores = NULL, risk.sc
     .wrap = c("survival_py_concordance", "survival_py_object")
   )
   if (formula_input) {
+    formula_response <- stats::model.response(formula_frame)
+    formula_timewt <- if (!inherits(formula_response, "Surv")) {
+      "n"
+    } else if ("timewt" %in% names(dots)) {
+      dots[["timewt"]]
+    } else {
+      "n"
+    }
+    formula_keepstrata <- if ("keepstrata" %in% names(dots)) {
+      dots[["keepstrata"]]
+    } else {
+      10
+    }
+    .concordance_collapsed_strata_check(
+      length(.as_numeric_vector(.result_field(result, "concordance"))),
+      .concordance_formula_strata_count(formula, formula_frame),
+      formula_keepstrata,
+      formula_timewt
+    )
     return(.as_native_concordance(result, Call, attr(formula_frame, "na.action")))
   }
   result
@@ -12589,6 +12641,18 @@ concordancefit <- function(y, x, strata, weights, ymin = NULL, ymax = NULL,
     keepstrata = keepstrata,
     std_err = isTRUE(std.err),
     `_row_names` = row.names(.as_native_surv(y))
+  )
+
+  input_strata_count <- if (missing(strata) || length(strata) == 0L) {
+    1L
+  } else {
+    length(unique(strata))
+  }
+  .concordance_collapsed_strata_check(
+    length(.as_numeric_vector(.result_field(result, "concordance"))),
+    input_strata_count,
+    keepstrata,
+    timewt
   )
 
   concordance <- .as_numeric_vector(.result_field(result, "concordance"))

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -4430,6 +4430,114 @@ test_that("reversed multi-score concordance ranks match reference errors", {
   )
 })
 
+test_that("collapsed single-score strata match reference behavior", {
+  data <- data.frame(
+    time = c(1, 2, 1, 2),
+    status = c(1, 0, 1, 0),
+    x = c(0.2, 0.6, 0.4, 0.8),
+    group = c("a", "a", "b", "b")
+  )
+  dimension_error <- "'x' must be an array of at least two dimensions"
+
+  for (keep in list(FALSE, 1)) {
+    expect_error(
+      concordancefit(
+        Surv(data$time, data$status),
+        data$x,
+        strata = data$group,
+        keepstrata = keep
+      ),
+      dimension_error,
+      fixed = TRUE
+    )
+    expect_error(
+      survival::concordancefit(
+        survival::Surv(data$time, data$status),
+        data$x,
+        strata = data$group,
+        keepstrata = keep
+      ),
+      dimension_error,
+      fixed = TRUE
+    )
+    expect_error(
+      concordance(
+        Surv(time, status) ~ x + strata(group),
+        data = data,
+        keepstrata = keep
+      ),
+      dimension_error,
+      fixed = TRUE
+    )
+    expect_error(
+      survival::concordance(
+        survival::Surv(time, status) ~ x + strata(group),
+        data = data,
+        keepstrata = keep
+      ),
+      dimension_error,
+      fixed = TRUE
+    )
+  }
+
+  for (keep in list(TRUE, 2)) {
+    bridged_fit <- concordancefit(
+      Surv(data$time, data$status),
+      data$x,
+      strata = data$group,
+      keepstrata = keep
+    )
+    reference_fit <- survival::concordancefit(
+      survival::Surv(data$time, data$status),
+      data$x,
+      strata = data$group,
+      keepstrata = keep
+    )
+    expect_equal(unclass(bridged_fit), unclass(reference_fit), tolerance = 1e-12)
+
+    bridged_formula <- concordance(
+      Surv(time, status) ~ x + strata(group),
+      data = data,
+      keepstrata = keep
+    )
+    reference_formula <- survival::concordance(
+      survival::Surv(time, status) ~ x + strata(group),
+      data = data,
+      keepstrata = keep
+    )
+    fields <- setdiff(names(reference_formula), "call")
+    expect_equal(
+      unclass(bridged_formula)[fields],
+      unclass(reference_formula)[fields],
+      tolerance = 1e-12
+    )
+  }
+
+  large_data <- data.frame(
+    group = rep(seq_len(11), each = 2),
+    time = rep(c(1, 2), 11),
+    status = rep(c(1, 0), 11),
+    x = seq_len(22) / 22
+  )
+  for (time_weight in c("n", "I")) {
+    bridged_fit <- concordancefit(
+      Surv(large_data$time, large_data$status),
+      large_data$x,
+      strata = large_data$group,
+      keepstrata = FALSE,
+      timewt = time_weight
+    )
+    reference_fit <- survival::concordancefit(
+      survival::Surv(large_data$time, large_data$status),
+      large_data$x,
+      strata = large_data$group,
+      keepstrata = FALSE,
+      timewt = time_weight
+    )
+    expect_equal(unclass(bridged_fit), unclass(reference_fit), tolerance = 1e-12)
+  }
+})
+
 test_that("stratified concordance results match reference shapes and diagnostics", {
   right_data <- data.frame(
     y = c(1, 3, 2, 4, 4, 2),
@@ -4588,16 +4696,26 @@ test_that("stratified concordance results match reference shapes and diagnostics
     tolerance = 1e-12
   )
 
-  collapsed_right <- concordance(
-    y ~ x + strata(group),
-    data = right_data,
-    weights = w,
-    keepstrata = FALSE
+  collapsed_error <- "'x' must be an array of at least two dimensions"
+  expect_error(
+    concordance(
+      y ~ x + strata(group),
+      data = right_data,
+      weights = w,
+      keepstrata = FALSE
+    ),
+    collapsed_error,
+    fixed = TRUE
   )
-  expect_equal(
-    collapsed_right$count,
-    colSums(reference_right$count),
-    tolerance = 1e-12
+  expect_error(
+    survival::concordance(
+      y ~ x + strata(group),
+      data = right_data,
+      weights = w,
+      keepstrata = FALSE
+    ),
+    collapsed_error,
+    fixed = TRUE
   )
 
   right_response <- Surv(right_data$y, rep(1L, nrow(right_data)))


### PR DESCRIPTION
## Summary
- reproduce survival 3.8.11 collapsed single-score strata behavior at the R boundary
- preserve retained-strata results and the >10-strata n/I rewrite
- keep Python-native collapsed strata results available

## Testing
- python -m pytest -q python/tests
- testthat::test_local("r/survivalr", reporter = "summary")
- R CMD check --no-manual survivalr_0.1.0.tar.gz