### PR TITLE
Honor fromtimeline repeated transitions

### DIFF
--- a/python/survival/_survival.pyi
+++ b/python/survival/_survival.pyi
@@ -5753,6 +5753,7 @@ def from_timeline_rows(
     id: list[int],
     time: list[float],
     status: list[int],
+    repeated: bool = True,
 ) -> FromTimelineRowsResult: ...
 def survcondense(
     id: list[int],

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -5606,6 +5606,7 @@ def fromtimeline(
     *,
     id: Any,
     states: Any | None = None,
+    repeated: Any = False,
     data: Any | None = None,
     id_name: Any = "id",
 ) -> dict[str, Any]:
@@ -5619,6 +5620,8 @@ def fromtimeline(
         raise ValueError("time, status, and id must have the same length")
     if any(not math.isfinite(value) for value in time_values):
         raise ValueError("time values must be finite")
+    state_values = _totimeline_state_values(states)
+    repeated_value = _normalize_bool_option(repeated, "repeated")
     id_name_value = str(id_name)
     column_names, columns = _fromtimeline_data_columns(data, n)
     static_columns = _fromtimeline_static_columns(columns, id_values, column_names, id_name_value)
@@ -5626,10 +5629,14 @@ def fromtimeline(
         [_hashable_group_value(value) for value in id_values],
         "id",
     )
-    plan = _core.from_timeline_rows(id_codes, time_values, status_values)
+    plan = _core.from_timeline_rows(
+        id_codes,
+        time_values,
+        status_values,
+        repeated_value or not state_values,
+    )
     removed_ids = [id_values[int(row)] for row in plan.removed_row]
 
-    state_values = _totimeline_state_values(states) if states is not None else []
     if state_values:
         state_levels = ["censor", *state_values]
         istate_levels = state_values

--- a/python/survival/r_api.pyi
+++ b/python/survival/r_api.pyi
@@ -193,6 +193,7 @@ def fromtimeline(
     *,
     id: Any,
     states: Any | None = None,
+    repeated: Any = False,
     data: Any | None = None,
     id_name: Any = "id",
 ) -> dict[str, Any]: ...

--- a/python/tests/test_binding_contract.py
+++ b/python/tests/test_binding_contract.py
@@ -3264,7 +3264,7 @@ def test_data_prep_low_level_bindings_are_typed():
         ],
         "surv2data": ["id", "time", "event_time", "event_status"],
         "surv2data_timeline": ["id", "time", "status", "repeated"],
-        "from_timeline_rows": ["id", "time", "status"],
+        "from_timeline_rows": ["id", "time", "status", "repeated"],
         "survcondense": ["id", "time1", "time2", "status"],
         "survcondense_plan": ["id_order", "start", "stop", "row_code"],
         "tcut": ["value", "breaks", "labels"],
@@ -3367,6 +3367,15 @@ def test_data_prep_low_level_bindings_are_typed():
     )
     assert censored_timeline_rows.status == [0, 0, 2, 3]
     assert censored_timeline_rows.istate == [1, 2, 1, 2]
+
+    suppressed_timeline_rows = core.from_timeline_rows(
+        [0, 0, 0, 0],
+        [0.0, 1.0, 2.0, 3.0],
+        [1, 0, 1, 2],
+        False,
+    )
+    assert suppressed_timeline_rows.status == [0, 0, 2]
+    assert suppressed_timeline_rows.istate == [1, 1, 1]
 
     collapsed = core.collapse(
         [1.0, 2.0, 3.0, 4.0, 2.0, 3.0, 4.0, 5.0, 1.0, 0.0, 1.0, 0.0],

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -2957,6 +2957,28 @@ def test_fromtimeline_builds_intervals_and_covariate_row_maps():
     assert censored_result["status"] == [0, 2]
     assert censored_result["istate"] == [1, 1]
 
+    repeated_result = survival.fromtimeline(
+        [0.0, 1.0, 2.0],
+        [1, 0, 1],
+        id=[1, 1, 1],
+        states=["entry", "ill"],
+    )
+    assert repeated_result["status"] == [0, 0]
+    assert repeated_result["istate"] == [1, 1]
+
+    retained_repeated_result = survival.fromtimeline(
+        [0.0, 1.0, 2.0],
+        [1, 0, 1],
+        id=[1, 1, 1],
+        states=["entry", "ill"],
+        repeated=True,
+    )
+    assert retained_repeated_result["status"] == [0, 1]
+    assert retained_repeated_result["istate"] == [1, 1]
+
+    with pytest.raises(TypeError, match="repeated must be True or False"):
+        survival.fromtimeline([0.0, 1.0], [1, 1], id=[1, 1], repeated="yes")
+
     with pytest.raises(ValueError, match="censored state"):
         survival.fromtimeline([0.0, 1.0], [0, 1], id=[1, 1])
 

--- a/src/api/python/classical/data_prep.rs
+++ b/src/api/python/classical/data_prep.rs
@@ -16,6 +16,17 @@ fn rttright_time_matrix_py(
     py.detach(move || rttright_time_matrix(time, status, times, weights, strata, timefix, renorm))
 }
 
+#[pyfunction(name = "from_timeline_rows")]
+#[pyo3(signature = (id, time, status, repeated=true))]
+fn from_timeline_rows_py(
+    id: Vec<usize>,
+    time: Vec<f64>,
+    status: Vec<i32>,
+    repeated: bool,
+) -> PyResult<FromTimelineRowsResult> {
+    crate::data_prep::surv2data_module::from_timeline_rows_with_repeated(id, time, status, repeated)
+}
+
 pub(super) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(tmerge, m)?)?;
     m.add_function(wrap_pyfunction!(tmerge_plan, m)?)?;
