### PR TITLE
Reject duplicate ordinary timeline times

### DIFF
--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -5408,6 +5408,8 @@ def Surv2data(
         for _, grouped_rows_iter in groupby(order, key=lambda idx: id_codes[idx]):
             grouped_rows = list(grouped_rows_iter)
             for current_row, next_row in zip(grouped_rows[:-1], grouped_rows[1:], strict=True):
+                if time_values[current_row] == time_values[next_row]:
+                    raise ValueError("duplicated time for an id")
                 next_status = status_values[next_row]
                 intervals.append(
                     (

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -2883,6 +2883,10 @@ def test_surv2data_converts_timeline_rows_to_counting_transitions():
 
     with pytest.raises(ValueError, match="duplicated time"):
         survival.Surv2data([0.0, 0.0], [1, 2], states=["a", "b"], id=[1, 1])
+    with pytest.raises(ValueError, match="duplicated time for an id"):
+        survival.Surv2data([0.0, 0.0], [0, 1], id=[1, 1])
+    with pytest.raises(ValueError, match="duplicated time for an id"):
+        survival.Surv2data([0.0, 1.0, 1.0], [0, 0, 1], id=[1, 1, 1])
     with pytest.raises(ValueError, match="everyone or no one should have an initial state"):
         survival.Surv2data(
             [0.0, 1.0, 0.0, 1.0],


### PR DESCRIPTION
## Summary
- reject duplicate time values per subject in ordinary timeline conversion
- perform the check during existing interval construction without another traversal
- cover fully and partially duplicated histories

## Testing
- .venv/bin/python -m pytest python/tests -q
- .venv/bin/ruff check python/survival/r_api.py python/tests/test_r_api.py
- .venv/bin/ruff format --check python/survival/r_api.py python/tests/test_r_api.py
- git diff --check