### PR TITLE
Match degenerate survdiff reference behavior

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -19008,10 +19008,63 @@ def _timefix_vectors(*vectors: list[float]) -> tuple[list[float], ...]:
     return tuple(_core.timefix_vectors(list(vectors), _SURVFIT_TIME_EPSILON))
 
 
-def _survdiff_result_from_components(components: Any, rho: float) -> Any:
+def _survdiff_singular_pivot(components: Any) -> int | None:
+    active = [idx for idx, value in enumerate(components.expected) if float(value) > 0.0]
+    size = len(active) - 1
+    if size <= 0:
+        return None
+    retained = active[1:]
+    matrix = [
+        [float(components.variance[row][column]) for column in retained]
+        for row in retained
+    ]
+    scale = max((abs(value) for row in matrix for value in row), default=0.0)
+    pivot_tolerance = math.ulp(scale) * max(size, 1) * 4.0
+    for column in range(size):
+        pivot_row = max(range(column, size), key=lambda row: abs(matrix[row][column]))
+        if abs(matrix[pivot_row][column]) <= pivot_tolerance:
+            return column + 1
+        if pivot_row != column:
+            matrix[column], matrix[pivot_row] = matrix[pivot_row], matrix[column]
+        pivot = matrix[column][column]
+        for row in range(column + 1, size):
+            factor = matrix[row][column] / pivot
+            matrix[row][column] = 0.0
+            for inner in range(column + 1, size):
+                matrix[row][inner] -= factor * matrix[column][inner]
+    return None
+
+
+def _survdiff_result_from_components(
+    components: Any,
+    rho: float,
+    reference_degenerate: bool = False,
+    emit_warnings: bool = True,
+) -> Any:
     statistic = float(components.chi_squared)
-    df = int(components.degrees_of_freedom)
-    p_value = 1.0 if df == 0 else float(_core.lrt_test(statistic / 2.0, 0.0, df).p_value)
+    if reference_degenerate:
+        df = sum(float(value) > 0.0 for value in components.expected) - 1
+        pivot = _survdiff_singular_pivot(components)
+        if pivot is not None:
+            raise ValueError(
+                f"Lapack routine dgesv: system is exactly singular: U[{pivot},{pivot}] = 0"
+            )
+        if df < 0:
+            if emit_warnings:
+                warnings.warn("NaNs produced", RuntimeWarning, stacklevel=3)
+            p_value = math.nan
+            df = 0
+        else:
+            p_value = (
+                1.0
+                if df == 0
+                else float(_core.lrt_test(statistic / 2.0, 0.0, df).p_value)
+            )
+    else:
+        df = int(components.degrees_of_freedom)
+        p_value = 1.0 if df == 0 else float(
+            _core.lrt_test(statistic / 2.0, 0.0, df).p_value
+        )
     variance = (
         float(components.variance[0][0]) if components.variance and components.variance[0] else 0.0
     )
@@ -19089,6 +19142,7 @@ def _stratified_survdiff(
     rho: float,
     timefix: bool,
     group_levels: Sequence[Any] | None = None,
+    emit_warnings: bool = True,
 ) -> Any:
     n = len(response)
     group_codes = _encode_groups(group, n, levels=group_levels)
@@ -19104,7 +19158,12 @@ def _stratified_survdiff(
             rho,
             timefix,
         )
