### PR TITLE
Match disabled standard-error concordance behavior

### DIFF
--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -8687,6 +8687,31 @@ def test_concordance_reversed_multi_score_ranks_remain_available_in_python():
     )
 
 
+def test_concordance_multi_score_without_standard_errors_remains_available_in_python():
+    result = survival.concordancefit(
+        survival.Surv([5, 4, 4, 3, 3, 6], [0, 1, 1, 0, 1, 1]),
+        {
+            "s1": [-1, 0, 1, 0.5, 0.5, 0],
+            "s2": [0.5, -0.5, 1, 0, -0.5, -0.5],
+        },
+        timewt="I",
+        influence=2,
+        ranks=True,
+        reverse=True,
+        keepstrata=1,
+        std_err=False,
+    )
+
+    assert result is not None
+    assert result.score_names == ["s1", "s2"]
+    assert result.concordance == pytest.approx([0.7954545454545454, 0.4318181818181818])
+    assert result.variance is None
+    assert result.conditional_variance is None
+    assert result.dfbeta is None
+    assert result.influence is None
+    assert result.ranks is None
+
+
 def test_concordance_collapsed_single_score_strata_remain_available_in_python():
     result = survival.concordancefit(
         survival.Surv([1, 2, 1, 2], [1, 0, 1, 0]),

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -11978,6 +11978,28 @@ concordance <- function(object, ..., formula) {
   invisible(NULL)
 }
 
+.concordance_disabled_standard_error_check <- function(n_scores, n_strata, timewt, std.err) {
+  disabled <- length(std.err) == 1L &&
+    (is.logical(std.err) || is.numeric(std.err)) &&
+    !is.na(std.err) &&
+    !as.logical(std.err)
+  if (!disabled || n_scores <= 1L) {
+    return(invisible(NULL))
+  }
+  time_weight <- match.arg(timewt, c("n", "S", "S/G", "n/G2", "I"))
+  if (n_strata > 10L && time_weight %in% c("n", "I")) {
+    n_strata <- 1L
+  }
+  if (n_strata <= 1L) {
+    matrix(numeric(n_scores * 5L), nrow = n_scores, ncol = 5L)[, 6L]
+  } else {
+    count <- matrix(numeric(n_strata * n_scores * 5L), ncol = 6L, byrow = TRUE)
+    count <- count[, seq_len(5L), drop = FALSE]
+    dimnames(count) <- list(seq_len(n_scores), seq_len(5L))
+  }
+  invisible(NULL)
+}
+
 .as_native_concordance <- function(result, Call, na.action = NULL) {
   concordance <- .as_numeric_vector(.result_field(result, "concordance"))
   score_names <- as.character(.result_field(result, "score_names"))
@@ -12648,6 +12670,12 @@ concordancefit <- function(y, x, strata, weights, ymin = NULL, ymax = NULL,
   } else {
     length(unique(strata))
   }
+  .concordance_disabled_standard_error_check(
+    length(.as_numeric_vector(.result_field(result, "concordance"))),
+    input_strata_count,
+    timewt,
+    std.err
+  )
   .concordance_collapsed_strata_check(
     length(.as_numeric_vector(.result_field(result, "concordance"))),
     input_strata_count,

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -4430,6 +4430,83 @@ test_that("reversed multi-score concordance ranks match reference errors", {
   )
 })
 
+test_that("disabled standard errors with multiple scores match reference errors", {
+  y <- Surv(c(5, 4, 4, 3, 3, 6), c(0, 1, 1, 0, 1, 1))
+  reference_y <- survival::Surv(c(5, 4, 4, 3, 3, 6), c(0, 1, 1, 0, 1, 1))
+  x <- cbind(
+    s1 = c(-1, 0, 1, 0.5, 0.5, 0),
+    s2 = c(0.5, -0.5, 1, 0, -0.5, -0.5)
+  )
+
+  for (reverse_value in c(FALSE, TRUE)) {
+    expect_error(
+      concordancefit(
+        y,
+        x,
+        timewt = "I",
+        influence = 2,
+        ranks = TRUE,
+        reverse = reverse_value,
+        keepstrata = 1,
+        std.err = FALSE
+      ),
+      "subscript out of bounds",
+      fixed = TRUE
+    )
+    expect_error(
+      survival::concordancefit(
+        reference_y,
+        x,
+        timewt = "I",
+        influence = 2,
+        ranks = TRUE,
+        reverse = reverse_value,
+        keepstrata = 1,
+        std.err = FALSE
+      ),
+      "subscript out of bounds",
+      fixed = TRUE
+    )
+  }
+
+  strata_values <- rep(c("a", "b"), each = 3)
+  dimension_error <- "length of 'dimnames' [1] not equal to array extent"
+  length_warning <- paste(
+    "data length [20] is not a sub-multiple or multiple",
+    "of the number of columns [6]"
+  )
+  expect_warning(
+    expect_error(
+      concordancefit(
+        y,
+        x,
+        strata = strata_values,
+        timewt = "S",
+        std.err = FALSE
+      ),
+      dimension_error,
+      fixed = TRUE
+    ),
+    length_warning,
+    fixed = TRUE
+  )
+  expect_warning(
+    expect_error(
+      survival::concordancefit(
+        reference_y,
+        x,
+        strata = strata_values,
+        timewt = "S",
+        std.err = FALSE
+      ),
+      dimension_error,
+      fixed = TRUE
+    ),
+    length_warning,
+    fixed = TRUE
+  )
+})
+
 test_that("collapsed single-score strata match reference behavior", {
   data <- data.frame(
     time = c(1, 2, 1, 2),


### PR DESCRIPTION
## Summary
- reproduce survival 3.8.11 multi-score failures with disabled standard-error output at the R boundary
- match unstratified and stratified matrix diagnostics, including the large-strata n/I rewrite
- keep Python-native multi-score results without standard errors available

## Testing
- python -m pytest -q python/tests
- testthat::test_local("r/survivalr", reporter = "summary")
- R CMD check --no-manual survivalr_0.1.0.tar.gz