### PR TITLE
Match counting concordance warning behavior

### DIFF
--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -11987,7 +11987,8 @@ concordance <- function(object, ..., formula) {
   invisible(NULL)
 }
 
-.concordance_disabled_standard_error_check <- function(n_scores, n_strata, timewt, std.err) {
+.concordance_disabled_standard_error_check <- function(
+    response, n_scores, n_strata, timewt, std.err) {
   disabled <- length(std.err) == 1L &&
     (is.logical(std.err) || is.numeric(std.err)) &&
     !is.na(std.err) &&
@@ -12002,7 +12003,18 @@ concordance <- function(object, ..., formula) {
   if (n_strata <= 1L) {
     matrix(numeric(n_scores * 5L), nrow = n_scores, ncol = 5L)[, 6L]
   } else {
-    count <- matrix(numeric(n_strata * n_scores * 5L), ncol = 6L, byrow = TRUE)
+    survival_response <- inherits(response, "Surv") ||
+      inherits(response, "survival_py_surv")
+    count_width <- if (survival_response && ncol(.as_native_surv(response)) == 3L) {
+      6L
+    } else {
+      5L
+    }
+    count <- matrix(
+      numeric(n_strata * n_scores * count_width),
+      ncol = 6L,
+      byrow = TRUE
+    )
     count <- count[, seq_len(5L), drop = FALSE]
     dimnames(count) <- list(seq_len(n_scores), seq_len(5L))
   }
@@ -12876,6 +12888,7 @@ concordancefit <- function(y, x, strata, weights, ymin = NULL, ymax = NULL,
     ymax
   )
   .concordance_disabled_standard_error_check(
+    y,
     n_scores,
     input_strata_count,
     timewt,

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -4557,6 +4557,60 @@ test_that("disabled standard errors with multiple scores match reference errors"
     length_warning,
     fixed = TRUE
   )
+
+  counting_y <- Surv(
+    c(4, 3, 0, 1, 3, 2, 3),
+    c(6, 6, 1, 4, 4, 5, 4),
+    c(1, 0, 0, 1, 0, 0, 0)
+  )
+  reference_counting_y <- survival::Surv(
+    c(4, 3, 0, 1, 3, 2, 3),
+    c(6, 6, 1, 4, 4, 5, 4),
+    c(1, 0, 0, 1, 0, 0, 0)
+  )
+  counting_x <- cbind(
+    s1 = c(0.5, 0, 1, -1, 1, 1, 1),
+    s2 = c(-1, 0, -1, 0.5, 0, 0, 0),
+    s3 = c(-0.5, 0.5, 0, 0.5, 0, -1, 1)
+  )
+  counting_strata <- c(3, 3, 1, 2, 1, 1, 2)
+  counting_weights <- c(2, 0.5, 1.5, 0.5, 2, 2, 0.5)
+  expect_no_warning(
+    expect_error(
+      concordancefit(
+        counting_y,
+        counting_x,
+        strata = counting_strata,
+        weights = counting_weights,
+        ymax = 6,
+        influence = 3,
+        ranks = TRUE,
+        reverse = TRUE,
+        keepstrata = 2,
+        std.err = FALSE
+      ),
+      dimension_error,
+      fixed = TRUE
+    )
+  )
+  expect_no_warning(
+    expect_error(
+      survival::concordancefit(
+        reference_counting_y,
+        counting_x,
+        strata = counting_strata,
+        weights = counting_weights,
+        ymax = 6,
+        influence = 3,
+        ranks = TRUE,
+        reverse = TRUE,
+        keepstrata = 2,
+        std.err = FALSE
+      ),
+      dimension_error,
+      fixed = TRUE
+    )
+  )
 })
 
 test_that("multi-score influence covariance matches reference shape", {


### PR DESCRIPTION
## Summary
- select concordance count assembly width from the response type when standard errors are disabled
- preserve the right-censored warning while removing the counting-process-only stray warning
- compare the no-warning counting diagnostic with the R reference

## Testing
- python -m pytest -q python/tests
- testthat::test_local("r/survivalr", reporter = "summary")
- R CMD check --no-manual survivalr_0.1.0.tar.gz