-        return _survdiff_result_from_components(components, rho)
+        return _survdiff_result_from_components(
+            components,
+            rho,
+            reference_degenerate=response.start is None,
+            emit_warnings=emit_warnings,
+        )
 
     components = _core.stratified_logrank_components(
         times,
@@ -19114,7 +19173,12 @@ def _stratified_survdiff(
         rho,
         timefix,
     )
-    return _survdiff_result_from_components(components, rho)
+    return _survdiff_result_from_components(
+        components,
+        rho,
+        reference_degenerate=True,
+        emit_warnings=emit_warnings,
+    )
 
 
 def survdiff(
@@ -19132,6 +19196,7 @@ def survdiff(
 
     na_action = _pop_dotted_keyword(kwargs, "na.action", "na_action", na_action, "fail")
     timefix = _pop_dotted_keyword(kwargs, "time.fix", "timefix", timefix, True)
+    emit_warnings = _normalize_bool_option(kwargs.pop("_emit_warnings", True), "_emit_warnings")
     if kwargs:
         unexpected = ", ".join(sorted(kwargs))
         raise TypeError(f"survdiff got unexpected keyword argument(s): {unexpected}")
@@ -19192,6 +19257,7 @@ def survdiff(
             rho_value,
             core_timefix,
             formula_group_levels,
+            emit_warnings,
         )
 
     groups = _encode_groups(group, len(response), levels=formula_group_levels)
@@ -19215,7 +19281,12 @@ def survdiff(
             rho_value,
             core_timefix,
         )
-    return _survdiff_result_from_components(components, rho_value)
+    return _survdiff_result_from_components(
+        components,
+        rho_value,
+        reference_degenerate=response.start is None,
+        emit_warnings=emit_warnings,
+    )
 
 
 def _coxph_wtest_b_matrix(b: Any) -> tuple[list[list[float | None]], bool]:

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -10543,6 +10543,42 @@ def test_survdiff_timefix_uses_aeq_surv_tolerance():
     assert exact.statistic != pytest.approx(fixed.statistic)
 
 
+def test_survdiff_matches_degenerate_reference_results():
+    all_censored = {
+        "time": [1.0, 2.0, 3.0, 4.0],
+        "status": [0, 0, 0, 0],
+        "group": [1, 1, 2, 2],
+    }
+    tied_events = {**all_censored, "time": [1.0] * 4, "status": [1] * 4}
+    disconnected_strata = {
+        "time": [5.0, 3.0, 5.0, 3.0, 8.0, 4.0, 1.0],
+        "status": [1, 1, 1, 1, 1, 0, 1],
+        "group": ["g4", "g1", "g2", "g2", "g3", "g1", "g3"],
+        "site": ["s3", "s3", "s1", "s1", "s2", "s2", "s1"],
+    }
+
+    with pytest.warns(RuntimeWarning, match="NaNs produced"):
+        result = survival.survdiff("Surv(time, status) ~ group", data=all_censored)
+
+    assert result.statistic == 0.0
+    assert math.isnan(result.p_value)
+    assert result.df == 0
+    with pytest.raises(
+        ValueError,
+        match=r"Lapack routine dgesv: system is exactly singular: U\[1,1\] = 0",
+    ):
+        survival.survdiff("Surv(time, status) ~ group", data=tied_events)
+    with pytest.raises(
+        ValueError,
+        match=r"Lapack routine dgesv: system is exactly singular: U\[2,2\] = 0",
+    ):
+        survival.survdiff(
+            "Surv(time, status) ~ group + strata(site)",
+            data=disconnected_strata,
+            rho=2.0,
+        )
+
+
 def test_survdiff_formula_accepts_dotted_na_action_alias():
     data = {
         "time": [1.0, 2.0, 3.0, 4.0],

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -10827,23 +10827,41 @@ pseudo <- function(fit, times, type, collapse = TRUE, data.frame = FALSE, ...) {
   )
 }
 
+.survdiff_translate_singular_error <- function(condition) {
+  pattern <- "Lapack routine dgesv: system is exactly singular: U\\[[0-9]+,[0-9]+\\] = 0"
+  message <- conditionMessage(condition)
+  location <- regexpr(pattern, message)
+  if (location[[1L]] > 0L) {
+    stop(regmatches(message, location), call. = FALSE)
+  }
+  stop(condition)
+}
+
 survdiff <- function(formula, data = NULL, subset = NULL, na.action = "fail",
                      rho = 0, timefix = TRUE, ..., group = NULL) {
   env <- parent.frame()
   group_values <- .eval_formula_arg(substitute(group), missing(group), data, env, vector = TRUE)
   subset_values <- .eval_formula_arg(substitute(subset), missing(subset), data, env, vector = TRUE)
-  .call_r_api(
-    "survdiff",
-    response = .as_formula_string(formula),
-    data = .as_python_data(data),
-    group = group_values,
-    subset = subset_values,
-    `na.action` = .as_na_action(na.action),
-    rho = rho,
-    timefix = timefix,
-    ...,
-    .wrap = c("survival_py_survdiff", "survival_py_object")
+  result <- tryCatch(
+    .call_r_api(
+      "survdiff",
+      response = .as_formula_string(formula),
+      data = .as_python_data(data),
+      group = group_values,
+      subset = subset_values,
+      `na.action` = .as_na_action(na.action),
+      rho = rho,
+      timefix = timefix,
+      `_emit_warnings` = FALSE,
+      ...,
+      .wrap = c("survival_py_survdiff", "survival_py_object")
+    ),
+    error = .survdiff_translate_singular_error
   )
+  if (isTRUE(is.nan(as.numeric(result$p_value)))) {
+    warning("NaNs produced", call. = FALSE)
+  }
+  result
 }
 
 .survcheck_events <- function(status, id, states) {

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -12472,6 +12472,36 @@ test_that("Kaplan-Meier and log-rank bridge results agree with R survival", {
   )
   expect_survdiff_equal(bridged_near_tie_diff, reference_near_tie_diff)
 
+  degenerate_diff_data <- data.frame(
+    time = 1:4,
+    status = rep(0, 4),
+    group = rep(c(1, 2), each = 2)
+  )
+  expect_warning(
+    bridged_degenerate_diff <- survdiff(
+      Surv(time, status) ~ group,
+      data = degenerate_diff_data
+    ),
+    "NaNs produced"
+  )
+  expect_warning(
+    reference_degenerate_diff <- survival::survdiff(
+      survival::Surv(time, status) ~ group,
+      data = degenerate_diff_data
+    ),
+    "NaNs produced"
+  )
+  expect_true(is.nan(as.numeric(bridged_degenerate_diff$p_value)))
+  expect_true(is.nan(reference_degenerate_diff$pvalue))
+  expect_error(
+    survdiff(
+      Surv(time, status) ~ group,
+      data = transform(degenerate_diff_data, time = rep(1, 4), status = rep(1, 4))
+    ),
+    "Lapack routine dgesv: system is exactly singular: U[1,1] = 0",
+    fixed = TRUE
+  )
+
   offset_diff_data <- data.frame(
     time = c(1, 2, 3, 4),
     status = c(1, 0, 1, 1),


### PR DESCRIPTION
## Summary

- derive right-censored `survdiff` degrees of freedom from groups with positive expected counts, matching the reference
- reproduce singular active-group covariance failures, including the reported pivot position
- return the reference `NaN` p-value and warning for all-censored data, with native R warning and error conditions at the bridge boundary

## Validation

- `cargo test` (1573 passed)
- `python -m pytest -q python/tests` (1116 passed)
- full R test suite (passed with 3 established warnings)
- strict Clippy checks
- Rust formatting check
- `R CMD build`
- `R CMD check --no-manual` (Status: OK)
- unrestricted deterministic `survdiff` comparison: all 1000 generated fixtures matched across two seeds, including successful results, warnings, and singular-matrix errors
- `git diff --check`
