### PR TITLE
Support first-only timeline events

### DIFF
--- a/python/survival/_survival.pyi
+++ b/python/survival/_survival.pyi
@@ -5754,6 +5754,7 @@ def from_timeline_rows(
     time: list[float],
     status: list[int],
     repeated: bool = True,
+    first_only: bool = False,
 ) -> FromTimelineRowsResult: ...
 def survcondense(
     id: list[int],

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -5621,7 +5621,7 @@ def fromtimeline(
     data: Any | None = None,
     id_name: Any = "id",
 ) -> dict[str, Any]:
-    """Convert right-censored timeline rows into R ``fromtimeline`` intervals."""
+    """Convert timeline rows, including first-event-only histories, into intervals."""
 
     time_values = _float_vector(time, "time")
     status_values = [int(value) for value in _int_vector(status, "status")]
@@ -5632,7 +5632,8 @@ def fromtimeline(
     if any(not math.isfinite(value) for value in time_values):
         raise ValueError("time values must be finite")
     state_values = _totimeline_state_values(states)
-    repeated_value = _normalize_bool_option(repeated, "repeated")
+    repeated_is_first = isinstance(repeated, str) and repeated.casefold() == "first"
+    repeated_value = True if repeated_is_first else _normalize_bool_option(repeated, "repeated")
     id_name_value = str(id_name)
     column_names, columns = _fromtimeline_data_columns(data, n)
     static_columns = _fromtimeline_static_columns(columns, id_values, column_names, id_name_value)
@@ -5645,6 +5646,7 @@ def fromtimeline(
         time_values,
         status_values,
         repeated_value or not state_values,
+        repeated_is_first,
     )
     removed_ids = [id_values[int(row)] for row in plan.removed_row]
     response_type = _timeline_response_type(

--- a/python/tests/test_binding_contract.py
+++ b/python/tests/test_binding_contract.py
@@ -3264,7 +3264,7 @@ def test_data_prep_low_level_bindings_are_typed():
         ],
         "surv2data": ["id", "time", "event_time", "event_status"],
         "surv2data_timeline": ["id", "time", "status", "repeated"],
-        "from_timeline_rows": ["id", "time", "status", "repeated"],
+        "from_timeline_rows": ["id", "time", "status", "repeated", "first_only"],
         "survcondense": ["id", "time1", "time2", "status"],
         "survcondense_plan": ["id_order", "start", "stop", "row_code"],
         "tcut": ["value", "breaks", "labels"],
@@ -3376,6 +3376,16 @@ def test_data_prep_low_level_bindings_are_typed():
     )
     assert suppressed_timeline_rows.status == [0, 0, 2]
     assert suppressed_timeline_rows.istate == [1, 1, 1]
+
+    first_only_timeline_rows = core.from_timeline_rows(
+        [0, 0, 0, 0],
+        [0.0, 1.0, 2.0, 3.0],
+        [1, 2, 1, 2],
+        True,
+        True,
+    )
+    assert first_only_timeline_rows.status == [2, 0, 0]
+    assert first_only_timeline_rows.istate == [1, 2, 2]
 
     absent_initial_state_rows = core.from_timeline_rows(
         [0, 0, 0, 1, 1, 1, 2],

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -3017,6 +3017,25 @@ def test_fromtimeline_builds_intervals_and_covariate_row_maps():
     assert retained_repeated_result["status"] == [0, 1]
     assert retained_repeated_result["istate"] == [1, 1]
 
+    first_only_result = survival.fromtimeline(
+        [0.0, 1.0, 2.0, 3.0],
+        [1, 2, 1, 2],
+        id=[1, 1, 1, 1],
+        states=["entry", "death"],
+        repeated="first",
+    )
+    assert first_only_result["status"] == [2, 0, 0]
+    assert first_only_result["istate"] == [1, 2, 2]
+
+    ordinary_first_only = survival.fromtimeline(
+        [0.0, 1.0, 2.0, 3.0, 4.0],
+        [0, 1, 0, 1, 1],
+        id=[1, 1, 1, 1, 1],
+        repeated="FIRST",
+    )
+    assert ordinary_first_only["status"] == [1, 0, 0, 0]
+    assert ordinary_first_only["istate"] is None
+
     with pytest.raises(TypeError, match="repeated must be True or False"):
         survival.fromtimeline([0.0, 1.0], [1, 1], id=[1, 1], repeated="yes")
 

--- a/src/api/python/classical/data_prep.rs
+++ b/src/api/python/classical/data_prep.rs
@@ -17,14 +17,17 @@ fn rttright_time_matrix_py(
 }
 
 #[pyfunction(name = "from_timeline_rows")]
-#[pyo3(signature = (id, time, status, repeated=true))]
+#[pyo3(signature = (id, time, status, repeated=true, first_only=false))]
 fn from_timeline_rows_py(
     id: Vec<usize>,
     time: Vec<f64>,
     status: Vec<i32>,
     repeated: bool,
+    first_only: bool,
 ) -> PyResult<FromTimelineRowsResult> {
-    crate::data_prep::surv2data_module::from_timeline_rows_with_repeated(id, time, status, repeated)
+    crate::data_prep::surv2data_module::from_timeline_rows_with_policy(
+        id, time, status, repeated, first_only,
+    )
 }
 
 pub(super) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {

--- a/src/data_prep/surv2data.rs
+++ b/src/data_prep/surv2data.rs
@@ -1,6 +1,6 @@
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::constants::TIME_EPSILON;
 use crate::internal::validation::{validate_binary_i32, validate_finite, validate_no_nan};
@@ -80,6 +80,16 @@ pub(crate) fn from_timeline_rows_with_repeated(
     status: Vec<i32>,
     repeated: bool,
 ) -> PyResult<FromTimelineRowsResult> {
+    from_timeline_rows_with_policy(id, time, status, repeated, false)
+}
+
+pub(crate) fn from_timeline_rows_with_policy(
+    id: Vec<usize>,
+    time: Vec<f64>,
+    mut status: Vec<i32>,
+    repeated: bool,
+    first_only: bool,
+) -> PyResult<FromTimelineRowsResult> {
     let n = id.len();
     validate_parallel_len("time", time.len(), n)?;
     validate_parallel_len("status", status.len(), n)?;
@@ -105,6 +115,7 @@ pub(crate) fn from_timeline_rows_with_repeated(
     let mut next_row = vec![NO_NEXT_ROW; n];
     let mut has_initial_state = None;
     let mut state_by_row = Vec::new();
+    let mut seen_events = HashSet::new();
     group_index.clear();
     for mut rows in groups {
         rows.sort_unstable_by(|&left, &right| {
@@ -114,6 +125,15 @@ pub(crate) fn from_timeline_rows_with_repeated(
         });
         if rows.windows(2).any(|pair| time[pair[0]] == time[pair[1]]) {
             return Err(PyValueError::new_err("duplicated time for an id"));
+        }
+        if first_only {
+            seen_events.clear();
+            for &row in &rows {
+                let event = status[row];
+                if event != 0 && !seen_events.insert(event) {
+                    status[row] = 0;
+                }
+            }
         }
         let first_row = rows[0];
         let current_has_state = status[first_row] != 0;
@@ -170,13 +190,13 @@ pub(crate) fn from_timeline_rows_with_repeated(
             result.stop.push(time[next]);
             let event = status[next];
             let current_state = has_initial_state.then(|| state_by_row[row]);
-            result
-                .status
-                .push(if !repeated && current_state == Some(event) {
+            result.status.push(
+                if !first_only && !repeated && current_state == Some(event) {
                     0
                 } else {
                     event
-                });
+                },
+            );
             if let Some(state) = current_state {
                 result.istate.push(state);
             }
@@ -754,6 +774,21 @@ mod tests {
         .unwrap();
         assert_eq!(transition_back.status, vec![2, 0, 1]);
         assert_eq!(transition_back.istate, vec![1, 2, 2]);
+    }
+
+    #[test]
+    fn from_timeline_rows_can_retain_only_each_subjects_first_event() {
+        let result = from_timeline_rows_with_policy(
+            vec![0, 1, 0, 1, 0, 1, 0, 1],
+            vec![0.0, 0.0, 1.0, 1.0, 2.0, 2.0, 3.0, 3.0],
+            vec![1, 1, 2, 2, 1, 1, 2, 2],
+            true,
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(result.status, vec![2, 2, 0, 0, 0, 0]);
+        assert_eq!(result.istate, vec![1, 1, 2, 2, 2, 2]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- support the documented first-occurrence-only repeated-event policy in timeline conversion
- suppress later occurrences during the existing native per-subject traversal
- preserve carried state and independent event histories across subjects
- cover multistate, ordinary, case-insensitive, and low-level binding behavior

## Testing
- cargo test --lib --no-default-features
- cargo test --lib --features ml
- cargo test --lib --features python,ml
- cargo clippy --all-targets --no-default-features -- -D warnings
- cargo clippy --all-targets --features ml -- -D warnings
- cargo clippy --all-targets --features python,ml -- -D warnings
- .venv/bin/python -m pytest python/tests -q
- Ruff, rustfmt, mypy, and git diff checks