### PR TITLE
Match cch factor phase-two roundoff

### DIFF
--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -25887,6 +25887,153 @@ def test_cch_formula_preserves_small_counting_process_offset_risk():
     assert fit.iterations == 2
 
 
+def test_cch_formula_matches_factor_phase_two_roundoff():
+    data = {
+        "start": [
+            1,
+            11,
+            4,
+            0,
+            2,
+            0,
+            13,
+            0,
+            0,
+            12,
+            15,
+            0,
+            14,
+            0,
+            3,
+            0,
+            1,
+            0,
+            2,
+            12,
+            17,
+            9,
+            8,
+            15,
+            4,
+            11,
+        ],
+        "stop": [
+            7,
+            16,
+            7,
+            1,
+            3,
+            1,
+            19,
+            1,
+            4,
+            13,
+            16,
+            2,
+            15,
+            4,
+            6,
+            2,
+            2,
+            2,
+            8,
+            15,
+            19,
+            12,
+            11,
+            18,
+            6,
+            17,
+        ],
+        "status": [1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 0, 0, 1, 1, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 1],
+        "group": [
+            "a",
+            "b",
+            "b",
+            "b",
+            "a",
+            "a",
+            "a",
+            "c",
+            "a",
+            "a",
+            "a",
+            "c",
+            "a",
+            "c",
+            "c",
+            "a",
+            "b",
+            "c",
+            "a",
+            "b",
+            "c",
+            "a",
+            "a",
+            "c",
+            "c",
+            "a",
+        ],
+        "id": list(range(1, 27)),
+        "subcohort": [
+            0,
+            1,
+            1,
+            1,
+            0,
+            1,
+            0,
+            1,
+            0,
+            1,
+            0,
+            1,
+            1,
+            0,
+            0,
+            1,
+            1,
+            1,
+            1,
+            1,
+            0,
+            1,
+            0,
+            1,
+            1,
+            0,
+        ],
+    }
+    fit = survival.cch(
+        "Surv(start, stop, status) ~ 0 + group",
+        data,
+        subcoh="subcohort",
+        id="id",
+        cohort_size=78,
+        method="Prentice",
+    )
+
+    assert survival.coef(fit) == pytest.approx(
+        [0.0790309428848383, -0.661618805430928], abs=1e-11
+    )
+    expected_phase_two = [
+        [4.55490857106397e54, 5.38436651550759e53],
+        [5.38436651550759e53, 1.6945134620883e53],
+    ]
+    for actual, expected in zip(fit.phase2var, expected_phase_two, strict=True):
+        assert actual == pytest.approx(expected, rel=1e-11)
+    for actual, expected in zip(fit.var, expected_phase_two, strict=True):
+        assert actual == pytest.approx(expected, rel=1e-11)
+    assert fit.fit.model_information_matrix[0] == pytest.approx(
+        [0.536078739349966, 0.234044458790259], abs=1e-11
+    )
+    assert fit.fit.model_information_matrix[1] == pytest.approx(
+        [0.234044458790259, 0.817122606277822], abs=1e-11
+    )
+    assert fit.offsets[:19] == pytest.approx([-45.714285714285715] * 19, abs=1e-12)
+    assert fit.offsets[19:] == pytest.approx([54.285714285714285] * 16, abs=1e-12)
+
+
 @pytest.mark.parametrize(
     ("method", "expected_coefficients", "expected_variance"),
     [

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -13139,6 +13139,43 @@ test_that("cch preserves small offset risk in counting-process data", {
   expect_equal(actual$iter, reference$iter)
 })
 
+test_that("cch matches factor phase-two roundoff", {
+  skip_if_not_installed("reticulate")
+  skip_if_not_installed("survival")
+  skip_if_not(reticulate::py_module_available("survival"), "Python survival package is unavailable")
+
+  data <- data.frame(
+    start = c(1, 11, 4, 0, 2, 0, 13, 0, 0, 12, 15, 0, 14, 0, 3, 0, 1, 0, 2, 12, 17, 9, 8, 15, 4, 11),
+    stop = c(7, 16, 7, 1, 3, 1, 19, 1, 4, 13, 16, 2, 15, 4, 6, 2, 2, 2, 8, 15, 19, 12, 11, 18, 6, 17),
+    status = c(1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 0, 0, 1, 1, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 1),
+    group = factor(c(
+      "a", "b", "b", "b", "a", "a", "a", "c", "a", "a", "a", "c", "a",
+      "c", "c", "a", "b", "c", "a", "b", "c", "a", "a", "c", "c", "a"
+    )),
+    id = seq_len(26),
+    subcohort = c(0, 1, 1, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1, 0, 0, 1, 1, 1, 1, 1, 0, 1, 0, 1, 1, 0)
+  )
+  args <- list(
+    formula = Surv(start, stop, status) ~ 0 + group,
+    data = data,
+    subcoh = ~subcohort,
+    id = ~id,
+    cohort.size = 78,
+    method = "Prentice"
+  )
+  actual <- do.call(cch, args)
+  reference <- do.call(survival::cch, args)
+
+  expect_equal(actual$coefficients, reference$coefficients, tolerance = 1e-11)
+  expect_equal(actual$var, reference$var, tolerance = 1e-11)
+  expect_equal(actual$naive.var, reference$naive.var, tolerance = 1e-11)
+  expect_equal(actual$phase2var, reference$phase2var, tolerance = 1e-11)
+  expect_equal(actual$loglik, reference$loglik, tolerance = 1e-11)
+  expect_equal(actual$score, reference$score, tolerance = 1e-11)
+  expect_equal(actual$iter, reference$iter)
+  expect_equal(actual$offset, reference$offset, tolerance = 1e-11)
+})
+
 test_that("cch stratified Borgan fits match survival", {
   skip_if_not_installed("reticulate")
   skip_if_not_installed("survival")

--- a/src/regression/cch.rs
+++ b/src/regression/cch.rs
@@ -1,3 +1,4 @@
+use crate::constants::{EXP_CLAMP_MAX, EXP_CLAMP_MIN};
 use crate::regression::coxph::{CoxPHFit, CoxPHModel, Subject, coxph_fit};
 use pyo3::prelude::*;
 use std::collections::HashSet;
@@ -680,15 +681,28 @@ fn augmented_fit(
         offsets.push(0.0);
     }
 
-    let fit = fit_cox(
+    let offset_mean = offsets.iter().sum::<f64>() / offsets.len() as f64;
+    let centered_offsets = offsets
+        .iter()
+        .map(|&offset| offset - offset_mean)
+        .collect::<Vec<_>>();
+    let mut fit = fit_cox(
         augmented_stop,
         augmented_status,
         augmented_covariates,
         augmented_start,
-        offsets.clone(),
+        centered_offsets.clone(),
         initial_coefficients.clone(),
         if prentice { 35 } else { 20 },
     )?;
+    for (linear_predictor, risk_score) in fit
+        .linear_predictors
+        .iter_mut()
+        .zip(fit.risk_scores.iter_mut())
+    {
+        *linear_predictor += offset_mean;
+        *risk_score = linear_predictor.clamp(EXP_CLAMP_MIN, EXP_CLAMP_MAX).exp();
+    }
     let dfbeta = fit.dfbeta()?;
     let phase2_rows = dfbeta[case_indices.len()..].to_vec();
     let phase2_scale = 1.0 - subcohort_indices.len() as f64 / cohort_size as f64;
@@ -703,7 +717,7 @@ fn augmented_fit(
         phase2_variance,
         variance: naive_variance.clone(),
         naive_variance,
-        offsets,
+        offsets: centered_offsets,
         robust: false,
     })
 }
@@ -1546,6 +1560,73 @@ mod tests {
         );
         assert!((result.score_test - 0.011_850_593_966_545_8).abs() < 1e-11);
         assert_eq!(result.iterations, 2);
+    }
+
+    #[test]
+    fn native_counting_process_prentice_matches_factor_phase_two_roundoff() {
+        let stop = vec![
+            7.0, 16.0, 7.0, 1.0, 3.0, 1.0, 19.0, 1.0, 4.0, 13.0, 16.0, 2.0, 15.0, 4.0, 6.0, 2.0,
+            2.0, 2.0, 8.0, 15.0, 19.0, 12.0, 11.0, 18.0, 6.0, 17.0,
+        ];
+        let status = vec![
+            1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 0, 0, 1, 1, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 1,
+        ];
+        let groups = [
+            1, 2, 2, 2, 1, 1, 1, 3, 1, 1, 1, 3, 1, 3, 3, 1, 2, 3, 1, 2, 3, 1, 1, 3, 3, 1,
+        ];
+        let covariates = groups
+            .into_iter()
+            .map(|group| vec![f64::from(group == 2), f64::from(group == 3)])
+            .collect();
+        let subcohort = vec![
+            0, 1, 1, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1, 0, 0, 1, 1, 1, 1, 1, 0, 1, 0, 1, 1, 0,
+        ];
+        let start = vec![
+            1.0, 11.0, 4.0, 0.0, 2.0, 0.0, 13.0, 0.0, 0.0, 12.0, 15.0, 0.0, 14.0, 0.0, 3.0, 0.0,
+            1.0, 0.0, 2.0, 12.0, 17.0, 9.0, 8.0, 15.0, 4.0, 11.0,
+        ];
+        let result = cch_fit(
+            stop,
+            status,
+            covariates,
+            subcohort,
+            (1..=26).collect(),
+            78,
+            Some(start),
+            "Prentice",
+            false,
+        )
+        .expect("factor Prentice fit should succeed");
+
+        assert_close(
+            &result.coefficients[0],
+            &[0.079_030_942_884_838_3, -0.661_618_805_430_928],
+        );
+        assert_matrix_close(
+            &result.model_information_matrix,
+            &[
+                vec![0.536_078_739_349_966, 0.234_044_458_790_259],
+                vec![0.234_044_458_790_259, 0.817_122_606_277_822],
+            ],
+        );
+        let expected_phase_two = [
+            [4.554_908_571_063_97e54, 5.384_366_515_507_59e53],
+            [5.384_366_515_507_59e53, 1.694_513_462_088_3e53],
+        ];
+        for (actual_row, expected_row) in result.phase2_variance.iter().zip(expected_phase_two) {
+            for (&actual, expected) in actual_row.iter().zip(expected_row) {
+                assert!(
+                    (actual / expected - 1.0).abs() < 1e-11,
+                    "expected {expected:.17e}, got {actual:.17e}"
+                );
+            }
+        }
+        assert_close(
+            &result.log_likelihood,
+            &[-1_710.608_339_894_93, -1_710.187_760_623_87],
+        );
+        assert!((result.score_test - 0.846_482_519_571_698).abs() < 1e-11);
+        assert_eq!(result.iterations, 3);
     }
 
     #[test]

--- a/src/regression/coxph_diagnostics.rs
+++ b/src/regression/coxph_diagnostics.rs
@@ -6,9 +6,7 @@ use crate::regression::coxph::CoxPHFit;
 use crate::regression::coxph_detail_module::{
     CoxphDetail, CoxphDetailOptions, compute_coxph_detail_with_options, coxph_detail,
 };
-use crate::regression::coxph_support::{
-    ActiveRiskSet, CompensatedSum, CoxSweepRow, StratifiedBaselineLookup,
-};
+use crate::regression::coxph_support::{ActiveRiskSet, CoxSweepRow, StratifiedBaselineLookup};
 use crate::regression::exact_ties::{exact_inclusion_probabilities, exact_tied_moments};
 use crate::residuals::agmart_module::{AgmartData, compute_agmart};
 use crate::residuals::coxmart_module::{CoxMartSurvivalData, CoxMartWeights, compute_coxmart};
@@ -1228,12 +1226,7 @@ impl CoxPHFit {
         }
 
         let risk: Vec<f64> = (0..n)
-            .map(|idx| {
-                self.linear_predictors[idx]
-                    .clamp(EXP_CLAMP_MIN, EXP_CLAMP_MAX)
-                    .exp()
-                    * self.weights[idx]
-            })
+            .map(|idx| self.linear_predictors[idx].exp() * self.weights[idx])
             .collect();
         Ok(self.score_residuals_counting_process_sweep(nvar, method, &risk, &order, entry_times))
     }
@@ -1251,7 +1244,7 @@ impl CoxPHFit {
         let scores = (method != 2).then(|| {
             self.linear_predictors
                 .iter()
-                .map(|&value| value.clamp(EXP_CLAMP_MIN, EXP_CLAMP_MAX).exp())
+                .map(|&value| value.exp())
                 .collect::<Vec<_>>()
         });
         let mut stratum_start = 0usize;
@@ -1428,16 +1421,26 @@ impl CoxPHFit {
         let scores: Vec<f64> = self
             .linear_predictors
             .iter()
-            .map(|&value| value.clamp(EXP_CLAMP_MIN, EXP_CLAMP_MAX).exp())
+            .map(|&value| value.exp())
             .collect();
+        let mut score_order = order.to_vec();
+        score_order.sort_by(|&lhs, &rhs| {
+            self.strata[lhs]
+                .cmp(&self.strata[rhs])
+                .then_with(|| self.event_times[lhs].total_cmp(&self.event_times[rhs]))
+                .then_with(|| self.status[rhs].cmp(&self.status[lhs]))
+                .then_with(|| lhs.cmp(&rhs))
+        });
         let mut stratum_start = 0usize;
-        while stratum_start < order.len() {
-            let stratum = self.strata[order[stratum_start]];
+        while stratum_start < score_order.len() {
+            let stratum = self.strata[score_order[stratum_start]];
             let mut stratum_end = stratum_start;
-            while stratum_end + 1 < order.len() && self.strata[order[stratum_end + 1]] == stratum {
+            while stratum_end + 1 < score_order.len()
+                && self.strata[score_order[stratum_end + 1]] == stratum
+            {
                 stratum_end += 1;
             }
-            let stratum_order = &order[stratum_start..=stratum_end];
+            let stratum_order = &score_order[stratum_start..=stratum_end];
             let rows: Vec<CoxSweepRow> = stratum_order
                 .iter()
                 .map(|&idx| CoxSweepRow {
@@ -1449,135 +1452,137 @@ impl CoxPHFit {
                     status: self.status[idx],
                 })
                 .collect();
-            let mut active = ActiveRiskSet::new(&rows, true);
-            let event_count = rows.iter().filter(|row| row.status == 1).count();
-            let mut event_times = Vec::with_capacity(event_count);
-            let mut cumulative_scalars = Vec::with_capacity(event_count);
-            let mut cumulative_xhazards = Vec::with_capacity(event_count);
-            let mut deaths: Vec<usize> = Vec::with_capacity(event_count);
-            let mut cumulative_scalar = CompensatedSum::default();
-            let mut cumulative_xhazard = vec![CompensatedSum::default(); nvar];
-            let mut active_risk_covariates = vec![CompensatedSum::default(); nvar];
-            let mut time_start = 0usize;
-            while time_start < rows.len() {
-                let event_time = rows[time_start].stop;
-                let mut time_end = time_start;
-                while time_end + 1 < rows.len() && same_time(rows[time_end + 1].stop, event_time) {
-                    time_end += 1;
+            let mut entry_order = (0..rows.len()).collect::<Vec<_>>();
+            entry_order.sort_by(|&lhs, &rhs| {
+                rows[lhs]
+                    .entry
+                    .total_cmp(&rows[rhs].entry)
+                    .then_with(|| lhs.cmp(&rhs))
+            });
+            let mut entry_pos = entry_order.len();
+            let mut person = rows.len();
+            let mut denom = 0.0;
+            let mut cumulative_hazard = 0.0_f64;
+            let mut risk_covariates = vec![0.0; nvar];
+            let mut cumulative_xhazard = vec![0.0; nvar];
+            let mut death_covariates = vec![0.0; nvar];
+            let mut mean = vec![0.0; nvar];
+            let mut hazard_fraction = vec![0.0; nvar];
+            let mut mean_hazard_fraction = vec![0.0; nvar];
+            let mut mean_sum = vec![0.0; nvar];
+            let mut deaths = Vec::new();
+
+            while person > 0 {
+                let event_time = rows[person - 1].stop;
+                while entry_pos > 0 && rows[entry_order[entry_pos - 1]].entry >= event_time {
+                    entry_pos -= 1;
+                    let row_idx = entry_order[entry_pos];
+                    let row = rows[row_idx];
+                    let original_idx = row.original_idx;
+                    denom -= row.risk;
+                    for col_idx in 0..nvar {
+                        let covariate = self.covariates[original_idx][col_idx];
+                        let hazard_difference =
+                            cumulative_hazard.mul_add(covariate, -cumulative_xhazard[col_idx]);
+                        residuals[original_idx][col_idx] = (-scores[original_idx])
+                            .mul_add(hazard_difference, residuals[original_idx][col_idx]);
+                        risk_covariates[col_idx] -= row.risk * covariate;
+                    }
                 }
 
-                active.advance_to(event_time, |row_idx, added| {
-                    let direction = if added { 1.0 } else { -1.0 };
-                    let original_idx = rows[row_idx].original_idx;
-                    for (col_idx, value) in active_risk_covariates.iter_mut().enumerate() {
-                        value.add(
-                            direction * rows[row_idx].risk * self.covariates[original_idx][col_idx],
-                        );
-                    }
-                });
-
+                let mut time_start = person - 1;
+                while time_start > 0 && same_time(rows[time_start - 1].stop, event_time) {
+                    time_start -= 1;
+                }
+                let mut death_risk = 0.0;
+                let mut death_weight = 0.0;
+                death_covariates.fill(0.0);
                 deaths.clear();
-                deaths.extend((time_start..=time_end).filter(|&idx| rows[idx].status == 1));
-                if !deaths.is_empty() && active.risk_sum > 0.0 {
-                    let deadwt: f64 = deaths.iter().map(|&idx| rows[idx].weight).sum();
-                    if method == 1 && deaths.len() > 1 {
-                        let death_count = deaths.len();
-                        let deaths_f = death_count as f64;
-                        let weight_average = deadwt / deaths_f;
-                        let death_risk: f64 = deaths.iter().map(|&idx| rows[idx].risk).sum();
-                        let mut death_covariates = vec![0.0; nvar];
+                for row_idx in (time_start..person).rev() {
+                    let row = rows[row_idx];
+                    let original_idx = row.original_idx;
+                    for col_idx in 0..nvar {
+                        let covariate = self.covariates[original_idx][col_idx];
+                        residuals[original_idx][col_idx] = scores[original_idx]
+                            * covariate.mul_add(cumulative_hazard, -cumulative_xhazard[col_idx]);
+                        risk_covariates[col_idx] += row.risk * covariate;
+                    }
+                    denom += row.risk;
+                    if row.status == 1 {
+                        deaths.push(row_idx);
+                        death_risk += row.risk;
+                        death_weight += row.weight;
+                        for (col_idx, value) in death_covariates.iter_mut().enumerate() {
+                            *value += row.risk * self.covariates[original_idx][col_idx];
+                        }
+                    }
+                }
+
+                if !deaths.is_empty() {
+                    if method == 0 || deaths.len() == 1 {
+                        let hazard = death_weight / denom;
+                        cumulative_hazard += hazard;
+                        for col_idx in 0..nvar {
+                            mean[col_idx] = risk_covariates[col_idx] / denom;
+                            cumulative_xhazard[col_idx] += mean[col_idx] * hazard;
+                        }
                         for &row_idx in &deaths {
                             let original_idx = rows[row_idx].original_idx;
-                            for (col_idx, value) in death_covariates.iter_mut().enumerate() {
-                                *value +=
-                                    rows[row_idx].risk * self.covariates[original_idx][col_idx];
-                            }
-                        }
-                        let mut mean = vec![0.0; nvar];
-                        for step in 0..death_count {
-                            let fraction = step as f64 / deaths_f;
-                            let step_denom = active.risk_sum - fraction * death_risk;
-                            if step_denom <= 0.0 {
-                                continue;
-                            }
-                            let hazard = weight_average / step_denom;
-                            for ((value, active_total), &death_total) in mean
-                                .iter_mut()
-                                .zip(active_risk_covariates.iter().map(|value| value.total()))
-                                .zip(&death_covariates)
-                            {
-                                *value = (active_total - fraction * death_total) / step_denom;
-                            }
-                            cumulative_scalar.add(hazard);
-                            for (col_idx, value) in cumulative_xhazard.iter_mut().enumerate() {
-                                value.add(mean[col_idx] * hazard);
-                            }
-                            for &row_idx in &deaths {
-                                let original_idx = rows[row_idx].original_idx;
-                                let score = scores[original_idx];
-                                for (col_idx, residual) in
-                                    residuals[original_idx].iter_mut().enumerate()
-                                {
-                                    let centered =
-                                        self.covariates[original_idx][col_idx] - mean[col_idx];
-                                    *residual +=
-                                        centered / deaths_f + score * hazard * fraction * centered;
-                                }
+                            for col_idx in 0..nvar {
+                                residuals[original_idx][col_idx] +=
+                                    self.covariates[original_idx][col_idx] - mean[col_idx];
                             }
                         }
                     } else {
-                        let hazard = deadwt / active.risk_sum;
-                        let mean: Vec<f64> = active_risk_covariates
-                            .iter()
-                            .map(|value| value.total() / active.risk_sum)
-                            .collect();
-                        cumulative_scalar.add(hazard);
-                        for (col_idx, value) in cumulative_xhazard.iter_mut().enumerate() {
-                            value.add(mean[col_idx] * hazard);
+                        hazard_fraction.fill(0.0);
+                        mean_hazard_fraction.fill(0.0);
+                        mean_sum.fill(0.0);
+                        let death_count = deaths.len() as f64;
+                        let mean_death_weight = death_weight / death_count;
+                        for step in 0..deaths.len() {
+                            let fraction = step as f64 / death_count;
+                            let step_denom = denom - fraction * death_risk;
+                            let hazard = mean_death_weight / step_denom;
+                            cumulative_hazard += hazard;
+                            for col_idx in 0..nvar {
+                                mean[col_idx] = (risk_covariates[col_idx]
+                                    - fraction * death_covariates[col_idx])
+                                    / step_denom;
+                                cumulative_xhazard[col_idx] += mean[col_idx] * hazard;
+                                hazard_fraction[col_idx] += hazard * fraction;
+                                mean_hazard_fraction[col_idx] += mean[col_idx] * hazard * fraction;
+                                mean_sum[col_idx] += mean[col_idx] / death_count;
+                            }
                         }
                         for &row_idx in &deaths {
                             let original_idx = rows[row_idx].original_idx;
-                            for (col_idx, residual) in
-                                residuals[original_idx].iter_mut().enumerate()
-                            {
-                                *residual += self.covariates[original_idx][col_idx] - mean[col_idx];
+                            for col_idx in 0..nvar {
+                                let covariate = self.covariates[original_idx][col_idx];
+                                let correction = covariate.mul_add(
+                                    hazard_fraction[col_idx],
+                                    -mean_hazard_fraction[col_idx],
+                                );
+                                residuals[original_idx][col_idx] = scores[original_idx].mul_add(
+                                    correction,
+                                    residuals[original_idx][col_idx] + covariate
+                                        - mean_sum[col_idx],
+                                );
                             }
                         }
                     }
-                    event_times.push(event_time);
-                    cumulative_scalars.push(cumulative_scalar);
-                    cumulative_xhazards.push(cumulative_xhazard.clone());
                 }
-
-                time_start = time_end + 1;
+                person = time_start;
             }
 
-            for row in &rows {
-                let step_index = |time: f64| match event_times
-                    .binary_search_by(|probe| probe.total_cmp(&time))
-                {
-                    Ok(idx) => Some(idx),
-                    Err(0) => None,
-                    Err(idx) => Some(idx - 1),
-                };
-                let start_index = step_index(row.entry);
-                let stop_index = step_index(row.stop);
-                let start_scalar =
-                    start_index.map_or_else(CompensatedSum::default, |idx| cumulative_scalars[idx]);
-                let stop_scalar =
-                    stop_index.map_or_else(CompensatedSum::default, |idx| cumulative_scalars[idx]);
-                let active_scalar = stop_scalar.difference(start_scalar);
-                let score = scores[row.original_idx];
-                for (col_idx, residual) in residuals[row.original_idx].iter_mut().enumerate() {
-                    let start_xhazard = start_index.map_or_else(CompensatedSum::default, |idx| {
-                        cumulative_xhazards[idx][col_idx]
-                    });
-                    let stop_xhazard = stop_index.map_or_else(CompensatedSum::default, |idx| {
-                        cumulative_xhazards[idx][col_idx]
-                    });
-                    *residual += score
-                        * (stop_xhazard.difference(start_xhazard)
-                            - active_scalar * self.covariates[row.original_idx][col_idx]);
+            while entry_pos > 0 {
+                entry_pos -= 1;
+                let row = rows[entry_order[entry_pos]];
+                let original_idx = row.original_idx;
+                for col_idx in 0..nvar {
+                    let hazard_difference = self.covariates[original_idx][col_idx]
+                        .mul_add(cumulative_hazard, -cumulative_xhazard[col_idx]);
+                    residuals[original_idx][col_idx] = (-scores[original_idx])
+                        .mul_add(hazard_difference, residuals[original_idx][col_idx]);
                 }
             }
 

--- a/src/regression/coxph_support.rs
+++ b/src/regression/coxph_support.rs
@@ -70,15 +70,6 @@ impl CompensatedSum {
     pub(super) fn total(self) -> f64 {
         self.sum + self.correction
     }
-
-    pub(super) fn difference(self, earlier: Self) -> f64 {
-        let mut difference = Self::default();
-        difference.add(self.sum);
-        difference.add(-earlier.sum);
-        difference.add(self.correction);
-        difference.add(-earlier.correction);
-        difference.total()
-    }
 }
 
 pub(super) struct ActiveRiskSet<'a> {
@@ -196,18 +187,12 @@ mod tests {
     use super::*;
 
     #[test]
-    fn compensated_sum_retains_small_remainders_and_differences() {
+    fn compensated_sum_retains_small_remainders() {
         let mut total = CompensatedSum::default();
         total.add(1e-40);
         total.add(1.0);
         total.add(-1.0);
         assert_eq!(total.total(), 1e-40);
-
-        let mut cumulative = CompensatedSum::default();
-        cumulative.add(1e40);
-        let earlier = cumulative;
-        cumulative.add(0.25);
-        assert_eq!(cumulative.difference(earlier), 0.25);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- center synthetic cch offsets before optimization and restore the mean in reported linear predictors
- compute counting-process score residuals with a reference-compatible backward recurrence and fused multiply-add rounding
- lock exact factor phase-two variance behavior in Rust, Python, and R bridge regressions

## Testing
- Rust suite: 1,580 passed
- Python suite: 1,124 passed
- installed R bridge suite
- built-package check: Status OK
- mypy, Ruff, Clippy, rustfmt, and whitespace checks
- seeded audit through case 14: 13 matched and one reference case skipped; the next mismatch is a separate right-censored SelfPrentice variance case