### PR TITLE
Match stratified concordance rank assembly

### DIFF
--- a/python/survival/_survival.pyi
+++ b/python/survival/_survival.pyi
@@ -7852,6 +7852,7 @@ def stratified_concordance_rank_rows(
     weights: list[float] | None = None,
     timewt: str = "n",
     order_scores: list[float] | None = None,
+    display_times: list[float] | None = None,
 ) -> list[tuple[float, float, float, float]]: ...
 def concordance_influence_rows(
     time: list[float],
@@ -7926,6 +7927,7 @@ def stratified_counting_concordance_rank_rows(
     timewt: str = "n",
     timefix: bool | None = None,
     order_scores: list[float] | None = None,
+    display_stop: list[float] | None = None,
 ) -> list[tuple[float, float, float, float]]: ...
 def counting_concordance_influence_rows(
     start: list[float],

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -26122,6 +26122,7 @@ def _concordance_rank_row_dicts(
 class _RightConcordanceData:
     times: list[float]
     status: list[int]
+    display_times: list[float]
     display_by_core_time: dict[float, float] | None
 
 
@@ -26140,6 +26141,7 @@ class _RightConcordanceInputs:
     risk: list[float]
     weights: list[float] | None
     strata: list[int] | None
+    display_times: list[float]
     padding_count: int
 
 
@@ -26151,6 +26153,7 @@ class _CountingConcordanceInputs:
     risk: list[float]
     weights: list[float] | None
     strata: list[int] | None
+    display_stop: list[float]
     padding_count: int
 
 
@@ -26215,6 +26218,7 @@ def _right_concordance_inputs(
         strata,
     )
     padding_count = len(padding)
+    dummy_display_time = max(data.display_times, default=0.0) + 1.0
     return _RightConcordanceInputs(
         [*data.times, *([max(data.times, default=0.0) + 1.0] * padding_count)],
         [*data.status, *([1] * padding_count)],
@@ -26225,6 +26229,7 @@ def _right_concordance_inputs(
             if strata is None
             else [*strata, *(int(group) for group in padding)]
         ),
+        [*data.display_times, *([dummy_display_time] * padding_count)],
         padding_count,
     )
 
@@ -26256,6 +26261,10 @@ def _counting_concordance_inputs(
             if strata is None
             else [*strata, *(int(group) for group in padding)]
         ),
+        [
+            *(value - data.display_offset for value in data.stop),
+            *([dummy_stop - data.display_offset] * padding_count),
+        ],
         padding_count,
     )
 
@@ -26409,7 +26418,7 @@ def _right_concordance_data(
     status = list(response.event)
     times, status = _concordance_bounded_times_and_status(times, status, ymin, ymax)
     core_times, display_by_core_time = _concordance_core_time_values(times, timefix)
-    return _RightConcordanceData(core_times, status, display_by_core_time)
+    return _RightConcordanceData(core_times, status, times, display_by_core_time)
 
 
 def _counting_concordance_data(
@@ -26545,8 +26554,8 @@ def _concordance_ranks(
                     inputs.weights,
                     timewt,
                     [*order_scores, *([0.0] * inputs.padding_count)],
+                    inputs.display_times,
                 ),
-                data.display_by_core_time,
             ),
             None,
         )
@@ -26578,11 +26587,9 @@ def _concordance_ranks(
                 timewt,
                 False,
                 [*order_scores, *([0.0] * inputs.padding_count)],
+                inputs.display_stop,
             )
         )
-        if data.display_offset > 0.0:
-            for row in rank_rows:
-                row["time"] -= data.display_offset
         return rank_rows, None
     return _unsupported_concordance_response()
 

--- a/python/tests/test_binding_contract.py
+++ b/python/tests/test_binding_contract.py
@@ -9823,6 +9823,7 @@ def test_counting_concordance_binding_is_typed():
         "weights",
         "timewt",
         "order_scores",
+        "display_times",
     ]
     assert _pyi_function_arg_names(stub_path, "concordance_influence_rows") == [
         "time",
@@ -9897,6 +9898,7 @@ def test_counting_concordance_binding_is_typed():
         "timewt",
         "timefix",
         "order_scores",
+        "display_stop",
     ]
     assert _pyi_function_arg_names(stub_path, "counting_concordance_influence_rows") == [
         "start",

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -8825,6 +8825,35 @@ def test_bounded_concordance_time_weights_use_the_original_event_count():
     assert right.influence[4] == pytest.approx([0.5, 7 / 18, 1 / 18, 0, 0])
 
 
+def test_stratified_concordance_rank_recycling_uses_display_times():
+    result = survival.concordancefit(
+        survival.Surv([2, 6, 7, 2, 1, 7, 6], [1, 0, 1, 0, 0, 1, 0]),
+        [0.5, 0.5, -1, 0.5, 0, 0.5, 1],
+        strata=[1, 1, 1, 2, 2, 2, 1],
+        weights=[1.5, 1.5, 0.5, 1.5, 1, 1.5, 0.5],
+        ymin=1,
+        timewt="n/G2",
+        influence=3,
+        ranks=True,
+        timefix=False,
+        keepstrata=True,
+    )
+
+    assert result is not None
+    assert result.ranks is not None
+    expected = [
+        [2, 4, 2, 4],
+        [7, 12.5, 7, 12.5],
+        [0, 1.5, 0, 1.5],
+        [7, 1.5, 1.5, 0],
+        [0, 7, 1.5, 1.5],
+        [1.5, 0, 7, 1.5],
+        [0, 0.5, 0, 0.5],
+    ]
+    for row, values in zip(result.ranks, expected, strict=True):
+        assert list(row.values()) == pytest.approx(values)
+
+
 def test_concordance_stratified_multi_score_remains_available_in_python():
     result = survival.concordancefit(
         survival.Surv([1, 2, 3, 1, 2, 3], [1, 0, 1, 1, 0, 1]),

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -12133,23 +12133,25 @@ concordance <- function(object, ..., formula) {
   }
   groups <- droplevels(as.factor(strata_values))
   event_counts <- vapply(split(status, groups), sum, numeric(1))
-  if (any(event_counts == 0)) {
-    if (n_scores > 1L) {
-      array(NULL, dim = c(0L, n_scores))
-    }
-    if (n_strata > 1L) {
-      stop(
-        "number of items to replace is not a multiple of replacement length",
-        call. = FALSE
-      )
-    }
-    return(invisible(NULL))
-  }
   rank_status <- status
   if (!is.null(ymax)) rank_status[event_time > ymax] <- 0
   rank_counts <- vapply(split(rank_status, groups), sum, numeric(1))
-  if (n_strata > 1L && any(rank_counts == 0)) {
-    stop("replacement has length zero", call. = FALSE)
+  for (index in seq_along(event_counts)) {
+    if (event_counts[[index]] == 0) {
+      if (n_scores > 1L) {
+        array(NULL, dim = c(0L, n_scores))
+      }
+      if (n_strata > 1L) {
+        stop(
+          "number of items to replace is not a multiple of replacement length",
+          call. = FALSE
+        )
+      }
+      return(invisible(NULL))
+    }
+    if (n_strata > 1L && rank_counts[[index]] == 0) {
+      stop("replacement has length zero", call. = FALSE)
+    }
   }
   invisible(NULL)
 }

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -5087,6 +5087,74 @@ test_that("uneven stratified concordance ranks match reference errors", {
   }
 })
 
+test_that("stratified concordance rank recycling uses display times", {
+  time <- c(2, 6, 7, 2, 1, 7, 6)
+  status <- c(1, 0, 1, 0, 0, 1, 0)
+  scores <- c(0.5, 0.5, -1, 0.5, 0, 0.5, 1)
+  groups <- c(1, 1, 1, 2, 2, 2, 1)
+  weights <- c(1.5, 1.5, 0.5, 1.5, 1, 1.5, 0.5)
+
+  bridged <- concordancefit(
+    Surv(time, status),
+    scores,
+    strata = groups,
+    weights = weights,
+    ymin = 1,
+    timewt = "n/G2",
+    influence = 3,
+    ranks = TRUE,
+    timefix = FALSE,
+    keepstrata = TRUE
+  )
+  reference <- survival::concordancefit(
+    survival::Surv(time, status),
+    scores,
+    strata = groups,
+    weights = weights,
+    ymin = 1,
+    timewt = "n/G2",
+    influence = 3,
+    ranks = TRUE,
+    timefix = FALSE,
+    keepstrata = TRUE
+  )
+  expect_equal(unclass(bridged), unclass(reference), tolerance = 1e-12)
+})
+
+test_that("stratified concordance rank errors follow stratum order", {
+  start <- rep(0, 6)
+  stop <- c(1, 2, 6, 2, 1, 2)
+  status <- c(1, 0, 1, 0, 0, 0)
+  scores <- seq_len(6)
+  groups <- rep(seq_len(3), each = 2)
+  replacement_error <- "replacement has length zero"
+
+  expect_error(
+    concordancefit(
+      Surv(start, stop, status),
+      scores,
+      strata = groups,
+      ymax = 5,
+      timewt = "S",
+      ranks = TRUE
+    ),
+    replacement_error,
+    fixed = TRUE
+  )
+  expect_error(
+    survival::concordancefit(
+      survival::Surv(start, stop, status),
+      scores,
+      strata = groups,
+      ymax = 5,
+      timewt = "S",
+      ranks = TRUE
+    ),
+    replacement_error,
+    fixed = TRUE
+  )
+})
+
 test_that("clustered concordance dfbeta matches reference order and names", {
   data <- data.frame(
     time = c(2, 3, 4, 5, 2),

--- a/src/concordance/basic.rs
+++ b/src/concordance/basic.rs
@@ -988,6 +988,7 @@ fn counting_concordance_rank_rows_for_vectors(
 fn reassemble_stratified_rank_rows(
     n: usize,
     groups: Vec<Vec<usize>>,
+    display_times: Option<&[f64]>,
     mut compute_group: impl FnMut(&[usize]) -> IndexedConcordanceRankRows,
 ) -> PyResult<ConcordanceRankRows> {
     let mut result = vec![[0.0; 4]; n];
@@ -998,10 +999,11 @@ fn reassemble_stratified_rank_rows(
                 "number of items to replace is not a multiple of replacement length",
             ));
         }
+        let group_indices = &indices;
         let source: Vec<f64> = (0..4)
             .flat_map(|column| {
                 group_rows.iter().map(move |row| match column {
-                    0 => row.1,
+                    0 => display_times.map_or(row.1, |values| values[group_indices[row.0]]),
                     1 => row.2,
                     2 => row.3,
                     _ => row.4,
@@ -1037,6 +1039,7 @@ fn split_indexed_rank_rows(rows: IndexedConcordanceRankRows) -> ConcordanceRankR
     (values, indices)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn stratified_right_concordance_rank_rows(
     time: &[f64],
     status: &[i32],
@@ -1045,23 +1048,29 @@ fn stratified_right_concordance_rank_rows(
     strata: &[i32],
     weights: Option<&[f64]>,
     time_weight: ConcordanceTimeWeight,
+    display_times: Option<&[f64]>,
 ) -> PyResult<ConcordanceRankRows> {
-    reassemble_stratified_rank_rows(time.len(), strata_groups(strata), |indices| {
-        let group_time: Vec<f64> = indices.iter().map(|&idx| time[idx]).collect();
-        let group_status: Vec<i32> = indices.iter().map(|&idx| status[idx]).collect();
-        let group_risk: Vec<f64> = indices.iter().map(|&idx| risk_scores[idx]).collect();
-        let group_order: Vec<f64> = indices.iter().map(|&idx| order_scores[idx]).collect();
-        let group_weights: Option<Vec<f64>> =
-            weights.map(|values| indices.iter().map(|&idx| values[idx]).collect());
-        right_concordance_rank_rows_for_vectors(
-            &group_time,
-            &group_status,
-            &group_risk,
-            &group_order,
-            group_weights.as_deref(),
-            time_weight,
-        )
-    })
+    reassemble_stratified_rank_rows(
+        time.len(),
+        strata_groups(strata),
+        display_times,
+        |indices| {
+            let group_time: Vec<f64> = indices.iter().map(|&idx| time[idx]).collect();
+            let group_status: Vec<i32> = indices.iter().map(|&idx| status[idx]).collect();
+            let group_risk: Vec<f64> = indices.iter().map(|&idx| risk_scores[idx]).collect();
+            let group_order: Vec<f64> = indices.iter().map(|&idx| order_scores[idx]).collect();
+            let group_weights: Option<Vec<f64>> =
+                weights.map(|values| indices.iter().map(|&idx| values[idx]).collect());
+            right_concordance_rank_rows_for_vectors(
+                &group_time,
+                &group_status,
+                &group_risk,
+                &group_order,
+                group_weights.as_deref(),
+                time_weight,
+            )
+        },
+    )
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1074,8 +1083,9 @@ fn stratified_counting_concordance_rank_rows_for_strata(
     strata: &[i32],
     weights: Option<&[f64]>,
     time_weight: ConcordanceTimeWeight,
+    display_stop: Option<&[f64]>,
 ) -> PyResult<ConcordanceRankRows> {
-    reassemble_stratified_rank_rows(stop.len(), strata_groups(strata), |indices| {
+    reassemble_stratified_rank_rows(stop.len(), strata_groups(strata), display_stop, |indices| {
         let group_start: Vec<f64> = indices.iter().map(|&idx| start[idx]).collect();
         let group_stop: Vec<f64> = indices.iter().map(|&idx| stop[idx]).collect();
         let group_status: Vec<i32> = indices.iter().map(|&idx| status[idx]).collect();
@@ -1788,7 +1798,8 @@ pub fn concordance_rank_rows(
 }
 
 #[pyfunction]
-#[pyo3(signature = (time, status, risk_scores, strata, weights=None, timewt="n".to_string(), order_scores=None))]
+#[allow(clippy::too_many_arguments)]
+#[pyo3(signature = (time, status, risk_scores, strata, weights=None, timewt="n".to_string(), order_scores=None, display_times=None))]
 pub fn stratified_concordance_rank_rows(
     time: Vec<f64>,
     status: Vec<i32>,
@@ -1797,6 +1808,7 @@ pub fn stratified_concordance_rank_rows(
     weights: Option<Vec<f64>>,
     timewt: String,
     order_scores: Option<Vec<f64>>,
+    display_times: Option<Vec<f64>>,
 ) -> PyResult<ConcordanceRankRows> {
     validate_right_concordance_inputs(&time, &status, &risk_scores, weights.as_deref())?;
     validate_strata_length(time.len(), &strata, "time")?;
@@ -1806,6 +1818,14 @@ pub fn stratified_concordance_rank_rows(
     {
         return Err(PyValueError::new_err(
             "order_scores must have the same length as time",
+        ));
+    }
+    if display_times
+        .as_ref()
+        .is_some_and(|values| values.len() != time.len())
+    {
+        return Err(PyValueError::new_err(
+            "display_times must have the same length as time",
         ));
     }
     let time_weight = parse_concordance_time_weight(&timewt)?;
@@ -1818,6 +1838,7 @@ pub fn stratified_concordance_rank_rows(
         &strata,
         weights.as_deref(),
         time_weight,
+        display_times.as_deref(),
     )
 }
 
@@ -2071,7 +2092,7 @@ pub fn counting_concordance_rank_rows(
 
 #[pyfunction]
 #[allow(clippy::too_many_arguments)]
-#[pyo3(signature = (start, stop, status, risk_scores, strata, weights=None, timewt="n".to_string(), timefix=None, order_scores=None))]
+#[pyo3(signature = (start, stop, status, risk_scores, strata, weights=None, timewt="n".to_string(), timefix=None, order_scores=None, display_stop=None))]
 pub fn stratified_counting_concordance_rank_rows(
     start: Vec<f64>,
     stop: Vec<f64>,
@@ -2082,6 +2103,7 @@ pub fn stratified_counting_concordance_rank_rows(
     timewt: String,
     timefix: Option<bool>,
     order_scores: Option<Vec<f64>>,
+    display_stop: Option<Vec<f64>>,
 ) -> PyResult<ConcordanceRankRows> {
     let (start, stop) = prepare_counting_concordance_times(&start, &stop, timefix);
     validate_counting_concordance_inputs(
@@ -2101,6 +2123,14 @@ pub fn stratified_counting_concordance_rank_rows(
             "order_scores must have the same length as start",
         ));
     }
+    if display_stop
+        .as_ref()
+        .is_some_and(|values| values.len() != start.len())
+    {
+        return Err(PyValueError::new_err(
+            "display_stop must have the same length as start",
+        ));
+    }
     let time_weight = parse_counting_concordance_time_weight(&timewt)?;
     let order_scores = order_scores.as_deref().unwrap_or(&risk_scores);
     stratified_counting_concordance_rank_rows_for_strata(
@@ -2112,6 +2142,7 @@ pub fn stratified_counting_concordance_rank_rows(
         &strata,
         weights.as_deref(),
         time_weight,
+        display_stop.as_deref(),
     )
 }
 
@@ -2979,6 +3010,7 @@ mod tests {
             None,
             "n".to_string(),
             None,
+            None,
         )
         .unwrap();
 
@@ -2994,6 +3026,36 @@ mod tests {
     }
 
     #[test]
+    fn stratified_concordance_rank_rows_recycle_display_times() {
+        initialize_python();
+
+        let rows = stratified_concordance_rank_rows(
+            vec![2e-9, 4e-9, 6e-9, 2e-9, 0.0, 6e-9, 4e-9],
+            vec![1, 0, 1, 0, 0, 1, 0],
+            vec![0.5, 0.5, -1.0, 0.5, 0.0, 0.5, 1.0],
+            vec![0, 0, 0, 1, 1, 1, 0],
+            Some(vec![1.5, 1.5, 0.5, 1.5, 1.0, 1.5, 0.5]),
+            "n/G2".to_string(),
+            None,
+            Some(vec![2.0, 6.0, 7.0, 2.0, 1.0, 7.0, 6.0]),
+        )
+        .unwrap();
+
+        assert_eq!(
+            rows,
+            vec![
+                (2.0, 4.0, 2.0, 4.0),
+                (7.0, 12.499999999999998, 7.0, 12.499999999999998),
+                (0.0, 1.5, 0.0, 1.5),
+                (7.0, 1.5, 1.5, 0.0),
+                (0.0, 7.0, 1.5, 1.5),
+                (1.5, 0.0, 7.0, 1.5),
+                (0.0, 0.5, 0.0, 0.5),
+            ]
+        );
+    }
+
+    #[test]
     fn stratified_concordance_rank_rows_reject_empty_stratum_residuals() {
         initialize_python();
 
@@ -3004,6 +3066,7 @@ mod tests {
             vec![0, 0, 1, 1],
             None,
             "n".to_string(),
+            None,
             None,
         )
         .unwrap_err();
@@ -3027,6 +3090,7 @@ mod tests {
             vec![0, 0, 1, 1],
             None,
             "n".to_string(),
+            None,
             None,
             None,
         )
@@ -3055,6 +3119,7 @@ mod tests {
             vec![0, 0, 0, 0, 1, 1, 1, 1],
             Some(vec![1.0, 2.0, 1.5, 0.5, 3.0, 1.0, 2.5, 2.0]),
             "n".to_string(),
+            None,
             None,
             None,
         )


### PR DESCRIPTION
## Summary
- preserve original display times when R-style stratified rank matrices recycle uneven residual rows
- make empty-rank error selection follow stratum order when bounds remove earlier event rows
- update typed bindings and cross-language regressions

## Validation
- cargo fmt --check
- cargo clippy --manifest-path Cargo.toml --all-targets --all-features -- -D warnings
- cargo test (1572 passed)
- .venv/bin/python -m pytest -q python/tests (1110 passed)
- .venv/bin/ruff check on modified Python files
- full R testthat suite (3 established warnings)
- R CMD build r/survivalr
- R CMD check --no-manual survivalr_0.1.0.tar.gz (Status: OK)
- deterministic 500-case concordance parity sweep