@@ -26,7 +37,7 @@ pub(super) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(survcondense_plan, m)?)?;
     m.add_function(wrap_pyfunction!(surv2data, m)?)?;
     m.add_function(wrap_pyfunction!(surv2data_timeline, m)?)?;
-    m.add_function(wrap_pyfunction!(from_timeline_rows, m)?)?;
+    m.add_function(wrap_pyfunction!(from_timeline_rows_py, m)?)?;
     m.add_function(wrap_pyfunction!(to_timeline, m)?)?;
     m.add_function(wrap_pyfunction!(from_timeline, m)?)?;
     m.add_function(wrap_pyfunction!(lvcf_indices, m)?)?;

--- a/src/data_prep/surv2data.rs
+++ b/src/data_prep/surv2data.rs
@@ -71,6 +71,15 @@ pub fn from_timeline_rows(
     time: Vec<f64>,
     status: Vec<i32>,
 ) -> PyResult<FromTimelineRowsResult> {
+    from_timeline_rows_with_repeated(id, time, status, true)
+}
+
+pub(crate) fn from_timeline_rows_with_repeated(
+    id: Vec<usize>,
+    time: Vec<f64>,
+    status: Vec<i32>,
+    repeated: bool,
+) -> PyResult<FromTimelineRowsResult> {
     let n = id.len();
     validate_parallel_len("time", time.len(), n)?;
     validate_parallel_len("status", status.len(), n)?;
@@ -144,7 +153,14 @@ pub fn from_timeline_rows(
         if next != NO_NEXT_ROW {
             result.start.push(time[row]);
             result.stop.push(time[next]);
-            result.status.push(status[next]);
+            let event = status[next];
+            result
+                .status
+                .push(if !repeated && event == state_by_row[row] {
+                    0
+                } else {
+                    event
+                });
             result.istate.push(state_by_row[row]);
             result.static_row.push(first_row);
             result.dynamic_row.push(row);
@@ -693,6 +709,33 @@ mod tests {
         assert_eq!(result.istate, vec![1, 2, 1, 2]);
         assert_eq!(result.static_row, vec![0, 1, 0, 1]);
         assert_eq!(result.dynamic_row, vec![0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn from_timeline_rows_suppresses_repeated_current_states() {
+        let id = vec![0, 0, 0, 0];
+        let time = vec![0.0, 1.0, 2.0, 3.0];
+        let status = vec![1, 0, 1, 2];
+
+        let suppressed =
+            from_timeline_rows_with_repeated(id.clone(), time.clone(), status.clone(), false)
+                .unwrap();
+        let retained = from_timeline_rows(id, time, status).unwrap();
+
+        assert_eq!(suppressed.status, vec![0, 0, 2]);
+        assert_eq!(suppressed.istate, vec![1, 1, 1]);
+        assert_eq!(retained.status, vec![0, 1, 2]);
+        assert_eq!(retained.istate, vec![1, 1, 1]);
+
+        let transition_back = from_timeline_rows_with_repeated(
+            vec![0, 0, 0, 0],
+            vec![0.0, 1.0, 2.0, 3.0],
+            vec![1, 2, 0, 1],
+            false,
+        )
+        .unwrap();
+        assert_eq!(transition_back.status, vec![2, 0, 1]);
+        assert_eq!(transition_back.istate, vec![1, 2, 2]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- suppress repeated current-state events by default for named multi-state timelines
- preserve ordinary timeline behavior and keep the low-level binding backward compatible
- retain explicit repeats and genuine transitions back to an earlier state

## Performance
- perform one integer comparison per emitted interval with no additional allocation

## Testing
- 1,473 native tests
- 851 interpreter-side tests, 18 skipped
- 102 low-level binding tests
- strict lint matrices for no-default, ml, and python+ml feature sets
- native and interpreter formatting, Ruff lint, and diff checks