### PR TITLE
Normalize concordance rank replacement errors

### DIFF
--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -8840,6 +8840,19 @@ def test_concordance_many_strata_ranks_remain_available_in_python():
     assert [row["time"] for row in result.ranks[0]][:3] == pytest.approx([1, 9, 17])
 
 
+def test_concordance_uneven_stratified_ranks_report_the_replacement_error():
+    with pytest.raises(
+        ValueError,
+        match="number of items to replace is not a multiple of replacement length",
+    ):
+        survival.concordancefit(
+            survival.Surv([1, 2, 3, 1, 2, 3], [1, 1, 0, 1, 1, 1]),
+            {"x": list(range(1, 7)), "z": list(range(6, 0, -1))},
+            strata=["a"] * 3 + ["b"] * 3,
+            ranks=True,
+        )
+
+
 def test_concordance_formula_accepts_numeric_outcomes_and_forces_rank_weights():
     data = {
         "y": [1.0, 3.0, 2.0, 4.0, 4.0, 2.0],

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -12090,6 +12090,7 @@ concordance <- function(object, ..., formula) {
       timewt,
       ymax
     )
+    stop(replacement_message, call. = FALSE)
   }
   invisible(NULL)
 }

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -4809,6 +4809,65 @@ test_that("many concordance strata collapse before rank assembly", {
   )
 })
 
+test_that("uneven stratified concordance ranks match reference errors", {
+  data <- data.frame(
+    time = c(1, 2, 3, 1, 2, 3),
+    status = c(1, 1, 0, 1, 1, 1),
+    x = seq_len(6),
+    z = rev(seq_len(6)),
+    group = rep(c("a", "b"), each = 3)
+  )
+  replacement_error <- "number of items to replace is not a multiple of replacement length"
+
+  for (scores in list(data$x, as.matrix(data[c("x", "z")]))) {
+    expect_error(
+      concordancefit(
+        Surv(data$time, data$status),
+        scores,
+        strata = data$group,
+        ranks = TRUE
+      ),
+      replacement_error,
+      fixed = TRUE
+    )
+    expect_error(
+      survival::concordancefit(
+        survival::Surv(data$time, data$status),
+        scores,
+        strata = data$group,
+        ranks = TRUE
+      ),
+      replacement_error,
+      fixed = TRUE
+    )
+  }
+
+  formulas <- list(
+    Surv(time, status) ~ x + strata(group),
+    Surv(time, status) ~ x + z + strata(group)
+  )
+  reference_formulas <- list(
+    survival::Surv(time, status) ~ x + strata(group),
+    survival::Surv(time, status) ~ x + z + strata(group)
+  )
+  for (index in seq_along(formulas)) {
+    expect_error(
+      concordance(formulas[[index]], data = data, ranks = TRUE),
+      replacement_error,
+      fixed = TRUE
+    )
+    expect_error(
+      survival::concordance(
+        reference_formulas[[index]],
+        data = data,
+        ranks = TRUE
+      ),
+      replacement_error,
+      fixed = TRUE
+    )
+  }
+})
+
 test_that("empty concordance rank strata match reference diagnostics", {
   data <- data.frame(
     time = c(1, 2, 1, 2),


### PR DESCRIPTION
## Summary
- normalize fallback stratified rank replacement errors at the R boundary
- retain the more specific diagnostics for empty strata and zero-weight rank groups
- cover single- and multi-score behavior through low-level and formula calls

## Testing
- python -m pytest -q python/tests
- ruff check python/tests/test_r_api.py
- testthat::test_local("r/survivalr", reporter = "summary")
- R CMD check --no-manual survivalr_0.1.0.tar.gz