### PR TITLE
Exclude concordance rank padding rows

### DIFF
--- a/python/survival/_survival.pyi
+++ b/python/survival/_survival.pyi
@@ -7853,6 +7853,7 @@ def stratified_concordance_rank_rows(
     timewt: str = "n",
     order_scores: list[float] | None = None,
     display_times: list[float] | None = None,
+    output_len: int | None = None,
 ) -> list[tuple[float, float, float, float]]: ...
 def concordance_influence_rows(
     time: list[float],
@@ -7928,6 +7929,7 @@ def stratified_counting_concordance_rank_rows(
     timefix: bool | None = None,
     order_scores: list[float] | None = None,
     display_stop: list[float] | None = None,
+    output_len: int | None = None,
 ) -> list[tuple[float, float, float, float]]: ...
 def counting_concordance_influence_rows(
     start: list[float],

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -26561,6 +26561,7 @@ def _concordance_ranks(
                 timewt,
                 [*order_scores, *([0.0] * inputs.padding_count)],
                 inputs.display_times,
+                len(response),
             ),
         )
         if reverse_recycled_ranks:
@@ -26599,6 +26600,7 @@ def _concordance_ranks(
                 False,
                 [*order_scores, *([0.0] * inputs.padding_count)],
                 inputs.display_stop,
+                len(response),
             )
         )
         if reverse_recycled_ranks:

--- a/python/tests/test_binding_contract.py
+++ b/python/tests/test_binding_contract.py
@@ -9765,6 +9765,7 @@ def test_counting_concordance_binding_is_typed():
     assert "timewt" in inspect.signature(core.stratified_concordance_summary).parameters
     assert "timewt" in inspect.signature(core.concordance_rank_rows).parameters
     assert "timewt" in inspect.signature(core.stratified_concordance_rank_rows).parameters
+    assert "output_len" in inspect.signature(core.stratified_concordance_rank_rows).parameters
     assert "timewt" in inspect.signature(core.concordance_influence_rows).parameters
     assert "timewt" in inspect.signature(core.stratified_concordance_influence_rows).parameters
     assert "timewt" in inspect.signature(core.counting_concordance_index).parameters
@@ -9772,6 +9773,10 @@ def test_counting_concordance_binding_is_typed():
     assert "timewt" in inspect.signature(core.stratified_counting_concordance_summary).parameters
     assert "timewt" in inspect.signature(core.counting_concordance_rank_rows).parameters
     assert "timewt" in inspect.signature(core.stratified_counting_concordance_rank_rows).parameters
