### PR TITLE
Match counting concordance time-weight errors

### DIFF
--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -9337,6 +9337,17 @@ def test_concordance_counting_process_uses_delayed_entry_risk_sets():
     assert reversed_result.reverse is True
 
 
+@pytest.mark.parametrize("timewt", ["S/G", "n/G2"])
+def test_concordance_counting_process_rejects_censoring_weights(timewt):
+    response = survival.Surv([0, 1, 2, 0], [1, 3, 4, 5], [1, 0, 1, 1])
+
+    with pytest.raises(
+        ValueError,
+        match="S/G and n/G2 timewt options are not supported for counting-process data",
+    ):
+        survival.concordancefit(response, [0.1, 0.4, 0.2, 0.8], timewt=timewt)
+
+
 def test_concordance_counting_process_ranks_use_delayed_entry_risk_sets():
     data = {
         "start": [0.0, 0.0, 0.5, 1.5],

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -12000,6 +12000,28 @@ concordance <- function(object, ..., formula) {
   invisible(NULL)
 }
 
+.concordance_translate_counting_timewt_error <- function(condition, timewt) {
+  backend_message <- "S/G and n/G2 timewt options are not supported for counting-process data"
+  if (grepl(backend_message, conditionMessage(condition), fixed = TRUE)) {
+    time_weight <- match.arg(timewt, c("n", "S", "S/G", "n/G2", "I"))
+    stop(
+      time_weight,
+      " timewt option not supported for (time1, time2) data",
+      call. = FALSE
+    )
+  }
+  stop(condition)
+}
+
+.concordance_call_with_timewt_translation <- function(method, diagnostic_timewt, ...) {
+  tryCatch(
+    .call_r_api(method, ...),
+    error = function(condition) {
+      .concordance_translate_counting_timewt_error(condition, diagnostic_timewt)
+    }
+  )
+}
+
 .as_native_concordance <- function(result, Call, na.action = NULL) {
   concordance <- .as_numeric_vector(.result_field(result, "concordance"))
   score_names <- as.character(.result_field(result, "score_names"))
@@ -12104,8 +12126,10 @@ concordance.default <- function(object, data = NULL, ..., scores = NULL, risk.sc
   source_row_names <- .concordance_source_row_names(formula, formula_data, env)
   python_na_action <- .as_na_action(effective_na_action)
   if (is.null(python_na_action)) python_na_action <- "pass"
-  result <- .call_r_api(
+  requested_timewt <- if ("timewt" %in% names(dots)) dots[["timewt"]] else "n"
+  result <- .concordance_call_with_timewt_translation(
     "concordance",
+    requested_timewt,
     response = .as_formula_string(formula),
     data = .as_python_data(formula_data),
     scores = score_values,
@@ -12123,7 +12147,7 @@ concordance.default <- function(object, data = NULL, ..., scores = NULL, risk.sc
     formula_timewt <- if (!inherits(formula_response, "Surv")) {
       "n"
     } else if ("timewt" %in% names(dots)) {
-      dots[["timewt"]]
+      requested_timewt
     } else {
       "n"
     }
@@ -12646,8 +12670,9 @@ concordancefit <- function(y, x, strata, weights, ymin = NULL, ymax = NULL,
     influence <- 0L
   }
   internal_influence <- if (isTRUE(std.err) && influence == 0L) 1L else influence
-  result <- .call_r_api(
+  result <- .concordance_call_with_timewt_translation(
     "concordancefit",
+    timewt,
     .as_python_surv(y),
     .as_python_optional_vector(x),
     strata = if (missing(strata)) NULL else .as_python_vector(strata),

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -4257,6 +4257,58 @@ test_that("concordance censoring weights use the post-death risk set", {
   }
 })
 
+test_that("counting concordance censoring-weight diagnostics match reference", {
+  data <- data.frame(
+    start = c(0, 1, 2, 0),
+    stop = c(1, 3, 4, 5),
+    status = c(1, 0, 1, 1),
+    x = c(0.1, 0.4, 0.2, 0.8)
+  )
+
+  for (time_weight in c("S/G", "n/G2")) {
+    expected_error <- paste(
+      time_weight,
+      "timewt option not supported for (time1, time2) data"
+    )
+    expect_error(
+      concordancefit(
+        Surv(data$start, data$stop, data$status),
+        data$x,
+        timewt = time_weight
+      ),
+      expected_error,
+      fixed = TRUE
+    )
+    expect_error(
+      survival::concordancefit(
+        survival::Surv(data$start, data$stop, data$status),
+        data$x,
+        timewt = time_weight
+      ),
+      expected_error,
+      fixed = TRUE
+    )
+    expect_error(
+      concordance(
+        Surv(start, stop, status) ~ x,
+        data = data,
+        timewt = time_weight
+      ),
+      expected_error,
+      fixed = TRUE
+    )
+    expect_error(
+      survival::concordance(
+        survival::Surv(start, stop, status) ~ x,
+        data = data,
+        timewt = time_weight
+      ),
+      expected_error,
+      fixed = TRUE
+    )
+  }
+})
+
 test_that("one-event concordance ranks match reference dimensions", {
   data <- data.frame(
     time = c(1, 2, 3),


### PR DESCRIPTION
## Summary
- match survival 3.8.11 counting-process diagnostics for S/G and n/G2 time weights at the R boundary
- centralize translation around the matching backend exception so earlier validation remains intact
- preserve the Python-native counting-process error message

## Testing
- python -m pytest -q python/tests
- testthat::test_local("r/survivalr", reporter = "summary")
- R CMD check --no-manual survivalr_0.1.0.tar.gz