### PR TITLE
Carry fromtimeline states through censoring

### DIFF
--- a/python/tests/test_binding_contract.py
+++ b/python/tests/test_binding_contract.py
@@ -3360,6 +3360,14 @@ def test_data_prep_low_level_bindings_are_typed():
     assert timeline_rows.dynamic_row == [0, 3, 4]
     assert timeline_rows.removed_row == [5]
 
+    censored_timeline_rows = core.from_timeline_rows(
+        [0, 1, 0, 1, 0, 1],
+        [0.0, 0.0, 1.0, 1.0, 2.0, 2.0],
+        [1, 2, 0, 0, 2, 3],
+    )
+    assert censored_timeline_rows.status == [0, 0, 2, 3]
+    assert censored_timeline_rows.istate == [1, 2, 1, 2]
+
     collapsed = core.collapse(
         [1.0, 2.0, 3.0, 4.0, 2.0, 3.0, 4.0, 5.0, 1.0, 0.0, 1.0, 0.0],
         [1, 1, 1, 1],

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -2948,6 +2948,15 @@ def test_fromtimeline_builds_intervals_and_covariate_row_maps():
     assert interleaved_result["static_row"] == [0, 3, 0]
     assert interleaved_result["dynamic_row"] == [0, 3, 4]
 
+    censored_result = survival.fromtimeline(
+        [0.0, 1.0, 2.0],
+        [1, 0, 2],
+        id=[1, 1, 1],
+        states=["entry", "ill"],
+    )
+    assert censored_result["status"] == [0, 2]
+    assert censored_result["istate"] == [1, 1]
+
     with pytest.raises(ValueError, match="censored state"):
         survival.fromtimeline([0.0, 1.0], [0, 1], id=[1, 1])
 

--- a/src/data_prep/surv2data.rs
+++ b/src/data_prep/surv2data.rs
@@ -94,6 +94,7 @@ pub fn from_timeline_rows(
 
     let capacity = n.saturating_sub(groups.len());
     let mut next_row = vec![NO_NEXT_ROW; n];
+    let mut state_by_row = vec![0; n];
     group_index.clear();
     for mut rows in groups {
         rows.sort_unstable_by(|&left, &right| {
@@ -114,10 +115,15 @@ pub fn from_timeline_rows(
             ));
         }
         group_index.insert(id[first_row], first_row);
+        let mut current_state = status[first_row];
         for pair in rows.windows(2) {
             let row = pair[0];
             let next = pair[1];
+            if status[row] != 0 {
+                current_state = status[row];
+            }
             next_row[row] = next;
+            state_by_row[row] = current_state;
         }
     }
 
@@ -139,7 +145,7 @@ pub fn from_timeline_rows(
             result.start.push(time[row]);
             result.stop.push(time[next]);
             result.status.push(status[next]);
-            result.istate.push(status[row]);
+            result.istate.push(state_by_row[row]);
             result.static_row.push(first_row);
             result.dynamic_row.push(row);
         }
@@ -670,6 +676,23 @@ mod tests {
         assert_eq!(result.static_row, vec![0, 3, 0]);
         assert_eq!(result.dynamic_row, vec![0, 3, 4]);
         assert_eq!(result.removed_row, vec![5]);
+    }
+
+    #[test]
+    fn from_timeline_rows_carries_states_through_censored_rows() {
+        let result = from_timeline_rows(
+            vec![0, 1, 0, 1, 0, 1],
+            vec![0.0, 0.0, 1.0, 1.0, 2.0, 2.0],
+            vec![1, 2, 0, 0, 2, 3],
+        )
+        .unwrap();
+
+        assert_eq!(result.start, vec![0.0, 0.0, 1.0, 1.0]);
+        assert_eq!(result.stop, vec![1.0, 1.0, 2.0, 2.0]);
+        assert_eq!(result.status, vec![0, 0, 2, 3]);
+        assert_eq!(result.istate, vec![1, 2, 1, 2]);
+        assert_eq!(result.static_row, vec![0, 1, 0, 1]);
+        assert_eq!(result.dynamic_row, vec![0, 1, 2, 3]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- carry the latest non-censored state across censored timeline rows
- preserve raw next-row status codes while deriving interval initial states independently
- keep input-order materialization linear with a compact 4-byte state scratch value per row
- cover interleaved subjects through native, binding, and public regressions

## Validation
- `cargo test --lib` (1,472 passed)
- `.venv/bin/pytest -q python/tests` (851 passed, 18 skipped)
- strict Clippy across no-default, `ml`, and `python,ml` feature sets
- native and Python formatting checks
- Python lint and `git diff --check`