### PR TITLE
Match aareg model-matrix column removal

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -28601,9 +28601,18 @@ def aareg(
     if terms.offsets:
         _offset_vector(data, terms.offsets, len(response))
 
-    design = _fit_formula_design(data, response_spec, terms, len(response))
-    rows = _design_rows_from_spec(data, design, len(response))
-    coefficient_names = ["Intercept", *_formula_design_output_names(design)]
+    design = _fit_formula_design(
+        data,
+        response_spec,
+        terms,
+        len(response),
+        include_intercept=True,
+    )
+    rows = [row[1:] for row in _design_rows_from_spec(data, design, len(response))]
+    design_names = _formula_design_output_names(design)[1:]
+    if not design_names:
+        raise ValueError("invalid 'length' argument")
+    coefficient_names = ["Intercept", *design_names]
     fit_weights = _optional_float_vector(weights, "weights", len(response))
     cluster_values = None if cluster is None else _materialize_labels(cluster, "cluster")
     if cluster_values is not None and len(cluster_values) != len(response):

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -26192,6 +26192,67 @@ def test_aareg_formula_validates_model_specific_options():
         survival.aareg("Surv(time, status) ~ x:cluster(group)", data=data, nmin=1)
 
 
+def test_aareg_formula_drops_the_reference_model_matrix_column():
+    data = {
+        "time": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+        "status": [1, 1, 1, 1, 1, 1],
+        "x": [0.0, 1.0, 2.0, 1.0, 3.0, -1.0],
+        "z": [1.0, 0.0, 1.0, 2.0, -1.0, 0.0],
+        "group": ["a", "b", "c", "a", "b", "c"],
+    }
+
+    for formula in ("Surv(time, status) ~ 1", "Surv(time, status) ~ 0 + x"):
+        with pytest.raises(ValueError, match="invalid 'length' argument"):
+            survival.aareg(formula, data=data, nmin=0)
+
+    def assert_matrix_close(actual: list[list[float]], expected: list[list[float]]) -> None:
+        for actual_row, expected_row in zip(actual, expected, strict=True):
+            for actual_value, expected_value in zip(actual_row, expected_row, strict=True):
+                if math.isnan(expected_value):
+                    assert math.isnan(actual_value)
+                else:
+                    assert actual_value == pytest.approx(expected_value)
+
+    dropped_numeric = survival.aareg(
+        "Surv(time, status) ~ 0 + x + z",
+        data=data,
+        nmin=0,
+        x=True,
+    )
+    reference_numeric = survival.aareg(
+        "Surv(time, status) ~ z",
+        data=data,
+        nmin=0,
+        x=True,
+    )
+    assert dropped_numeric.coefficient_names == ["Intercept", "z"]
+    assert dropped_numeric.n == reference_numeric.n
+    assert dropped_numeric.times == reference_numeric.times
+    assert dropped_numeric.nrisk == pytest.approx(reference_numeric.nrisk)
+    assert_matrix_close(dropped_numeric.coefficient, reference_numeric.coefficient)
+    assert dropped_numeric.test_statistic == pytest.approx(reference_numeric.test_statistic)
+    assert_matrix_close(dropped_numeric.test_variance, reference_numeric.test_variance)
+    assert dropped_numeric.x == reference_numeric.x
+
+    dropped_factor = survival.aareg(
+        "Surv(time, status) ~ 0 + group",
+        data=data,
+        nmin=0,
+        x=True,
+    )
+    reference_factor = survival.aareg(
+        "Surv(time, status) ~ group",
+        data=data,
+        nmin=0,
+        x=True,
+    )
+    assert dropped_factor.coefficient_names == reference_factor.coefficient_names
+    assert dropped_factor.n == reference_factor.n
+    assert dropped_factor.times == reference_factor.times
+    assert_matrix_close(dropped_factor.coefficient, reference_factor.coefficient)
+    assert dropped_factor.x == reference_factor.x
+
+
 def test_aareg_multivariable_variance_test_preserves_reference_name_error():
     data = {
         "time": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -6598,12 +6598,13 @@ aareg <- function(formula, data, weights, subset, na.action, qrtol = 1e-07,
   cluster_values <- stats::model.extract(frame, "cluster")
 
   design <- stats::model.matrix(Terms, frame)
-  assign <- attr(design, "assign")
-  keep <- assign != 0L
-  design <- design[, keep, drop = FALSE]
+  design <- design[, -1L, drop = FALSE]
   storage.mode(design) <- "double"
   nused <- nrow(design)
   nvar <- ncol(design)
+  if (nvar == 0L) {
+    stop("invalid 'length' argument", call. = FALSE)
+  }
 
   fit_weights <- stats::model.extract(frame, "weights")
   if (length(fit_weights) == 0L) {

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -4275,6 +4275,56 @@ test_that("R formula wrappers delegate to the Python survival package", {
   expect_equal(nrow(aft_dfbeta), nrow(data))
 })
 
+test_that("aareg drops the reference model-matrix column", {
+  skip_if_not_installed("reticulate")
+  skip_if_not(reticulate::py_module_available("survival"), "Python survival package is unavailable")
+
+  data <- data.frame(
+    time = 1:6,
+    status = rep(1, 6),
+    x = c(0, 1, 2, 1, 3, -1),
+    z = c(1, 0, 1, 2, -1, 0),
+    group = factor(c("a", "b", "c", "a", "b", "c"))
+  )
+  length_error <- "invalid 'length' argument"
+  expect_error(aareg(Surv(time, status) ~ 1, data = data, nmin = 0), length_error, fixed = TRUE)
+  expect_error(
+    survival::aareg(survival::Surv(time, status) ~ 1, data = data, nmin = 0),
+    length_error,
+    fixed = TRUE
+  )
+  expect_error(
+    aareg(Surv(time, status) ~ 0 + x, data = data, nmin = 0),
+    length_error,
+    fixed = TRUE
+  )
+  expect_error(
+    survival::aareg(survival::Surv(time, status) ~ 0 + x, data = data, nmin = 0),
+    length_error,
+    fixed = TRUE
+  )
+
+  bridged_numeric <- aareg(Surv(time, status) ~ 0 + x + z, data = data, nmin = 0, x = TRUE)
+  reference_numeric <- survival::aareg(
+    survival::Surv(time, status) ~ 0 + x + z,
+    data = data,
+    nmin = 0,
+    x = TRUE
+  )
+  bridged_numeric$call <- reference_numeric$call
+  expect_equal(bridged_numeric, reference_numeric, tolerance = 1e-10)
+
+  bridged_factor <- aareg(Surv(time, status) ~ 0 + group, data = data, nmin = 0, x = TRUE)
+  reference_factor <- survival::aareg(
+    survival::Surv(time, status) ~ 0 + group,
+    data = data,
+    nmin = 0,
+    x = TRUE
+  )
+  bridged_factor$call <- reference_factor$call
+  expect_equal(bridged_factor, reference_factor, tolerance = 1e-10)
+})
+
 test_that("multi-covariate aareg variance tests preserve reference errors", {
   skip_if_not_installed("reticulate")
   skip_if_not(reticulate::py_module_available("survival"), "Python survival package is unavailable")


### PR DESCRIPTION
## Summary
- build the aareg formula matrix with its native intercept coding, then remove column one exactly as upstream does
- preserve the silent first-predictor removal for no-intercept formulas
- reproduce the `invalid 'length' argument` failure when no predictor columns remain
- leave low-level intercept-only fitting available

## Validation
- `pytest python/tests` (1,121 passed)
- focused Python aareg formula tests
- Ruff and mypy
- package-native R bridge suite
- fresh built R package check (`Status: OK`)
- 998 fresh clustered and unclustered randomized comparisons; two reference elapsed-time loops skipped