### PR TITLE
Match stratified multi-score concordance behavior

### DIFF
--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -8712,6 +8712,25 @@ def test_concordance_multi_score_without_standard_errors_remains_available_in_py
     assert result.ranks is None
 
 
+def test_concordance_stratified_multi_score_remains_available_in_python():
+    result = survival.concordancefit(
+        survival.Surv([1, 2, 3, 1, 2, 3], [1, 0, 1, 1, 0, 1]),
+        {
+            "x": [1 / 6, 2 / 6, 3 / 6, 4 / 6, 5 / 6, 1],
+            "z": [1, 5 / 6, 4 / 6, 3 / 6, 2 / 6, 1 / 6],
+        },
+        strata=["a", "a", "a", "b", "b", "b"],
+        influence=3,
+    )
+
+    assert result is not None
+    assert result.score_names == ["x", "z"]
+    assert result.concordance == pytest.approx([1.0, 0.0])
+    assert result.comparable == pytest.approx([4.0, 4.0])
+    assert result.conditional_variance == pytest.approx([1 / 12, 1 / 12])
+    assert result.variance == [[0.0, 0.0], [0.0, 0.0]]
+
+
 def test_concordance_collapsed_single_score_strata_remain_available_in_python():
     result = survival.concordancefit(
         survival.Surv([1, 2, 1, 2], [1, 0, 1, 0]),

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -12000,6 +12000,20 @@ concordance <- function(object, ..., formula) {
   invisible(NULL)
 }
 
+.concordance_multi_score_strata_check <- function(n_scores, n_strata, timewt) {
+  if (n_scores <= 1L || n_strata <= 1L) {
+    return(invisible(NULL))
+  }
+  time_weight <- match.arg(timewt, c("n", "S", "S/G", "n/G2", "I"))
+  if (n_strata > 10L && time_weight %in% c("n", "I")) {
+    return(invisible(NULL))
+  }
+  count <- matrix(numeric(n_strata * n_scores * 6L), ncol = 6L, byrow = TRUE)
+  count <- count[, seq_len(5L), drop = FALSE]
+  dimnames(count) <- list(seq_len(n_scores), seq_len(5L))
+  invisible(NULL)
+}
+
 .concordance_translate_counting_timewt_error <- function(condition, timewt) {
   backend_message <- "S/G and n/G2 timewt options are not supported for counting-process data"
   if (grepl(backend_message, conditionMessage(condition), fixed = TRUE)) {
@@ -12156,9 +12170,18 @@ concordance.default <- function(object, data = NULL, ..., scores = NULL, risk.sc
     } else {
       10
     }
+    formula_n_scores <- length(
+      .as_numeric_vector(.result_field(result, "concordance"))
+    )
+    formula_strata_count <- .concordance_formula_strata_count(formula, formula_frame)
+    .concordance_multi_score_strata_check(
+      formula_n_scores,
+      formula_strata_count,
+      formula_timewt
+    )
     .concordance_collapsed_strata_check(
-      length(.as_numeric_vector(.result_field(result, "concordance"))),
-      .concordance_formula_strata_count(formula, formula_frame),
+      formula_n_scores,
+      formula_strata_count,
       formula_keepstrata,
       formula_timewt
     )
@@ -12690,25 +12713,31 @@ concordancefit <- function(y, x, strata, weights, ymin = NULL, ymax = NULL,
     `_row_names` = row.names(.as_native_surv(y))
   )
 
+  concordance <- .as_numeric_vector(.result_field(result, "concordance"))
+  n_scores <- length(concordance)
   input_strata_count <- if (missing(strata) || length(strata) == 0L) {
     1L
   } else {
     length(unique(strata))
   }
   .concordance_disabled_standard_error_check(
-    length(.as_numeric_vector(.result_field(result, "concordance"))),
+    n_scores,
     input_strata_count,
     timewt,
     std.err
   )
+  .concordance_multi_score_strata_check(
+    n_scores,
+    input_strata_count,
+    timewt
+  )
   .concordance_collapsed_strata_check(
-    length(.as_numeric_vector(.result_field(result, "concordance"))),
+    n_scores,
     input_strata_count,
     keepstrata,
     timewt
   )
 
-  concordance <- .as_numeric_vector(.result_field(result, "concordance"))
   multi_score <- length(concordance) > 1L
   score_names <- if (!is.null(input_score_names) && length(input_score_names) == length(concordance)) {
     as.character(input_score_names)

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -4581,6 +4581,104 @@ test_that("multi-score influence covariance matches reference shape", {
   expect_equal(unclass(bridged), unclass(reference), tolerance = 1e-12)
 })
 
+test_that("stratified multi-score assembly matches reference behavior", {
+  data <- data.frame(
+    time = rep(c(1, 2, 3), 2),
+    status = rep(c(1, 0, 1), 2),
+    x = seq_len(6) / 6,
+    z = rev(seq_len(6)) / 6,
+    group = rep(c("a", "b"), each = 3)
+  )
+  score_matrix <- as.matrix(data[c("x", "z")])
+  dimension_error <- "length of 'dimnames' [1] not equal to array extent"
+
+  for (time_weight in c("n", "S", "S/G", "n/G2", "I")) {
+    expect_error(
+      concordancefit(
+        Surv(data$time, data$status),
+        score_matrix,
+        strata = data$group,
+        timewt = time_weight,
+        keepstrata = TRUE
+      ),
+      dimension_error,
+      fixed = TRUE
+    )
+    expect_error(
+      survival::concordancefit(
+        survival::Surv(data$time, data$status),
+        score_matrix,
+        strata = data$group,
+        timewt = time_weight,
+        keepstrata = TRUE
+      ),
+      dimension_error,
+      fixed = TRUE
+    )
+    expect_error(
+      concordance(
+        Surv(time, status) ~ x + z + strata(group),
+        data = data,
+        timewt = time_weight,
+        keepstrata = TRUE
+      ),
+      dimension_error,
+      fixed = TRUE
+    )
+    expect_error(
+      survival::concordance(
+        survival::Surv(time, status) ~ x + z + strata(group),
+        data = data,
+        timewt = time_weight,
+        keepstrata = TRUE
+      ),
+      dimension_error,
+      fixed = TRUE
+    )
+  }
+
+  large_data <- data.frame(
+    group = rep(seq_len(11), each = 2),
+    time = rep(c(1, 2), 11),
+    status = rep(c(1, 0), 11),
+    x = seq_len(22) / 22,
+    z = rev(seq_len(22)) / 22
+  )
+  large_scores <- as.matrix(large_data[c("x", "z")])
+  for (time_weight in c("n", "I")) {
+    bridged_fit <- concordancefit(
+      Surv(large_data$time, large_data$status),
+      large_scores,
+      strata = large_data$group,
+      timewt = time_weight
+    )
+    reference_fit <- survival::concordancefit(
+      survival::Surv(large_data$time, large_data$status),
+      large_scores,
+      strata = large_data$group,
+      timewt = time_weight
+    )
+    expect_equal(unclass(bridged_fit), unclass(reference_fit), tolerance = 1e-12)
+
+    bridged_formula <- concordance(
+      Surv(time, status) ~ x + z + strata(group),
+      data = large_data,
+      timewt = time_weight
+    )
+    reference_formula <- survival::concordance(
+      survival::Surv(time, status) ~ x + z + strata(group),
+      data = large_data,
+      timewt = time_weight
+    )
+    fields <- setdiff(names(reference_formula), "call")
+    expect_equal(
+      unclass(bridged_formula)[fields],
+      unclass(reference_formula)[fields],
+      tolerance = 1e-12
+    )
+  }
+})
+
 test_that("collapsed single-score strata match reference behavior", {
   data <- data.frame(
     time = c(1, 2, 1, 2),


### PR DESCRIPTION
## Summary
- reproduce survival 3.8.11 multi-score/multi-strata assembly behavior at the R boundary
- preserve the >10-strata n/I rewrite that yields successful results
- keep Python-native stratified multi-score results available

## Testing
- python -m pytest -q python/tests
- testthat::test_local("r/survivalr", reporter = "summary")
- R CMD check --no-manual survivalr_0.1.0.tar.gz