### PR TITLE
Match Cox risk-set expansion semantics

### DIFF
--- a/src/core/coxcount1.rs
+++ b/src/core/coxcount1.rs
@@ -101,36 +101,22 @@ pub struct CoxCountOutput {
     #[pyo3(get)]
     pub status: Vec<i32>,
 }
-#[pyfunction]
-pub fn coxcount1(
-    time: Vec<f64>,
-    status: Vec<f64>,
-    strata: Vec<i32>,
-) -> PyResult<Py<CoxCountOutput>> {
-    validate_coxcount1_inputs(&time, &status, &strata)?;
-    let time_slice = &time;
-    let status_slice = &status;
-    let strata_slice = &strata;
-    let n = time_slice.len();
+fn coxcount1_impl(time: &[f64], status: &[f64], strata: &[i32]) -> PyResult<CoxCountOutput> {
+    validate_coxcount1_inputs(time, status, strata)?;
+    let n = time.len();
     let mut ntime = 0;
     let mut nrow = 0;
-    let mut _stratastart = 0;
     let mut nrisk = 0;
     let mut i = 0;
     while i < n {
-        if strata_slice[i] == 1 {
-            _stratastart = i;
+        if strata[i] == 1 {
             nrisk = 0;
         }
         nrisk += 1;
-        if status_slice[i] == 1.0 {
-            let dtime = time_slice[i];
+        if status[i] == 1.0 {
+            let dtime = time[i];
             let mut j = i + 1;
-            while j < n
-                && (time_slice[j] - dtime).abs() < f64::EPSILON
-                && status_slice[j] == 1.0
-                && strata_slice[j] == 0
-            {
+            while j < n && time[j] == dtime && status[j] == 1.0 && strata[j] == 0 {
                 nrisk += 1;
                 j += 1;
             }
@@ -144,23 +130,19 @@ pub fn coxcount1(
     let mut nrisk_vec = Vec::with_capacity(ntime);
     let mut index_vec = Vec::with_capacity(nrow);
     let mut status_vec = Vec::with_capacity(nrow);
-    let mut _stratastart = 0;
+    let mut stratum_start = 0;
     let mut i = 0;
     while i < n {
-        if strata_slice[i] == 1 {
-            _stratastart = i;
+        if strata[i] == 1 {
+            stratum_start = i;
         }
-        if status_slice[i] == 1.0 {
-            let dtime = time_slice[i];
+        if status[i] == 1.0 {
+            let dtime = time[i];
             let mut j = i + 1;
-            while j < n
-                && (time_slice[j] - dtime).abs() < f64::EPSILON
-                && status_slice[j] == 1.0
-                && strata_slice[j] == 0
-            {
+            while j < n && time[j] == dtime && status[j] == 1.0 && strata[j] == 0 {
                 j += 1;
             }
-            for k in _stratastart..i {
+            for k in stratum_start..i {
                 status_vec.push(0);
                 index_vec.push((k + 1) as i32);
             }
@@ -169,54 +151,53 @@ pub fn coxcount1(
                 index_vec.push((k + 1) as i32);
             }
             time_vec.push(dtime);
-            nrisk_vec.push((j - _stratastart) as i32);
+            nrisk_vec.push((j - stratum_start) as i32);
             i = j - 1;
         }
         i += 1;
     }
-    Python::attach(|py| {
-        Py::new(
-            py,
-            CoxCountOutput {
-                time: time_vec,
-                nrisk: nrisk_vec,
-                index: index_vec,
-                status: status_vec,
-            },
-        )
+    Ok(CoxCountOutput {
+        time: time_vec,
+        nrisk: nrisk_vec,
+        index: index_vec,
+        status: status_vec,
     })
 }
+
 #[pyfunction]
-pub fn coxcount2(
-    time1: Vec<f64>,
-    time2: Vec<f64>,
+pub fn coxcount1(
+    time: Vec<f64>,
     status: Vec<f64>,
-    sort1: Vec<usize>,
-    sort2: Vec<usize>,
     strata: Vec<i32>,
 ) -> PyResult<Py<CoxCountOutput>> {
-    validate_coxcount2_inputs(&time1, &time2, &status, &sort1, &sort2, &strata)?;
-    let time1_slice = &time1;
-    let time2_slice = &time2;
-    let status_slice = &status;
-    let sort1_slice = &sort1;
-    let sort2_slice = &sort2;
-    let strata_slice = &strata;
-    let n = time1_slice.len();
+    let output = coxcount1_impl(&time, &status, &strata)?;
+    Python::attach(|py| Py::new(py, output))
+}
+
+fn coxcount2_impl(
+    time1: &[f64],
+    time2: &[f64],
+    status: &[f64],
+    sort1: &[usize],
+    sort2: &[usize],
+    strata: &[i32],
+) -> PyResult<CoxCountOutput> {
+    validate_coxcount2_inputs(time1, time2, status, sort1, sort2, strata)?;
+    let n = time1.len();
     let mut ntime = 0;
     let mut nrow = 0;
     let mut j = 0;
     let mut i = 0;
     let mut nrisk = 0;
     while i < n {
-        let iptr = sort2_slice[i];
-        if strata_slice[i] == 1 {
+        let iptr = sort2[i];
+        if strata[i] == 1 {
             nrisk = 0;
             j = i;
         }
-        if status_slice[iptr] == 1.0 {
-            let dtime = time2_slice[iptr];
-            while j < i && time1_slice[sort1_slice[j]] >= dtime {
+        if status[iptr] == 1.0 {
+            let dtime = time2[iptr];
+            while j < i && time1[sort1[j]] >= dtime {
                 if nrisk == 0 {
                     return Err(value_error(
                         "coxcount2 sort order is inconsistent with the risk set",
@@ -227,10 +208,9 @@ pub fn coxcount2(
             }
             nrisk += 1;
             i += 1;
-            while i < n
-                && strata_slice[i] == 0
-                && (time2_slice[sort2_slice[i]] - dtime).abs() < f64::EPSILON
-            {
+            // The native routine indexes boundary markers through the original
+            // row number while extending a tied counting-process event set.
+            while i < n && strata[sort2[i]] == 0 && time2[sort2[i]] == dtime {
                 nrisk += 1;
                 i += 1;
             }
@@ -245,38 +225,34 @@ pub fn coxcount2(
     let mut nrisk_vec = Vec::with_capacity(ntime);
     let mut index_vec = Vec::with_capacity(nrow);
     let mut status_vec = Vec::with_capacity(nrow);
-    let mut atrisk = vec![None; n];
+    let mut atrisk = vec![0; n];
     let mut who = Vec::with_capacity(n);
     let mut j = 0;
     let mut i = 0;
     while i < n {
-        let iptr = sort2_slice[i];
-        if strata_slice[i] == 1 {
-            atrisk.iter_mut().for_each(|x| *x = None);
+        let iptr = sort2[i];
+        if strata[i] == 1 {
             who.clear();
             j = i;
         }
-        if status_slice[iptr] == 0.0 {
-            if atrisk[iptr].is_none() {
-                atrisk[iptr] = Some(who.len());
-                who.push(iptr);
-            }
+        if status[iptr] == 0.0 {
+            atrisk[iptr] = who.len();
+            who.push(iptr);
             i += 1;
         } else {
-            let dtime = time2_slice[iptr];
+            let dtime = time2[iptr];
             while j < i {
-                let jptr = sort1_slice[j];
-                if time1_slice[jptr] >= dtime {
-                    if let Some(pos) = atrisk[jptr]
-                        && pos < who.len()
-                    {
-                        if let Some(last) = who.pop()
-                            && pos < who.len()
-                        {
-                            who[pos] = last;
-                            atrisk[last] = Some(pos);
-                        }
-                        atrisk[jptr] = None;
+                let jptr = sort1[j];
+                if time1[jptr] >= dtime {
+                    let pos = atrisk[jptr];
+                    if pos >= who.len() || who[pos] != jptr {
+                        return Err(value_error(
+                            "coxcount2 sort order is inconsistent with the risk set",
+                        ));
+                    }
+                    who.swap_remove(pos);
+                    if pos < who.len() {
+                        atrisk[who[pos]] = pos;
                     }
                     j += 1;
                 } else {
@@ -287,38 +263,43 @@ pub fn coxcount2(
                 status_vec.push(0);
                 index_vec.push((k + 1) as i32);
             }
-            let mut events = vec![iptr];
+            status_vec.push(1);
+            index_vec.push((iptr + 1) as i32);
+            atrisk[iptr] = who.len();
+            who.push(iptr);
             i += 1;
-            while i < n
-                && strata_slice[i] == 0
-                && (time2_slice[sort2_slice[i]] - dtime).abs() < f64::EPSILON
-            {
-                events.push(sort2_slice[i]);
-                i += 1;
-            }
-            for &k in &events {
+            // Preserve the same original-row boundary lookup used above.
+            while i < n && strata[sort2[i]] == 0 && time2[sort2[i]] == dtime {
+                let k = sort2[i];
                 status_vec.push(1);
                 index_vec.push((k + 1) as i32);
-                if atrisk[k].is_none() {
-                    atrisk[k] = Some(who.len());
-                    who.push(k);
-                }
+                atrisk[k] = who.len();
+                who.push(k);
+                i += 1;
             }
             time_vec.push(dtime);
             nrisk_vec.push(who.len() as i32);
         }
     }
-    Python::attach(|py| {
-        Py::new(
-            py,
-            CoxCountOutput {
-                time: time_vec,
-                nrisk: nrisk_vec,
-                index: index_vec,
-                status: status_vec,
-            },
-        )
+    Ok(CoxCountOutput {
+        time: time_vec,
+        nrisk: nrisk_vec,
+        index: index_vec,
+        status: status_vec,
     })
+}
+
+#[pyfunction]
+pub fn coxcount2(
+    time1: Vec<f64>,
+    time2: Vec<f64>,
+    status: Vec<f64>,
+    sort1: Vec<usize>,
+    sort2: Vec<usize>,
+    strata: Vec<i32>,
+) -> PyResult<Py<CoxCountOutput>> {
+    let output = coxcount2_impl(&time1, &time2, &status, &sort1, &sort2, &strata)?;
+    Python::attach(|py| Py::new(py, output))
 }
 
 #[cfg(test)]
@@ -379,5 +360,42 @@ mod tests {
         };
 
         assert!(err.to_string().contains("sort1 must be a permutation"));
+    }
+
+    #[test]
+    fn coxcount1_keeps_adjacent_floating_point_times_separate() {
+        initialize_python();
+        let previous = f64::from_bits(1.0f64.to_bits() - 1);
+        let output = coxcount1_impl(&[1.0, previous], &[1.0, 1.0], &[1, 0]).unwrap();
+
+        assert_eq!(output.time, vec![1.0, previous]);
+        assert_eq!(output.nrisk, vec![1, 2]);
+        assert_eq!(output.index, vec![1, 1, 2]);
+        assert_eq!(output.status, vec![1, 0, 1]);
+    }
+
+    #[test]
+    fn coxcount2_matches_stratified_tied_event_reference() {
+        initialize_python();
+        let output = coxcount2_impl(
+            &[
+                0.0, 4.0, 5.0, 1.0, 6.0, 1.0, 3.0, 5.0, 1.0, 2.0, 2.0, 5.0, 5.0,
+            ],
+            &[
+                5.0, 5.0, 6.0, 4.0, 9.0, 4.0, 4.0, 6.0, 4.0, 5.0, 3.0, 9.0, 8.0,
+            ],
+            &[
+                1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0,
+            ],
+            &[4, 12, 6, 10, 0, 7, 11, 1, 9, 3, 5, 2, 8],
+            &[4, 12, 0, 6, 10, 11, 7, 1, 9, 3, 5, 2, 8],
+            &[1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0],
+        )
+        .unwrap();
+
+        assert_eq!(output.time, vec![9.0, 5.0, 9.0, 4.0, 4.0, 6.0]);
+        assert_eq!(output.nrisk, vec![1, 1, 1, 2, 3, 1]);
+        assert_eq!(output.index, vec![5, 1, 12, 10, 4, 10, 4, 6, 3]);
+        assert_eq!(output.status, vec![1, 1, 1, 0, 1, 0, 0, 1, 1]);
     }
 }


### PR DESCRIPTION
## Summary
- preserve exact event-time equality and stratified tied-event boundary behavior in low-level Cox risk-set expansion
- split pure expansion builders from the Python wrappers for direct regression coverage
- remove full at-risk marker clears at stratum boundaries and temporary tied-event allocations
- add exact adjacent-time and stratified tied-event reference tests

## Testing
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check
- python -m pytest python/tests -q
- 1,000 randomized low-level risk-set expansion comparisons against the native routines
- 100 randomized stratified counting-process time-transform fit comparisons
- optimized extension build
- git diff --check