### PR TITLE
Use aeqSurv tolerance for survdiff time fixes

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -19178,6 +19178,10 @@ def survdiff(
     fix_time = _normalize_bool_option(timefix, "timefix")
     if formula_offsets is not None:
         return _survdiff_offset_result(response, formula_offsets, rho_value)
+    core_timefix = fix_time
+    if fix_time and response.type == "right":
+        response = aeqSurv(response)
+        core_timefix = False
     if group is None:
         raise ValueError("group is required")
     if formula_strata is not None:
@@ -19186,7 +19190,7 @@ def survdiff(
             group,
             formula_strata,
             rho_value,
-            fix_time,
+            core_timefix,
             formula_group_levels,
         )
 
@@ -19200,7 +19204,7 @@ def survdiff(
             list(response.start),
             None,
             rho_value,
-            fix_time,
+            core_timefix,
         )
     else:
         components = _core.survdiff2(
@@ -19209,7 +19213,7 @@ def survdiff(
             group_codes,
             None,
             rho_value,
-            fix_time,
+            core_timefix,
         )
     return _survdiff_result_from_components(components, rho_value)
 

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -10521,6 +10521,28 @@ def test_survdiff_timefix_false_uses_exact_event_times():
     assert exact.expected == pytest.approx(low_level.expected)
 
 
+def test_survdiff_timefix_uses_aeq_surv_tolerance():
+    data = {
+        "time": [4.0, 1.0, 5.0, 1.0 + 5e-9, 1.0],
+        "status": [0, 1, 1, 1, 0],
+        "group": [20, 10, 20, 10, 10],
+    }
+
+    fixed = survival.survdiff("Surv(time, status) ~ group", data=data, rho=-0.5)
+    exact = survival.survdiff(
+        "Surv(time, status) ~ group",
+        data=data,
+        rho=-0.5,
+        timefix=False,
+    )
+
+    assert fixed.observed == pytest.approx([2.0, 1.29099444873581])
+    assert fixed.expected == pytest.approx([1.2, 2.09099444873581])
+    assert fixed.variance_diagonal == pytest.approx([0.36, 0.36])
+    assert fixed.statistic == pytest.approx(1.77777777777778)
+    assert exact.statistic != pytest.approx(fixed.statistic)
+
+
 def test_survdiff_formula_accepts_dotted_na_action_alias():
     data = {
         "time": [1.0, 2.0, 3.0, 4.0],

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -12455,6 +12455,23 @@ test_that("Kaplan-Meier and log-rank bridge results agree with R survival", {
   )
   expect_survdiff_equal(bridged_ordered_diff, reference_ordered_diff)
 
+  near_tie_diff_data <- data.frame(
+    time = c(4, 1, 5, 1 + 5e-9, 1),
+    status = c(0, 1, 1, 1, 0),
+    group = c(20, 10, 20, 10, 10)
+  )
+  bridged_near_tie_diff <- survdiff(
+    Surv(time, status) ~ group,
+    data = near_tie_diff_data,
+    rho = -0.5
+  )
+  reference_near_tie_diff <- survival::survdiff(
+    survival::Surv(time, status) ~ group,
+    data = near_tie_diff_data,
+    rho = -0.5
+  )
+  expect_survdiff_equal(bridged_near_tie_diff, reference_near_tie_diff)
+
   offset_diff_data <- data.frame(
     time = c(1, 2, 3, 4),
     status = c(1, 0, 1, 1),


### PR DESCRIPTION
## Summary

- normalize right-censored `survdiff` times with the existing `aeqSurv` implementation when `timefix=TRUE`
- run the numerical core with exact equality after normalization
- cover a near-tie outside the old fixed window that changes weighted observed, expected, variance, and test-statistic values

## Validation

- `cargo test` (1573 passed)
- `python -m pytest -q python/tests` (1115 passed)
- full R test suite (passed with 3 established warnings)
- strict Clippy checks
- Rust formatting check
- `R CMD build`
- `R CMD check --no-manual` (Status: OK)
- deterministic `survdiff` comparison: every reference-success case matched across 1000 generated right-censored fixtures over two seeds, including near ties, factor groups, optional strata, and varied `rho`
- `git diff --check`
