### PR TITLE
Honor factor levels in survdiff group order

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -18914,6 +18914,30 @@ def _survdiff_r_ordered_levels(values: list[Any]) -> tuple[Any, ...]:
     return _r_formula_ordered_levels(values, "survdiff formula groups")
 
 
+def _survdiff_declared_group_levels(
+    data: Any,
+    terms: _FormulaTerms,
+    values: list[Any],
+) -> tuple[Any, ...] | None:
+    if len(terms.covariates) != 1 or not isinstance(terms.covariates[0], _CovariateTerm):
+        return None
+    term = terms.covariates[0]
+    if term.factor_options is not None:
+        return None
+    declared = _formula_declared_factor_levels(data, term)
+    if declared is None:
+        return None
+    observed = {
+        _factor_value_key(value) for value in values if not _is_missing_value(value)
+    }
+    ordered: list[Any] = []
+    for level in declared:
+        normalized = _factor_level_value(level)
+        if _factor_value_key(normalized) in observed:
+            ordered.append(normalized)
+    return tuple(ordered)
+
+
 def _survdiff_formula_groups(
     data: Any,
     terms: _FormulaTerms,
@@ -18924,7 +18948,9 @@ def _survdiff_formula_groups(
             raise ValueError("survdiff formula has no groups to test")
         raise ValueError("survdiff formula requires at least one grouping term")
     group = _combined_formula_groups(data, [], terms.covariates, n)
-    group_levels = _survdiff_r_ordered_levels(group)
+    group_levels = _survdiff_declared_group_levels(data, terms, group)
+    if group_levels is None:
+        group_levels = _survdiff_r_ordered_levels(group)
     strata = _combined_columns(data, terms.strata, n) if terms.strata else None
     return group, group_levels, strata
 

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -7631,6 +7631,25 @@ def test_logrank_multigroup_matches_r_survdiff_chisquare():
     )
 
 
+def test_survdiff_formula_preserves_declared_factor_group_order():
+    data = {
+        "time": [5.0, 4.0, 1.0, 5.0, 6.0, 1.0, 3.0],
+        "status": [0, 0, 0, 1, 0, 0, 0],
+        "group": survival.r_api._r_factor(
+            ["g2", "g3", "g4", "g1", "g3", "g2", "g1"],
+            ["g4", "g3", "g2", "g1", "unused"],
+        ),
+    }
+
+    result = survival.survdiff("Surv(time, status) ~ group", data=data, rho=0.5)
+
+    assert result.observed == pytest.approx([0.0, 0.0, 0.0, 1.0])
+    assert result.expected == pytest.approx([0.0, 1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0])
+    assert survival.as_data_frame(result)["variance"] == pytest.approx(
+        [0.0, 2.0 / 9.0, 2.0 / 9.0, 2.0 / 9.0]
+    )
+
+
 def test_survdiff_formula_accepts_general_rho():
     data = _toy_data()
     result = survival.survdiff("Surv(time, status) ~ group", data=data, rho=0.5)

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -12435,6 +12435,26 @@ test_that("Kaplan-Meier and log-rank bridge results agree with R survival", {
     tolerance = 1e-06
   )
 
+  ordered_diff_data <- data.frame(
+    time = c(5, 4, 1, 5, 6, 1, 3),
+    status = c(0, 0, 0, 1, 0, 0, 0),
+    group = factor(
+      c("g2", "g3", "g4", "g1", "g3", "g2", "g1"),
+      levels = c("g4", "g3", "g2", "g1", "unused")
+    )
+  )
+  bridged_ordered_diff <- survdiff(
+    Surv(time, status) ~ group,
+    data = ordered_diff_data,
+    rho = 0.5
+  )
+  reference_ordered_diff <- survival::survdiff(
+    survival::Surv(time, status) ~ group,
+    data = ordered_diff_data,
+    rho = 0.5
+  )
+  expect_survdiff_equal(bridged_ordered_diff, reference_ordered_diff)
+
   offset_diff_data <- data.frame(
     time = c(1, 2, 3, 4),
     status = c(1, 0, 1, 1),


### PR DESCRIPTION
## Summary

- preserve declared R factor levels when assigning formula-group codes for `survdiff`
- drop unused levels while retaining the declared order of observed groups
- cover a reversed four-level factor with an unused level in Python and R-facing tests

## Validation

- `cargo test` (1573 passed)
- `python -m pytest -q python/tests` (1114 passed)
- full R test suite (passed with 3 established warnings)
- strict Clippy checks
- Rust formatting check
- `R CMD build`
- `R CMD check --no-manual` (Status: OK)
- deterministic `survdiff` comparison: every reference-success case matched across 500 generated right-censored fixtures spanning character, factor, and numeric groups with optional strata
- `git diff --check`
