### PR TITLE
Preserve concordance rank recycling error order

### DIFF
--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -12112,7 +12112,8 @@ concordance <- function(object, ..., formula) {
 }
 
 .concordance_empty_rank_strata_check <- function(
-    response, n_scores, strata, ranks, timewt, ymax = NULL, keepstrata = 10) {
+    response, n_scores, strata, ranks, timewt, ymax = NULL, keepstrata = 10,
+    check_recycling = FALSE) {
   survival_response <- inherits(response, "Surv") || inherits(response, "survival_py_surv")
   if (!isTRUE(ranks) || !survival_response) {
     return(invisible(NULL))
@@ -12140,7 +12141,9 @@ concordance <- function(object, ..., formula) {
     n_strata <- 1L
   }
   groups <- droplevels(as.factor(strata_values))
-  event_counts <- vapply(split(status, groups), sum, numeric(1))
+  grouped_status <- split(status, groups)
+  group_sizes <- lengths(grouped_status)
+  event_counts <- vapply(grouped_status, sum, numeric(1))
   rank_status <- status
   if (!is.null(ymax)) rank_status[event_time > ymax] <- 0
   rank_counts <- vapply(split(rank_status, groups), sum, numeric(1))
@@ -12156,6 +12159,13 @@ concordance <- function(object, ..., formula) {
         )
       }
       return(invisible(NULL))
+    }
+    if (isTRUE(check_recycling) && rank_counts[[index]] > 0 &&
+        group_sizes[[index]] %% rank_counts[[index]] != 0) {
+      stop(
+        "number of items to replace is not a multiple of replacement length",
+        call. = FALSE
+      )
     }
     if (n_strata > 1L && rank_counts[[index]] == 0) {
       stop("replacement has length zero", call. = FALSE)
@@ -12176,7 +12186,8 @@ concordance <- function(object, ..., formula) {
       ranks,
       timewt,
       ymax,
-      keepstrata
+      keepstrata,
+      check_recycling = TRUE
     )
     stop(replacement_message, call. = FALSE)
   }

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -5234,6 +5234,43 @@ test_that("stratified concordance rank errors follow stratum order", {
   )
 })
 
+test_that("non-recyclable rank strata fail before later empty strata", {
+  time <- c(4, 5, 5, 3, 6, 4, 7, 5, 7, 6)
+  status <- c(0, 1, 0, 1, 0, 0, 1, 0, 0, 0)
+  scores <- seq_along(time)
+  groups <- rep(seq_len(2), each = 5)
+  replacement_error <- "number of items to replace is not a multiple of replacement length"
+
+  for (score_input in list(scores, cbind(x = scores, z = rev(scores)))) {
+    expect_error(
+      concordancefit(
+        Surv(time, status),
+        score_input,
+        strata = groups,
+        ymax = 5,
+        timewt = "S",
+        ranks = TRUE,
+        reverse = TRUE
+      ),
+      replacement_error,
+      fixed = TRUE
+    )
+    expect_error(
+      survival::concordancefit(
+        survival::Surv(time, status),
+        score_input,
+        strata = groups,
+        ymax = 5,
+        timewt = "S",
+        ranks = TRUE,
+        reverse = TRUE
+      ),
+      replacement_error,
+      fixed = TRUE
+    )
+  }
+})
+
 test_that("multi-score rank errors finish stratum construction first", {
   time <- c(6, 7, 1, 2)
   status <- c(1, 1, 0, 0)


### PR DESCRIPTION
## Summary
- preserve reference stratum order when translating concordance rank recycling failures
- report an earlier non-recyclable stratum before a later empty bounded stratum
- reuse grouped status data while limiting the divisibility check to confirmed recycling failures
- cover one- and two-score rank inputs against the reference implementation

## Validation
- cargo test (1573 passed)
- RUSTFLAGS=-Dwarnings cargo clippy --all-targets --all-features -- -D warnings
- .venv/bin/python -m pytest -q python/tests (1113 passed)
- cargo fmt --check
- full R testthat suite (3 established warnings)
- R CMD build r/survivalr
- R CMD check --no-manual survivalr_0.1.0.tar.gz (Status: OK)
- ninth through thirteenth deterministic concordance seeds: all 500 generated fixtures matched after repairing case 107 and clean-process verification of allocation-sensitive reference cases