+    assert (
+        "output_len"
+        in inspect.signature(core.stratified_counting_concordance_rank_rows).parameters
+    )
     assert "timewt" in inspect.signature(core.counting_concordance_influence_rows).parameters
     assert (
         "timewt"
@@ -9824,6 +9829,7 @@ def test_counting_concordance_binding_is_typed():
         "timewt",
         "order_scores",
         "display_times",
+        "output_len",
     ]
     assert _pyi_function_arg_names(stub_path, "concordance_influence_rows") == [
         "time",
@@ -9899,6 +9905,7 @@ def test_counting_concordance_binding_is_typed():
         "timefix",
         "order_scores",
         "display_stop",
+        "output_len",
     ]
     assert _pyi_function_arg_names(stub_path, "counting_concordance_influence_rows") == [
         "start",

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -8888,6 +8888,40 @@ def test_reversed_stratified_counting_ranks_flip_after_recycling():
         assert list(row.values()) == pytest.approx(values)
 
 
+def test_bounded_stratified_counting_ranks_exclude_time_weight_padding():
+    result = survival.concordancefit(
+        survival.Surv(
+            [2, 1, 1, 2, 0, 4],
+            [6, 3, 4, 4, 4, 7],
+            [0, 1, 1, 0, 0, 1],
+        ),
+        [-1, -0.5, 1, -1, 0, 0],
+        strata=[1, 2, 1, 2, 2, 1],
+        weights=[1, 0.5, 2, 0.5, 0.5, 1],
+        ymin=3,
+        ymax=5,
+        timewt="I",
+        cluster=[2, 1, 3, 3, 1, 2],
+        ranks=True,
+        reverse=True,
+        timefix=False,
+        keepstrata=True,
+    )
+
+    assert result is not None
+    assert result.ranks is not None
+    expected = [
+        [4, -2, 1, -1 / 3],
+        [3, -0.5, 1.5, 0],
+        [-1 / 3, -4, 2, 1],
+        [0, -3, 0.5, 1.5],
+        [1.5, 0, 3, 0.5],
+        [1, 1 / 3, 4, 2],
+    ]
+    for row, values in zip(result.ranks, expected, strict=True):
+        assert list(row.values()) == pytest.approx(values)
+
+
 def test_concordance_stratified_multi_score_remains_available_in_python():
     result = survival.concordancefit(
         survival.Surv([1, 2, 3, 1, 2, 3], [1, 0, 1, 1, 0, 1]),

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -5159,6 +5159,47 @@ test_that("reversed stratified counting ranks flip after recycling", {
   expect_equal(unclass(bridged), unclass(reference), tolerance = 1e-12)
 })
 
+test_that("bounded stratified ranks exclude time-weight padding rows", {
+  start <- c(2, 1, 1, 2, 0, 4)
+  stop <- c(6, 3, 4, 4, 4, 7)
+  status <- c(0, 1, 1, 0, 0, 1)
+  scores <- c(-1, -0.5, 1, -1, 0, 0)
+  groups <- c(1, 2, 1, 2, 2, 1)
+  weights <- c(1, 0.5, 2, 0.5, 0.5, 1)
+  clusters <- c(2, 1, 3, 3, 1, 2)
+
+  bridged <- concordancefit(
+    Surv(start, stop, status),
+    scores,
+    strata = groups,
+    weights = weights,
+    ymin = 3,
+    ymax = 5,
+    timewt = "I",
+    cluster = clusters,
+    ranks = TRUE,
+    reverse = TRUE,
+    timefix = FALSE,
+    keepstrata = TRUE
+  )
+  reference <- survival::concordancefit(
+    survival::Surv(start, stop, status),
+    scores,
+    strata = groups,
+    weights = weights,
+    ymin = 3,
+    ymax = 5,
+    timewt = "I",
+    cluster = clusters,
+    ranks = TRUE,
+    reverse = TRUE,
+    timefix = FALSE,
+    keepstrata = TRUE
+  )
+
+  expect_equal(unclass(bridged), unclass(reference), tolerance = 1e-12)
+})
+
 test_that("stratified concordance rank errors follow stratum order", {
   start <- rep(0, 6)
   stop <- c(1, 2, 6, 2, 1, 2)

--- a/src/concordance/basic.rs
+++ b/src/concordance/basic.rs
@@ -989,11 +989,33 @@ fn reassemble_stratified_rank_rows(
     n: usize,
     groups: Vec<Vec<usize>>,
     display_times: Option<&[f64]>,
+    output_len: Option<usize>,
     mut compute_group: impl FnMut(&[usize]) -> IndexedConcordanceRankRows,
 ) -> PyResult<ConcordanceRankRows> {
-    let mut result = vec![[0.0; 4]; n];
+    let output_len = output_len.unwrap_or(n);
+    if output_len > n {
+        return Err(PyValueError::new_err(
+            "output_len cannot exceed the input length",
+        ));
+    }
+    let mut result = vec![[0.0; 4]; output_len];
     for indices in groups {
-        let group_rows = compute_group(&indices);
+        let mut group_rows = compute_group(&indices);
+        let filtered_indices;
+        let output_indices = if output_len == n {
+            indices.as_slice()
+        } else {
+            group_rows.retain(|row| indices[row.0] < output_len);
+            filtered_indices = indices
+                .iter()
+                .copied()
+                .filter(|&index| index < output_len)
+                .collect::<Vec<_>>();
+            filtered_indices.as_slice()
+        };
+        if output_indices.is_empty() {
+            continue;
+        }
         if group_rows.is_empty() {
             return Err(PyValueError::new_err(
                 "number of items to replace is not a multiple of replacement length",
@@ -1010,16 +1032,16 @@ fn reassemble_stratified_rank_rows(
                 })
             })
             .collect();
-        let target_len = indices.len() * 4;
-        if target_len % source.len() != 0 {
+        let target_len = output_indices.len() * 4;
+        if !target_len.is_multiple_of(source.len()) {
             return Err(PyValueError::new_err(
                 "number of items to replace is not a multiple of replacement length",
             ));
         }
         for column in 0..4 {
-            for (local_idx, &original_idx) in indices.iter().enumerate() {
+            for (local_idx, &original_idx) in output_indices.iter().enumerate() {
                 result[original_idx][column] =
-                    source[(column * indices.len() + local_idx) % source.len()];
+                    source[(column * output_indices.len() + local_idx) % source.len()];
             }
         }
     }
@@ -1049,11 +1071,13 @@ fn stratified_right_concordance_rank_rows(
     weights: Option<&[f64]>,
     time_weight: ConcordanceTimeWeight,
     display_times: Option<&[f64]>,
+    output_len: Option<usize>,
 ) -> PyResult<ConcordanceRankRows> {
     reassemble_stratified_rank_rows(
         time.len(),
         strata_groups(strata),
         display_times,
+        output_len,
         |indices| {
             let group_time: Vec<f64> = indices.iter().map(|&idx| time[idx]).collect();
             let group_status: Vec<i32> = indices.iter().map(|&idx| status[idx]).collect();
@@ -1084,25 +1108,32 @@ fn stratified_counting_concordance_rank_rows_for_strata(
     weights: Option<&[f64]>,
     time_weight: ConcordanceTimeWeight,
     display_stop: Option<&[f64]>,
+    output_len: Option<usize>,
 ) -> PyResult<ConcordanceRankRows> {
-    reassemble_stratified_rank_rows(stop.len(), strata_groups(strata), display_stop, |indices| {
-        let group_start: Vec<f64> = indices.iter().map(|&idx| start[idx]).collect();
-        let group_stop: Vec<f64> = indices.iter().map(|&idx| stop[idx]).collect();
-        let group_status: Vec<i32> = indices.iter().map(|&idx| status[idx]).collect();
-        let group_risk: Vec<f64> = indices.iter().map(|&idx| risk_scores[idx]).collect();
-        let group_order: Vec<f64> = indices.iter().map(|&idx| order_scores[idx]).collect();
-        let group_weights: Option<Vec<f64>> =
-            weights.map(|values| indices.iter().map(|&idx| values[idx]).collect());
-        counting_concordance_rank_rows_for_vectors(
-            &group_start,
-            &group_stop,
-            &group_status,
-            &group_risk,
-            &group_order,
-            group_weights.as_deref(),
-            time_weight,
-        )
-    })
+    reassemble_stratified_rank_rows(
+        stop.len(),
+        strata_groups(strata),
+        display_stop,
+        output_len,
+        |indices| {
+            let group_start: Vec<f64> = indices.iter().map(|&idx| start[idx]).collect();
+            let group_stop: Vec<f64> = indices.iter().map(|&idx| stop[idx]).collect();
+            let group_status: Vec<i32> = indices.iter().map(|&idx| status[idx]).collect();
+            let group_risk: Vec<f64> = indices.iter().map(|&idx| risk_scores[idx]).collect();
+            let group_order: Vec<f64> = indices.iter().map(|&idx| order_scores[idx]).collect();
+            let group_weights: Option<Vec<f64>> =
+                weights.map(|values| indices.iter().map(|&idx| values[idx]).collect());
+            counting_concordance_rank_rows_for_vectors(
+                &group_start,
+                &group_stop,
+                &group_status,
+                &group_risk,
+                &group_order,
+                group_weights.as_deref(),
+                time_weight,
+            )
+        },
+    )
 }
 
 fn add_influence_pair(
@@ -1799,7 +1830,7 @@ pub fn concordance_rank_rows(
 
 #[pyfunction]
 #[allow(clippy::too_many_arguments)]
-#[pyo3(signature = (time, status, risk_scores, strata, weights=None, timewt="n".to_string(), order_scores=None, display_times=None))]
+#[pyo3(signature = (time, status, risk_scores, strata, weights=None, timewt="n".to_string(), order_scores=None, display_times=None, output_len=None))]
 pub fn stratified_concordance_rank_rows(
     time: Vec<f64>,
     status: Vec<i32>,
@@ -1809,6 +1840,7 @@ pub fn stratified_concordance_rank_rows(
     timewt: String,
     order_scores: Option<Vec<f64>>,
     display_times: Option<Vec<f64>>,
+    output_len: Option<usize>,
 ) -> PyResult<ConcordanceRankRows> {
     validate_right_concordance_inputs(&time, &status, &risk_scores, weights.as_deref())?;
     validate_strata_length(time.len(), &strata, "time")?;
@@ -1839,6 +1871,7 @@ pub fn stratified_concordance_rank_rows(
         weights.as_deref(),
         time_weight,
         display_times.as_deref(),
+        output_len,
     )
 }
 
@@ -2092,7 +2125,7 @@ pub fn counting_concordance_rank_rows(
 
 #[pyfunction]
 #[allow(clippy::too_many_arguments)]
-#[pyo3(signature = (start, stop, status, risk_scores, strata, weights=None, timewt="n".to_string(), timefix=None, order_scores=None, display_stop=None))]
+#[pyo3(signature = (start, stop, status, risk_scores, strata, weights=None, timewt="n".to_string(), timefix=None, order_scores=None, display_stop=None, output_len=None))]
 pub fn stratified_counting_concordance_rank_rows(
     start: Vec<f64>,
     stop: Vec<f64>,
@@ -2104,6 +2137,7 @@ pub fn stratified_counting_concordance_rank_rows(
     timefix: Option<bool>,
     order_scores: Option<Vec<f64>>,
     display_stop: Option<Vec<f64>>,
+    output_len: Option<usize>,
 ) -> PyResult<ConcordanceRankRows> {
     let (start, stop) = prepare_counting_concordance_times(&start, &stop, timefix);
     validate_counting_concordance_inputs(
@@ -2143,6 +2177,7 @@ pub fn stratified_counting_concordance_rank_rows(
         weights.as_deref(),
         time_weight,
         display_stop.as_deref(),
+        output_len,
     )
 }
 
@@ -3011,6 +3046,7 @@ mod tests {
             "n".to_string(),
             None,
             None,
+            None,
         )
         .unwrap();
 
@@ -3038,6 +3074,7 @@ mod tests {
             "n/G2".to_string(),
             None,
             Some(vec![2.0, 6.0, 7.0, 2.0, 1.0, 7.0, 6.0]),
+            None,
         )
         .unwrap();
 
@@ -3068,6 +3105,7 @@ mod tests {
             "n".to_string(),
             None,
             None,
+            None,
         )
         .unwrap_err();
 
@@ -3093,6 +3131,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .unwrap();
 
@@ -3103,6 +3142,38 @@ mod tests {
                 (0.5, 1.0, 0.5, 1.0),
                 (1.0, 2.0, 1.0, 2.0),
                 (-0.5, 1.0, -0.5, 1.0),
+            ]
+        );
+    }
+
+    #[test]
+    fn stratified_counting_rank_rows_exclude_time_weight_padding() {
+        initialize_python();
+
+        let rows = stratified_counting_concordance_rank_rows(
+            vec![2.0, 1.0, 1.0, 2.0, 0.0, 4.0, 0.0],
+            vec![6.0, 3.0, 4.0, 4.0, 4.0, 7.0, 8.0],
+            vec![0, 1, 1, 0, 0, 0, 1],
+            vec![1.0, 0.5, -1.0, 1.0, 0.0, 0.0, 0.0],
+            vec![0, 1, 0, 1, 1, 0, 0],
+            Some(vec![1.0, 0.5, 2.0, 0.5, 0.5, 1.0, 0.0]),
+            "I".to_string(),
+            Some(false),
+            Some(vec![-1.0, -0.5, 1.0, -1.0, 0.0, 0.0, 0.0]),
+            Some(vec![6.0, 3.0, 4.0, 4.0, 4.0, 7.0, 8.0]),
+            Some(6),
+        )
+        .unwrap();
+
+        assert_eq!(
+            rows,
+            vec![
+                (4.0, 2.0, 1.0, -1.0 / 3.0),
+                (3.0, 0.5, 1.5, 0.0),
+                (-1.0 / 3.0, 4.0, 2.0, 1.0),
+                (0.0, 3.0, 0.5, 1.5),
+                (1.5, 0.0, 3.0, 0.5),
+                (1.0, -1.0 / 3.0, 4.0, 2.0),
             ]
         );
     }
@@ -3119,6 +3190,7 @@ mod tests {
             vec![0, 0, 0, 0, 1, 1, 1, 1],
             Some(vec![1.0, 2.0, 1.5, 0.5, 3.0, 1.0, 2.5, 2.0]),
             "n".to_string(),
+            None,
             None,
             None,
             None,


### PR DESCRIPTION
## Summary
- keep bounded time-weight padding in risk-set calculations while excluding it from rank-table output
- recycle stratified residuals over original observations only
- preserve the allocation-free common path when no padding is present
- add Rust, Python, R, and typed-binding regressions

## Validation
- cargo test (1573 passed)
- RUSTFLAGS=-Dwarnings cargo clippy --all-targets --all-features -- -D warnings
- .venv/bin/python -m pytest -q python/tests (1113 passed)
- .venv/bin/ruff check modified Python files
- cargo fmt --check
- full R testthat suite (3 established warnings)
- R CMD build r/survivalr
- R CMD check --no-manual survivalr_0.1.0.tar.gz (Status: OK)
- seventh and eighth deterministic concordance seeds: all 500 generated fixtures matched after clean-process verification of allocation-sensitive reference cases
