### PR TITLE
Classify timeline response shapes by intervals

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -5340,6 +5340,23 @@ def _surv2data_status_values(status: Any) -> list[int | None]:
     return values
 
 
+def _timeline_response_type(
+    rows: Sequence[int],
+    id_codes: Sequence[int],
+    *,
+    multistate: bool,
+) -> str:
+    right_type = "mright" if multistate else "right"
+    counting_type = "mcounting" if multistate else "counting"
+    seen = bytearray(max(id_codes, default=-1) + 1)
+    for row in rows:
+        subject = id_codes[row]
+        if seen[subject]:
+            return counting_type
+        seen[subject] = 1
+    return right_type
+
+
 def Surv2data(
     time: Any,
     status: Any,
@@ -5407,7 +5424,7 @@ def Surv2data(
         stops = [interval[2] for interval in intervals]
         output_status = [interval[3] for interval in intervals]
         output_ids = [interval[4] for interval in intervals]
-        response_type = "right" if starts and all(value == 0.0 for value in starts) else "counting"
+        response_type = _timeline_response_type(rows, id_codes, multistate=False)
         return {
             "row": rows,
             "start": starts,
@@ -5426,15 +5443,7 @@ def Surv2data(
     )
     rows = [int(value) for value in result.row_index]
     starts = [float(value) for value in result.start]
-    response_type = (
-        "mright"
-        if state_values and starts and all(value == 0.0 for value in starts)
-        else "mcounting"
-        if state_values
-        else "right"
-        if starts and all(value == 0.0 for value in starts)
-        else "counting"
-    )
+    response_type = _timeline_response_type(rows, id_codes, multistate=True)
     return {
         "row": rows,
         "start": starts,
@@ -5636,6 +5645,11 @@ def fromtimeline(
         repeated_value or not state_values,
     )
     removed_ids = [id_values[int(row)] for row in plan.removed_row]
+    response_type = _timeline_response_type(
+        plan.dynamic_row,
+        id_codes,
+        multistate=bool(state_values),
+    )
     has_initial_state = bool(plan.istate)
     if not plan.start and id_codes:
         first_subject = id_codes[0]
@@ -5663,6 +5677,7 @@ def fromtimeline(
         "state_levels": state_levels,
         "istate_levels": istate_levels,
         "removed_id": removed_ids,
+        "type": response_type,
     }
 
 

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -2844,6 +2844,24 @@ def test_surv2data_converts_timeline_rows_to_counting_transitions():
     )
     assert ordinary_result["row"] == [0, 1, 2, 3]
     assert ordinary_result["status"] == [1, 1, 1, 0]
+    assert ordinary_result["type"] == "counting"
+
+    ordinary_right = survival.Surv2data(
+        [5.0, 9.0, 2.0, 8.0],
+        [0, 1, 0, 1],
+        id=[1, 1, 2, 2],
+    )
+    assert ordinary_right["start"] == pytest.approx([5.0, 2.0])
+    assert ordinary_right["type"] == "right"
+
+    multistate_right = survival.Surv2data(
+        [5.0, 9.0, 2.0, 8.0],
+        [1, 2, 1, 2],
+        states=["entry", "death"],
+        id=[1, 1, 2, 2],
+    )
+    assert multistate_right["start"] == pytest.approx([5.0, 2.0])
+    assert multistate_right["type"] == "mright"
 
     carried_state = survival.Surv2data(
         [0.0, 1.0, 2.0, 3.0],
@@ -2923,6 +2941,7 @@ def test_fromtimeline_builds_intervals_and_covariate_row_maps():
     assert result["static"] == [True, False, True]
     assert result["static_row"] == [0, 0, 3, 3]
     assert result["dynamic_row"] == [0, 1, 3, 4]
+    assert result["type"] == "counting"
 
     multistate_result = survival.fromtimeline(
         [0.0, 2.0, 5.0, 0.0, 3.0, 6.0],
@@ -2934,6 +2953,24 @@ def test_fromtimeline_builds_intervals_and_covariate_row_maps():
     assert multistate_result["istate"] == [1, 2, 1, 2]
     assert multistate_result["state_levels"] == ["censor", "entry", "ill", "death"]
     assert multistate_result["istate_levels"] == ["entry", "ill", "death"]
+    assert multistate_result["type"] == "mcounting"
+
+    ordinary_right = survival.fromtimeline(
+        [5.0, 9.0, 2.0, 8.0],
+        [0, 1, 0, 1],
+        id=[1, 1, 2, 2],
+    )
+    assert ordinary_right["start"] == pytest.approx([5.0, 2.0])
+    assert ordinary_right["type"] == "right"
+
+    multistate_right = survival.fromtimeline(
+        [5.0, 9.0, 2.0, 8.0],
+        [1, 2, 1, 2],
+        id=[1, 1, 2, 2],
+        states=["entry", "death"],
+    )
+    assert multistate_right["start"] == pytest.approx([5.0, 2.0])
+    assert multistate_right["type"] == "mright"
 
     interleaved_result = survival.fromtimeline(
         [0.0, 3.0, 4.0, 0.0, 2.0],
@@ -3011,6 +3048,7 @@ def test_fromtimeline_builds_intervals_and_covariate_row_maps():
     assert singleton_initial_states["istate"] == []
     assert singleton_initial_states["istate_levels"] == ["ill", "death"]
     assert singleton_initial_states["removed_id"] == [1, 2]
+    assert singleton_initial_states["type"] == "mright"
 
     with pytest.raises(ValueError, match="everyone or no one should have an initial state"):
         survival.fromtimeline(


### PR DESCRIPTION
## Summary
- classify timeline conversions as right-censored when each retained subject contributes at most one interval
- classify them as counting-process responses when any subject contributes multiple intervals
- add matching `type` metadata to `fromtimeline` for ordinary and multistate responses
- preserve existing start/stop arrays for callers while correcting the response classification

## Performance
- replace response-wide start-time comparisons with a compact one-byte-per-subject ownership scan
- stop as soon as a second interval is found for any subject

## Testing
- verified nonzero-entry right-censored and multi-interval counting behavior against the reference implementation
- public-side suite (749 passed, 18 skipped)
- focused conversion regressions (2 passed)
- Ruff lint, interpreter formatting, and diff checks