### PR TITLE
Match weighted Efron martingale residuals

### DIFF
--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -1499,6 +1499,32 @@ test_that("R formula wrappers delegate to the Python survival package", {
   expect_equal(bridged_cox_fit$means, reference_cox_fit$means, tolerance = 1e-12)
   expect_equal(bridged_cox_fit$method, reference_cox_fit$method)
 
+  weighted_efron_args <- list(
+    x = matrix(c(-0.5, 0.3, 1.1, -0.2, 0.7, 0.9), ncol = 1L),
+    y = survival::Surv(c(1, 2, 2, 3, 4, 5), c(0, 1, 1, 0, 1, 0)),
+    strata = NULL,
+    offset = c(0.1, -0.2, 0.05, 0, 0.15, -0.1),
+    init = 0.35,
+    weights = c(0.5, 4, 1.25, 2.5, 0.75, 3),
+    method = "efron",
+    rownames = as.character(seq_len(6L)),
+    resid = TRUE,
+    nocenter = c(-1, 0, 1)
+  )
+  bridged_weighted_efron <- do.call(
+    coxph.fit,
+    c(weighted_efron_args, list(control = coxph.control(iter.max = 0)))
+  )
+  reference_weighted_efron <- do.call(
+    survival::coxph.fit,
+    c(weighted_efron_args, list(control = survival::coxph.control(iter.max = 0)))
+  )
+  expect_equal(
+    bridged_weighted_efron$residuals,
+    reference_weighted_efron$residuals,
+    tolerance = 1e-12
+  )
+
   bridged_stratified_cox_fit <- coxph.fit(
     cox_fit_x,
     cox_fit_y,

--- a/src/regression/coxph.rs
+++ b/src/regression/coxph.rs
@@ -1117,6 +1117,48 @@ mod tests {
     }
 
     #[test]
+    fn weighted_efron_martingale_residuals_match_tied_death_adjustment() {
+        let fit = coxph_fit(
+            vec![1.0, 2.0, 2.0, 3.0, 4.0, 5.0],
+            vec![0, 1, 1, 0, 1, 0],
+            vec![
+                vec![-0.5],
+                vec![0.3],
+                vec![1.1],
+                vec![-0.2],
+                vec![0.7],
+                vec![0.9],
+            ],
+            None,
+            Some(vec![0.5, 4.0, 1.25, 2.5, 0.75, 3.0]),
+            Some(vec![0.1, -0.2, 0.05, 0.0, 0.15, -0.1]),
+            Some(vec![0.35]),
+            Some(0),
+            None,
+            None,
+            Some("efron"),
+            None,
+            Some(vec![-1.0, 0.0, 1.0]),
+        )
+        .expect("weighted Efron fit should succeed");
+
+        let residuals = fit
+            .martingale_residuals()
+            .expect("martingale residuals should compute");
+        assert_close_vec(
+            &residuals,
+            &[
+                0.0,
+                0.6925430252928146,
+                0.4776514121598462,
+                -0.4382541097187386,
+                0.07193586128657424,
+                -0.7751843293463833,
+            ],
+        );
+    }
+
+    #[test]
     fn default_rank_tolerance_preserves_near_collinear_columns() {
         let n = 20;
         let time = (1..=n).map(|value| value as f64).collect::<Vec<_>>();

--- a/src/regression/coxph_diagnostics.rs
+++ b/src/regression/coxph_diagnostics.rs
@@ -4,6 +4,7 @@ use crate::regression::cox_optimizer::Method as CoxMethod;
 use crate::regression::coxph::CoxPHFit;
 use crate::regression::coxph_support::{ActiveRiskSet, CoxSweepRow, StratifiedBaselineLookup};
 use crate::regression::exact_ties::{exact_inclusion_probabilities, exact_tied_moments};
+use crate::residuals::coxmart_module::{CoxMartSurvivalData, CoxMartWeights, compute_coxmart};
 use crate::scoring::coxscore2::{CoxScoreData, CoxScoreParams, compute_cox_score_residuals};
 use crate::validation::ProportionalityTest;
 use crate::validation::hypothesis_tests::proportional_hazards_chi2;
@@ -523,7 +524,81 @@ pub fn cox_interval_cumulative_hazard_se(
 }
 
 impl CoxPHFit {
+    fn right_censored_expected_events(&self) -> Vec<f64> {
+        let n = self.event_times.len();
+        let row_strata = self.row_strata_cow();
+        let order = diagnostic_order(row_strata.as_ref(), &self.event_times);
+        let centered_linear_predictors: Vec<f64> = {
+            let center = self
+                .coefficients
+                .first()
+                .map(|coefficients| {
+                    coefficients
+                        .iter()
+                        .zip(&self.means)
+                        .map(|(&coefficient, &mean)| coefficient * mean)
+                        .sum()
+                })
+                .unwrap_or(0.0);
+            order
+                .iter()
+                .map(|&idx| self.linear_predictors[idx] - center)
+                .collect()
+        };
+        let max_linear_predictor = centered_linear_predictors
+            .iter()
+            .copied()
+            .fold(f64::NEG_INFINITY, f64::max);
+        let overflow_threshold = f64::MAX.ln();
+        let shift = if max_linear_predictor > overflow_threshold {
+            overflow_threshold - (1.0 + max_linear_predictor)
+        } else {
+            0.0
+        };
+        let score: Vec<f64> = centered_linear_predictors
+            .iter()
+            .map(|&value| (value + shift).exp())
+            .collect();
+        let time: Vec<f64> = order.iter().map(|&idx| self.event_times[idx]).collect();
+        let status: Vec<i32> = order.iter().map(|&idx| self.status[idx]).collect();
+        let weights: Vec<f64> = order.iter().map(|&idx| self.weights[idx]).collect();
+        let mut stratum_ends = vec![0; n];
+        for sorted_idx in 0..n {
+            if sorted_idx + 1 == n
+                || row_strata[order[sorted_idx]] != row_strata[order[sorted_idx + 1]]
+            {
+                stratum_ends[sorted_idx] = 1;
+            }
+        }
+
+        let mut sorted_residuals = vec![0.0; n];
+        compute_coxmart(
+            n,
+            i32::from(self.method == "efron"),
+            CoxMartSurvivalData {
+                time: &time,
+                status: &status,
+                strata: &stratum_ends,
+            },
+            CoxMartWeights {
+                score: &score,
+                wt: &weights,
+            },
+            &mut sorted_residuals,
+        );
+
+        let mut expected = vec![0.0; n];
+        for (sorted_idx, &original_idx) in order.iter().enumerate() {
+            expected[original_idx] =
+                self.status[original_idx] as f64 - sorted_residuals[sorted_idx];
+        }
+        expected
+    }
+
     pub(crate) fn expected_events_internal(&self) -> PyResult<Vec<f64>> {
+        if self.entry_times.is_none() && matches!(self.method.as_str(), "breslow" | "efron") {
+            return Ok(self.right_censored_expected_events());
+        }
         let (times, hazards, hazard_strata) = self.basehaz_with_strata_internal(false)?;
         let baseline = StratifiedBaselineLookup::from_components(&times, &hazards, &hazard_strata);
         let entry_times = self.entry_times.as_deref();


### PR DESCRIPTION
## Summary\n- compute right-censored Cox event expectations with the dedicated sorted martingale sweep\n- preserve Efron's tied-death adjustment for weighted event rows\n- reuse the shared expectation path for martingale, deviance, and partial residual diagnostics\n- add native and R-facing regression coverage for unequal weights, offsets, and initialized coefficients\n\n## Validation\n- 1,459 native tests without default features\n- 1,668 native tests with ML features\n- 1,682 native tests with Python and ML features\n- 851 Python tests passed; 18 skipped\n- full compatibility suite\n- 464 randomized nondegenerate right-censored differential cases\n- documentation tests\n- strict Clippy across default, ML, and Python/ML configurations\n- Ruff formatting and lint checks\n- mypy interface checks\n- diff whitespace checks