### PR TITLE
Support absent fromtimeline initial states

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -5636,10 +5636,18 @@ def fromtimeline(
         repeated_value or not state_values,
     )
     removed_ids = [id_values[int(row)] for row in plan.removed_row]
+    has_initial_state = bool(plan.istate)
+    if not plan.start and id_codes:
+        first_subject = id_codes[0]
+        first_row = min(
+            (row for row, subject in enumerate(id_codes) if subject == first_subject),
+            key=time_values.__getitem__,
+        )
+        has_initial_state = status_values[first_row] != 0
 
     if state_values:
         state_levels = ["censor", *state_values]
-        istate_levels = state_values
+        istate_levels = state_values if has_initial_state else []
     else:
         state_levels = []
         istate_levels = []
@@ -5648,7 +5656,7 @@ def fromtimeline(
         "start": plan.start,
         "stop": plan.stop,
         "status": plan.status,
-        "istate": plan.istate,
+        "istate": plan.istate if has_initial_state else None,
         "static": static_columns,
         "static_row": plan.static_row,
         "dynamic_row": plan.dynamic_row,

--- a/python/tests/test_binding_contract.py
+++ b/python/tests/test_binding_contract.py
@@ -3377,6 +3377,25 @@ def test_data_prep_low_level_bindings_are_typed():
     assert suppressed_timeline_rows.status == [0, 0, 2]
     assert suppressed_timeline_rows.istate == [1, 1, 1]
 
+    absent_initial_state_rows = core.from_timeline_rows(
+        [0, 0, 0, 1, 1, 1, 2],
+        [0.0, 1.0, 2.0, 0.0, 2.0, 4.0, 0.0],
+        [0, 0, 1, 0, 2, 0, 0],
+        False,
+    )
+    assert absent_initial_state_rows.status == [0, 1, 2, 0]
+    assert absent_initial_state_rows.istate == []
+    assert absent_initial_state_rows.static_row == [0, 0, 3, 3]
+    assert absent_initial_state_rows.dynamic_row == [0, 1, 3, 4]
+    assert absent_initial_state_rows.removed_row == [6]
+
+    with pytest.raises(ValueError, match="everyone or no one should have an initial state"):
+        core.from_timeline_rows(
+            [0, 0, 1],
+            [0.0, 1.0, 0.0],
+            [0, 1, 1],
+        )
+
     collapsed = core.collapse(
         [1.0, 2.0, 3.0, 4.0, 2.0, 3.0, 4.0, 5.0, 1.0, 0.0, 1.0, 0.0],
         [1, 1, 1, 1],

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -2979,8 +2979,48 @@ def test_fromtimeline_builds_intervals_and_covariate_row_maps():
     with pytest.raises(TypeError, match="repeated must be True or False"):
         survival.fromtimeline([0.0, 1.0], [1, 1], id=[1, 1], repeated="yes")
 
-    with pytest.raises(ValueError, match="censored state"):
-        survival.fromtimeline([0.0, 1.0], [0, 1], id=[1, 1])
+    absent_initial_state = survival.fromtimeline(
+        [0.0, 1.0, 2.0, 0.0, 2.0, 4.0],
+        [0, 0, 1, 0, 1, 0],
+        id=[1, 1, 1, 2, 2, 2],
+    )
+    assert absent_initial_state["start"] == pytest.approx([0.0, 1.0, 0.0, 2.0])
+    assert absent_initial_state["stop"] == pytest.approx([1.0, 2.0, 2.0, 4.0])
+    assert absent_initial_state["status"] == [0, 1, 1, 0]
+    assert absent_initial_state["istate"] is None
+    assert absent_initial_state["istate_levels"] == []
+
+    absent_multistate = survival.fromtimeline(
+        [0.0, 1.0, 2.0, 0.0, 2.0, 4.0],
+        [0, 0, 1, 0, 2, 0],
+        id=[1, 1, 1, 2, 2, 2],
+        states=["ill", "death"],
+    )
+    assert absent_multistate["status"] == [0, 1, 2, 0]
+    assert absent_multistate["istate"] is None
+    assert absent_multistate["state_levels"] == ["censor", "ill", "death"]
+    assert absent_multistate["istate_levels"] == []
+
+    singleton_initial_states = survival.fromtimeline(
+        [0.0, 0.0],
+        [1, 2],
+        id=[1, 2],
+        states=["ill", "death"],
+    )
+    assert singleton_initial_states["start"] == []
+    assert singleton_initial_states["istate"] == []
+    assert singleton_initial_states["istate_levels"] == ["ill", "death"]
+    assert singleton_initial_states["removed_id"] == [1, 2]
+
+    with pytest.raises(ValueError, match="everyone or no one should have an initial state"):
+        survival.fromtimeline(
+            [0.0, 1.0, 0.0, 1.0],
+            [0, 1, 1, 2],
+            id=[1, 1, 2, 2],
+        )
+
+    with pytest.raises(ValueError, match="everyone or no one should have an initial state"):
+        survival.fromtimeline([0.0, 1.0, 0.0], [0, 1, 1], id=[1, 1, 2])
 
     with pytest.raises(ValueError, match="duplicated time for an id"):
         survival.fromtimeline([0.0, 1.0, 1.0], [1, 2, 3], id=[1, 1, 1])

--- a/src/data_prep/surv2data.rs
+++ b/src/data_prep/surv2data.rs
@@ -103,7 +103,8 @@ pub(crate) fn from_timeline_rows_with_repeated(
 
     let capacity = n.saturating_sub(groups.len());
     let mut next_row = vec![NO_NEXT_ROW; n];
-    let mut state_by_row = vec![0; n];
+    let mut has_initial_state = None;
+    let mut state_by_row = Vec::new();
     group_index.clear();
     for mut rows in groups {
         rows.sort_unstable_by(|&left, &right| {
@@ -115,32 +116,46 @@ pub(crate) fn from_timeline_rows_with_repeated(
             return Err(PyValueError::new_err("duplicated time for an id"));
         }
         let first_row = rows[0];
+        let current_has_state = status[first_row] != 0;
+        if has_initial_state.is_some_and(|expected| expected != current_has_state) {
+            return Err(PyValueError::new_err(
+                "everyone or no one should have an initial state",
+            ));
+        }
+        if has_initial_state.is_none() {
+            has_initial_state = Some(current_has_state);
+            if current_has_state {
+                state_by_row.resize(n, 0);
+            }
+        }
         if rows.len() < 2 {
             continue;
         }
-        if status[first_row] == 0 {
-            return Err(PyValueError::new_err(
-                "no observation should start in a censored state",
-            ));
-        }
         group_index.insert(id[first_row], first_row);
-        let mut current_state = status[first_row];
-        for pair in rows.windows(2) {
-            let row = pair[0];
-            let next = pair[1];
-            if status[row] != 0 {
-                current_state = status[row];
+        if current_has_state {
+            let mut current_state = status[first_row];
+            for pair in rows.windows(2) {
+                let row = pair[0];
+                let next = pair[1];
+                if status[row] != 0 {
+                    current_state = status[row];
+                }
+                next_row[row] = next;
+                state_by_row[row] = current_state;
             }
-            next_row[row] = next;
-            state_by_row[row] = current_state;
+        } else {
+            for pair in rows.windows(2) {
+                next_row[pair[0]] = pair[1];
+            }
         }
     }
 
+    let has_initial_state = has_initial_state.unwrap_or(false);
     let mut result = FromTimelineRowsResult {
         start: Vec::with_capacity(capacity),
         stop: Vec::with_capacity(capacity),
         status: Vec::with_capacity(capacity),
-        istate: Vec::with_capacity(capacity),
+        istate: Vec::with_capacity(if has_initial_state { capacity } else { 0 }),
         static_row: Vec::with_capacity(capacity),
         dynamic_row: Vec::with_capacity(capacity),
         removed_row: Vec::new(),
@@ -154,14 +169,17 @@ pub(crate) fn from_timeline_rows_with_repeated(
             result.start.push(time[row]);
             result.stop.push(time[next]);
             let event = status[next];
+            let current_state = has_initial_state.then(|| state_by_row[row]);
             result
                 .status
-                .push(if !repeated && event == state_by_row[row] {
+                .push(if !repeated && current_state == Some(event) {
                     0
                 } else {
                     event
                 });
-            result.istate.push(state_by_row[row]);
+            if let Some(state) = current_state {
+                result.istate.push(state);
+            }
             result.static_row.push(first_row);
             result.dynamic_row.push(row);
         }
@@ -739,10 +757,45 @@ mod tests {
     }
 
     #[test]
-    fn timeline_rows_validate_inputs_and_initial_states() {
+    fn timeline_rows_validate_inputs() {
         assert!(from_timeline_rows(vec![0], vec![], vec![1]).is_err());
         assert!(from_timeline_rows(vec![0], vec![f64::NAN], vec![1]).is_err());
-        assert!(from_timeline_rows(vec![0, 0], vec![0.0, 1.0], vec![0, 1]).is_err());
+    }
+
+    #[test]
+    fn from_timeline_rows_handles_absent_and_mixed_initial_states() {
+        let absent = from_timeline_rows_with_repeated(
+            vec![0, 0, 0, 1, 1, 1, 2],
+            vec![0.0, 1.0, 2.0, 0.0, 2.0, 4.0, 0.0],
+            vec![0, 0, 1, 0, 2, 0, 0],
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(absent.start, vec![0.0, 1.0, 0.0, 2.0]);
+        assert_eq!(absent.stop, vec![1.0, 2.0, 2.0, 4.0]);
+        assert_eq!(absent.status, vec![0, 1, 2, 0]);
+        assert!(absent.istate.is_empty());
+        assert_eq!(absent.static_row, vec![0, 0, 3, 3]);
+        assert_eq!(absent.dynamic_row, vec![0, 1, 3, 4]);
+        assert_eq!(absent.removed_row, vec![6]);
+
+        let mixed =
+            from_timeline_rows(vec![0, 0, 1, 1], vec![0.0, 1.0, 0.0, 1.0], vec![0, 1, 1, 2])
+                .unwrap_err();
+        assert!(
+            mixed
+                .to_string()
+                .contains("everyone or no one should have an initial state")
+        );
+
+        let singleton_mixed =
+            from_timeline_rows(vec![0, 0, 1], vec![0.0, 1.0, 0.0], vec![0, 1, 1]).unwrap_err();
+        assert!(
+            singleton_mixed
+                .to_string()
+                .contains("everyone or no one should have an initial state")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- accept timelines where every subject starts in the censored state and preserve their event statuses
- reject mixed initial-state modes with the reference-compatible error, including single-row subjects
- expose the absent public `istate` column as `None` while keeping the low-level result type stable
- retain state metadata for stateful timelines that contain only single-row subjects

## Performance
- skip the per-row carried-state buffer when initial states are absent
- avoid reserving an output state vector in the absent-state path

## Testing
- `cargo test --all-features --workspace` (1,697 passed)
- public-side suite (749 passed, 18 skipped)
- low-level suite (102 passed)
- optimized-extension focused regressions (2 passed)
- strict Clippy checks for no-default, `ml`, and `python,ml`
- native/interpreter formatting, Ruff lint, and diff checks