### PR TITLE
Avoid duplicate sorting for first-only timelines

### DIFF
--- a/python/survival/_survival.pyi
+++ b/python/survival/_survival.pyi
@@ -5748,6 +5748,7 @@ def surv2data_timeline(
     time: list[float],
     status: list[int | None],
     repeated: bool = False,
+    first_only: bool = False,
 ) -> Surv2TimelineResult: ...
 def from_timeline_rows(
     id: list[int],

--- a/python/survival/r_api.py
+++ b/python/survival/r_api.py
@@ -5382,28 +5382,23 @@ def Surv2data(
 
     id_codes = _encode_labels(id_values, "id")
     repeated_is_first = isinstance(repeated, str) and repeated.lower() == "first"
-    if repeated_is_first:
-        seen_by_id: dict[int, set[int]] = {}
-        for row_idx in sorted(
-            range(len(time_values)),
-            key=lambda idx: (id_codes[idx], time_values[idx]),
-        ):
-            status_value = status_values[row_idx]
-            if status_value in (None, 0):
-                continue
-            seen = seen_by_id.setdefault(id_codes[row_idx], set())
-            if status_value in seen:
-                status_values[row_idx] = 0
-            else:
-                seen.add(status_value)
-        repeated_value = True
-    else:
-        repeated_value = _normalize_bool_option(repeated, "repeated")
+    repeated_value = True if repeated_is_first else _normalize_bool_option(repeated, "repeated")
     if not state_values:
         order = sorted(
             range(len(time_values)),
             key=lambda idx: (id_codes[idx], time_values[idx]),
         )
+        if repeated_is_first:
+            seen_by_id: dict[int, set[int]] = {}
+            for row_idx in order:
+                status_value = status_values[row_idx]
+                if status_value in (None, 0):
+                    continue
+                seen = seen_by_id.setdefault(id_codes[row_idx], set())
+                if status_value in seen:
+                    status_values[row_idx] = 0
+                else:
+                    seen.add(status_value)
         intervals: list[tuple[int, float, float, int, Any]] = []
         for _, grouped_rows_iter in groupby(order, key=lambda idx: id_codes[idx]):
             grouped_rows = list(grouped_rows_iter)
@@ -5442,6 +5437,7 @@ def Surv2data(
         time_values,
         status_values,
         repeated_value,
+        repeated_is_first,
     )
     rows = [int(value) for value in result.row_index]
     starts = [float(value) for value in result.start]

--- a/python/tests/test_binding_contract.py
+++ b/python/tests/test_binding_contract.py
@@ -3263,7 +3263,7 @@ def test_data_prep_low_level_bindings_are_typed():
             "renorm",
         ],
         "surv2data": ["id", "time", "event_time", "event_status"],
-        "surv2data_timeline": ["id", "time", "status", "repeated"],
+        "surv2data_timeline": ["id", "time", "status", "repeated", "first_only"],
         "from_timeline_rows": ["id", "time", "status", "repeated", "first_only"],
         "survcondense": ["id", "time1", "time2", "status"],
         "survcondense_plan": ["id_order", "start", "stop", "row_code"],

--- a/python/tests/test_r_api.py
+++ b/python/tests/test_r_api.py
@@ -2837,6 +2837,17 @@ def test_surv2data_converts_timeline_rows_to_counting_transitions():
     )
     assert repeated_first_result["status"] == [2, 0, 0]
 
+    shuffled_first_result = survival.Surv2data(
+        [2.0, 0.0, 1.0, 0.0, 2.0, 1.0],
+        [2, 1, 2, 1, 2, 2],
+        states=["entry", "death"],
+        id=["a", "a", "a", "b", "b", "b"],
+        repeated="first",
+    )
+    assert shuffled_first_result["row"] == [1, 2, 3, 5]
+    assert shuffled_first_result["status"] == [2, 0, 2, 0]
+    assert shuffled_first_result["istate"] == [1, 2, 1, 2]
+
     ordinary_result = survival.Surv2data(
         [0.0, 0.0, 2.0, 3.0, 5.0, 6.0],
         [0, 0, 1, 1, 1, 0],

--- a/python/tests/test_utilities.py
+++ b/python/tests/test_utilities.py
@@ -181,6 +181,12 @@ def test_surv2data_and_survcondense_public_apis():
         [0.0, 0.0, 5.0, 2.0, 3.0],
         [1, 1, 3, 2, None],
     )
+    first_only_timeline = survival.surv2data_timeline(
+        [1, 1, 1, 1],
+        [0.0, 1.0, 2.0, 3.0],
+        [1, 2, 1, 2],
+        first_only=True,
+    )
     condensed = survival.survcondense(
         [2, 1, 1, 2],
         [0.0, 0.0, 5.0, 3.0],
@@ -198,6 +204,8 @@ def test_surv2data_and_survcondense_public_apis():
     assert timeline.stop == pytest.approx([2.0, 3.0, 5.0])
     assert timeline.status == [2, 0, 3]
     assert timeline.istate == [1, 1, 2]
+    assert first_only_timeline.status == [2, 0, 0]
+    assert first_only_timeline.istate == [1, 2, 2]
 
     assert condensed.id == [1, 2, 2]
     assert condensed.time1 == pytest.approx([0.0, 0.0, 3.0])

--- a/src/api/python/classical/data_prep.rs
+++ b/src/api/python/classical/data_prep.rs
@@ -30,6 +30,20 @@ fn from_timeline_rows_py(
     )
 }
 
