### PR TITLE
Match multi-score concordance rank error order

### DIFF
--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -12136,11 +12136,11 @@ concordance <- function(object, ..., formula) {
   rank_status <- status
   if (!is.null(ymax)) rank_status[event_time > ymax] <- 0
   rank_counts <- vapply(split(rank_status, groups), sum, numeric(1))
+  if (n_scores > 1L && any(event_counts == 0)) {
+    array(NULL, dim = c(0L, n_scores))
+  }
   for (index in seq_along(event_counts)) {
     if (event_counts[[index]] == 0) {
-      if (n_scores > 1L) {
-        array(NULL, dim = c(0L, n_scores))
-      }
       if (n_strata > 1L) {
         stop(
           "number of items to replace is not a multiple of replacement length",

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -5193,6 +5193,40 @@ test_that("stratified concordance rank errors follow stratum order", {
   )
 })
 
+test_that("multi-score rank errors finish stratum construction first", {
+  time <- c(6, 7, 1, 2)
+  status <- c(1, 1, 0, 0)
+  scores <- cbind(
+    x = c(0.2, 0.8, 0.4, 0.6),
+    z = c(0.9, 0.1, 0.3, 0.7)
+  )
+  groups <- c(1, 1, 2, 2)
+  null_error <- "'data' must be of a vector type, was 'NULL'"
+
+  expect_error(
+    concordancefit(
+      Surv(time, status),
+      scores,
+      strata = groups,
+      ymax = 5,
+      ranks = TRUE
+    ),
+    null_error,
+    fixed = TRUE
+  )
+  expect_error(
+    survival::concordancefit(
+      survival::Surv(time, status),
+      scores,
+      strata = groups,
+      ymax = 5,
+      ranks = TRUE
+    ),
+    null_error,
+    fixed = TRUE
+  )
+})
+
 test_that("clustered concordance dfbeta matches reference order and names", {
   data <- data.frame(
     time = c(2, 3, 4, 5, 2),


### PR DESCRIPTION
## Summary
- preserve multi-score stratum construction errors before rank-table assignment errors
- match the reference null-array failure when a later stratum has no events
- add a four-row R regression for the precedence boundary

## Validation
- .venv/bin/python -m pytest -q python/tests (1112 passed)
- cargo fmt --check
- full R testthat suite (3 established warnings)
- R CMD build r/survivalr
- R CMD check --no-manual survivalr_0.1.0.tar.gz (Status: OK)
- third and fourth deterministic concordance seeds: all 500 generated fixtures matched after clean-process verification of allocation-sensitive reference cases
