### PR TITLE
Recycle retained concordance strata counts

### DIFF
--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -8730,6 +8730,26 @@ def test_concordance_multi_score_without_standard_errors_remains_available_in_py
     assert result.ranks is None
 
 
+def test_concordance_strata_without_standard_errors_remain_available_in_python():
+    result = survival.concordancefit(
+        survival.Surv([4, 6, 5, 7, 2, 5, 4, 2, 2, 4], [0, 0, 1, 0, 1, 0, 1, 0, 0, 0]),
+        [-0.5, -0.5, -1, 1, 0.5, -0.5, 0, -0.5, -1, 0.5],
+        strata=[1, 3, 1, 2, 2, 1, 3, 3, 1, 2],
+        ymax=4,
+        keepstrata=True,
+        std_err=False,
+    )
+
+    assert result is not None
+    assert result.concordance == pytest.approx(0.5)
+    assert result.strata_counts == [
+        [0, 0, 0, 0, 0],
+        [1, 0, 1, 0, 0],
+        [0, 1, 0, 0, 0],
+    ]
+    assert result.variance is None
+
+
 def test_concordance_stratified_multi_score_remains_available_in_python():
     result = survival.concordancefit(
         survival.Surv([1, 2, 3, 1, 2, 3], [1, 0, 1, 1, 0, 1]),

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -12021,6 +12021,29 @@ concordance <- function(object, ..., formula) {
   invisible(NULL)
 }
 
+.concordance_disabled_standard_error_strata_values <- function(
+    result, n_scores, std.err) {
+  disabled <- length(std.err) == 1L &&
+    (is.logical(std.err) || is.numeric(std.err)) &&
+    !is.na(std.err) &&
+    !as.logical(std.err)
+  if (!disabled || n_scores != 1L || !is.matrix(result$count)) {
+    return(result)
+  }
+
+  count_names <- colnames(result$count)
+  strata_names <- rownames(result$count)
+  count <- matrix(as.vector(t(result$count)), ncol = 6L, byrow = TRUE)
+  totals <- colSums(count)
+  comparable <- sum(totals[seq_len(3L)])
+  result$concordance <- (
+    1 + (totals[[1L]] - totals[[2L]]) / comparable
+  ) / 2
+  result$count <- count[, seq_len(5L), drop = FALSE]
+  dimnames(result$count) <- list(strata_names, count_names)
+  result
+}
+
 .concordance_multi_score_strata_check <- function(n_scores, n_strata, timewt) {
   if (n_scores <= 1L || n_strata <= 1L) {
     return(invisible(NULL))
@@ -12928,6 +12951,11 @@ concordancefit <- function(y, x, strata, weights, ymin = NULL, ymax = NULL,
     concordance = if (length(concordance) == 1L) concordance[[1L]] else concordance,
     count = .concordancefit_count(result, if (multi_score) score_names else NULL),
     n = as.integer(.result_field(result, "n"))
+  )
+  out <- .concordance_disabled_standard_error_strata_values(
+    out,
+    n_scores,
+    std.err
   )
   variance <- .result_field(result, "variance")
   conditional_variance <- .as_numeric_vector(.result_field(result, "conditional_variance"))

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -4613,6 +4613,47 @@ test_that("disabled standard errors with multiple scores match reference errors"
   )
 })
 
+test_that("disabled standard errors recycle retained strata counts like reference", {
+  data <- data.frame(
+    time = c(4, 6, 5, 7, 2, 5, 4, 2, 2, 4),
+    status = c(0, 0, 1, 0, 1, 0, 1, 0, 0, 0),
+    x = c(-0.5, -0.5, -1, 1, 0.5, -0.5, 0, -0.5, -1, 0.5),
+    group = c(1, 3, 1, 2, 2, 1, 3, 3, 1, 2)
+  )
+  warning_message <- paste(
+    "data length [15] is not a sub-multiple or multiple",
+    "of the number of columns [6]"
+  )
+
+  bridged <- NULL
+  expect_warning(
+    bridged <- concordancefit(
+      Surv(data$time, data$status),
+      as.matrix(data["x"]),
+      strata = data$group,
+      ymax = 4,
+      keepstrata = TRUE,
+      std.err = FALSE
+    ),
+    warning_message,
+    fixed = TRUE
+  )
+  reference <- NULL
+  expect_warning(
+    reference <- survival::concordancefit(
+      survival::Surv(data$time, data$status),
+      as.matrix(data["x"]),
+      strata = data$group,
+      ymax = 4,
+      keepstrata = TRUE,
+      std.err = FALSE
+    ),
+    warning_message,
+    fixed = TRUE
+  )
+  expect_equal(unclass(bridged), unclass(reference), tolerance = 1e-12)
+})
+
 test_that("multi-score influence covariance matches reference shape", {
   time <- c(1, 2, 3, 4, 5, 6)
   status <- c(1, 1, 0, 1, 0, 1)


### PR DESCRIPTION
## Summary
- reproduce retained single-score strata count recycling when standard errors are disabled
- match the reference warning, altered count matrix, and concordance at the R boundary
- preserve the clean Python-native strata count result

## Testing
- python -m pytest -q python/tests
- ruff check python/tests/test_r_api.py
- testthat::test_local("r/survivalr", reporter = "summary")
- R CMD check --no-manual survivalr_0.1.0.tar.gz