### PR TITLE
Match counting-process Cox reported means

### DIFF
--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -1567,6 +1567,35 @@ test_that("R formula wrappers delegate to the Python survival package", {
   expect_equal(bridged_agreg_fit$first, reference_agreg_fit$first, tolerance = 1e-12)
   expect_equal(bridged_agreg_fit$info, reference_agreg_fit$info)
 
+  weighted_agreg_args <- list(
+    x = agreg_fit_x,
+    y = agreg_fit_y,
+    strata = NULL,
+    offset = c(0.1, -0.2, 0.05, 0, 0.15, -0.1),
+    init = c(0.35),
+    weights = c(0.5, 4, 1.25, 2.5, 0.75, 3),
+    method = "breslow",
+    rownames = as.character(seq_len(nrow(agreg_fit_x)))
+  )
+  bridged_weighted_agreg_fit <- do.call(
+    agreg.fit,
+    c(weighted_agreg_args, list(control = coxph.control(iter.max = 0)))
+  )
+  reference_weighted_agreg_fit <- do.call(
+    survival::agreg.fit,
+    c(weighted_agreg_args, list(control = survival::coxph.control(iter.max = 0)))
+  )
+  expect_equal(
+    bridged_weighted_agreg_fit$means,
+    reference_weighted_agreg_fit$means,
+    tolerance = 1e-12
+  )
+  expect_equal(
+    bridged_weighted_agreg_fit$linear.predictors,
+    reference_weighted_agreg_fit$linear.predictors,
+    tolerance = 1e-12
+  )
+
   bridged_agexact_fit <- agexact.fit(
     agreg_fit_x,
     agreg_fit_y,

--- a/src/regression/cch.rs
+++ b/src/regression/cch.rs
@@ -333,7 +333,7 @@ fn weighted_crossproduct(rows: &[Vec<f64>], divisors: &[f64]) -> Vec<Vec<f64>> {
     result
 }
 
-fn column_means(rows: &[Vec<f64>]) -> Vec<f64> {
+fn centered_rows(rows: &[Vec<f64>]) -> Vec<Vec<f64>> {
     if rows.is_empty() {
         return Vec::new();
     }
@@ -347,24 +347,6 @@ fn column_means(rows: &[Vec<f64>]) -> Vec<f64> {
     for mean in &mut means {
         *mean /= rows.len() as f64;
     }
-    means
-}
-
-fn counting_process_means(rows: &[Vec<f64>]) -> Vec<f64> {
-    let mut means = column_means(rows);
-    for column_idx in 0..means.len() {
-        if rows
-            .iter()
-            .all(|row| matches!(row[column_idx], -1.0 | 0.0 | 1.0))
-        {
-            means[column_idx] = 0.0;
-        }
-    }
-    means
-}
-
-fn centered_rows(rows: &[Vec<f64>]) -> Vec<Vec<f64>> {
-    let means = column_means(rows);
     rows.iter()
         .map(|row| {
             row.iter()
@@ -602,7 +584,7 @@ fn fit_weighted_cox(
     initial_beta: Option<Vec<f64>>,
     max_iter: usize,
 ) -> PyResult<CoxPHFit> {
-    let mut fit = coxph_fit(
+    coxph_fit(
         stop,
         status,
         covariates,
@@ -616,11 +598,7 @@ fn fit_weighted_cox(
         Some("efron"),
         Some(start),
         Some(vec![-1.0, 0.0, 1.0]),
-    )?;
-    // The counting-process fitter reports ordinary design means even when
-    // sampling weights are present.
-    fit.means = counting_process_means(&fit.covariates);
-    Ok(fit)
+    )
 }
 
 struct CchComputation {

--- a/src/regression/coxph.rs
+++ b/src/regression/coxph.rs
@@ -567,6 +567,24 @@ fn validate_method_weights(method: CoxMethod, weights: Option<&[f64]>) -> PyResu
     Ok(())
 }
 
+fn counting_process_means(covariates: &[Vec<f64>], doscale: &[bool]) -> Vec<f64> {
+    let mut means = vec![0.0; doscale.len()];
+    for row in covariates {
+        for ((mean, &value), &center) in means.iter_mut().zip(row).zip(doscale) {
+            if center {
+                *mean += value;
+            }
+        }
+    }
+    let denominator = covariates.len() as f64;
+    for (mean, &center) in means.iter_mut().zip(doscale) {
+        if center {
+            *mean /= denominator;
+        }
+    }
+    means
+}
+
 #[pyfunction]
 #[pyo3(signature = (time, status, covariates, strata=None, weights=None, offset=None, initial_beta=None, max_iter=None, eps=None, toler=None, method=None, entry_times=None, nocenter=None))]
 #[allow(clippy::too_many_arguments)]
@@ -703,6 +721,9 @@ pub fn coxph_fit(
             })
             .collect()
     };
+    let reported_counting_process_means = entry_times
+        .as_ref()
+        .map(|_| counting_process_means(&covariates, &doscale));
     let mut order: Vec<usize> = (0..n).collect();
     order.sort_by(|&lhs, &rhs| {
         strata_values[lhs]
@@ -756,8 +777,17 @@ pub fn coxph_fit(
     cox_fit
         .fit()
         .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("Cox fit failed: {}", e)))?;
-    let (beta, means, score_vector, information, log_likelihood, score_test, flag, iterations) =
-        cox_fit.results();
+    let (
+        beta,
+        optimizer_means,
+        score_vector,
+        information,
+        log_likelihood,
+        score_test,
+        flag,
+        iterations,
+    ) = cox_fit.results();
+    let means = reported_counting_process_means.unwrap_or(optimizer_means);
     let mut linear_predictors = Vec::with_capacity(n);
     let mut risk_scores = Vec::with_capacity(n);
     for (row, &offset) in covariates.iter().zip(offset_vec.iter()) {
@@ -1053,6 +1083,37 @@ mod tests {
         );
         assert_eq!(fit.convergence_flag, 2);
         assert_eq!(fit.iterations, 4);
+    }
+
+    #[test]
+    fn counting_process_fit_reports_unweighted_means() {
+        let time = vec![2.0, 3.0, 4.0, 5.0];
+        let status = vec![1, 0, 1, 1];
+        let covariates = vec![
+            vec![0.0, 0.0],
+            vec![1.0, 1.0],
+            vec![2.0, 0.0],
+            vec![8.0, 1.0],
+        ];
+        let weights = vec![1.0, 1.0, 1.0, 50.0];
+        let fit = coxph_fit(
+            time,
+            status,
+            covariates,
+            None,
+            Some(weights),
+            None,
+            None,
+            Some(0),
+            None,
+            None,
+            Some("breslow"),
+            Some(vec![0.0, 1.0, 0.5, 2.0]),
+            Some(vec![-1.0, 0.0, 1.0]),
+        )
+        .expect("weighted counting-process fit should succeed");
+
+        assert_close_vec(&fit.means, &[2.75, 0.0]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary\n- report ordinary design means for counting-process Cox results while preserving no-center columns\n- keep the estimator's internal weighted scaling unchanged and centralize the behavior for CCH/Borgan callers\n- add native and compatibility regression coverage for weighted fits, offsets, and initialized coefficients\n\n## Validation\n- 1,458 native tests without default features\n- 1,667 native tests with ML features\n- 1,681 native tests with Python and ML features\n- 851 Python tests passed; 18 skipped\n- full compatibility suite\n- 180 randomized nondegenerate differential cases\n- documentation tests\n- strict Clippy across default, ML, and Python/ML configurations\n- Ruff formatting and lint checks\n- mypy interface checks\n- diff whitespace checks