### PR TITLE
Match reversed stratified concordance rank recycling

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -26521,6 +26521,7 @@ def _concordance_ranks(
     timewt: str,
     ymin: float | None,
     ymax: float | None,
+    reverse_recycled_ranks: bool = False,
 ) -> tuple[list[dict[str, float]], list[int] | None]:
     if strata is None:
         return _single_concordance_ranks(
@@ -26534,6 +26535,9 @@ def _concordance_ranks(
             ymax,
         )
     strata_codes = strata.codes(len(response))
+    recycled_risk_values = (
+        [-value for value in risk_values] if reverse_recycled_ranks else risk_values
+    )
     if response.type == "right":
         data = _right_concordance_data(response, timefix, ymin, ymax)
         inputs = _right_concordance_inputs(
@@ -26544,21 +26548,25 @@ def _concordance_ranks(
             timewt,
             strata_codes,
         )
-        return (
-            _concordance_rank_row_dicts(
-                _core.stratified_concordance_rank_rows(
-                    inputs.times,
-                    inputs.status,
-                    inputs.risk,
-                    cast(list[int], inputs.strata),
-                    inputs.weights,
-                    timewt,
-                    [*order_scores, *([0.0] * inputs.padding_count)],
-                    inputs.display_times,
-                ),
+        rank_rows = _concordance_rank_row_dicts(
+            _core.stratified_concordance_rank_rows(
+                inputs.times,
+                inputs.status,
+                [
+                    *recycled_risk_values,
+                    *([0.0] * inputs.padding_count),
+                ],
+                cast(list[int], inputs.strata),
+                inputs.weights,
+                timewt,
+                [*order_scores, *([0.0] * inputs.padding_count)],
+                inputs.display_times,
             ),
-            None,
         )
+        if reverse_recycled_ranks:
+            for row in rank_rows:
+                row["rank"] = -row["rank"]
+        return rank_rows, None
     if response.type == "counting":
         data = _counting_concordance_data(
             response,
@@ -26581,7 +26589,10 @@ def _concordance_ranks(
                 inputs.start,
                 inputs.stop,
                 inputs.status,
-                inputs.risk,
+                [
+                    *recycled_risk_values,
+                    *([0.0] * inputs.padding_count),
+                ],
                 cast(list[int], inputs.strata),
                 inputs.weights,
                 timewt,
@@ -26590,6 +26601,9 @@ def _concordance_ranks(
                 inputs.display_stop,
             )
         )
+        if reverse_recycled_ranks:
+            for row in rank_rows:
+                row["rank"] = -row["rank"]
         return rank_rows, None
     return _unsupported_concordance_response()
 
@@ -26912,6 +26926,7 @@ def _single_score_concordance_result(
     row_names: list[str] | None = None,
     retain_strata: bool = False,
     strata_names: list[str] | None = None,
+    reverse_recycled_ranks: bool = False,
 ) -> ConcordanceResult:
     if len(score_values) != len(response):
         raise ValueError("scores must have the same length as the Surv response")
@@ -26943,6 +26958,7 @@ def _single_score_concordance_result(
             time_weight,
             lower_bound,
             upper_bound,
+            reverse_recycled_ranks,
         )
     rank_names = (
         [row_names[index] for index in rank_indices]
@@ -27002,6 +27018,7 @@ def _multi_score_concordance_result(
     influence_value: int,
     include_ranks: bool,
     row_names: list[str] | None = None,
+    reverse_recycled_ranks: bool = False,
 ) -> ConcordanceResult:
     # The reference fit always computes dfbeta values for standard errors,
     # even when the caller does not request that diagnostic in the result.
@@ -27020,6 +27037,7 @@ def _multi_score_concordance_result(
             3,
             include_ranks,
             row_names,
+            reverse_recycled_ranks=reverse_recycled_ranks,
         )
         for score_values in score_columns
     ]
@@ -27298,6 +27316,7 @@ def concordance(
             row_names,
             retain_strata,
             strata_values.names if strata_values is not None else None,
+            reverse_recycled_ranks=reverse_scores,
         )
         if score_names is not None:
             result = ConcordanceResult(
@@ -27339,6 +27358,7 @@ def concordance(
             influence_value,
             include_ranks,
             row_names,
+            reverse_recycled_ranks=reverse_scores,
         ),
         weight_values,
     )
@@ -27503,6 +27523,7 @@ def concordancefit(
             row_names,
             retain_strata,
             strata_values.names if strata_values is not None else None,
+            reverse_recycled_ranks=reverse_value,
         )
     else:
         computed = _multi_score_concordance_result(
@@ -27520,6 +27541,7 @@ def concordancefit(
             internal_influence,
             include_ranks,
             row_names,
+            reverse_recycled_ranks=reverse_value,
         )
 
     dfbeta = _concordancefit_dfbeta(computed.dfbeta)

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -8854,6 +8854,40 @@ def test_stratified_concordance_rank_recycling_uses_display_times():
         assert list(row.values()) == pytest.approx(values)
 
 
+def test_reversed_stratified_counting_ranks_flip_after_recycling():
+    result = survival.concordancefit(
+        survival.Surv(
+            [0, 4, 3, 1, 3, 1, 2],
+            [2, 8, 7, 5, 7, 3, 5],
+            [1, 0, 0, 0, 1, 0, 1],
+        ),
+        [1, 0.5, 1, 0.5, -1, 0, -0.5],
+        strata=[1, 1, 1, 2, 1, 2, 2],
+        weights=[1.5, 1.5, 0.5, 1.5, 1, 1.5, 0.5],
+        ymin=2,
+        timewt="I",
+        influence=2,
+        ranks=True,
+        reverse=True,
+        timefix=False,
+        keepstrata=10,
+    )
+
+    assert result is not None
+    assert result.ranks is not None
+    expected = [
+        [2, -1, 2, 1],
+        [7, -1, 7, 1],
+        [0, -1.5, 0, 1.5],
+        [5, -0.5, 2, 0.75],
+        [2 / 3, -1, 2 / 3, 1],
+        [0.75, -5, 0.5, 2],
+        [2, -0.75, 5, 0.5],
+    ]
+    for row, values in zip(result.ranks, expected, strict=True):
+        assert list(row.values()) == pytest.approx(values)
+
+
 def test_concordance_stratified_multi_score_remains_available_in_python():
     result = survival.concordancefit(
         survival.Surv([1, 2, 3, 1, 2, 3], [1, 0, 1, 1, 0, 1]),

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -5121,6 +5121,44 @@ test_that("stratified concordance rank recycling uses display times", {
   expect_equal(unclass(bridged), unclass(reference), tolerance = 1e-12)
 })
 
+test_that("reversed stratified counting ranks flip after recycling", {
+  start <- c(0, 4, 3, 1, 3, 1, 2)
+  stop <- c(2, 8, 7, 5, 7, 3, 5)
+  status <- c(1, 0, 0, 0, 1, 0, 1)
+  scores <- c(1, 0.5, 1, 0.5, -1, 0, -0.5)
+  groups <- c(1, 1, 1, 2, 1, 2, 2)
+  weights <- c(1.5, 1.5, 0.5, 1.5, 1, 1.5, 0.5)
+
+  bridged <- concordancefit(
+    Surv(start, stop, status),
+    scores,
+    strata = groups,
+    weights = weights,
+    ymin = 2,
+    timewt = "I",
+    influence = 2,
+    ranks = TRUE,
+    reverse = TRUE,
+    timefix = FALSE,
+    keepstrata = 10
+  )
+  reference <- survival::concordancefit(
+    survival::Surv(start, stop, status),
+    scores,
+    strata = groups,
+    weights = weights,
+    ymin = 2,
+    timewt = "I",
+    influence = 2,
+    ranks = TRUE,
+    reverse = TRUE,
+    timefix = FALSE,
+    keepstrata = 10
+  )
+
+  expect_equal(unclass(bridged), unclass(reference), tolerance = 1e-12)
+})
+
 test_that("stratified concordance rank errors follow stratum order", {
   start <- rep(0, 6)
   stop <- c(1, 2, 6, 2, 1, 2)


### PR DESCRIPTION
## Summary
- reconstruct pre-reversal rank contributions before stratified column-major recycling
- apply the final rank sign change after the recycled table has been assembled
- add Python and R regressions for uneven counting-process strata

## Validation
- .venv/bin/python -m pytest -q python/tests (1112 passed)
- .venv/bin/ruff check python/survival/r_api.py python/tests/test_r_api.py
- cargo fmt --check
- full R testthat suite (3 established warnings)
- R CMD build r/survivalr
- R CMD check --no-manual survivalr_0.1.0.tar.gz (Status: OK)
- third deterministic concordance seed through case 366 after the fix
