### PR TITLE
Stabilize counting-process cch covariance

### DIFF
--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -25836,6 +25836,57 @@ def test_cch_formula_matches_r_counting_process_results():
     assert len(fit.martingale_residuals()) == len(fit.status)
 
 
+def test_cch_formula_preserves_small_counting_process_offset_risk():
+    data = {
+        "start": [1, 8, 6, 13, 3, 14, 4, 0, 10, 12, 16, 11, 4, 1, 13, 14, 6, 8, 9, 13, 4],
+        "stop": [3, 13, 11, 15, 5, 16, 9, 1, 12, 14, 19, 16, 9, 3, 15, 18, 7, 9, 10, 15, 10],
+        "status": [0, 1, 1, 1, 1, 0, 1, 1, 0, 0, 1, 1, 0, 0, 0, 1, 1, 1, 1, 0, 1],
+        "x": [
+            -2.36601980289781,
+            -0.939726558703197,
+            0.672805414806265,
+            -0.476183125795317,
+            -0.636546918038443,
+            -0.687008929997081,
+            0.535019844914994,
+            -0.210862903347529,
+            0.705276653609758,
+            -0.678855799561129,
+            -0.832078189498332,
+            -0.956832544488333,
+            -0.230958721600656,
+            -0.542591235128462,
+            -1.20622632983076,
+            1.48683179341071,
+            1.28963847269521,
+            0.271588841450844,
+            -1.63591043582559,
+            -0.831208786158255,
+            -0.890202805534755,
+        ],
+        "id": list(range(1, 22)),
+        "subcohort": [1, 1, 0, 1, 0, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1, 1, 0, 0, 0, 1, 0],
+    }
+    fit = survival.cch(
+        "Surv(start, stop, status) ~ x",
+        data,
+        subcoh="subcohort",
+        id="id",
+        cohort_size=63,
+        method="Prentice",
+    )
+
+    assert survival.coef(fit) == pytest.approx([0.291262177689472], abs=1e-11)
+    assert fit.var[0] == pytest.approx([0.344113006027074], abs=1e-11)
+    assert fit.naive_var[0] == pytest.approx([0.344113006027074], abs=1e-11)
+    assert fit.phase2var[0] == pytest.approx([0.150259455416288], abs=1e-11)
+    assert fit.log_likelihood == pytest.approx(
+        [-1207.81781102863, -1207.81190638963], abs=1e-11
+    )
+    assert fit.score_test == pytest.approx(0.0118505939665458, abs=1e-11)
+    assert fit.iterations == 2
+
+
 @pytest.mark.parametrize(
     ("method", "expected_coefficients", "expected_variance"),
     [

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -13098,6 +13098,47 @@ test_that("cch unstratified fits match survival for right and counting data", {
   }
 })
 
+test_that("cch preserves small offset risk in counting-process data", {
+  skip_if_not_installed("reticulate")
+  skip_if_not_installed("survival")
+  skip_if_not(reticulate::py_module_available("survival"), "Python survival package is unavailable")
+
+  data <- data.frame(
+    start = c(1, 8, 6, 13, 3, 14, 4, 0, 10, 12, 16, 11, 4, 1, 13, 14, 6, 8, 9, 13, 4),
+    stop = c(3, 13, 11, 15, 5, 16, 9, 1, 12, 14, 19, 16, 9, 3, 15, 18, 7, 9, 10, 15, 10),
+    status = c(0, 1, 1, 1, 1, 0, 1, 1, 0, 0, 1, 1, 0, 0, 0, 1, 1, 1, 1, 0, 1),
+    x = c(
+      -2.36601980289781, -0.939726558703197, 0.672805414806265,
+      -0.476183125795317, -0.636546918038443, -0.687008929997081,
+      0.535019844914994, -0.210862903347529, 0.705276653609758,
+      -0.678855799561129, -0.832078189498332, -0.956832544488333,
+      -0.230958721600656, -0.542591235128462, -1.20622632983076,
+      1.48683179341071, 1.28963847269521, 0.271588841450844,
+      -1.63591043582559, -0.831208786158255, -0.890202805534755
+    ),
+    id = seq_len(21),
+    subcohort = c(1, 1, 0, 1, 0, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1, 1, 0, 0, 0, 1, 0)
+  )
+  args <- list(
+    formula = Surv(start, stop, status) ~ x,
+    data = data,
+    subcoh = ~subcohort,
+    id = ~id,
+    cohort.size = 63,
+    method = "Prentice"
+  )
+  actual <- do.call(cch, args)
+  reference <- do.call(survival::cch, args)
+
+  expect_equal(actual$coefficients, reference$coefficients, tolerance = 1e-11)
+  expect_equal(actual$var, reference$var, tolerance = 1e-11)
+  expect_equal(actual$naive.var, reference$naive.var, tolerance = 1e-11)
+  expect_equal(actual$phase2var, reference$phase2var, tolerance = 1e-11)
+  expect_equal(actual$loglik, reference$loglik, tolerance = 1e-11)
+  expect_equal(actual$score, reference$score, tolerance = 1e-11)
+  expect_equal(actual$iter, reference$iter)
+})
+
 test_that("cch stratified Borgan fits match survival", {
   skip_if_not_installed("reticulate")
   skip_if_not_installed("survival")

--- a/src/regression/cch.rs
+++ b/src/regression/cch.rs
@@ -1481,6 +1481,74 @@ mod tests {
     }
 
     #[test]
+    fn native_counting_process_prentice_preserves_small_offset_risk() {
+        let stop = vec![
+            3.0, 13.0, 11.0, 15.0, 5.0, 16.0, 9.0, 1.0, 12.0, 14.0, 19.0, 16.0, 9.0, 3.0, 15.0,
+            18.0, 7.0, 9.0, 10.0, 15.0, 10.0,
+        ];
+        let status = vec![
+            0, 1, 1, 1, 1, 0, 1, 1, 0, 0, 1, 1, 0, 0, 0, 1, 1, 1, 1, 0, 1,
+        ];
+        let x = [
+            -2.366_019_802_897_81,
+            -0.939_726_558_703_197,
+            0.672_805_414_806_265,
+            -0.476_183_125_795_317,
+            -0.636_546_918_038_443,
+            -0.687_008_929_997_081,
+            0.535_019_844_914_994,
+            -0.210_862_903_347_529,
+            0.705_276_653_609_758,
+            -0.678_855_799_561_129,
+            -0.832_078_189_498_332,
+            -0.956_832_544_488_333,
+            -0.230_958_721_600_656,
+            -0.542_591_235_128_462,
+            -1.206_226_329_830_76,
+            1.486_831_793_410_71,
+            1.289_638_472_695_21,
+            0.271_588_841_450_844,
+            -1.635_910_435_825_59,
+            -0.831_208_786_158_255,
+            -0.890_202_805_534_755,
+        ];
+        let covariates = x.into_iter().map(|value| vec![value]).collect();
+        let subcohort = vec![
+            1, 1, 0, 1, 0, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1, 1, 0, 0, 0, 1, 0,
+        ];
+        let start = vec![
+            1.0, 8.0, 6.0, 13.0, 3.0, 14.0, 4.0, 0.0, 10.0, 12.0, 16.0, 11.0, 4.0, 1.0, 13.0, 14.0,
+            6.0, 8.0, 9.0, 13.0, 4.0,
+        ];
+        let result = cch_fit(
+            stop,
+            status,
+            covariates,
+            subcohort,
+            (1..=21).collect(),
+            63,
+            Some(start),
+            "Prentice",
+            false,
+        )
+        .expect("counting-process Prentice fit should succeed");
+
+        assert_close(&result.coefficients[0], &[0.291_262_177_689_472]);
+        assert_matrix_close(
+            &result.model_information_matrix,
+            &[vec![0.193_853_550_610_786]],
+        );
+        assert_matrix_close(&result.phase2_variance, &[vec![0.150_259_455_416_288]]);
+        assert_matrix_close(&result.information_matrix, &[vec![0.344_113_006_027_074]]);
+        assert_close(
+            &result.log_likelihood,
+            &[-1_207.817_811_028_63, -1_207.811_906_389_63],
+        );
+        assert!((result.score_test - 0.011_850_593_966_545_8).abs() < 1e-11);
+        assert_eq!(result.iterations, 2);
+    }
+
+    #[test]
     fn native_stratified_borgan_results_match_r_survival() {
         let (start, stop, status, covariates, subcohort, id) = r_parity_fixture();
         let stratum = (0..stop.len()).map(|idx| idx % 2).collect::<Vec<_>>();

--- a/src/regression/cox_optimizer.rs
+++ b/src/regression/cox_optimizer.rs
@@ -1294,13 +1294,35 @@ impl CoxFit {
                 }
 
                 if ndead > 0 {
-                    let denom = stop_denom - unentered_denom;
+                    let mut denom = stop_denom - unentered_denom;
+                    let denom_scale = stop_denom.abs() + unentered_denom.abs();
+                    let reliable_difference = denom.is_finite()
+                        && denom > 0.0
+                        && (denom_scale == 0.0 || denom > 64.0 * f64::EPSILON * denom_scale);
                     event_a.fill(0.0);
                     event_cmat.fill(0.0);
                     for i in 0..nvar {
                         event_a[i] = stop_a[i] - unentered_a[i];
                         for j in 0..=i {
                             event_cmat[(i, j)] = stop_cmat[(i, j)] - unentered_cmat[(i, j)];
+                        }
+                    }
+                    if !reliable_difference {
+                        denom = 0.0;
+                        event_a.fill(0.0);
+                        event_cmat.fill(0.0);
+                        for person in stratum_start..=stratum_end {
+                            if entry_times[person] < event_time && self.time[person] >= event_time {
+                                add_risk_sums(
+                                    &self.covar,
+                                    nvar,
+                                    person,
+                                    risk_vals[person],
+                                    &mut denom,
+                                    &mut event_a,
+                                    &mut event_cmat,
+                                );
+                            }
                         }
                     }
                     if matches!(method, Method::Breslow) || ndead == 1 {

--- a/src/regression/coxph_diagnostics.rs
+++ b/src/regression/coxph_diagnostics.rs
@@ -6,7 +6,9 @@ use crate::regression::coxph::CoxPHFit;
 use crate::regression::coxph_detail_module::{
     CoxphDetail, CoxphDetailOptions, compute_coxph_detail_with_options, coxph_detail,
 };
-use crate::regression::coxph_support::{ActiveRiskSet, CoxSweepRow, StratifiedBaselineLookup};
+use crate::regression::coxph_support::{
+    ActiveRiskSet, CompensatedSum, CoxSweepRow, StratifiedBaselineLookup,
+};
 use crate::regression::exact_ties::{exact_inclusion_probabilities, exact_tied_moments};
 use crate::residuals::agmart_module::{AgmartData, compute_agmart};
 use crate::residuals::coxmart_module::{CoxMartSurvivalData, CoxMartWeights, compute_coxmart};
@@ -1453,9 +1455,9 @@ impl CoxPHFit {
             let mut cumulative_scalars = Vec::with_capacity(event_count);
             let mut cumulative_xhazards = Vec::with_capacity(event_count);
             let mut deaths: Vec<usize> = Vec::with_capacity(event_count);
-            let mut cumulative_scalar = 0.0;
-            let mut cumulative_xhazard = vec![0.0; nvar];
-            let mut active_risk_covariates = vec![0.0; nvar];
+            let mut cumulative_scalar = CompensatedSum::default();
+            let mut cumulative_xhazard = vec![CompensatedSum::default(); nvar];
+            let mut active_risk_covariates = vec![CompensatedSum::default(); nvar];
             let mut time_start = 0usize;
             while time_start < rows.len() {
                 let event_time = rows[time_start].stop;
@@ -1468,8 +1470,9 @@ impl CoxPHFit {
                     let direction = if added { 1.0 } else { -1.0 };
                     let original_idx = rows[row_idx].original_idx;
                     for (col_idx, value) in active_risk_covariates.iter_mut().enumerate() {
-                        *value +=
-                            direction * rows[row_idx].risk * self.covariates[original_idx][col_idx];
+                        value.add(
+                            direction * rows[row_idx].risk * self.covariates[original_idx][col_idx],
+                        );
                     }
                 });
 
@@ -1498,16 +1501,16 @@ impl CoxPHFit {
                                 continue;
                             }
                             let hazard = weight_average / step_denom;
-                            for ((value, &active_total), &death_total) in mean
+                            for ((value, active_total), &death_total) in mean
                                 .iter_mut()
-                                .zip(&active_risk_covariates)
+                                .zip(active_risk_covariates.iter().map(|value| value.total()))
                                 .zip(&death_covariates)
                             {
                                 *value = (active_total - fraction * death_total) / step_denom;
                             }
-                            cumulative_scalar += hazard;
+                            cumulative_scalar.add(hazard);
                             for (col_idx, value) in cumulative_xhazard.iter_mut().enumerate() {
-                                *value += mean[col_idx] * hazard;
+                                value.add(mean[col_idx] * hazard);
                             }
                             for &row_idx in &deaths {
                                 let original_idx = rows[row_idx].original_idx;
@@ -1526,11 +1529,11 @@ impl CoxPHFit {
                         let hazard = deadwt / active.risk_sum;
                         let mean: Vec<f64> = active_risk_covariates
                             .iter()
-                            .map(|&value| value / active.risk_sum)
+                            .map(|value| value.total() / active.risk_sum)
                             .collect();
-                        cumulative_scalar += hazard;
+                        cumulative_scalar.add(hazard);
                         for (col_idx, value) in cumulative_xhazard.iter_mut().enumerate() {
-                            *value += mean[col_idx] * hazard;
+                            value.add(mean[col_idx] * hazard);
                         }
                         for &row_idx in &deaths {
                             let original_idx = rows[row_idx].original_idx;
@@ -1559,18 +1562,21 @@ impl CoxPHFit {
                 };
                 let start_index = step_index(row.entry);
                 let stop_index = step_index(row.stop);
-                let start_scalar = start_index.map_or(0.0, |idx| cumulative_scalars[idx]);
-                let stop_scalar = stop_index.map_or(0.0, |idx| cumulative_scalars[idx]);
-                let active_scalar = stop_scalar - start_scalar;
+                let start_scalar =
+                    start_index.map_or_else(CompensatedSum::default, |idx| cumulative_scalars[idx]);
+                let stop_scalar =
+                    stop_index.map_or_else(CompensatedSum::default, |idx| cumulative_scalars[idx]);
+                let active_scalar = stop_scalar.difference(start_scalar);
                 let score = scores[row.original_idx];
                 for (col_idx, residual) in residuals[row.original_idx].iter_mut().enumerate() {
-                    let start_xhazard =
-                        start_index.map_or(0.0, |idx| cumulative_xhazards[idx][col_idx]);
-                    let stop_xhazard =
-                        stop_index.map_or(0.0, |idx| cumulative_xhazards[idx][col_idx]);
+                    let start_xhazard = start_index.map_or_else(CompensatedSum::default, |idx| {
+                        cumulative_xhazards[idx][col_idx]
+                    });
+                    let stop_xhazard = stop_index.map_or_else(CompensatedSum::default, |idx| {
+                        cumulative_xhazards[idx][col_idx]
+                    });
                     *residual += score
-                        * (stop_xhazard
-                            - start_xhazard
+                        * (stop_xhazard.difference(start_xhazard)
                             - active_scalar * self.covariates[row.original_idx][col_idx]);
                 }
             }

--- a/src/regression/coxph_support.rs
+++ b/src/regression/coxph_support.rs
@@ -50,6 +50,37 @@ pub(super) struct CoxSweepRow {
     pub(super) status: i32,
 }
 
+#[derive(Clone, Copy, Default)]
+pub(super) struct CompensatedSum {
+    sum: f64,
+    correction: f64,
+}
+
+impl CompensatedSum {
+    pub(super) fn add(&mut self, value: f64) {
+        let next = self.sum + value;
+        self.correction += if self.sum.abs() >= value.abs() {
+            (self.sum - next) + value
+        } else {
+            (value - next) + self.sum
+        };
+        self.sum = next;
+    }
+
+    pub(super) fn total(self) -> f64 {
+        self.sum + self.correction
+    }
+
+    pub(super) fn difference(self, earlier: Self) -> f64 {
+        let mut difference = Self::default();
+        difference.add(self.sum);
+        difference.add(-earlier.sum);
+        difference.add(self.correction);
+        difference.add(-earlier.correction);
+        difference.total()
+    }
+}
+
 pub(super) struct ActiveRiskSet<'a> {
     rows: &'a [CoxSweepRow],
     use_entry_times: bool,
@@ -58,6 +89,7 @@ pub(super) struct ActiveRiskSet<'a> {
     active_rows: Vec<bool>,
     entry_pos: usize,
     stop_pos: usize,
+    risk_accumulator: CompensatedSum,
     pub(super) risk_sum: f64,
 }
 
@@ -87,11 +119,13 @@ impl<'a> ActiveRiskSet<'a> {
         } else {
             Vec::new()
         };
-        let risk_sum = if use_entry_times {
-            0.0
-        } else {
-            rows.iter().map(|row| row.risk).sum()
-        };
+        let mut risk_accumulator = CompensatedSum::default();
+        if !use_entry_times {
+            for row in rows {
+                risk_accumulator.add(row.risk);
+            }
+        }
+        let risk_sum = risk_accumulator.total();
 
         Self {
             rows,
@@ -101,6 +135,7 @@ impl<'a> ActiveRiskSet<'a> {
             active_rows,
             entry_pos: 0,
             stop_pos: 0,
+            risk_accumulator,
             risk_sum,
         }
     }
@@ -116,7 +151,8 @@ impl<'a> ActiveRiskSet<'a> {
                 let row_idx = self.entry_order[self.entry_pos];
                 if !self.active_rows[row_idx] {
                     self.active_rows[row_idx] = true;
-                    self.risk_sum += self.rows[row_idx].risk;
+                    self.risk_accumulator.add(self.rows[row_idx].risk);
+                    self.risk_sum = self.risk_accumulator.total();
                     on_change(row_idx, true);
                 }
                 self.entry_pos += 1;
@@ -127,7 +163,8 @@ impl<'a> ActiveRiskSet<'a> {
                 let row_idx = self.stop_order[self.stop_pos];
                 if self.active_rows[row_idx] {
                     self.active_rows[row_idx] = false;
-                    self.risk_sum -= self.rows[row_idx].risk;
+                    self.risk_accumulator.add(-self.rows[row_idx].risk);
+                    self.risk_sum = self.risk_accumulator.total();
                     on_change(row_idx, false);
                 }
                 self.stop_pos += 1;
@@ -137,7 +174,8 @@ impl<'a> ActiveRiskSet<'a> {
                 && self.rows[self.stop_order[self.stop_pos]].stop < event_time
             {
                 let row_idx = self.stop_order[self.stop_pos];
-                self.risk_sum -= self.rows[row_idx].risk;
+                self.risk_accumulator.add(-self.rows[row_idx].risk);
+                self.risk_sum = self.risk_accumulator.total();
                 on_change(row_idx, false);
                 self.stop_pos += 1;
             }
@@ -156,6 +194,21 @@ pub(super) fn cumulative_step_at(times: &[f64], values: &[f64], time: f64) -> f6
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn compensated_sum_retains_small_remainders_and_differences() {
+        let mut total = CompensatedSum::default();
+        total.add(1e-40);
+        total.add(1.0);
+        total.add(-1.0);
+        assert_eq!(total.total(), 1e-40);
+
+        let mut cumulative = CompensatedSum::default();
+        cumulative.add(1e40);
+        let earlier = cumulative;
+        cumulative.add(0.25);
+        assert_eq!(cumulative.difference(earlier), 0.25);
+    }
 
     #[test]
     fn cumulative_step_at_uses_last_prior_value() {


### PR DESCRIPTION
## Summary
- rebuild cancellation-prone counting-process risk totals when cumulative subtraction loses the active denominator
- retain small active-risk and cumulative-hazard terms with compensated sums in Cox diagnostics
- add exact Rust, Python, and R regressions for the one-covariate Prentice fixture

## Testing
- `cargo test --lib` (1,579 passed)
- `.venv/bin/python -m pytest python/tests -q` (1,123 passed)
- full R bridge suite
- `R CMD check` on the built package (`Status: OK`)
- Ruff, mypy, Clippy, and `git diff --check`
- randomized cch audit advanced past the fixed fixture to a separate factor-variance discrepancy