+#[pyfunction(name = "surv2data_timeline")]
+#[pyo3(signature = (id, time, status, repeated=false, first_only=false))]
+fn surv2data_timeline_py(
+    id: Vec<i64>,
+    time: Vec<f64>,
+    status: Vec<Option<i32>>,
+    repeated: bool,
+    first_only: bool,
+) -> PyResult<Surv2TimelineResult> {
+    crate::data_prep::surv2data_module::surv2data_timeline_with_policy(
+        id, time, status, repeated, first_only,
+    )
+}
+
 pub(super) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(tmerge, m)?)?;
     m.add_function(wrap_pyfunction!(tmerge_plan, m)?)?;
@@ -39,7 +53,7 @@ pub(super) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(survcondense, m)?)?;
     m.add_function(wrap_pyfunction!(survcondense_plan, m)?)?;
     m.add_function(wrap_pyfunction!(surv2data, m)?)?;
-    m.add_function(wrap_pyfunction!(surv2data_timeline, m)?)?;
+    m.add_function(wrap_pyfunction!(surv2data_timeline_py, m)?)?;
     m.add_function(wrap_pyfunction!(from_timeline_rows_py, m)?)?;
     m.add_function(wrap_pyfunction!(to_timeline, m)?)?;
     m.add_function(wrap_pyfunction!(from_timeline, m)?)?;

--- a/src/data_prep/surv2data.rs
+++ b/src/data_prep/surv2data.rs
@@ -215,6 +215,16 @@ pub fn surv2data_timeline(
     status: Vec<Option<i32>>,
     repeated: bool,
 ) -> PyResult<Surv2TimelineResult> {
+    surv2data_timeline_with_policy(id, time, status, repeated, false)
+}
+
+pub(crate) fn surv2data_timeline_with_policy(
+    id: Vec<i64>,
+    time: Vec<f64>,
+    mut status: Vec<Option<i32>>,
+    repeated: bool,
+    first_only: bool,
+) -> PyResult<Surv2TimelineResult> {
     let n = id.len();
     if time.len() != n || status.len() != n {
         return Err(PyValueError::new_err(
@@ -234,8 +244,12 @@ pub fn surv2data_timeline(
     let mut next_row = vec![NO_NEXT_ROW; n];
     let mut n_intervals = 0;
     let mut has_initial_state = None;
+    let mut seen_events = HashSet::new();
     for (position, &current) in order.iter().enumerate() {
         if position == 0 || id[order[position - 1]] != id[current] {
+            if first_only {
+                seen_events.clear();
+            }
             let current_has_state = status[current].is_some_and(|value| value != 0);
             if has_initial_state.is_some_and(|expected| expected != current_has_state) {
                 return Err(PyValueError::new_err(
@@ -243,6 +257,12 @@ pub fn surv2data_timeline(
                 ));
             }
             has_initial_state = Some(current_has_state);
+        }
+        if first_only {
+            let event = status[current].unwrap_or(0);
+            if event != 0 && !seen_events.insert(event) {
+                status[current] = Some(0);
+            }
         }
 
         let Some(&next) = order.get(position + 1) else {
@@ -293,7 +313,7 @@ pub fn surv2data_timeline(
         }
         let istate = has_initial_state.then(|| state_by_row[row_index]);
         let mut event = status[next].unwrap_or(0);
-        if !repeated && istate == Some(event) {
+        if !first_only && !repeated && istate == Some(event) {
             event = 0;
         }
         result.row_index.push(row_index);
@@ -711,6 +731,34 @@ mod tests {
             mixed
                 .to_string()
                 .contains("everyone or no one should have an initial state")
+        );
+    }
+
+    #[test]
+    fn surv2data_timeline_can_retain_only_each_subjects_first_event() {
+        let result = surv2data_timeline_with_policy(
+            vec![1, 2, 1, 1, 2, 1, 2, 2],
+            vec![2.0, 3.0, 0.0, 3.0, 0.0, 1.0, 2.0, 1.0],
+            vec![
+                Some(1),
+                Some(2),
+                Some(1),
+                Some(2),
+                Some(1),
+                Some(2),
+                Some(1),
+                Some(2),
+            ],
+            true,
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(result.row_index, vec![0, 2, 4, 5, 6, 7]);
+        assert_eq!(result.status, vec![0, 2, 2, 0, 0, 0]);
+        assert_eq!(
+            result.istate,
+            vec![Some(2), Some(1), Some(1), Some(2), Some(2), Some(2)]
         );
     }
 


### PR DESCRIPTION
## Summary
- suppress multistate first-only events during the existing native sorted traversal
- reuse the ordinary timeline ordering for first-only suppression and interval construction
- preserve the public Rust function signature while adding a backward-compatible optional binding flag
- cover shuffled subjects, native state carry, low-level binding behavior, and the typed signature

## Performance
- 100,000-row multistate median: repeated `true` 0.0350s, repeated `"first"` 0.0357s
- first-only overhead falls from about 28% before the change to 1.9%

## Testing
- `cargo test --lib --no-default-features` (1,476 passed)
- `cargo test --lib --features ml` (1,685 passed)
- `cargo test --lib --features python,ml` (1,699 passed)
- `.venv/bin/python -m pytest python/ test/ -q` (851 passed, 18 skipped)
- strict Clippy across no-default, `ml`, and `python,ml` configurations
- Rust formatting, Ruff formatting/lint, mypy stubs, and `git diff --check`