### PR TITLE
Normalize zero-pair concordance values

### DIFF
--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -8828,6 +8828,26 @@ def test_concordance_zero_weight_rank_tables_remain_available_in_python():
         )
 
 
+def test_concordance_zero_pair_diagnostics_remain_finite_in_python():
+    response = survival.Surv([4, 1, 6, 5, 2, 6, 5], [0, 0, 0, 1, 0, 1, 0])
+    result = survival.concordancefit(
+        response,
+        {
+            "x": [1, 0, 0.5, 0, 0, 1, 1],
+            "z": [0, -0.5, -0.5, 1, 0.5, 0, -1],
+        },
+        ymax=4,
+        timewt="S/G",
+        influence=3,
+    )
+
+    assert result is not None
+    assert result.concordance == pytest.approx([0.5, 0.5])
+    assert result.variance == [[0.0, 0.0], [0.0, 0.0]]
+    assert result.dfbeta is not None
+    assert all(value == 0.0 for column in result.dfbeta for value in column)
+
+
 def test_concordance_collapsed_single_score_strata_remain_available_in_python():
     result = survival.concordancefit(
         survival.Surv([1, 2, 1, 2], [1, 0, 1, 0]),

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -12184,6 +12184,7 @@ concordance <- function(object, ..., formula) {
       !("rank" %in% names(out$ranks))) {
     out$ranks[, "rank"] <- -out$ranks[, "rank"]
   }
+  out <- .concordance_zero_pair_values(out)
   out <- .concordance_empty_rank_values(out)
   if (length(na.action)) out$na.action <- na.action
   out$call <- Call
@@ -12805,6 +12806,42 @@ survConcordance.fit <- function(y, x, strata, weight) {
   result
 }
 
+.concordance_zero_pair_values <- function(result) {
+  if (is.null(result$count) || length(result$count) == 0L) {
+    return(result)
+  }
+
+  multi_score <- length(result$concordance) > 1L
+  comparable <- if (multi_score && is.matrix(result$count)) {
+    rowSums(result$count[, seq_len(3L), drop = FALSE])
+  } else if (is.matrix(result$count)) {
+    sum(result$count[, seq_len(3L), drop = FALSE])
+  } else {
+    sum(result$count[seq_len(3L)])
+  }
+  empty <- comparable == 0
+  if (!any(empty)) {
+    return(result)
+  }
+
+  if (!multi_score) {
+    result$concordance[] <- NaN
+    if (!is.null(result$var)) result$var[] <- NaN
+    if (!is.null(result$cvar)) result$cvar[] <- NaN
+    if (!is.null(result$dfbeta)) result$dfbeta[] <- NaN
+    return(result)
+  }
+
+  result$concordance[empty] <- NaN
+  if (!is.null(result$cvar)) result$cvar[empty] <- NaN
+  if (!is.null(result$var)) {
+    result$var[empty, ] <- NaN
+    result$var[, empty] <- NaN
+  }
+  if (!is.null(result$dfbeta)) result$dfbeta[, empty] <- NaN
+  result
+}
+
 .concordancefit_rank_result <- function(rows, row_names = NULL, score_names = NULL) {
   multi_score <- !is.null(score_names) && length(score_names) > 1L
   if (multi_score) {
@@ -13040,6 +13077,7 @@ concordancefit <- function(y, x, strata, weights, ymin = NULL, ymax = NULL,
       out$ranks[, "rank"] <- -out$ranks[, "rank"]
     }
   }
+  out <- .concordance_zero_pair_values(out)
   .concordance_empty_rank_values(out)
 }
 

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -5232,6 +5232,62 @@ test_that("empty concordance rank tables match reference shapes", {
   }
 })
 
+test_that("zero-pair concordance diagnostics match reference values", {
+  data <- data.frame(
+    time = c(4, 1, 6, 5, 2, 6, 5),
+    status = c(0, 0, 0, 1, 0, 1, 0),
+    x = c(1, 0, 0.5, 0, 0, 1, 1),
+    z = c(0, -0.5, -0.5, 1, 0.5, 0, -1)
+  )
+  score_sets <- list(as.matrix(data["x"]), as.matrix(data[c("x", "z")]))
+
+  for (scores in score_sets) {
+    bridged <- concordancefit(
+      Surv(data$time, data$status),
+      scores,
+      ymax = 4,
+      timewt = "S/G",
+      influence = 3
+    )
+    reference <- survival::concordancefit(
+      survival::Surv(data$time, data$status),
+      scores,
+      ymax = 4,
+      timewt = "S/G",
+      influence = 3
+    )
+    expect_equal(unclass(bridged), unclass(reference), tolerance = 1e-12)
+  }
+
+  formulas <- list(Surv(time, status) ~ x, Surv(time, status) ~ x + z)
+  reference_formulas <- list(
+    survival::Surv(time, status) ~ x,
+    survival::Surv(time, status) ~ x + z
+  )
+  for (index in seq_along(formulas)) {
+    bridged <- concordance(
+      formulas[[index]],
+      data = data,
+      ymax = 4,
+      timewt = "S/G",
+      influence = 3
+    )
+    reference <- survival::concordance(
+      reference_formulas[[index]],
+      data = data,
+      ymax = 4,
+      timewt = "S/G",
+      influence = 3
+    )
+    fields <- setdiff(names(reference), "call")
+    expect_equal(
+      unclass(bridged)[fields],
+      unclass(reference)[fields],
+      tolerance = 1e-12
+    )
+  }
+})
+
 test_that("collapsed single-score strata match reference behavior", {
   data <- data.frame(
     time = c(1, 2, 1, 2),


### PR DESCRIPTION
## Summary
- propagate undefined zero-pair diagnostics through the R boundary
- match concordance, covariance, conditional variance, and dfbeta values for single and multiple scores
- preserve finite Python-native fallback diagnostics

## Testing
- python -m pytest -q python/tests
- ruff check python/tests/test_r_api.py
- testthat::test_local("r/survivalr", reporter = "summary")
- R CMD check --no-manual survivalr_0.1.0.tar.gz
- seeded concordance parity replay through case 45