### PR TITLE
Preserve zero-pair concordance variance ratios

### DIFF
--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -8952,6 +8952,25 @@ def test_concordance_zero_pair_diagnostics_remain_finite_in_python():
     assert all(value == 0.0 for column in result.dfbeta for value in column)
 
 
+def test_stratified_counting_zero_pair_conditional_variance_is_infinite():
+    result = survival.concordancefit(
+        survival.Surv(
+            [2, 3, 0, 2, 4],
+            [5, 6, 1, 4, 5],
+            [1, 0, 0, 0, 1],
+        ),
+        [0, 0.5, 1, 1, 1],
+        strata=[2, 1, 1, 1, 2],
+        ymax=5,
+        timewt="S",
+        influence=2,
+    )
+
+    assert result is not None
+    assert result.comparable == 0
+    assert math.isinf(result.conditional_variance)
+
+
 def test_concordance_collapsed_single_score_strata_remain_available_in_python():
     result = survival.concordancefit(
         survival.Surv([1, 2, 1, 2], [1, 0, 1, 0]),

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -12882,13 +12882,11 @@ survConcordance.fit <- function(y, x, strata, weight) {
   if (!multi_score) {
     result$concordance[] <- NaN
     if (!is.null(result$var)) result$var[] <- NaN
-    if (!is.null(result$cvar)) result$cvar[] <- NaN
     if (!is.null(result$dfbeta)) result$dfbeta[] <- NaN
     return(result)
   }
 
   result$concordance[empty] <- NaN
-  if (!is.null(result$cvar)) result$cvar[empty] <- NaN
   if (!is.null(result$var)) {
     result$var[empty, ] <- NaN
     result$var[, empty] <- NaN

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -5534,6 +5534,34 @@ test_that("zero-pair concordance diagnostics match reference values", {
   }
 })
 
+test_that("zero-pair conditional variance preserves infinite ratios", {
+  start <- c(2, 3, 0, 2, 4)
+  stop <- c(5, 6, 1, 4, 5)
+  status <- c(1, 0, 0, 0, 1)
+  scores <- c(0, 0.5, 1, 1, 1)
+  groups <- c(2, 1, 1, 1, 2)
+
+  bridged <- concordancefit(
+    Surv(start, stop, status),
+    scores,
+    strata = groups,
+    ymax = 5,
+    timewt = "S",
+    influence = 2
+  )
+  reference <- survival::concordancefit(
+    survival::Surv(start, stop, status),
+    scores,
+    strata = groups,
+    ymax = 5,
+    timewt = "S",
+    influence = 2
+  )
+
+  expect_equal(unclass(bridged), unclass(reference), tolerance = 1e-12)
+  expect_true(is.infinite(bridged$cvar))
+})
+
 test_that("collapsed single-score strata match reference behavior", {
   data <- data.frame(
     time = c(1, 2, 1, 2),


### PR DESCRIPTION
## Summary
- preserve the computed conditional-variance ratio when no comparable pairs remain
- retain `NaN` for zero-over-zero while allowing positive-over-zero to remain `Inf`
- add Python and R regressions for the stratified counting boundary

## Validation
- .venv/bin/python -m pytest -q python/tests (1111 passed)
- .venv/bin/ruff check python/tests/test_r_api.py
- cargo fmt --check
- full R testthat suite (3 established warnings)
- R CMD build r/survivalr
- R CMD check --no-manual survivalr_0.1.0.tar.gz (Status: OK)
- second deterministic concordance seed: all 500 generated cases matched after the fix
