### PR TITLE
Match cch model-matrix column removal

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -20554,6 +20554,8 @@ def coef_names(fit: Any, *, complete: Any | None = None) -> list[str]:
     include_complete = (
         _is_coxph_fit(fit) if complete is None else _normalize_bool_option(complete, "complete")
     )
+    if isinstance(fit, CchModelResult):
+        return list(fit.coefficient_names)
     if _is_survreg_fit(fit):
         location_width = len(_location_beta(fit))
         names = _fit_location_coef_names(fit, location_width)
@@ -24920,9 +24922,10 @@ def _prediction_inputs(
                     f"newdata column {sparse_frailty.formula.term.column!r} contains unknown level "
                     f"{unknown!r}"
                 )
-        return _design_rows_from_spec(newdata, design, n, prediction=True), (
-            offsets if any(offsets) else None
-        )
+        rows = _design_rows_from_spec(newdata, design, n, prediction=True)
+        if isinstance(fit, CchModelResult):
+            return [row[1:] for row in rows], None
+        return rows, (offsets if any(offsets) else None)
     coefficient_names = getattr(fit, "coefficient_names", None)
     if coefficient_names is not None and (
         isinstance(newdata, Mapping) or hasattr(newdata, "columns")
@@ -28409,11 +28412,19 @@ def cch(
     if terms.clusters:
         raise ValueError("cluster() terms are not supported by cch")
 
-    design = _fit_formula_design(data, response_spec, terms, len(response))
-    rows = _design_rows_from_spec(data, design, len(response))
-    if not rows or not rows[0]:
-        raise ValueError("cch formula must contain at least one covariate")
-    coefficient_names = tuple(_formula_design_output_names(design))
+    design = _fit_formula_design(
+        data,
+        response_spec,
+        terms,
+        len(response),
+        include_intercept=True,
+    )
+    design_names = _formula_design_output_names(design)
+    if len(design_names) < 2:
+        raise ValueError("subscript out of bounds")
+    rows = [row[1:] for row in _design_rows_from_spec(data, design, len(response))]
+    selected_names = design_names[1:]
+    coefficient_names = () if len(selected_names) == 1 else tuple(selected_names)
 
     raw_subcohort = _materialize_1d(subcohort_values, "subcoh")
     if len(raw_subcohort) != len(response):

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -25929,6 +25929,49 @@ def test_cch_formula_expands_factors_and_validates_sampling_inputs():
         )
 
 
+def test_cch_formula_drops_the_reference_model_matrix_column():
+    data = _cch_parity_data()
+    common = {
+        "subcoh": "subcohort",
+        "id": "id",
+        "cohort_size": 80,
+        "method": "Prentice",
+    }
+
+    for formula in ("Surv(stop, status) ~ 1", "Surv(stop, status) ~ 0 + x"):
+        with pytest.raises(ValueError, match="subscript out of bounds"):
+            survival.cch(formula, data, **common)
+
+    one_covariate = survival.cch("Surv(stop, status) ~ x", data, **common)
+    assert survival.coef_names(one_covariate) == []
+
+    dropped_numeric = survival.cch("Surv(stop, status) ~ 0 + x + z", data, **common)
+    reference_numeric = survival.cch("Surv(stop, status) ~ z", data, **common)
+    assert survival.coef_names(dropped_numeric) == []
+    assert survival.coef(dropped_numeric) == pytest.approx(survival.coef(reference_numeric))
+    for actual, expected in zip(
+        survival.vcov(dropped_numeric),
+        survival.vcov(reference_numeric),
+        strict=True,
+    ):
+        assert actual == pytest.approx(expected)
+    assert dropped_numeric.means == pytest.approx(reference_numeric.means)
+    assert dropped_numeric.x == reference_numeric.x
+    assert survival.predict(
+        dropped_numeric,
+        {"x": [100.0], "z": [0.25]},
+        reference="zero",
+    ) == pytest.approx(
+        survival.predict(reference_numeric, {"z": [0.25]}, reference="zero")
+    )
+
+    dropped_factor = survival.cch("Surv(stop, status) ~ 0 + group", data, **common)
+    reference_factor = survival.cch("Surv(stop, status) ~ group", data, **common)
+    assert survival.coef_names(dropped_factor) == []
+    assert survival.coef(dropped_factor) == pytest.approx(survival.coef(reference_factor))
+    assert dropped_factor.x == reference_factor.x
+
+
 def test_aareg_formula_matches_weighted_right_censored_reference_values():
     data = {
         "stop": [1.0, 2.0, 2.0, 3.0, 4.0, 4.0],

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -7177,17 +7177,26 @@ cch <- function(formula, data, subcoh, id, stratum = NULL, cohort.size,
   }
 
   design <- stats::model.matrix(Terms, frame)
-  if (attr(Terms, "intercept") == 1L) {
-    design <- design[, -1L, drop = FALSE]
+  if (ncol(design) < 2L) {
+    stop("subscript out of bounds", call. = FALSE)
   }
-  if (ncol(design) == 0L) {
-    stop("cch formula must contain at least one covariate", call. = FALSE)
+  design <- design[, 2:ncol(design)]
+  coefficient_names <- dimnames(design)[[2L]]
+  fit_design <- if (is.null(dim(design))) {
+    matrix(as.numeric(design), ncol = 1L)
+  } else {
+    design
   }
-  coefficient_names <- colnames(design)
+  assignment_label <- if (method %in% c("Prentice", "SelfPrentice")) "aX" else "X"
+  internal_fit_names <- if (length(coefficient_names) == 0L) {
+    assignment_label
+  } else {
+    paste0(assignment_label, coefficient_names)
+  }
   common_args <- list(
     stop = as.list(stop_time),
     status = as.list(status),
-    covariates = .coxph_fit_covariates(design, nrow(design)),
+    covariates = .coxph_fit_covariates(fit_design, nrow(fit_design)),
     subcohort = as.list(as.integer(subcoh)),
     id = as.list(as.integer(factor(id, levels = unique(id))) - 1L),
     start = if (is.null(start_time)) NULL else as.list(start_time),
@@ -7227,7 +7236,9 @@ cch <- function(formula, data, subcoh, id, stratum = NULL, cohort.size,
     coefficient_names
   )
   fit_x <- .as_numeric_matrix(.result_field(result, "covariates"))
-  colnames(fit_x) <- coefficient_names
+  rownames(fit_x) <- as.character(seq_len(nrow(fit_x)))
+  colnames(fit_x) <- internal_fit_names
+  attr(fit_x, "assign") <- rep.int(1L, ncol(fit_x))
   fit_start <- .as_numeric_vector(.result_field(result, "entry_times"))
   fit_stop <- .as_numeric_vector(.result_field(result, "event_times"))
   fit_status <- as.integer(.as_numeric_vector(.result_field(result, "status")))
@@ -7241,12 +7252,12 @@ cch <- function(formula, data, subcoh, id, stratum = NULL, cohort.size,
     iter = as.integer(.result_field(result, "iterations")),
     linear.predictors = .as_numeric_vector(.result_field(result, "linear_predictors")),
     residuals = .as_numeric_vector(.result_field(result, "residuals")),
-    means = stats::setNames(.as_numeric_vector(.result_field(result, "means")), coefficient_names),
+    means = stats::setNames(.as_numeric_vector(.result_field(result, "means")), internal_fit_names),
     method = method,
     n = as.integer(.result_field(result, "n")),
     nevent = as.integer(.result_field(result, "nevent")),
     terms = Terms,
-    assign = attr(design, "assign"),
+    assign = stats::setNames(list(seq_len(ncol(fit_design))), assignment_label),
     naive.var = naive_variance,
     x = fit_x,
     y = fit_y,
@@ -7264,7 +7275,7 @@ cch <- function(formula, data, subcoh, id, stratum = NULL, cohort.size,
     out$opt <- .as_numeric_matrix(.result_field(result, "optimization_fraction"))
     out$delta <- .as_numeric_matrix(.result_field(result, "phase2_score_matrix"))
     out$sc <- .as_numeric_matrix(.result_field(result, "collapsed_score_rows"))
-    internal_score_names <- paste0("X", coefficient_names)
+    internal_score_names <- internal_fit_names
     dimnames(out$opt) <- list(c("opt", rep("", max(0L, nrow(out$opt) - 1L))), NULL)
     if (identical(method, "II.Borgan")) {
       dimnames(out$delta) <- list(internal_score_names, internal_score_names)

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -13189,6 +13189,47 @@ test_that("cch rejects invalid unstratified sampling inputs", {
   )
 })
 
+test_that("cch drops the reference model-matrix column", {
+  skip_if_not_installed("reticulate")
+  skip_if_not_installed("survival")
+  skip_if_not(reticulate::py_module_available("survival"), "Python survival package is unavailable")
+
+  data <- data.frame(
+    stop = c(5, 12, 3, 18, 9, 1, 15, 7, 20, 4, 11, 16, 2, 14, 6, 10, 13, 8, 17, 19),
+    status = c(1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1),
+    x = c(-1.2, .4, .9, -.3, 1.4, -.8, .2, 1.1, -.5, .7, -1, .1, 1.7, -.6, .5, -1.5, 1, -.1, .8, -.9),
+    z = c(0, 1, 1, 0, 1, 0, 0, 1, 0, 1, 1, 0, 1, 0, 1, 0, 1, 0, 0, 1),
+    group = factor(rep(c("a", "b"), 10)),
+    id = seq_len(20),
+    subcohort = c(rep(1, 14), rep(0, 6))
+  )
+  common <- list(data = data, subcoh = ~subcohort, id = ~id, cohort.size = 80)
+  expect_error(
+    do.call(cch, c(list(formula = Surv(stop, status) ~ 1), common)),
+    "subscript out of bounds",
+    fixed = TRUE
+  )
+  expect_error(
+    do.call(cch, c(list(formula = Surv(stop, status) ~ 0 + x), common)),
+    "subscript out of bounds",
+    fixed = TRUE
+  )
+
+  compare_shape <- function(formula) {
+    actual <- do.call(cch, c(list(formula = formula), common))
+    reference <- do.call(survival::cch, c(list(formula = formula), common))
+    expect_equal(actual$coefficients, reference$coefficients, tolerance = 1e-11)
+    expect_equal(actual$var, reference$var, tolerance = 1e-11)
+    expect_equal(actual$naive.var, reference$naive.var, tolerance = 1e-11)
+    expect_equal(actual$means, reference$means, tolerance = 1e-11)
+    expect_equal(actual$x, reference$x, tolerance = 1e-11)
+    expect_equal(actual$assign, reference$assign)
+  }
+  compare_shape(Surv(stop, status) ~ x)
+  compare_shape(Surv(stop, status) ~ 0 + x + z)
+  compare_shape(Surv(stop, status) ~ 0 + group)
+})
+
 test_that("low-level Cox survival curves match right and counting-process fits", {
   skip_if_not_installed("reticulate")
   skip_if_not_installed("survival")


### PR DESCRIPTION
## Summary
- reproduce the positional `2:ncol(X)` model-matrix selection used by the reference cch front end
- preserve `subscript out of bounds` failures when fewer than two source columns exist
- preserve unnamed one-predictor coefficients and covariance matrices after dimension dropping
- match method-specific internal `x`, mean, and assignment names
- rebuild prediction rows with the same first-column removal

## Validation
- `pytest python/tests` (1,122 passed)
- focused Python cch tests (8 passed)
- complete package-native R bridge suite
- fresh built R package check (`Status: OK`)
- Ruff and mypy
- targeted right/counting, numeric/factor, and single/multiple-column reference comparisons