### PR TITLE
Match collapsed concordance warning behavior

### DIFF
--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -11969,7 +11969,8 @@ concordance <- function(object, ..., formula) {
   ncol(design)
 }
 
-.concordance_collapsed_strata_check <- function(n_scores, n_strata, keepstrata, timewt) {
+.concordance_collapsed_strata_check <- function(
+    n_scores, n_strata, keepstrata, timewt, response = NULL, std.err = TRUE) {
   if (n_scores != 1L || n_strata <= 1L) {
     return(invisible(NULL))
   }
@@ -11982,6 +11983,16 @@ concordance <- function(object, ..., formula) {
   }
   time_weight <- match.arg(timewt, c("n", "S", "S/G", "n/G2", "I"))
   if (!retain_strata && !(n_strata > 10L && time_weight %in% c("n", "I"))) {
+    disabled <- length(std.err) == 1L &&
+      (is.logical(std.err) || is.numeric(std.err)) &&
+      !is.na(std.err) &&
+      !as.logical(std.err)
+    survival_response <- inherits(response, "Surv") ||
+      inherits(response, "survival_py_surv")
+    counting_response <- survival_response && ncol(.as_native_surv(response)) == 3L
+    if (disabled && !counting_response) {
+      matrix(numeric(n_strata * 5L), ncol = 6L, byrow = TRUE)
+    }
     colSums(numeric())
   }
   invisible(NULL)
@@ -12972,7 +12983,9 @@ concordancefit <- function(y, x, strata, weights, ymin = NULL, ymax = NULL,
     n_scores,
     input_strata_count,
     keepstrata,
-    timewt
+    timewt,
+    y,
+    std.err
   )
 
   multi_score <- length(concordance) > 1L

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -4654,6 +4654,57 @@ test_that("disabled standard errors recycle retained strata counts like referenc
   expect_equal(unclass(bridged), unclass(reference), tolerance = 1e-12)
 })
 
+test_that("disabled standard errors warn before collapsed strata errors", {
+  data <- data.frame(
+    time = c(3, 2, 1, 1, 1, 3, 1, 4),
+    status = c(1, 0, 0, 0, 1, 0, 0, 0),
+    x = c(0.5, 1, -0.5, -1, 0.5, 0, 0, 0),
+    group = c(1, 2, 2, 1, 2, 1, 2, 1)
+  )
+  warning_message <- paste(
+    "data length [10] is not a sub-multiple or multiple",
+    "of the number of columns [6]"
+  )
+  dimension_error <- "'x' must be an array of at least two dimensions"
+
+  expect_warning(
+    expect_error(
+      concordancefit(
+        Surv(data$time, data$status),
+        data$x,
+        strata = data$group,
+        ymin = 3,
+        timewt = "S",
+        reverse = TRUE,
+        keepstrata = 1,
+        std.err = FALSE
+      ),
+      dimension_error,
+      fixed = TRUE
+    ),
+    warning_message,
+    fixed = TRUE
+  )
+  expect_warning(
+    expect_error(
+      survival::concordancefit(
+        survival::Surv(data$time, data$status),
+        data$x,
+        strata = data$group,
+        ymin = 3,
+        timewt = "S",
+        reverse = TRUE,
+        keepstrata = 1,
+        std.err = FALSE
+      ),
+      dimension_error,
+      fixed = TRUE
+    ),
+    warning_message,
+    fixed = TRUE
+  )
+})
+
 test_that("multi-score influence covariance matches reference shape", {
   time <- c(1, 2, 3, 4, 5, 6)
   status <- c(1, 1, 0, 1, 0, 1)


### PR DESCRIPTION
## Summary
- reproduce the right-censored count recycling warning when standard errors are disabled
- preserve the following collapsed-strata dimension error
- keep counting-process behavior unchanged

## Testing
- python -m pytest -q python/tests
- testthat::test_local("r/survivalr", reporter = "summary")
- R CMD check --no-manual survivalr_0.1.0.tar.gz
- seeded concordance parity replay through case 50