### PR TITLE
Reject duplicate subject times in fromtimeline

### DIFF
--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -2913,6 +2913,9 @@ def test_fromtimeline_builds_intervals_and_covariate_row_maps():
     with pytest.raises(ValueError, match="censored state"):
         survival.fromtimeline([0.0, 1.0], [0, 1], id=[1, 1])
 
+    with pytest.raises(ValueError, match="duplicated time for an id"):
+        survival.fromtimeline([0.0, 1.0, 1.0], [1, 2, 3], id=[1, 1, 1])
+
 
 def test_surv_accepts_named_response_arguments():
     positional = survival.Surv([1, 2, 3], [1, 2, 1])

--- a/src/data_prep/surv2data.rs
+++ b/src/data_prep/surv2data.rs
@@ -106,9 +106,11 @@ pub fn from_timeline_rows(
                 .total_cmp(&time[right])
                 .then_with(|| left.cmp(&right))
         });
+        if rows.windows(2).any(|pair| time[pair[0]] == time[pair[1]]) {
+            return Err(PyValueError::new_err("duplicated time for an id"));
+        }
         let first_row = rows[0];
-        let last_row = rows[rows.len() - 1];
-        if rows.len() < 2 || time[first_row] == time[last_row] {
+        if rows.len() < 2 {
             result.removed_row.push(first_row);
             continue;
         }
@@ -563,5 +565,19 @@ mod tests {
         assert!(from_timeline_rows(vec![0], vec![], vec![1]).is_err());
         assert!(from_timeline_rows(vec![0], vec![f64::NAN], vec![1]).is_err());
         assert!(from_timeline_rows(vec![0, 0], vec![0.0, 1.0], vec![0, 1]).is_err());
+    }
+
+    #[test]
+    fn timeline_rows_reject_duplicate_times_within_a_subject() {
+        let partial_tie =
+            from_timeline_rows(vec![0, 0, 0], vec![0.0, 1.0, 1.0], vec![1, 2, 3]).unwrap_err();
+        assert!(
+            partial_tie
+                .to_string()
+                .contains("duplicated time for an id")
+        );
+
+        let all_tied = from_timeline_rows(vec![0, 0], vec![1.0, 1.0], vec![1, 2]).unwrap_err();
+        assert!(all_tied.to_string().contains("duplicated time for an id"));
     }
 }


### PR DESCRIPTION
## Summary
- reject duplicate observation times within each subject before constructing intervals
- preserve single-observation subject removal behavior
- cover partial and fully tied timelines at the native boundary and public interface

## Validation
- cargo test --lib (1,468 passed)
- python -m pytest python/tests (851 passed, 18 skipped)
- cargo clippy across no-default, ml, and python+ml feature sets with warnings denied
- cargo fmt --all -- --check
- ruff format python/ test/ --check
- ruff check python/ test/
- git diff --check