### PR TITLE
Count empty concordance strata in warnings

### DIFF
--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -11999,7 +11999,7 @@ concordance <- function(object, ..., formula) {
 }
 
 .concordance_disabled_standard_error_check <- function(
-    response, n_scores, n_strata, timewt, std.err) {
+    response, n_scores, n_strata, timewt, std.err, strata = NULL) {
   disabled <- length(std.err) == 1L &&
     (is.logical(std.err) || is.numeric(std.err)) &&
     !is.na(std.err) &&
@@ -12016,13 +12016,24 @@ concordance <- function(object, ..., formula) {
   } else {
     survival_response <- inherits(response, "Surv") ||
       inherits(response, "survival_py_surv")
-    count_width <- if (survival_response && ncol(.as_native_surv(response)) == 3L) {
+    native_response <- if (survival_response) .as_native_surv(response) else NULL
+    count_width <- if (!is.null(native_response) && ncol(native_response) == 3L) {
       6L
     } else {
       5L
     }
+    count_length <- n_strata * n_scores * count_width
+    if (!is.null(native_response) && !is.null(strata) && count_width < 6L) {
+      status <- native_response[, ncol(native_response)]
+      event_counts <- vapply(
+        split(status, droplevels(as.factor(strata))),
+        sum,
+        numeric(1)
+      )
+      count_length <- count_length + n_scores * sum(event_counts == 0)
+    }
     count <- matrix(
-      numeric(n_strata * n_scores * count_width),
+      numeric(count_length),
       ncol = 6L,
       byrow = TRUE
     )
@@ -12972,7 +12983,8 @@ concordancefit <- function(y, x, strata, weights, ymin = NULL, ymax = NULL,
     n_scores,
     input_strata_count,
     timewt,
-    std.err
+    std.err,
+    input_strata
   )
   .concordance_multi_score_strata_check(
     n_scores,

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -4558,6 +4558,45 @@ test_that("disabled standard errors with multiple scores match reference errors"
     fixed = TRUE
   )
 
+  sparse_y <- Surv(seq_len(6), c(1, 0, 0, 0, 1, 0))
+  reference_sparse_y <- survival::Surv(seq_len(6), c(1, 0, 0, 0, 1, 0))
+  sparse_x <- cbind(s1 = seq_len(6), s2 = rev(seq_len(6)))
+  sparse_strata <- rep(seq_len(3), each = 2)
+  sparse_warning <- paste(
+    "data length [32] is not a sub-multiple or multiple",
+    "of the number of rows [6]"
+  )
+  expect_warning(
+    expect_error(
+      concordancefit(
+        sparse_y,
+        sparse_x,
+        strata = sparse_strata,
+        timewt = "S",
+        std.err = FALSE
+      ),
+      dimension_error,
+      fixed = TRUE
+    ),
+    sparse_warning,
+    fixed = TRUE
+  )
+  expect_warning(
+    expect_error(
+      survival::concordancefit(
+        reference_sparse_y,
+        sparse_x,
+        strata = sparse_strata,
+        timewt = "S",
+        std.err = FALSE
+      ),
+      dimension_error,
+      fixed = TRUE
+    ),
+    sparse_warning,
+    fixed = TRUE
+  )
+
   counting_y <- Surv(
     c(4, 3, 0, 1, 3, 2, 3),
     c(6, 6, 1, 4, 4, 5, 4),


### PR DESCRIPTION
## Summary
- account for six-field zero-event strata in disabled-standard-error count assembly
- reproduce exact mixed-width recycling warnings for multi-score fits
- retain the reference dimension error after warning emission

## Testing
- python -m pytest -q python/tests
- testthat::test_local("r/survivalr", reporter = "summary")
- R CMD check --no-manual survivalr_0.1.0.tar.gz
- seeded concordance parity replay through case 54