### PR TITLE
Preserve multi-score covariance shape

### DIFF
--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -12711,8 +12711,12 @@ concordancefit <- function(y, x, strata, weights, ymin = NULL, ymax = NULL,
     dfbeta_matrix <- do.call(cbind, dfbeta_columns)
   }
   if (isTRUE(std.err) && !is.null(variance)) {
-    if (multi_score && !is.null(dfbeta_matrix)) {
-      out$var <- crossprod(dfbeta_matrix)
+    if (multi_score) {
+      out$var <- if (!is.null(dfbeta_matrix)) {
+        crossprod(dfbeta_matrix)
+      } else {
+        .as_numeric_matrix(variance)
+      }
     } else {
       out$var <- .as_numeric_vector(variance)
     }

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -4507,6 +4507,28 @@ test_that("disabled standard errors with multiple scores match reference errors"
   )
 })
 
+test_that("multi-score influence covariance matches reference shape", {
+  time <- c(1, 2, 3, 4, 5, 6)
+  status <- c(1, 1, 0, 1, 0, 1)
+  x <- cbind(
+    s1 = c(0, 0.5, 1, -0.5, 0, 0.5),
+    s2 = c(1, 0, -0.5, 0.5, 0, -1)
+  )
+  bridged <- concordancefit(
+    Surv(time, status),
+    x,
+    influence = 2
+  )
+  reference <- survival::concordancefit(
+    survival::Surv(time, status),
+    x,
+    influence = 2
+  )
+
+  expect_true(is.matrix(bridged$var))
+  expect_equal(unclass(bridged), unclass(reference), tolerance = 1e-12)
+})
+
 test_that("collapsed single-score strata match reference behavior", {
   data <- data.frame(
     time = c(1, 2, 1, 2),


### PR DESCRIPTION
## Summary
- preserve the multi-score covariance matrix when influence=2
- use the covariance already returned by Python when dfbeta output is omitted
- add an R-reference shape and value regression

## Testing
- python -m pytest -q python/tests
- testthat::test_local("r/survivalr", reporter = "summary")
- R CMD check --no-manual survivalr_0.1.0.tar.gz