### PR TITLE
Use n weights for single-event concordance

### DIFF
--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -8750,6 +8750,34 @@ def test_concordance_strata_without_standard_errors_remain_available_in_python()
     assert result.variance is None
 
 
+def test_concordance_single_event_strata_use_unweighted_time_counts():
+    result = survival.concordancefit(
+        survival.Surv(
+            [4, 6, 4, 4, 7, 2, 5, 3, 5, 3],
+            [0, 1, 1, 0, 0, 1, 0, 0, 0, 0],
+        ),
+        [0.5, -1, -0.5, 1, 1, -0.5, 0, 0.5, 1, 0.5],
+        strata=[1, 2, 2, 2, 1, 1, 1, 3, 3, 3],
+        timewt="I",
+        reverse=True,
+        keepstrata=True,
+        influence=3,
+    )
+
+    assert result is not None
+    assert result.concordance == pytest.approx(1 / 11)
+    assert result.strata_counts is not None
+    expected_counts = [
+        [0, 3, 0, 0, 0],
+        [1 / 3, 1 / 3, 0, 0, 0],
+        [0, 0, 0, 0, 0],
+    ]
+    for actual, expected in zip(result.strata_counts, expected_counts, strict=True):
+        assert actual == pytest.approx(expected)
+    assert result.variance == pytest.approx(0.01980739020558704)
+    assert result.conditional_variance == pytest.approx(0.10950413223140498)
+
+
 def test_concordance_stratified_multi_score_remains_available_in_python():
     result = survival.concordancefit(
         survival.Surv([1, 2, 3, 1, 2, 3], [1, 0, 1, 1, 0, 1]),

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -11969,8 +11969,33 @@ concordance <- function(object, ..., formula) {
   ncol(design)
 }
 
+.concordance_zero_event_strata <- function(response, strata, n_strata) {
+  survival_response <- inherits(response, "Surv") ||
+    inherits(response, "survival_py_surv")
+  if (!survival_response || is.null(strata)) {
+    return(rep(FALSE, n_strata))
+  }
+  native_response <- .as_native_surv(response)
+  status <- native_response[, ncol(native_response)]
+  event_counts <- vapply(
+    split(status, droplevels(as.factor(strata))),
+    sum,
+    numeric(1)
+  )
+  event_counts == 0
+}
+
+.concordance_disabled_count_length <- function(
+    response, strata, n_strata, n_scores = 1L) {
+  n_scores * (
+    n_strata * 5L +
+      sum(.concordance_zero_event_strata(response, strata, n_strata))
+  )
+}
+
 .concordance_collapsed_strata_check <- function(
-    n_scores, n_strata, keepstrata, timewt, response = NULL, std.err = TRUE) {
+    n_scores, n_strata, keepstrata, timewt, response = NULL,
+    std.err = TRUE, strata = NULL) {
   if (n_scores != 1L || n_strata <= 1L) {
     return(invisible(NULL))
   }
@@ -11987,11 +12012,13 @@ concordance <- function(object, ..., formula) {
       (is.logical(std.err) || is.numeric(std.err)) &&
       !is.na(std.err) &&
       !as.logical(std.err)
-    survival_response <- inherits(response, "Surv") ||
-      inherits(response, "survival_py_surv")
-    counting_response <- survival_response && ncol(.as_native_surv(response)) == 3L
-    if (disabled && !counting_response) {
-      matrix(numeric(n_strata * 5L), ncol = 6L, byrow = TRUE)
+    if (disabled) {
+      count_length <- .concordance_disabled_count_length(
+        response,
+        strata,
+        n_strata
+      )
+      matrix(numeric(count_length), ncol = 6L, byrow = TRUE)
     }
     colSums(numeric())
   }
@@ -12014,24 +12041,12 @@ concordance <- function(object, ..., formula) {
   if (n_strata <= 1L) {
     matrix(numeric(n_scores * 5L), nrow = n_scores, ncol = 5L)[, 6L]
   } else {
-    survival_response <- inherits(response, "Surv") ||
-      inherits(response, "survival_py_surv")
-    native_response <- if (survival_response) .as_native_surv(response) else NULL
-    count_width <- if (!is.null(native_response) && ncol(native_response) == 3L) {
-      6L
-    } else {
-      5L
-    }
-    count_length <- n_strata * n_scores * count_width
-    if (!is.null(native_response) && !is.null(strata) && count_width < 6L) {
-      status <- native_response[, ncol(native_response)]
-      event_counts <- vapply(
-        split(status, droplevels(as.factor(strata))),
-        sum,
-        numeric(1)
-      )
-      count_length <- count_length + n_scores * sum(event_counts == 0)
-    }
+    count_length <- .concordance_disabled_count_length(
+      response,
+      strata,
+      n_strata,
+      n_scores
+    )
     count <- matrix(
       numeric(count_length),
       ncol = 6L,
@@ -12044,7 +12059,7 @@ concordance <- function(object, ..., formula) {
 }
 
 .concordance_disabled_standard_error_strata_values <- function(
-    result, n_scores, std.err) {
+    result, n_scores, std.err, response = NULL, strata = NULL, reverse = FALSE) {
   disabled <- length(std.err) == 1L &&
     (is.logical(std.err) || is.numeric(std.err)) &&
     !is.na(std.err) &&
@@ -12055,13 +12070,29 @@ concordance <- function(object, ..., formula) {
 
   count_names <- colnames(result$count)
   strata_names <- rownames(result$count)
-  count <- matrix(as.vector(t(result$count)), ncol = 6L, byrow = TRUE)
+  raw_count <- result$count
+  if (isTRUE(reverse)) {
+    raw_count <- raw_count[, c(2L, 1L, 3L, 4L, 5L), drop = FALSE]
+  }
+  append_sixth <- .concordance_zero_event_strata(
+    response,
+    strata,
+    nrow(raw_count)
+  )
+  count_values <- unlist(lapply(seq_len(nrow(raw_count)), function(index) {
+    c(raw_count[index, ], if (append_sixth[[index]]) 0)
+  }), use.names = FALSE)
+  count <- matrix(count_values, ncol = 6L, byrow = TRUE)
   totals <- colSums(count)
   comparable <- sum(totals[seq_len(3L)])
   result$concordance <- (
     1 + (totals[[1L]] - totals[[2L]]) / comparable
   ) / 2
+  if (isTRUE(reverse)) result$concordance <- 1 - result$concordance
   result$count <- count[, seq_len(5L), drop = FALSE]
+  if (isTRUE(reverse)) {
+    result$count <- result$count[, c(2L, 1L, 3L, 4L, 5L), drop = FALSE]
+  }
   dimnames(result$count) <- list(strata_names, count_names)
   result
 }
@@ -12997,7 +13028,8 @@ concordancefit <- function(y, x, strata, weights, ymin = NULL, ymax = NULL,
     keepstrata,
     timewt,
     y,
-    std.err
+    std.err,
+    input_strata
   )
 
   multi_score <- length(concordance) > 1L
@@ -13017,7 +13049,10 @@ concordancefit <- function(y, x, strata, weights, ymin = NULL, ymax = NULL,
   out <- .concordance_disabled_standard_error_strata_values(
     out,
     n_scores,
-    std.err
+    std.err,
+    y,
+    input_strata,
+    reverse
   )
   variance <- .result_field(result, "variance")
   conditional_variance <- .as_numeric_vector(.result_field(result, "conditional_variance"))

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -4693,6 +4693,94 @@ test_that("disabled standard errors recycle retained strata counts like referenc
   expect_equal(unclass(bridged), unclass(reference), tolerance = 1e-12)
 })
 
+test_that("single-event strata use unweighted time counts like reference", {
+  data <- data.frame(
+    time = c(4, 6, 4, 4, 7, 2, 5, 3, 5, 3),
+    status = c(0, 1, 1, 0, 0, 1, 0, 0, 0, 0),
+    x = c(0.5, -1, -0.5, 1, 1, -0.5, 0, 0.5, 1, 0.5),
+    group = c(1, 2, 2, 2, 1, 1, 1, 3, 3, 3)
+  )
+
+  bridged <- concordancefit(
+    Surv(data$time, data$status),
+    data$x,
+    strata = data$group,
+    timewt = "I",
+    reverse = TRUE,
+    keepstrata = TRUE,
+    influence = 3
+  )
+  reference <- survival::concordancefit(
+    survival::Surv(data$time, data$status),
+    data$x,
+    strata = data$group,
+    timewt = "I",
+    reverse = TRUE,
+    keepstrata = TRUE,
+    influence = 3
+  )
+  expect_equal(unclass(bridged), unclass(reference), tolerance = 1e-12)
+
+  warning_message <- paste(
+    "data length [16] is not a sub-multiple or multiple",
+    "of the number of rows [3]"
+  )
+  bridged_no_error <- NULL
+  expect_warning(
+    bridged_no_error <- concordancefit(
+      Surv(data$time, data$status),
+      data$x,
+      strata = data$group,
+      timewt = "I",
+      reverse = TRUE,
+      keepstrata = TRUE,
+      std.err = FALSE
+    ),
+    warning_message,
+    fixed = TRUE
+  )
+  reference_no_error <- NULL
+  expect_warning(
+    reference_no_error <- survival::concordancefit(
+      survival::Surv(data$time, data$status),
+      data$x,
+      strata = data$group,
+      timewt = "I",
+      reverse = TRUE,
+      keepstrata = TRUE,
+      std.err = FALSE
+    ),
+    warning_message,
+    fixed = TRUE
+  )
+  expect_equal(
+    unclass(bridged_no_error),
+    unclass(reference_no_error),
+    tolerance = 1e-12
+  )
+
+  bridged_formula <- concordance(
+    Surv(time, status) ~ x + strata(group),
+    data = data,
+    timewt = "I",
+    keepstrata = TRUE,
+    influence = 3
+  )
+  reference_formula <- survival::concordance(
+    survival::Surv(time, status) ~ x + strata(group),
+    data = data,
+    timewt = "I",
+    keepstrata = TRUE,
+    influence = 3
+  )
+  fields <- setdiff(names(reference_formula), "call")
+  expect_equal(
+    unclass(bridged_formula)[fields],
+    unclass(reference_formula)[fields],
+    tolerance = 1e-12
+  )
+})
+
 test_that("disabled standard errors warn before collapsed strata errors", {
   data <- data.frame(
     time = c(3, 2, 1, 1, 1, 3, 1, 4),

--- a/src/concordance/basic.rs
+++ b/src/concordance/basic.rs
@@ -236,6 +236,17 @@ fn concordance_time_weight_multiplier(
     }
 }
 
+fn effective_concordance_time_weight(
+    status: &[i32],
+    time_weight: ConcordanceTimeWeight,
+) -> ConcordanceTimeWeight {
+    if status.iter().sum::<i32>() < 2 {
+        ConcordanceTimeWeight::N
+    } else {
+        time_weight
+    }
+}
+
 fn multiplier_at(multipliers: &[(f64, f64)], time: f64) -> f64 {
     match multipliers.binary_search_by(|(candidate, _)| candidate.total_cmp(&time)) {
         Ok(idx) => multipliers[idx].1,
@@ -292,6 +303,7 @@ fn right_concordance_time_weight_multipliers_by(
     time_weight: ConcordanceTimeWeight,
     times_match: impl Fn(f64, f64) -> bool,
 ) -> Vec<(f64, f64)> {
+    let time_weight = effective_concordance_time_weight(status, time_weight);
     if time_weight == ConcordanceTimeWeight::N {
         let mut values: Vec<f64> = time
             .iter()
@@ -549,6 +561,7 @@ fn counting_concordance_time_weight_multipliers(
     weights: Option<&[f64]>,
     time_weight: ConcordanceTimeWeight,
 ) -> Vec<(f64, f64)> {
+    let time_weight = effective_concordance_time_weight(status, time_weight);
     let mut event_indices: Vec<usize> = status
         .iter()
         .enumerate()
@@ -1355,6 +1368,7 @@ fn right_concordance_summary_for_vectors(
     weights: Option<&[f64]>,
     time_weight: ConcordanceTimeWeight,
 ) -> ConcordanceSummary {
+    let time_weight = effective_concordance_time_weight(status, time_weight);
     if time_weight == ConcordanceTimeWeight::N {
         match weights {
             Some(values) => concordance_summary_with_horizon_and_weights(
@@ -1386,6 +1400,7 @@ fn counting_concordance_summary_for_vectors(
     weights: Option<&[f64]>,
     time_weight: ConcordanceTimeWeight,
 ) -> ConcordanceSummary {
+    let time_weight = effective_concordance_time_weight(status, time_weight);
     if time_weight == ConcordanceTimeWeight::N {
         match weights {
             Some(values) => counting_process_concordance_summary_with_weights(
@@ -2507,6 +2522,38 @@ mod tests {
             );
             assert_eq!(multipliers, vec![(1.0, 1.0), (2.0, 1.0), (3.0, 4.0)]);
         }
+    }
+
+    #[test]
+    fn single_event_concordance_uses_unweighted_time_counts() {
+        let time = [4.0, 7.0, 2.0, 5.0];
+        let status = [0, 0, 1, 0];
+        let risk = [0.5, 1.0, -0.5, 0.0];
+        let unweighted = right_concordance_summary_for_vectors(
+            &time,
+            &status,
+            &risk,
+            None,
+            ConcordanceTimeWeight::N,
+        );
+        let importance = right_concordance_summary_for_vectors(
+            &time,
+            &status,
+            &risk,
+            None,
+            ConcordanceTimeWeight::I,
+        );
+
+        assert_eq!(importance, unweighted);
+        assert_eq!(
+            right_concordance_time_weight_multipliers(
+                &time,
+                &status,
+                None,
+                ConcordanceTimeWeight::I,
+            ),
+            vec![(2.0, 1.0)]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- force per-stratum n weighting when fewer than two events are present
- apply the fallback consistently to summaries, ranks, influence, and conditional variance
- reconstruct disabled-standard-error count streams before reverse and recycling

## Testing
- cargo test
- cargo fmt --check
- python -m pytest -q python/tests
- ruff check python/tests/test_r_api.py
- testthat::test_local("r/survivalr", reporter = "summary")
- R CMD check --no-manual survivalr_0.1.0.tar.gz
- seeded concordance replay through case 74 with independent counting-S case 48 isolated