### PR TITLE
Restore fromtimeline input row order

### DIFF
--- a/python/tests/test_binding_contract.py
+++ b/python/tests/test_binding_contract.py
@@ -3352,12 +3352,12 @@ def test_data_prep_low_level_bindings_are_typed():
         [0.0, 3.0, 4.0, 0.0, 2.0, 1.0],
         [1, 2, 3, 1, 2, 1],
     )
-    assert timeline_rows.start == [0.0, 2.0, 0.0]
-    assert timeline_rows.stop == [2.0, 4.0, 3.0]
-    assert timeline_rows.status == [2, 3, 2]
-    assert timeline_rows.istate == [1, 2, 1]
-    assert timeline_rows.static_row == [0, 0, 3]
-    assert timeline_rows.dynamic_row == [0, 4, 3]
+    assert timeline_rows.start == [0.0, 0.0, 2.0]
+    assert timeline_rows.stop == [2.0, 3.0, 4.0]
+    assert timeline_rows.status == [2, 2, 3]
+    assert timeline_rows.istate == [1, 1, 2]
+    assert timeline_rows.static_row == [0, 3, 0]
+    assert timeline_rows.dynamic_row == [0, 3, 4]
     assert timeline_rows.removed_row == [5]
 
     collapsed = core.collapse(

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -2935,6 +2935,19 @@ def test_fromtimeline_builds_intervals_and_covariate_row_maps():
     assert multistate_result["state_levels"] == ["censor", "entry", "ill", "death"]
     assert multistate_result["istate_levels"] == ["entry", "ill", "death"]
 
+    interleaved_result = survival.fromtimeline(
+        [0.0, 3.0, 4.0, 0.0, 2.0],
+        [1, 2, 3, 1, 2],
+        id=[1, 2, 1, 2, 1],
+        states=["entry", "ill", "death"],
+    )
+    assert interleaved_result["start"] == pytest.approx([0.0, 0.0, 2.0])
+    assert interleaved_result["stop"] == pytest.approx([2.0, 3.0, 4.0])
+    assert interleaved_result["status"] == [2, 2, 3]
+    assert interleaved_result["istate"] == [1, 1, 2]
+    assert interleaved_result["static_row"] == [0, 3, 0]
+    assert interleaved_result["dynamic_row"] == [0, 3, 4]
+
     with pytest.raises(ValueError, match="censored state"):
         survival.fromtimeline([0.0, 1.0], [0, 1], id=[1, 1])
 

--- a/src/data_prep/surv2data.rs
+++ b/src/data_prep/surv2data.rs
@@ -5,6 +5,8 @@ use std::collections::HashMap;
 use crate::constants::TIME_EPSILON;
 use crate::internal::validation::{validate_binary_i32, validate_finite, validate_no_nan};
 
+const NO_NEXT_ROW: usize = usize::MAX;
+
 #[pyclass(from_py_object)]
 #[derive(Debug, Clone)]
 pub struct Surv2DataResult {
@@ -91,15 +93,8 @@ pub fn from_timeline_rows(
     }
 
     let capacity = n.saturating_sub(groups.len());
-    let mut result = FromTimelineRowsResult {
-        start: Vec::with_capacity(capacity),
-        stop: Vec::with_capacity(capacity),
-        status: Vec::with_capacity(capacity),
-        istate: Vec::with_capacity(capacity),
-        static_row: Vec::with_capacity(capacity),
-        dynamic_row: Vec::with_capacity(capacity),
-        removed_row: Vec::new(),
-    };
+    let mut next_row = vec![NO_NEXT_ROW; n];
+    group_index.clear();
     for mut rows in groups {
         rows.sort_unstable_by(|&left, &right| {
             time[left]
@@ -111,7 +106,6 @@ pub fn from_timeline_rows(
         }
         let first_row = rows[0];
         if rows.len() < 2 {
-            result.removed_row.push(first_row);
             continue;
         }
         if status[first_row] == 0 {
@@ -119,9 +113,29 @@ pub fn from_timeline_rows(
                 "no observation should start in a censored state",
             ));
         }
+        group_index.insert(id[first_row], first_row);
         for pair in rows.windows(2) {
             let row = pair[0];
             let next = pair[1];
+            next_row[row] = next;
+        }
+    }
+
+    let mut result = FromTimelineRowsResult {
+        start: Vec::with_capacity(capacity),
+        stop: Vec::with_capacity(capacity),
+        status: Vec::with_capacity(capacity),
+        istate: Vec::with_capacity(capacity),
+        static_row: Vec::with_capacity(capacity),
+        dynamic_row: Vec::with_capacity(capacity),
+        removed_row: Vec::new(),
+    };
+    for (row, next) in next_row.into_iter().enumerate() {
+        let Some(&first_row) = group_index.get(&id[row]) else {
+            result.removed_row.push(row);
+            continue;
+        };
+        if next != NO_NEXT_ROW {
             result.start.push(time[row]);
             result.stop.push(time[next]);
             result.status.push(status[next]);
@@ -141,8 +155,6 @@ pub fn surv2data_timeline(
     status: Vec<Option<i32>>,
     repeated: bool,
 ) -> PyResult<Surv2TimelineResult> {
-    const NO_NEXT_ROW: usize = usize::MAX;
-
     let n = id.len();
     if time.len() != n || status.len() != n {
         return Err(PyValueError::new_err(
@@ -643,7 +655,7 @@ mod tests {
     }
 
     #[test]
-    fn from_timeline_rows_sorts_within_subject_and_tracks_removed_rows() {
+    fn from_timeline_rows_restores_input_order_and_tracks_removed_rows() {
         let result = from_timeline_rows(
             vec![0, 1, 0, 1, 0, 2],
             vec![0.0, 3.0, 4.0, 0.0, 2.0, 1.0],
@@ -651,12 +663,12 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(result.start, vec![0.0, 2.0, 0.0]);
-        assert_eq!(result.stop, vec![2.0, 4.0, 3.0]);
-        assert_eq!(result.status, vec![2, 3, 2]);
-        assert_eq!(result.istate, vec![1, 2, 1]);
-        assert_eq!(result.static_row, vec![0, 0, 3]);
-        assert_eq!(result.dynamic_row, vec![0, 4, 3]);
+        assert_eq!(result.start, vec![0.0, 0.0, 2.0]);
+        assert_eq!(result.stop, vec![2.0, 3.0, 4.0]);
+        assert_eq!(result.status, vec![2, 2, 3]);
+        assert_eq!(result.istate, vec![1, 1, 2]);
+        assert_eq!(result.static_row, vec![0, 3, 0]);
+        assert_eq!(result.dynamic_row, vec![0, 3, 4]);
         assert_eq!(result.removed_row, vec![5]);
     }
 


### PR DESCRIPTION
## Summary
- restore original input-row ordering for intervals built from interleaved subjects
- retain per-subject chronological sorting and materialize results with one linear row scan instead of a second comparison sort
- reuse the subject lookup and add a contiguous successor-row scratch array
- cover native, binding, and public behavior for interleaved timelines

## Validation
- `cargo test --lib` (1,471 passed)
- `.venv/bin/pytest -q python/tests` (851 passed, 18 skipped)
- strict Clippy across no-default, `ml`, and `python,ml` feature sets
- native and Python formatting checks
- Python lint and `git diff --check`