### PR TITLE
Match Prentice delayed-entry roundoff

### DIFF
--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -26034,6 +26034,64 @@ def test_cch_formula_matches_factor_phase_two_roundoff():
     assert fit.offsets[19:] == pytest.approx([54.285714285714285] * 16, abs=1e-12)
 
 
+def test_cch_formula_matches_delayed_entry_factor_roundoff():
+    data = {
+        "start": [6, 0, 0, 5, 0, 14, 5, 1, 2, 2, 7, 1, 3, 7, 0, 5, 9, 0, 4, 0],
+        "stop": [12, 3, 2, 8, 2, 17, 10, 6, 3, 3, 8, 5, 8, 11, 1, 8, 11, 5, 9, 1],
+        "status": [0, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+        "group": [
+            "a",
+            "a",
+            "b",
+            "b",
+            "c",
+            "a",
+            "c",
+            "a",
+            "a",
+            "b",
+            "c",
+            "b",
+            "c",
+            "b",
+            "c",
+            "a",
+            "b",
+            "b",
+            "b",
+            "b",
+        ],
+        "id": list(range(1, 21)),
+        "subcohort": [1, 1, 0, 1, 0, 0, 1, 1, 1, 1, 1, 1, 0, 1, 0, 1, 1, 1, 1, 1],
+    }
+    fit = survival.cch(
+        "Surv(start, stop, status) ~ 0 + group",
+        data,
+        subcoh="subcohort",
+        id="id",
+        cohort_size=60,
+        method="Prentice",
+    )
+
+    assert survival.coef(fit) == pytest.approx(
+        [1.0909193210480745, 1.932782521394574], abs=1e-11
+    )
+    expected_phase_two = [
+        [7.186983559093221e55, 1.9556591655713782e56],
+        [1.9556591655713782e56, 5.902264325547351e56],
+    ]
+    for actual, expected in zip(fit.phase2var, expected_phase_two, strict=True):
+        assert actual == pytest.approx(expected, rel=1e-11)
+    for actual, expected in zip(fit.var, expected_phase_two, strict=True):
+        assert actual == pytest.approx(expected, rel=1e-11)
+    assert fit.means == pytest.approx([0.0, 0.0], abs=1e-15)
+    assert fit.log_likelihood == pytest.approx(
+        [-1620.065518335, -1618.89535847212], abs=1e-11
+    )
+    assert fit.score_test == pytest.approx(2.10915895645869, abs=1e-11)
+    assert fit.iterations == 4
+
+
 def test_cch_formula_matches_self_prentice_phase_two_roundoff():
     data = {
         "stop": [

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -13176,6 +13176,44 @@ test_that("cch matches factor phase-two roundoff", {
   expect_equal(actual$offset, reference$offset, tolerance = 1e-11)
 })
 
+test_that("cch matches delayed-entry factor roundoff", {
+  skip_if_not_installed("reticulate")
+  skip_if_not_installed("survival")
+  skip_if_not(reticulate::py_module_available("survival"), "Python survival package is unavailable")
+
+  data <- data.frame(
+    start = c(6, 0, 0, 5, 0, 14, 5, 1, 2, 2, 7, 1, 3, 7, 0, 5, 9, 0, 4, 0),
+    stop = c(12, 3, 2, 8, 2, 17, 10, 6, 3, 3, 8, 5, 8, 11, 1, 8, 11, 5, 9, 1),
+    status = c(0, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1),
+    group = factor(c(
+      "a", "a", "b", "b", "c", "a", "c", "a", "a", "b",
+      "c", "b", "c", "b", "c", "a", "b", "b", "b", "b"
+    )),
+    id = seq_len(20),
+    subcohort = c(1, 1, 0, 1, 0, 0, 1, 1, 1, 1, 1, 1, 0, 1, 0, 1, 1, 1, 1, 1)
+  )
+  args <- list(
+    formula = Surv(start, stop, status) ~ 0 + group,
+    data = data,
+    subcoh = ~subcohort,
+    id = ~id,
+    cohort.size = 60,
+    method = "Prentice"
+  )
+  actual <- do.call(cch, args)
+  reference <- do.call(survival::cch, args)
+
+  expect_equal(actual$coefficients, reference$coefficients, tolerance = 1e-11)
+  expect_equal(actual$var, reference$var, tolerance = 1e-11)
+  expect_equal(actual$naive.var, reference$naive.var, tolerance = 1e-11)
+  expect_equal(actual$phase2var, reference$phase2var, tolerance = 1e-11)
+  expect_equal(actual$means, reference$means, tolerance = 1e-11)
+  expect_equal(actual$loglik, reference$loglik, tolerance = 1e-11)
+  expect_equal(actual$score, reference$score, tolerance = 1e-11)
+  expect_equal(actual$iter, reference$iter)
+  expect_equal(actual$offset, reference$offset, tolerance = 1e-11)
+})
+
 test_that("cch matches SelfPrentice phase-two roundoff", {
   skip_if_not_installed("reticulate")
   skip_if_not_installed("survival")

--- a/src/regression/cch.rs
+++ b/src/regression/cch.rs
@@ -1736,6 +1736,60 @@ mod tests {
     }
 
     #[test]
+    fn native_prentice_matches_delayed_entry_factor_roundoff() {
+        let stop = vec![
+            12.0, 3.0, 2.0, 8.0, 2.0, 17.0, 10.0, 6.0, 3.0, 3.0, 8.0, 5.0, 8.0, 11.0, 1.0, 8.0,
+            11.0, 5.0, 9.0, 1.0,
+        ];
+        let status = vec![0, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1];
+        let groups = [1, 1, 2, 2, 3, 1, 3, 1, 1, 2, 3, 2, 3, 2, 3, 1, 2, 2, 2, 2];
+        let covariates = groups
+            .into_iter()
+            .map(|group| vec![f64::from(group == 2), f64::from(group == 3)])
+            .collect();
+        let subcohort = vec![1, 1, 0, 1, 0, 0, 1, 1, 1, 1, 1, 1, 0, 1, 0, 1, 1, 1, 1, 1];
+        let start = vec![
+            6.0, 0.0, 0.0, 5.0, 0.0, 14.0, 5.0, 1.0, 2.0, 2.0, 7.0, 1.0, 3.0, 7.0, 0.0, 5.0, 9.0,
+            0.0, 4.0, 0.0,
+        ];
+        let result = cch_fit(
+            stop,
+            status,
+            covariates,
+            subcohort,
+            (1..=20).collect(),
+            60,
+            Some(start),
+            "Prentice",
+            false,
+        )
+        .expect("delayed-entry Prentice fit should succeed");
+
+        assert_close(
+            &result.coefficients[0],
+            &[1.090_919_321_048_074_5, 1.932_782_521_394_574],
+        );
+        let expected_phase_two = [
+            [7.186_983_559_093_221e55, 1.955_659_165_571_378_2e56],
+            [1.955_659_165_571_378_2e56, 5.902_264_325_547_351e56],
+        ];
+        for (actual_row, expected_row) in result.phase2_variance.iter().zip(expected_phase_two) {
+            for (&actual, expected) in actual_row.iter().zip(expected_row) {
+                assert!(
+                    (actual / expected - 1.0).abs() < 1e-11,
+                    "expected {expected:.17e}, got {actual:.17e}"
+                );
+            }
+        }
+        assert_close(
+            &result.log_likelihood,
+            &[-1_620.065_518_335, -1_618.895_358_472_12],
+        );
+        assert!((result.score_test - 2.109_158_956_458_69).abs() < 1e-11);
+        assert_eq!(result.iterations, 4);
+    }
+
+    #[test]
     fn native_stratified_borgan_results_match_r_survival() {
         let (start, stop, status, covariates, subcohort, id) = r_parity_fixture();
         let stratum = (0..stop.len()).map(|idx| idx % 2).collect::<Vec<_>>();

--- a/src/regression/cox_optimizer.rs
+++ b/src/regression/cox_optimizer.rs
@@ -93,12 +93,71 @@ fn add_risk_sums(
     }
 }
 
+fn remove_risk_sums(
+    covar: &Array2<f64>,
+    nvar: usize,
+    person: usize,
+    risk: f64,
+    denom: &mut f64,
+    a: &mut [f64],
+    cmat: &mut Array2<f64>,
+) {
+    *denom -= risk;
+    for i in 0..nvar {
+        let covar_i = covar[(person, i)];
+        let risk_covar_i = risk * covar_i;
+        a[i] -= risk_covar_i;
+        for j in 0..=i {
+            cmat[(i, j)] -= risk_covar_i * covar[(person, j)];
+        }
+    }
+}
+
 fn sort_entry_order(order: &mut [usize], entry_times: &Array1<f64>) {
     order.sort_by(|&lhs, &rhs| {
         entry_times[rhs]
             .total_cmp(&entry_times[lhs])
             .then_with(|| rhs.cmp(&lhs))
     });
+}
+
+fn sort_entry_order_by_input(
+    order: &mut [usize],
+    entry_times: &Array1<f64>,
+    input_order: &[usize],
+) {
+    order.sort_by(|&lhs, &rhs| {
+        entry_times[rhs]
+            .total_cmp(&entry_times[lhs])
+            .then_with(|| input_order[lhs].cmp(&input_order[rhs]))
+    });
+}
+
+fn counting_used_rows(
+    time: &Array1<f64>,
+    status: &Array1<i32>,
+    entry_times: &Array1<f64>,
+    strata: &Array1<i32>,
+) -> Vec<bool> {
+    // Intervals that span no event time are excluded from the native fit.
+    let mut used = vec![false; time.len()];
+    let mut stratum_start = 0;
+    for stratum_end in 0..time.len() {
+        if strata[stratum_end] != 1 {
+            continue;
+        }
+        let event_times = (stratum_start..=stratum_end)
+            .filter_map(|person| (status[person] != 0).then_some(time[person]))
+            .collect::<Vec<_>>();
+        for person in stratum_start..=stratum_end {
+            let first_event =
+                event_times.partition_point(|&event_time| event_time <= entry_times[person]);
+            used[person] =
+                first_event < event_times.len() && event_times[first_event] <= time[person];
+        }
+        stratum_start = stratum_end + 1;
+    }
+    used
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -163,6 +222,7 @@ pub(crate) struct CoxFit {
     status: Array1<i32>,
     entry_times: Option<Array1<f64>>,
     all_entered_before_first_event: bool,
+    counting_used: Option<Vec<bool>>,
     entry_order: Option<Vec<usize>>,
     covar: Array2<f64>,
     strata: Array1<i32>,
@@ -338,6 +398,9 @@ impl CoxFit {
                 .unwrap_or(f64::INFINITY);
             entries.iter().all(|&entry| entry < first_event_time)
         });
+        let counting_used = entry_times
+            .as_ref()
+            .map(|entries| counting_used_rows(&time, &status, entries, &strata));
         let entry_order = entry_times.as_ref().map(|entry_times| {
             let mut order: Vec<usize> = (0..entry_times.len()).collect();
             let mut stratum_start = 0;
@@ -358,6 +421,7 @@ impl CoxFit {
             status,
             entry_times,
             all_entered_before_first_event,
+            counting_used,
             entry_order,
             covar,
             strata,
@@ -398,6 +462,28 @@ impl CoxFit {
         self.penalty = CoxPenalty::Dense(Array2::from_shape_fn(penalty.dim(), |(row, column)| {
             penalty[(row, column)] * self.scale[row] * self.scale[column]
         }));
+    }
+
+    /// Restores stable original-row ordering for equal entry times after stop-time sorting.
+    pub(crate) fn preserve_entry_input_order(&mut self, input_order: &[usize]) {
+        let (Some(entry_times), Some(entry_order)) =
+            (self.entry_times.as_ref(), self.entry_order.as_mut())
+        else {
+            return;
+        };
+        debug_assert_eq!(input_order.len(), entry_times.len());
+        let mut stratum_start = 0;
+        for stratum_end in 0..self.strata.len() {
+            if self.strata[stratum_end] != 1 {
+                continue;
+            }
+            sort_entry_order_by_input(
+                &mut entry_order[stratum_start..=stratum_end],
+                entry_times,
+                input_order,
+            );
+            stratum_start = stratum_end + 1;
+        }
     }
 
     pub(crate) fn set_frailty_penalty(
@@ -1211,35 +1297,35 @@ impl CoxFit {
             .entry_order
             .as_deref()
             .expect("entry order must accompany counting-process entry times");
+        let used = self
+            .counting_used
+            .as_deref()
+            .expect("counting-process rows must have a usage mask");
         let nvar = self.covar.ncols();
         let nused = self.covar.nrows();
         let method = self.method;
         self.u.fill(0.0);
         self.imat.fill(0.0);
 
-        let (zbeta_vals, risk_vals): (Vec<f64>, Vec<f64>) = if nused > PARALLEL_THRESHOLD_MEDIUM {
+        let zbeta_vals: Vec<f64> = if nused > PARALLEL_THRESHOLD_MEDIUM {
             (0..nused)
                 .into_par_iter()
                 .map(|person| {
-                    let zbeta = self.offset[person]
-                        + beta
-                            .iter()
-                            .enumerate()
-                            .fold(0.0, |acc, (i, &b)| acc + b * self.covar[(person, i)]);
-                    (zbeta, zbeta.exp() * self.weights[person])
+                    beta.iter()
+                        .enumerate()
+                        .fold(0.0, |acc, (i, &b)| acc + b * self.covar[(person, i)])
+                        + self.offset[person]
                 })
-                .unzip()
+                .collect()
         } else {
             (0..nused)
                 .map(|person| {
-                    let zbeta = self.offset[person]
-                        + beta
-                            .iter()
-                            .enumerate()
-                            .fold(0.0, |acc, (i, &b)| acc + b * self.covar[(person, i)]);
-                    (zbeta, zbeta.exp() * self.weights[person])
+                    beta.iter()
+                        .enumerate()
+                        .fold(0.0, |acc, (i, &b)| acc + b * self.covar[(person, i)])
+                        + self.offset[person]
                 })
-                .unzip()
+                .collect()
         };
 
         let mut loglik = 0.0;
@@ -1250,57 +1336,56 @@ impl CoxFit {
             }
 
             let start_order = &entry_order[stratum_start..=stratum_end];
-
-            let mut stop_denom = 0.0;
-            let mut stop_a = vec![0.0; nvar];
-            let mut stop_cmat: Array2<f64> = Array2::zeros((nvar, nvar));
-            let mut unentered_denom = 0.0;
-            let mut unentered_a = vec![0.0; nvar];
-            let mut unentered_cmat: Array2<f64> = Array2::zeros((nvar, nvar));
+            // Maintain active sums in descending event-time order to avoid
+            // subtracting two large cumulative totals at every event.
+            let mut denom = 0.0;
+            let mut a = vec![0.0; nvar];
+            let mut cmat: Array2<f64> = Array2::zeros((nvar, nvar));
             let mut stop_ptr = stratum_end as isize;
             let mut start_ptr = 0usize;
-            let mut time_end = stratum_end;
+            let mut nrisk = 0usize;
+            let mut eta_sum = 0.0;
+            let mut recenter = 0.0;
             let mut death_a = vec![0.0; nvar];
             let mut death_cmat: Array2<f64> = Array2::zeros((nvar, nvar));
-            let mut event_a = vec![0.0; nvar];
-            let mut event_cmat: Array2<f64> = Array2::zeros((nvar, nvar));
 
             loop {
-                let event_time = self.time[time_end];
-                while stop_ptr >= stratum_start as isize
-                    && self.time[stop_ptr as usize] >= event_time
-                {
-                    let person = stop_ptr as usize;
-                    add_risk_sums(
-                        &self.covar,
-                        nvar,
-                        person,
-                        risk_vals[person],
-                        &mut stop_denom,
-                        &mut stop_a,
-                        &mut stop_cmat,
-                    );
-                    stop_ptr -= 1;
+                let mut event_ptr = stop_ptr;
+                while event_ptr >= stratum_start as isize && self.status[event_ptr as usize] == 0 {
+                    event_ptr -= 1;
                 }
+                if event_ptr < stratum_start as isize {
+                    break;
+                }
+                let event_time = self.time[event_ptr as usize];
+
                 while start_ptr < start_order.len()
                     && entry_times[start_order[start_ptr]] >= event_time
                 {
                     let person = start_order[start_ptr];
-                    add_risk_sums(
-                        &self.covar,
-                        nvar,
-                        person,
-                        risk_vals[person],
-                        &mut unentered_denom,
-                        &mut unentered_a,
-                        &mut unentered_cmat,
-                    );
+                    if used[person] {
+                        debug_assert!(nrisk > 0);
+                        nrisk -= 1;
+                        if nrisk == 0 {
+                            eta_sum = 0.0;
+                            denom = 0.0;
+                            a.fill(0.0);
+                            cmat.fill(0.0);
+                        } else {
+                            eta_sum -= zbeta_vals[person];
+                            let risk = (zbeta_vals[person] - recenter).exp() * self.weights[person];
+                            remove_risk_sums(
+                                &self.covar,
+                                nvar,
+                                person,
+                                risk,
+                                &mut denom,
+                                &mut a,
+                                &mut cmat,
+                            );
+                        }
+                    }
                     start_ptr += 1;
-                }
-
-                let mut time_start = time_end;
-                while time_start > stratum_start && self.time[time_start - 1] == event_time {
-                    time_start -= 1;
                 }
 
                 let mut ndead = 0usize;
@@ -1309,109 +1394,98 @@ impl CoxFit {
                 death_a.fill(0.0);
                 death_cmat.fill(0.0);
 
-                for person in time_start..=time_end {
-                    if self.status[person] == 0 {
+                while stop_ptr >= stratum_start as isize
+                    && self.time[stop_ptr as usize] >= event_time
+                {
+                    let person = stop_ptr as usize;
+                    stop_ptr -= 1;
+                    if !used[person] {
                         continue;
                     }
-                    ndead += 1;
-                    deadwt += self.weights[person];
-                    loglik += self.weights[person] * zbeta_vals[person];
-                    add_risk_sums(
-                        &self.covar,
-                        nvar,
-                        person,
-                        risk_vals[person],
-                        &mut denom2,
-                        &mut death_a,
-                        &mut death_cmat,
-                    );
-                    for i in 0..nvar {
-                        self.u[i] += self.weights[person] * self.covar[(person, i)];
-                    }
-                }
-
-                if ndead > 0 {
-                    let mut denom = stop_denom - unentered_denom;
-                    let denom_scale = stop_denom.abs() + unentered_denom.abs();
-                    let reliable_difference = denom.is_finite()
-                        && denom > 0.0
-                        && (denom_scale == 0.0 || denom > 64.0 * f64::EPSILON * denom_scale);
-                    event_a.fill(0.0);
-                    event_cmat.fill(0.0);
-                    for i in 0..nvar {
-                        event_a[i] = stop_a[i] - unentered_a[i];
-                        for j in 0..=i {
-                            event_cmat[(i, j)] = stop_cmat[(i, j)] - unentered_cmat[(i, j)];
-                        }
-                    }
-                    if !reliable_difference {
-                        denom = 0.0;
-                        event_a.fill(0.0);
-                        event_cmat.fill(0.0);
-                        for person in stratum_start..=stratum_end {
-                            if entry_times[person] < event_time && self.time[person] >= event_time {
-                                add_risk_sums(
-                                    &self.covar,
-                                    nvar,
-                                    person,
-                                    risk_vals[person],
-                                    &mut denom,
-                                    &mut event_a,
-                                    &mut event_cmat,
-                                );
+                    nrisk += 1;
+                    eta_sum += zbeta_vals[person];
+                    let eta_shift = eta_sum / nrisk as f64 - recenter;
+                    if eta_shift.abs() > 200.0 {
+                        recenter = eta_sum / nrisk as f64;
+                        if denom > 0.0 {
+                            let scale = (-eta_shift).exp();
+                            denom *= scale;
+                            for i in 0..nvar {
+                                a[i] *= scale;
+                                for j in 0..=i {
+                                    cmat[(i, j)] *= scale;
+                                }
                             }
                         }
                     }
-                    if matches!(method, Method::Breslow) || ndead == 1 {
-                        loglik -= deadwt * denom.ln();
+                    let risk = (zbeta_vals[person] - recenter).exp() * self.weights[person];
+                    if self.status[person] == 0 {
+                        add_risk_sums(
+                            &self.covar,
+                            nvar,
+                            person,
+                            risk,
+                            &mut denom,
+                            &mut a,
+                            &mut cmat,
+                        );
+                    } else {
+                        ndead += 1;
+                        deadwt += self.weights[person];
+                        loglik += self.weights[person] * (zbeta_vals[person] - recenter);
+                        add_risk_sums(
+                            &self.covar,
+                            nvar,
+                            person,
+                            risk,
+                            &mut denom2,
+                            &mut death_a,
+                            &mut death_cmat,
+                        );
                         for i in 0..nvar {
-                            let temp = event_a[i] / denom;
-                            self.u[i] -= deadwt * temp;
+                            self.u[i] += self.weights[person] * self.covar[(person, i)];
+                        }
+                    }
+                }
+
+                debug_assert!(ndead > 0);
+                if matches!(method, Method::Breslow) || ndead == 1 {
+                    denom += denom2;
+                    loglik -= deadwt * denom.ln();
+                    for i in 0..nvar {
+                        a[i] += death_a[i];
+                        let temp = a[i] / denom;
+                        self.u[i] -= deadwt * temp;
+                        for j in 0..=i {
+                            cmat[(i, j)] += death_cmat[(i, j)];
+                            let val = deadwt * (cmat[(i, j)] - temp * a[j]) / denom;
+                            self.imat[(j, i)] += val;
+                            if i != j {
+                                self.imat[(i, j)] += val;
+                            }
+                        }
+                    }
+                } else {
+                    let death_count = ndead as f64;
+                    let weight_average = deadwt / death_count;
+                    for _ in 0..ndead {
+                        denom += denom2 / death_count;
+                        loglik -= weight_average * denom.ln();
+                        for i in 0..nvar {
+                            a[i] += death_a[i] / death_count;
+                            let temp = a[i] / denom;
+                            self.u[i] -= weight_average * temp;
                             for j in 0..=i {
-                                let val = deadwt * (event_cmat[(i, j)] - temp * event_a[j]) / denom;
+                                cmat[(i, j)] += death_cmat[(i, j)] / death_count;
+                                let val = weight_average * (cmat[(i, j)] - temp * a[j]) / denom;
                                 self.imat[(j, i)] += val;
                                 if i != j {
                                     self.imat[(i, j)] += val;
                                 }
                             }
                         }
-                    } else {
-                        let death_count = ndead as f64;
-                        let risk_fraction = denom2 / death_count;
-                        let weight_average = deadwt / death_count;
-                        let mut efron_denom = denom - denom2;
-                        for i in 0..nvar {
-                            event_a[i] -= death_a[i];
-                            for j in 0..=i {
-                                event_cmat[(i, j)] -= death_cmat[(i, j)];
-                            }
-                        }
-                        for _ in 0..ndead {
-                            efron_denom += risk_fraction;
-                            loglik -= weight_average * efron_denom.ln();
-                            for i in 0..nvar {
-                                event_a[i] += death_a[i] / death_count;
-                                let temp = event_a[i] / efron_denom;
-                                self.u[i] -= weight_average * temp;
-                                for j in 0..=i {
-                                    event_cmat[(i, j)] += death_cmat[(i, j)] / death_count;
-                                    let val = weight_average
-                                        * (event_cmat[(i, j)] - temp * event_a[j])
-                                        / efron_denom;
-                                    self.imat[(j, i)] += val;
-                                    if i != j {
-                                        self.imat[(i, j)] += val;
-                                    }
-                                }
-                            }
-                        }
                     }
                 }
-
-                if time_start == stratum_start {
-                    break;
-                }
-                time_end = time_start - 1;
             }
             stratum_start = stratum_end + 1;
         }

--- a/src/regression/coxph.rs
+++ b/src/regression/coxph.rs
@@ -955,6 +955,9 @@ pub fn coxph_fit(
     .map_err(|e| {
         pyo3::exceptions::PyRuntimeError::new_err(format!("Cox fit initialization failed: {}", e))
     })?;
+    if counting_process {
+        cox_fit.preserve_entry_input_order(&order);
+    }
     if let Some(values) = ridge_penalty.as_ref() {
         cox_fit.set_ridge_penalty(values);
     } else if let Some(values) = penalty_matrix.as_ref() {


### PR DESCRIPTION
## Summary
- replace counting-process cumulative subtraction with an active risk-set recurrence matching upstream update order
- preserve original row order for tied entry times and exclude intervals spanning no event
- add exact delayed-entry factor regression checks across Rust, Python, and R

## Validation
- cargo test --lib (1582 passed)
- Python suite (1126 passed)
- full R suite
- built R package check (Status: OK)
- cargo fmt and all-feature clippy
- Python lint and type checks
- seeded comparison matched cases 1-63 before a separate case at 64
- counting benchmark: 0.45 ms at 1k rows, 1.6 ms at 5k, 5.3 ms at 20k