### PR TITLE
Match multivariable aareg variance errors

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -28639,11 +28639,12 @@ def aareg(
         taper=_aareg_taper_values(taper),
         test=test_name,
     )
-    test_names = (
-        coefficient_names[1:]
-        if test_name == "variance" and len(coefficient_names) > 2
-        else coefficient_names
-    )
+    if len(coefficient_names) != len(raw.test_statistic):
+        raise ValueError(
+            f"'names' attribute [{len(coefficient_names)}] must be the same length as the "
+            f"vector [{len(raw.test_statistic)}]"
+        )
+    test_names = coefficient_names
     model_frame = (
         _formula_model_frame(
             data,

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -26129,6 +26129,41 @@ def test_aareg_formula_validates_model_specific_options():
         survival.aareg("Surv(time, status) ~ x:cluster(group)", data=data, nmin=1)
 
 
+def test_aareg_multivariable_variance_test_preserves_reference_name_error():
+    data = {
+        "time": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+        "status": [1, 1, 1, 1, 1, 1],
+        "x": [0.0, 1.0, 2.0, 1.0, 3.0, -1.0],
+        "z": [1.0, 0.0, 1.0, 2.0, -1.0, 0.0],
+    }
+
+    with pytest.raises(
+        ValueError,
+        match=r"'names' attribute \[3\] must be the same length as the vector \[2\]",
+    ):
+        survival.aareg(
+            "Surv(time, status) ~ x + z",
+            data=data,
+            nmin=1,
+            test="variance",
+        )
+    with pytest.raises(ValueError, match="nmin threshold"):
+        survival.aareg(
+            "Surv(time, status) ~ x + z",
+            data=data,
+            nmin=99,
+            test="variance",
+        )
+
+    single = survival.aareg(
+        "Surv(time, status) ~ x",
+        data=data,
+        nmin=1,
+        test="variance",
+    )
+    assert single.test_statistic_names == ["Intercept", "x"]
+
+
 def test_aareg_explicit_cluster_overrides_formula_cluster_like_r():
     data = {
         "time": [1.0, 2.0, 2.0, 3.0, 4.0, 4.0],

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -6685,14 +6685,9 @@ aareg <- function(formula, data, weights, subset, na.action, qrtol = 1e-07,
   coefficient <- .as_numeric_matrix(.result_field(result, "coefficient"))
   coefficient[is.nan(coefficient)] <- NA_real_
   dimnames(coefficient) <- list(as.character(event_times), coefficient_names)
-  test_names <- if (identical(test, "variance") && nvar > 1L) {
-    colnames(design)
-  } else {
-    coefficient_names
-  }
   test_statistic <- .as_numeric_vector(.result_field(result, "test_statistic"))
   test_statistic[is.nan(test_statistic)] <- NA_real_
-  names(test_statistic) <- test_names
+  names(test_statistic) <- coefficient_names
   test_variance <- .as_numeric_matrix(.result_field(result, "test_variance"))
   test_variance[is.nan(test_variance)] <- NA_real_
   if (nvar > 1L && !identical(test, "variance")) {

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -4241,6 +4241,62 @@ test_that("R formula wrappers delegate to the Python survival package", {
   expect_equal(nrow(aft_dfbeta), nrow(data))
 })
 
+test_that("multi-covariate aareg variance tests preserve reference errors", {
+  skip_if_not_installed("reticulate")
+  skip_if_not(reticulate::py_module_available("survival"), "Python survival package is unavailable")
+
+  data <- data.frame(
+    time = 1:6,
+    status = rep(1, 6),
+    x = c(0, 1, 2, 1, 3, -1),
+    z = c(1, 0, 1, 2, -1, 0)
+  )
+  name_error <- "'names' attribute \\[3\\] must be the same length as the vector \\[2\\]"
+  expect_error(
+    aareg(Surv(time, status) ~ x + z, data = data, nmin = 1, test = "variance"),
+    name_error
+  )
+  expect_error(
+    survival::aareg(
+      survival::Surv(time, status) ~ x + z,
+      data = data,
+      nmin = 1,
+      test = "variance"
+    ),
+    name_error
+  )
+
+  expect_error(
+    aareg(Surv(time, status) ~ x + z, data = data, nmin = 99, test = "variance"),
+    "nmin threshold"
+  )
+  expect_error(
+    survival::aareg(
+      survival::Surv(time, status) ~ x + z,
+      data = data,
+      nmin = 99,
+      test = "variance"
+    ),
+    "threshold 'nmin'",
+    fixed = TRUE
+  )
+
+  bridged_single <- aareg(
+    Surv(time, status) ~ x,
+    data = data,
+    nmin = 1,
+    test = "variance"
+  )
+  reference_single <- survival::aareg(
+    survival::Surv(time, status) ~ x,
+    data = data,
+    nmin = 1,
+    test = "variance"
+  )
+  bridged_single$call <- reference_single$call
+  expect_equal(bridged_single, reference_single, tolerance = 1e-10)
+})
+
 test_that("right-censored concordance includes censors at the death time", {
   data <- data.frame(
     time = c(1, 3, 2, 4, 4, 5),


### PR DESCRIPTION
## Summary

- reproduce the upstream multivariable `test = "variance"` result-naming failure in both formula-facing wrappers
- keep the low-level numeric fit available and perform result-name validation only after fitting succeeds
- preserve the neighboring behavior: numeric fit errors occur first, and one-covariate variance tests remain valid

## Validation

- focused Python formula tests: 4 passed
- focused R bridge regression: passed
- original seed 20260822 case 17: matched
- randomized comparison: 500 unclustered and 500 clustered fits matched, including reference-error cases
- full Python suite: 1,101 passed, 18 skipped
- built R source package check: `Status: OK`
- Ruff, mypy, Cargo formatting, and diff checks passed
