### PR TITLE
Support zero-covariate Cox null models

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -18,6 +18,7 @@ wil = "wil"
 consts = "consts"
 parms = "parms"
 parm = "parm"
+inital = "inital"
 
 [files]
 extend-exclude = [

--- a/r/survivalr/R/bridge.R
+++ b/r/survivalr/R/bridge.R
@@ -8321,10 +8321,19 @@ coxph.control <- function(eps = 1e-09, toler.chol = .Machine$double.eps^0.75,
     stop("y must have 2 or 3 columns", call. = FALSE)
   }
   n <- length(time)
-  covariate_matrix <- as.matrix(x)
+  covariate_matrix <- if (!is.matrix(x) && length(x) == 0L) {
+    matrix(numeric(), nrow = n, ncol = 0L)
+  } else {
+    as.matrix(x)
+  }
+  null_model <- ncol(covariate_matrix) == 0L
   x_names <- colnames(covariate_matrix)
   if (is.null(x_names)) {
-    x_names <- paste0("X", seq_len(ncol(covariate_matrix)))
+    x_names <- if (null_model) {
+      character()
+    } else {
+      paste0("X", seq_len(ncol(covariate_matrix)))
+    }
   }
   covariates <- .coxph_fit_covariates(covariate_matrix, n)
 
@@ -8347,6 +8356,12 @@ coxph.control <- function(eps = 1e-09, toler.chol = .Machine$double.eps^0.75,
   }
   if (!is.null(init)) {
     init <- as.numeric(init)
+  }
+  if (null_model) {
+    if (isTRUE(include_agreg_info) && length(init) != 0L) {
+      stop("Wrong length for inital values", call. = FALSE)
+    }
+    init <- NULL
   }
   if (missing(control) || is.null(control)) {
     control <- coxph.control()
@@ -8375,7 +8390,7 @@ coxph.control <- function(eps = 1e-09, toler.chol = .Machine$double.eps^0.75,
       weights = weights,
       offset = offset,
       initial_beta = if (is.null(init)) NULL else as.list(init),
-      max_iter = as.integer(control[["iter.max"]]),
+      max_iter = if (null_model) 0L else as.integer(control[["iter.max"]]),
       eps = as.numeric(control[["eps"]]),
       toler = as.numeric(control[["toler.chol"]]),
       method = method,
@@ -8383,6 +8398,37 @@ coxph.control <- function(eps = 1e-09, toler.chol = .Machine$double.eps^0.75,
       nocenter = if (is.null(nocenter)) NULL else as.list(as.numeric(nocenter))
     ))
   )
+
+  if (null_model) {
+    loglik <- .as_numeric_vector(.result_field(fit, "log_likelihood"))
+    null_loglik <- if (isTRUE(include_agreg_info)) {
+      loglik[[length(loglik)]]
+    } else {
+      loglik[[1L]]
+    }
+    martingale <- NULL
+    if (isTRUE(resid)) {
+      martingale <- .as_numeric_vector(
+        do.call(reticulate::py_get_attr(fit, "martingale_residuals"), list())
+      )
+      names(martingale) <- as.character(rownames)
+    }
+    out <- list(
+      loglik = null_loglik,
+      linear.predictors = offset
+    )
+    if (!isTRUE(include_agreg_info) && isTRUE(resid)) {
+      out$residuals <- martingale
+    }
+    out$method <- method
+    if (isTRUE(include_class)) {
+      out$class <- c("coxph.null", "coxph")
+    }
+    if (isTRUE(include_agreg_info) && isTRUE(resid)) {
+      out$residuals <- martingale
+    }
+    return(out)
+  }
 
   coefficient_matrix <- .as_numeric_matrix(.result_field(fit, "coefficients"))
   coefficients <- if (nrow(coefficient_matrix) == 0L) {

--- a/r/survivalr/tests/testthat/test-python-bridge.R
+++ b/r/survivalr/tests/testthat/test-python-bridge.R
@@ -3123,6 +3123,102 @@ test_that("R formula wrappers delegate to the Python survival package", {
   expect_equal(nrow(aft_dfbeta), nrow(data))
 })
 
+test_that("zero-covariate low-level Cox fits match null-model results", {
+  skip_if_not_installed("reticulate")
+  skip_if_not_installed("survival")
+  skip_if_not(
+    reticulate::py_module_available("survival"),
+    "Python survival package is unavailable"
+  )
+
+  right_y <- survival::Surv(
+    c(1, 2, 2, 3, 4, 5),
+    c(1, 0, 1, 1, 0, 1)
+  )
+  right_args <- list(
+    x = matrix(numeric(), nrow = 6L, ncol = 0L),
+    y = right_y,
+    strata = c(1, 1, 1, 2, 2, 2),
+    offset = c(0.1, -0.2, 0, 0.3, -0.1, 0.2),
+    init = NULL,
+    weights = c(1, 2, 0.5, 1.5, 3, 1),
+    method = "efron",
+    rownames = letters[1:6]
+  )
+  for (keep_residuals in c(TRUE, FALSE)) {
+    bridged <- do.call(
+      coxph.fit,
+      c(
+        right_args,
+        list(control = coxph.control(iter.max = 20), resid = keep_residuals)
+      )
+    )
+    reference <- do.call(
+      survival::coxph.fit,
+      c(
+        right_args,
+        list(control = survival::coxph.control(iter.max = 20), resid = keep_residuals)
+      )
+    )
+    expect_equal(bridged, reference, tolerance = 1e-12)
+  }
+
+  vector_args <- right_args
+  vector_args$x <- numeric()
+  expect_equal(
+    do.call(
+      coxph.fit,
+      c(vector_args, list(control = coxph.control(iter.max = 20)))
+    ),
+    do.call(
+      survival::coxph.fit,
+      c(vector_args, list(control = survival::coxph.control(iter.max = 20)))
+    ),
+    tolerance = 1e-12
+  )
+
+  counting_args <- list(
+    x = matrix(numeric(), nrow = 6L, ncol = 0L),
+    y = survival::Surv(
+      c(0, 0, 1, 2, 3, 4),
+      c(2, 3, 4, 5, 6, 7),
+      c(1, 0, 1, 1, 0, 1)
+    ),
+    strata = c(1, 1, 1, 2, 2, 2),
+    offset = c(0.1, -0.2, 0, 0.3, -0.1, 0.2),
+    init = NULL,
+    weights = c(1, 2, 0.5, 1.5, 3, 1),
+    method = "efron",
+    rownames = letters[1:6]
+  )
+  for (keep_residuals in c(TRUE, FALSE)) {
+    bridged <- do.call(
+      agreg.fit,
+      c(
+        counting_args,
+        list(control = coxph.control(iter.max = 20), resid = keep_residuals)
+      )
+    )
+    reference <- do.call(
+      survival::agreg.fit,
+      c(
+        counting_args,
+        list(control = survival::coxph.control(iter.max = 20), resid = keep_residuals)
+      )
+    )
+    expect_equal(bridged, reference, tolerance = 1e-12)
+  }
+  invalid_counting_args <- counting_args
+  invalid_counting_args$init <- 1
+  expect_error(
+    do.call(
+      agreg.fit,
+      c(invalid_counting_args, list(control = coxph.control()))
+    ),
+    "Wrong length for inital values"
+  )
+})
+
 test_that("tmerge matches native interval, metadata, and class semantics", {
   skip_if_not_installed("reticulate")
   skip_if_not_installed("survival")


### PR DESCRIPTION
## Summary
- accept both zero-column matrices and empty vectors in low-level Cox fit entry points
- return reference-compatible null-model fields, ordering, residual names, and class metadata for right-censored and counting-process fits
- force the zero-iteration native path and preserve counting-process initial-value validation

## Testing
- 200 randomized null-model differential cases
- `testthat::test_local("r/survivalr")`
- `R CMD check --no-manual --no-build-vignettes r/survivalr`
- `.venv/bin/python -m pytest python/tests/test_r_package_layout.py -q`
- R syntax parsing
- `git diff --check`