### PR TITLE
Order clustered concordance dfbeta rows

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -935,6 +935,7 @@ class ConcordanceResult:
     score_names: list[str] | None = None
     strata_counts: list[list[float]] | None = None
     strata_names: list[str] | None = None
+    cluster_names: list[str] | None = None
 
     @property
     def c_index(self) -> float | list[float]:
@@ -26145,6 +26146,16 @@ class _ConcordanceStrata:
         return [_concordance_strata_label(value) for value in self.levels]
 
 
+@dataclass(frozen=True)
+class _ConcordanceCluster:
+    values: list[Any]
+    levels: tuple[Any, ...]
+
+    @property
+    def names(self) -> list[str]:
+        return [_concordance_strata_label(value) for value in self.levels]
+
+
 @lru_cache(maxsize=512)
 def _concordance_formula_response_spec(formula: str) -> _ConcordanceFormulaResponseSpec:
     lhs, separator, _rhs = formula.partition("~")
@@ -26546,26 +26557,31 @@ def _concordance_influence(
     return _unsupported_concordance_response()
 
 
-def _concordance_cluster_values(cluster: Any, n: int) -> list[Any]:
+def _concordance_cluster_values(cluster: Any, n: int) -> _ConcordanceCluster:
     values = _materialize_labels(cluster, "cluster")
     if len(values) != n:
         raise ValueError("cluster must have the same length as the Surv response")
-    _label_levels(values, "cluster")
-    return values
+    declared = _mstate_categories(cluster)
+    if declared is None:
+        levels = _r_formula_ordered_levels(values, "cluster")
+    else:
+        observed = {_factor_value_key(value) for value in values}
+        levels = tuple(
+            level
+            for level in _materialize_1d(declared, "cluster levels")
+            if _factor_value_key(level) in observed
+        )
+    return _ConcordanceCluster(values, levels)
 
 
 def _clustered_concordance_dfbeta(
     dfbeta: list[float],
-    cluster: list[Any],
+    cluster: _ConcordanceCluster,
 ) -> tuple[list[float], float]:
-    collapsed: dict[Any, float] = {}
-    order: list[Any] = []
-    for label, value in zip(cluster, dfbeta, strict=True):
-        if label not in collapsed:
-            collapsed[label] = 0.0
-            order.append(label)
-        collapsed[label] += value
-    cluster_dfbeta = [collapsed[label] for label in order]
+    collapsed = {_factor_value_key(level): 0.0 for level in cluster.levels}
+    for label, value in zip(cluster.values, dfbeta, strict=True):
+        collapsed[_factor_value_key(label)] += value
+    cluster_dfbeta = [collapsed[_factor_value_key(level)] for level in cluster.levels]
     return cluster_dfbeta, math.fsum(value * value for value in cluster_dfbeta)
 
 
@@ -26689,7 +26705,7 @@ def _single_score_concordance_result(
     score_values: list[float],
     weight_values: list[float] | None,
     strata_values: _ConcordanceStrata | None,
-    cluster_values: list[Any] | None,
+    cluster_values: _ConcordanceCluster | None,
     reverse_scores: bool,
     fix_time: bool,
     time_weight: str,
@@ -26771,6 +26787,7 @@ def _single_score_concordance_result(
             else None
         ),
         strata_names=strata_names if retain_strata else None,
+        cluster_names=cluster_values.names if cluster_values is not None else None,
     )
 
 
@@ -26780,7 +26797,7 @@ def _multi_score_concordance_result(
     score_names: list[str],
     weight_values: list[float] | None,
     strata_values: _ConcordanceStrata | None,
-    cluster_values: list[Any] | None,
+    cluster_values: _ConcordanceCluster | None,
     reverse_scores: bool,
     fix_time: bool,
     time_weight: str,
@@ -26840,6 +26857,7 @@ def _multi_score_concordance_result(
             for result in results
         ],
         score_names=score_names,
+        cluster_names=results[0].cluster_names if results else None,
     )
 
 
@@ -26881,6 +26899,7 @@ def _public_concordance_result(
         score_names=result.score_names,
         strata_counts=result.strata_counts,
         strata_names=result.strata_names,
+        cluster_names=result.cluster_names,
     )
 
 
@@ -27104,6 +27123,7 @@ def concordance(
                 score_names=score_names,
                 strata_counts=result.strata_counts,
                 strata_names=result.strata_names,
+                cluster_names=result.cluster_names,
             )
         return _public_concordance_result(result, weight_values)
 
@@ -27245,7 +27265,7 @@ def concordancefit(
     if cluster is not None:
         candidate = _materialize_labels(cluster, "cluster")
         if candidate:
-            cluster_values = _concordance_cluster_values(candidate, len(response))
+            cluster_values = _concordance_cluster_values(cluster, len(response))
 
     time_weight = _normalize_concordance_timewt(timewt)
     influence_value = _normalize_concordance_influence(influence)
@@ -27332,6 +27352,7 @@ def concordancefit(
         score_names=score_names if len(score_columns) > 1 else None,
         strata_counts=computed.strata_counts,
         strata_names=computed.strata_names,
+        cluster_names=computed.cluster_names,
     )
 
 

--- a/python/survival/r_api.pyi
+++ b/python/survival/r_api.pyi
@@ -486,6 +486,7 @@ class ConcordanceResult:
     score_names: list[str] | None
     strata_counts: list[list[float]] | None
     strata_names: list[str] | None
+    cluster_names: list[str] | None
     @property
     def c_index(self) -> float | list[float]: ...
     @property

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -8181,6 +8181,24 @@ def test_concordance_cluster_collapses_dfbeta_for_robust_variance():
         assert clustered_row == pytest.approx(unclustered_row)
 
 
+def test_concordance_cluster_dfbeta_uses_r_group_order():
+    result = survival.concordancefit(
+        survival.Surv([2, 3, 4, 5, 2], [0, 1, 1, 0, 1]),
+        [-1, 0, 1, 0, 1],
+        cluster=[2, 1, 1, 2, 3],
+        ymin=3,
+        timewt="S",
+        influence=3,
+        timefix=False,
+    )
+
+    assert result is not None
+    assert result.cluster_names == ["1", "2", "3"]
+    assert result.dfbeta == pytest.approx(
+        [0.168888888888889, -0.128888888888889, -0.04]
+    )
+
+
 def test_concordance_accepts_case_weights():
     data = {
         "time": [1.0, 2.0, 3.0, 4.0],

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -12523,11 +12523,19 @@ concordance.survival_py_model <- function(object, ..., newdata, cluster, ymin, y
   if (identical(name, "dfbeta")) {
     value <- .result_field(object, name)
     if (is.null(value)) return(NULL)
+    cluster_names <- as.character(.result_field(object, "cluster_names"))
     if (multi_score) {
       matrix_value <- do.call(cbind, lapply(value, .as_numeric_vector))
+      if (length(cluster_names) == nrow(matrix_value)) {
+        rownames(matrix_value) <- cluster_names
+      }
       return(matrix_value)
     }
-    return(.as_numeric_vector(value))
+    vector_value <- .as_numeric_vector(value)
+    if (length(cluster_names) == length(vector_value)) {
+      names(vector_value) <- cluster_names
+    }
+    return(vector_value)
   }
 
   if (identical(name, "influence")) {
@@ -12924,6 +12932,7 @@ concordancefit <- function(y, x, strata, weights, ymin = NULL, ymax = NULL,
   variance <- .result_field(result, "variance")
   conditional_variance <- .as_numeric_vector(.result_field(result, "conditional_variance"))
   dfbeta <- .result_field(result, "dfbeta")
+  cluster_names <- as.character(.result_field(result, "cluster_names"))
   dfbeta_matrix <- NULL
   if (multi_score && !is.null(dfbeta)) {
     dfbeta_columns <- lapply(dfbeta, .as_numeric_vector)
@@ -12932,6 +12941,9 @@ concordancefit <- function(y, x, strata, weights, ymin = NULL, ymax = NULL,
       stop("concordance dfbeta values must be rectangular", call. = FALSE)
     }
     dfbeta_matrix <- do.call(cbind, dfbeta_columns)
+    if (length(cluster_names) == nrow(dfbeta_matrix)) {
+      rownames(dfbeta_matrix) <- cluster_names
+    }
   }
   if (isTRUE(std.err) && !is.null(variance)) {
     if (multi_score) {
@@ -12954,7 +12966,11 @@ concordancefit <- function(y, x, strata, weights, ymin = NULL, ymax = NULL,
       out$dfbeta <- if (multi_score && !is.null(dfbeta_matrix)) {
         dfbeta_matrix
       } else {
-        .as_numeric_vector(dfbeta)
+        dfbeta_vector <- .as_numeric_vector(dfbeta)
+        if (length(cluster_names) == length(dfbeta_vector)) {
+          names(dfbeta_vector) <- cluster_names
+        }
+        dfbeta_vector
       }
     }
   }

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -4868,6 +4868,70 @@ test_that("uneven stratified concordance ranks match reference errors", {
   }
 })
 
+test_that("clustered concordance dfbeta matches reference order and names", {
+  data <- data.frame(
+    time = c(2, 3, 4, 5, 2),
+    status = c(0, 1, 1, 0, 1),
+    x = c(-1, 0, 1, 0, 1),
+    z = c(1, -1, 0, 0.5, 1),
+    cluster = c(2, 1, 1, 2, 3)
+  )
+
+  for (scores in list(data$x, as.matrix(data[c("x", "z")]))) {
+    bridged <- concordancefit(
+      Surv(data$time, data$status),
+      scores,
+      cluster = data$cluster,
+      ymin = 3,
+      timewt = "S",
+      influence = 3,
+      timefix = FALSE
+    )
+    reference <- survival::concordancefit(
+      survival::Surv(data$time, data$status),
+      scores,
+      cluster = data$cluster,
+      ymin = 3,
+      timewt = "S",
+      influence = 3,
+      timefix = FALSE
+    )
+    expect_equal(unclass(bridged), unclass(reference), tolerance = 1e-12)
+  }
+
+  formulas <- list(Surv(time, status) ~ x, Surv(time, status) ~ x + z)
+  reference_formulas <- list(
+    survival::Surv(time, status) ~ x,
+    survival::Surv(time, status) ~ x + z
+  )
+  for (index in seq_along(formulas)) {
+    bridged <- concordance(
+      formulas[[index]],
+      data = data,
+      cluster = data$cluster,
+      ymin = 3,
+      timewt = "S",
+      influence = 3,
+      timefix = FALSE
+    )
+    reference <- survival::concordance(
+      reference_formulas[[index]],
+      data = data,
+      cluster = data$cluster,
+      ymin = 3,
+      timewt = "S",
+      influence = 3,
+      timefix = FALSE
+    )
+    fields <- setdiff(names(reference), "call")
+    expect_equal(
+      unclass(bridged)[fields],
+      unclass(reference)[fields],
+      tolerance = 1e-12
+    )
+  }
+})
+
 test_that("empty concordance rank strata match reference diagnostics", {
   data <- data.frame(
     time = c(1, 2, 1, 2),


### PR DESCRIPTION
## Summary
- aggregate clustered concordance dfbeta values in R group order
- carry cluster labels through Python result metadata
- restore vector names and matrix row names at the R boundary

## Testing
- python -m pytest -q python/tests
- ruff check python/survival/r_api.py python/tests/test_r_api.py
- testthat::test_local("r/survivalr", reporter = "summary")
- R CMD check --no-manual survivalr_0.1.0.tar.gz